### PR TITLE
fix(branding): update package metadata and HTML titles to Smalruby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6359,7 +6359,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -6370,7 +6369,6 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -6403,7 +6401,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -6413,7 +6410,6 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -6424,7 +6420,6 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -6435,7 +6430,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -8521,18 +8515,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@scratch/scratch-gui": {
-      "resolved": "packages/scratch-gui",
-      "link": true
-    },
-    "node_modules/@scratch/scratch-render": {
-      "resolved": "packages/scratch-render",
-      "link": true
-    },
-    "node_modules/@scratch/scratch-svg-renderer": {
-      "resolved": "packages/scratch-svg-renderer",
-      "link": true
-    },
     "node_modules/@scratch/scratch-vm": {
       "resolved": "packages/scratch-vm",
       "link": true
@@ -8862,29 +8844,28 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "5.6.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8935,7 +8916,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/ci-detect": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8944,7 +8925,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/config": {
       "version": "4.2.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8963,7 +8944,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8975,7 +8956,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/fs": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8988,7 +8969,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/git": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9008,7 +8989,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "1.0.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9024,7 +9005,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
       "version": "1.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9033,7 +9014,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "2.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9048,7 +9029,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9063,7 +9044,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/move-file": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9076,13 +9057,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9091,7 +9072,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9103,7 +9084,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9115,7 +9096,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/query": {
       "version": "1.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9129,7 +9110,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "4.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9145,7 +9126,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9154,13 +9135,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9172,7 +9153,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/agentkeepalive": {
       "version": "4.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9186,7 +9167,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9199,7 +9180,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9208,7 +9189,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9223,19 +9204,19 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/are-we-there-yet": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9248,19 +9229,19 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/bin-links": {
       "version": "3.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9277,7 +9258,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9286,7 +9267,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9295,7 +9276,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9304,7 +9285,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9313,7 +9294,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/cacache": {
       "version": "16.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9342,7 +9323,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9358,7 +9339,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9367,7 +9348,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -9379,7 +9360,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9388,7 +9369,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9401,7 +9382,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9416,7 +9397,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9425,7 +9406,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/cmd-shim": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9437,7 +9418,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9449,13 +9430,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -9464,7 +9445,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9477,25 +9458,25 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -9507,7 +9488,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9524,13 +9505,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9539,7 +9520,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9548,13 +9529,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/depd": {
       "version": "1.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9563,7 +9544,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9573,7 +9554,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -9582,23 +9563,22 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9607,19 +9587,19 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.12",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9631,19 +9611,19 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/gauge": {
       "version": "4.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9662,7 +9642,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/glob": {
       "version": "8.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9681,13 +9661,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.10",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9699,7 +9679,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9708,13 +9688,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/hosted-git-info": {
       "version": "5.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9726,13 +9706,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9746,7 +9726,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9759,7 +9739,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9768,10 +9748,9 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -9781,7 +9760,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/ignore-walk": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9793,7 +9772,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9802,7 +9781,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9811,13 +9790,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9827,13 +9806,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/ini": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9842,7 +9821,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/init-package-json": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9860,13 +9839,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9875,7 +9854,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -9887,7 +9866,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/is-core-module": {
       "version": "2.10.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9899,7 +9878,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9908,25 +9887,25 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -9935,28 +9914,28 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/just-diff": {
       "version": "5.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.4.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmaccess": {
       "version": "6.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9971,7 +9950,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmdiff": {
       "version": "4.0.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9990,7 +9969,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmexec": {
       "version": "4.0.14",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10015,7 +9994,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmfund": {
       "version": "3.0.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10027,7 +10006,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmhook": {
       "version": "8.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10040,7 +10019,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmorg": {
       "version": "4.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10053,7 +10032,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmpack": {
       "version": "4.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10067,7 +10046,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmpublish": {
       "version": "6.0.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10083,7 +10062,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmsearch": {
       "version": "5.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10095,7 +10074,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmteam": {
       "version": "4.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10108,7 +10087,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/libnpmversion": {
       "version": "3.0.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10124,7 +10103,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/lru-cache": {
       "version": "7.13.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10133,7 +10112,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/make-fetch-happen": {
       "version": "10.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10160,7 +10139,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minimatch": {
       "version": "5.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10172,7 +10151,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minipass": {
       "version": "3.3.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10184,7 +10163,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10196,7 +10175,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minipass-fetch": {
       "version": "2.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10213,7 +10192,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10225,7 +10204,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10235,7 +10214,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10247,7 +10226,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10259,7 +10238,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10272,7 +10251,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -10284,7 +10263,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10298,19 +10277,19 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.8",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10319,7 +10298,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/node-gyp": {
       "version": "9.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10343,7 +10322,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10353,7 +10332,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10373,7 +10352,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10385,7 +10364,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10400,7 +10379,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/nopt": {
       "version": "6.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10415,7 +10394,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/normalize-package-data": {
       "version": "4.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10430,7 +10409,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-audit-report": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10442,7 +10421,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-bundled": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10454,7 +10433,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10463,7 +10442,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-install-checks": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10475,13 +10454,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-package-arg": {
       "version": "9.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10496,7 +10475,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-packlist": {
       "version": "5.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10514,7 +10493,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10523,7 +10502,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "7.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10538,7 +10517,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10547,7 +10526,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-profile": {
       "version": "6.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10560,7 +10539,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "13.3.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10578,13 +10557,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/npmlog": {
       "version": "6.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10599,7 +10578,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10608,7 +10587,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
       "bin": {
@@ -10617,7 +10596,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10632,7 +10611,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/pacote": {
       "version": "13.6.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10667,7 +10646,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/parse-conflict-json": {
       "version": "2.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10681,7 +10660,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10690,7 +10669,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.0.10",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10703,7 +10682,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/proc-log": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10712,7 +10691,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -10721,7 +10700,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -10730,13 +10709,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10749,7 +10728,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10758,7 +10737,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -10766,7 +10745,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/read": {
       "version": "1.0.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10778,7 +10757,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/read-cmd-shim": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10787,7 +10766,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/read-package-json": {
       "version": "5.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10802,7 +10781,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/read-package-json-fast": {
       "version": "2.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10815,7 +10794,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10824,7 +10803,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10838,7 +10817,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10850,7 +10829,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10859,7 +10838,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10874,7 +10853,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10884,7 +10863,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10904,7 +10883,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10916,7 +10895,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -10936,14 +10915,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/semver": {
       "version": "7.3.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10958,7 +10936,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10970,19 +10948,19 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10992,7 +10970,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/socks": {
       "version": "2.7.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11006,7 +10984,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "7.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11020,7 +10998,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/spdx-correct": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11030,13 +11008,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11046,13 +11024,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/ssri": {
       "version": "9.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11064,7 +11042,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11073,7 +11051,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11087,7 +11065,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11099,7 +11077,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11111,7 +11089,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/tar": {
       "version": "6.1.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11128,19 +11106,19 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/treeverse": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11149,7 +11127,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/unique-filename": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11161,7 +11139,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/unique-slug": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11173,13 +11151,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11189,7 +11167,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11201,13 +11179,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/walk-up-path": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11216,7 +11194,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11231,7 +11209,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/wide-align": {
       "version": "1.1.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11240,13 +11218,13 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11259,7 +11237,7 @@
     },
     "node_modules/@semantic-release/npm/node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -11665,6 +11643,22 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@smalruby/scratch-gui": {
+      "resolved": "packages/scratch-gui",
+      "link": true
+    },
+    "node_modules/@smalruby/scratch-render": {
+      "resolved": "packages/scratch-render",
+      "link": true
+    },
+    "node_modules/@smalruby/scratch-svg-renderer": {
+      "resolved": "packages/scratch-svg-renderer",
+      "link": true
+    },
+    "node_modules/@smalruby/scratch-vm": {
+      "resolved": "packages/scratch-vm",
+      "link": true
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.8",
@@ -13102,7 +13096,6 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
@@ -13113,7 +13106,6 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "*",
@@ -13124,7 +13116,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -13486,7 +13477,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -14129,7 +14120,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
@@ -14140,28 +14130,24 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
@@ -14173,14 +14159,12 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -14193,7 +14177,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
@@ -14203,7 +14186,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
@@ -14213,14 +14195,12 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -14237,7 +14217,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -14251,7 +14230,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -14264,7 +14242,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -14279,7 +14256,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -14358,14 +14334,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/abab": {
@@ -14427,7 +14401,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -14474,7 +14447,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -14548,7 +14520,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -14565,7 +14536,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -14583,7 +14553,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -17112,7 +17081,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
@@ -19620,7 +19588,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -20903,7 +20870,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -21395,7 +21361,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -23421,7 +23386,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/global": {
@@ -28127,7 +28091,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
@@ -28834,7 +28797,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
@@ -29991,7 +29953,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -31142,7 +31103,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nerf-dart": {
@@ -37037,13 +36997,26 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-draggable": {
@@ -37800,6 +37773,16 @@
         "esprima": "~4.0.0"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/redux-mock-store": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.5.tgz",
@@ -38210,7 +38193,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -38667,7 +38649,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -38677,7 +38658,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -42238,7 +42218,6 @@
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -42257,7 +42236,6 @@
       "version": "5.3.16",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
       "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -42292,7 +42270,6 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -42303,7 +42280,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -42318,7 +42294,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -42328,7 +42303,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -42344,14 +42318,12 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -43645,7 +43617,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -44727,7 +44699,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
       "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -44777,7 +44748,6 @@
       "version": "5.104.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -45095,7 +45065,6 @@
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
       "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -45109,14 +45078,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -45130,7 +45097,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -45140,7 +45106,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -45154,7 +45119,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -46163,7 +46127,7 @@
       }
     },
     "packages/scratch-gui": {
-      "name": "@scratch/scratch-gui",
+      "name": "@smalruby/scratch-gui",
       "version": "12.3.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -46171,9 +46135,9 @@
         "@microbit/microbit-universal-hex": "0.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-context-menu": "2.2.16",
-        "@scratch/scratch-render": "12.3.1",
-        "@scratch/scratch-svg-renderer": "12.3.1",
-        "@scratch/scratch-vm": "12.3.1",
+        "@smalruby/scratch-render": "12.3.1",
+        "@smalruby/scratch-svg-renderer": "12.3.1",
+        "@smalruby/scratch-vm": "12.3.1",
         "@tensorflow-models/face-detection": "1.0.3",
         "@tensorflow/tfjs": "4.22.0",
         "@testing-library/user-event": "14.6.1",
@@ -46304,11 +46268,11 @@
       "extraneous": true
     },
     "packages/scratch-render": {
-      "name": "@scratch/scratch-render",
+      "name": "@smalruby/scratch-render",
       "version": "12.3.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-svg-renderer": "12.3.1",
+        "@smalruby/scratch-svg-renderer": "12.3.1",
         "grapheme-breaker": "0.3.2",
         "hull.js": "0.2.10",
         "ify-loader": "1.1.0",
@@ -46475,7 +46439,7 @@
       }
     },
     "packages/scratch-svg-renderer": {
-      "name": "@scratch/scratch-svg-renderer",
+      "name": "@smalruby/scratch-svg-renderer",
       "version": "12.3.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -46546,12 +46510,13 @@
       }
     },
     "packages/scratch-vm": {
-      "name": "@scratch/scratch-vm",
+      "name": "@smalruby/scratch-vm",
       "version": "12.3.1",
+      "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@scratch/scratch-render": "12.3.1",
-        "@scratch/scratch-svg-renderer": "12.3.1",
+        "@smalruby/scratch-render": "12.3.1",
+        "@smalruby/scratch-svg-renderer": "12.3.1",
         "@vernier/godirect": "1.8.3",
         "arraybuffer-loader": "1.0.8",
         "atob": "2.1.2",

--- a/packages/scratch-gui/package.json
+++ b/packages/scratch-gui/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@scratch/scratch-gui",
+  "name": "@smalruby/scratch-gui",
   "version": "12.3.1",
   "description": "Graphical User Interface for creating and running Scratch 3.0 projects",
-  "author": "Massachusetts Institute of Technology",
+  "author": "Ruby Programming Shounendan",
   "license": "AGPL-3.0-only",
-  "homepage": "https://github.com/scratchfoundation/scratch-gui#readme",
+  "homepage": "https://github.com/smalruby/smalruby3-editor#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scratchfoundation/scratch-editor.git"
+    "url": "https://github.com/smalruby/smalruby3-editor.git"
   },
   "main": "./dist/scratch-gui.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/scratch-gui/package.json
+++ b/packages/scratch-gui/package.json
@@ -66,9 +66,9 @@
     "@microbit/microbit-universal-hex": "0.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-context-menu": "2.2.16",
-    "@scratch/scratch-render": "12.3.1",
-    "@scratch/scratch-svg-renderer": "12.3.1",
-    "@scratch/scratch-vm": "12.3.1",
+    "@smalruby/scratch-render": "12.3.1",
+    "@smalruby/scratch-svg-renderer": "12.3.1",
+    "@smalruby/scratch-vm": "12.3.1",
     "@tensorflow-models/face-detection": "1.0.3",
     "@tensorflow/tfjs": "4.22.0",
     "@testing-library/user-event": "14.6.1",
@@ -213,7 +213,7 @@
       "src/test.js"
     ],
     "moduleNameMapper": {
-      "^@scratch/scratch-vm/(.*)$": "<rootDir>/../scratch-vm/$1",
+      "^@smalruby/scratch-vm/(.*)$": "<rootDir>/../scratch-vm/$1",
       "^scratch-vm/(.*)$": "<rootDir>/../scratch-vm/$1",
       "opal": "<rootDir>/opal/opal.min.js",
       "opal-parser": "<rootDir>/opal/opal-parser.min.js",

--- a/packages/scratch-gui/test/helpers/expect-to-equal-blocks.js
+++ b/packages/scratch-gui/test/helpers/expect-to-equal-blocks.js
@@ -1,5 +1,5 @@
-import Blocks from '@scratch/scratch-vm/src/engine/blocks';
-import Variable from '@scratch/scratch-vm/src/engine/variable';
+import Blocks from '@smalruby/scratch-vm/src/engine/blocks';
+import Variable from '@smalruby/scratch-vm/src/engine/variable';
 import RubyToBlocksConverter from '../../src/lib/ruby-to-blocks-converter';
 
 // for debug

--- a/packages/scratch-gui/test/unit/components/menu-bar.test.jsx
+++ b/packages/scratch-gui/test/unit/components/menu-bar.test.jsx
@@ -10,7 +10,7 @@ import {PLATFORM} from '../../../src/lib/platform';
 
 import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
-import VM from '@scratch/scratch-vm';
+import VM from '@smalruby/scratch-vm';
 
 describe('MenuBar Component', () => {
     const store = configureStore()({

--- a/packages/scratch-gui/test/unit/containers/sprite-selector-item.test.jsx
+++ b/packages/scratch-gui/test/unit/containers/sprite-selector-item.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {renderWithIntl} from '../../helpers/intl-helpers.jsx';
 import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
-import VM from '@scratch/scratch-vm';
+import VM from '@smalruby/scratch-vm';
 
 import SpriteSelectorItemContainer from '../../../src/containers/sprite-selector-item';
 import {legacyConfig} from '../../../src/legacy-config';

--- a/packages/scratch-gui/test/unit/util/cloud-manager-hoc.test.jsx
+++ b/packages/scratch-gui/test/unit/util/cloud-manager-hoc.test.jsx
@@ -2,7 +2,7 @@ import 'web-audio-test-api';
 
 import React from 'react';
 import configureStore from 'redux-mock-store';
-import VM from '@scratch/scratch-vm';
+import VM from '@smalruby/scratch-vm';
 import {LoadingState} from '../../../src/reducers/project-state';
 import CloudProvider from '../../../src/lib/cloud-provider';
 import {render} from '@testing-library/react';

--- a/packages/scratch-gui/test/unit/util/define-dynamic-block.test.js
+++ b/packages/scratch-gui/test/unit/util/define-dynamic-block.test.js
@@ -1,6 +1,6 @@
 import defineDynamicBlock from '../../../src/lib/define-dynamic-block';
 
-import BlockType from '@scratch/scratch-vm/src/extension-support/block-type';
+import BlockType from '@smalruby/scratch-vm/src/extension-support/block-type';
 
 const MockScratchBlocks = {
     OUTPUT_SHAPE_HEXAGONAL: 1,

--- a/packages/scratch-gui/test/unit/util/project-saver-hoc.test.jsx
+++ b/packages/scratch-gui/test/unit/util/project-saver-hoc.test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import {render} from '@testing-library/react';
 import {LoadingState} from '../../../src/reducers/project-state';
-import VM from '@scratch/scratch-vm';
+import VM from '@smalruby/scratch-vm';
 import {legacyConfig} from '../../../src/legacy-config';
 
 import projectSaverHOC from '../../../src/lib/project-saver-hoc.jsx';

--- a/packages/scratch-gui/test/unit/util/sb-file-uploader-hoc.test.jsx
+++ b/packages/scratch-gui/test/unit/util/sb-file-uploader-hoc.test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import {renderWithIntl} from '../../helpers/intl-helpers.jsx';
 import {LoadingState} from '../../../src/reducers/project-state';
-import VM from '@scratch/scratch-vm';
+import VM from '@smalruby/scratch-vm';
 
 import SBFileUploaderHOC from '../../../src/lib/sb-file-uploader-hoc.jsx';
 import {IntlProvider} from 'react-intl';

--- a/packages/scratch-gui/test/unit/util/vm-listener-hoc.test.jsx
+++ b/packages/scratch-gui/test/unit/util/vm-listener-hoc.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import {render} from '@testing-library/react';
-import VM from '@scratch/scratch-vm';
+import VM from '@smalruby/scratch-vm';
 
 import vmListenerHOC from '../../../src/lib/vm-listener-hoc.jsx';
 import '@testing-library/jest-dom';

--- a/packages/scratch-gui/test/unit/util/vm-manager-hoc.test.jsx
+++ b/packages/scratch-gui/test/unit/util/vm-manager-hoc.test.jsx
@@ -7,7 +7,7 @@ WebAudioTestAPI.setState({
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import {render} from '@testing-library/react';
-import VM from '@scratch/scratch-vm';
+import VM from '@smalruby/scratch-vm';
 import {LoadingState} from '../../../src/reducers/project-state';
 
 import vmManagerHOC from '../../../src/lib/vm-manager-hoc.jsx';

--- a/packages/scratch-gui/webpack.config.js
+++ b/packages/scratch-gui/webpack.config.js
@@ -210,7 +210,7 @@ const buildConfig = baseConfig.clone()
         ...commonHtmlWebpackPluginOptions,
         chunks: ['gui'],
         template: 'src/playground/index.ejs',
-        title: 'Scratch 3.0 GUI',
+        title: 'Smalruby',
         originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
         pwa: process.env.NODE_ENV === 'production'
     }))
@@ -219,7 +219,7 @@ const buildConfig = baseConfig.clone()
         chunks: ['guistandalone'],
         filename: 'standalone.html',
         template: 'src/playground/index.ejs',
-        title: 'Scratch 3.0 GUI: Standalone Mode',
+        title: 'Smalruby: Standalone Mode',
         originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
         pwa: process.env.NODE_ENV === 'production'
     }))
@@ -228,7 +228,7 @@ const buildConfig = baseConfig.clone()
         chunks: ['blocksonly'],
         filename: 'blocks-only.html',
         template: 'src/playground/index.ejs',
-        title: 'Scratch 3.0 GUI: Blocks Only Example',
+        title: 'Smalruby: Blocks Only Example',
         originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
         pwa: process.env.NODE_ENV === 'production'
     }))
@@ -237,7 +237,7 @@ const buildConfig = baseConfig.clone()
         chunks: ['compatibilitytesting'],
         filename: 'compatibility-testing.html',
         template: 'src/playground/index.ejs',
-        title: 'Scratch 3.0 GUI: Compatibility Testing',
+        title: 'Smalruby: Compatibility Testing',
         originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
         pwa: process.env.NODE_ENV === 'production'
     }))
@@ -246,7 +246,7 @@ const buildConfig = baseConfig.clone()
         chunks: ['player'],
         filename: 'player.html',
         template: 'src/playground/index.ejs',
-        title: 'Scratch 3.0 GUI: Player Example',
+        title: 'Smalruby: Player Example',
         originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
         pwa: process.env.NODE_ENV === 'production'
     }))

--- a/packages/scratch-render/package.json
+++ b/packages/scratch-render/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@scratch/scratch-render",
+  "name": "@smalruby/scratch-render",
   "version": "12.3.1",
   "description": "WebGL Renderer for Scratch 3.0",
-  "author": "Massachusetts Institute of Technology",
+  "author": "Ruby Programming Shounendan",
   "license": "AGPL-3.0-only",
-  "homepage": "https://github.com/scratchfoundation/scratch-render#readme",
+  "homepage": "https://github.com/smalruby/smalruby3-editor#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scratchfoundation/scratch-editor.git"
+    "url": "https://github.com/smalruby/smalruby3-editor.git"
   },
   "main": "./dist/node/scratch-render.js",
   "exports": {
@@ -46,7 +46,7 @@
     "iOS >= 8"
   ],
   "dependencies": {
-    "@scratch/scratch-svg-renderer": "12.3.1",
+    "@smalruby/scratch-svg-renderer": "12.3.1",
     "grapheme-breaker": "0.3.2",
     "hull.js": "0.2.10",
     "ify-loader": "1.1.0",

--- a/packages/scratch-svg-renderer/package.json
+++ b/packages/scratch-svg-renderer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scratch/scratch-svg-renderer",
+  "name": "@smalruby/scratch-svg-renderer",
   "version": "12.3.1",
   "description": "SVG renderer for Scratch",
   "main": "./dist/node/scratch-svg-renderer.js",
@@ -25,12 +25,12 @@
     "test:unit": "tap ./test/*.js",
     "watch": "webpack --watch"
   },
-  "author": "Massachusetts Institute of Technology",
+  "author": "Ruby Programming Shounendan",
   "license": "AGPL-3.0-only",
-  "homepage": "https://github.com/scratchfoundation/scratch-svg-renderer#readme",
+  "homepage": "https://github.com/smalruby/smalruby3-editor#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scratchfoundation/scratch-editor.git"
+    "url": "https://github.com/smalruby/smalruby3-editor.git"
   },
   "peerDependencies": {
     "scratch-render-fonts": "^1.0.0"

--- a/packages/scratch-vm/package.json
+++ b/packages/scratch-vm/package.json
@@ -52,8 +52,8 @@
     "allow-incomplete-coverage": true
   },
   "dependencies": {
-    "@scratch/scratch-render": "12.3.1",
-    "@scratch/scratch-svg-renderer": "12.3.1",
+    "@smalruby/scratch-render": "12.3.1",
+    "@smalruby/scratch-svg-renderer": "12.3.1",
     "@vernier/godirect": "1.8.3",
     "arraybuffer-loader": "1.0.8",
     "atob": "2.1.2",

--- a/packages/scratch-vm/package.json
+++ b/packages/scratch-vm/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@scratch/scratch-vm",
+  "name": "@smalruby/scratch-vm",
   "version": "12.3.1",
   "description": "Virtual Machine for Scratch 3.0",
-  "author": "Massachusetts Institute of Technology",
+  "author": "Ruby Programming Shounendan",
   "license": "AGPL-3.0-only",
-  "homepage": "https://github.com/scratchfoundation/scratch-vm#readme",
+  "homepage": "https://github.com/smalruby/smalruby3-editor#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scratchfoundation/scratch-editor.git"
+    "url": "https://github.com/smalruby/smalruby3-editor.git"
   },
   "main": "./dist/node/scratch-vm.js",
   "browser": "./dist/web/scratch-vm.js",


### PR DESCRIPTION
## Summary

Update package metadata and HTML titles from Scratch 3.0 to Smalruby branding.
This is Phase 1 of the critical branding fixes identified in the migration
analysis.

## Changes

### Package Metadata (package.json)

**packages/scratch-gui/package.json**:
- Package scope: `@scratch/scratch-gui` → `@smalruby/scratch-gui`
- Author: `Massachusetts Institute of Technology` → `Ruby Programming Shounendan`
- Repository: `scratchfoundation/scratch-editor` → `smalruby/smalruby3-editor`
- Homepage: Updated to point to smalruby3-editor repository
- **Dependencies**: Updated to reference `@smalruby/scratch-vm`, `@smalruby/scratch-render`, `@smalruby/scratch-svg-renderer`
- **Jest config**: Updated moduleNameMapper for `@smalruby/scratch-vm`

**packages/scratch-vm/package.json**:
- Package scope: `@scratch/scratch-vm` → `@smalruby/scratch-vm`
- Author: `Massachusetts Institute of Technology` → `Ruby Programming Shounendan`
- Repository: `scratchfoundation/scratch-editor` → `smalruby/smalruby3-editor`
- Homepage: Updated to point to smalruby3-editor repository
- **Dependencies**: Updated to reference `@smalruby/scratch-render`, `@smalruby/scratch-svg-renderer`

**packages/scratch-render/package.json**:
- Package scope: `@scratch/scratch-render` → `@smalruby/scratch-render`
- Author: Updated to `Ruby Programming Shounendan`
- Repository: Updated to point to smalruby3-editor
- **Dependencies**: Updated to reference `@smalruby/scratch-svg-renderer`

**packages/scratch-svg-renderer/package.json**:
- Package scope: `@scratch/scratch-svg-renderer` → `@smalruby/scratch-svg-renderer`
- Author: Updated to `Ruby Programming Shounendan`
- Repository: Updated to point to smalruby3-editor

### HTML Titles (webpack.config.js)

Updated all HtmlWebpackPlugin instances:
- Main GUI: `"Scratch 3.0 GUI"` → `"Smalruby"`
- Standalone: `"Scratch 3.0 GUI: Standalone Mode"` → `"Smalruby: Standalone Mode"`
- Blocks Only: `"Scratch 3.0 GUI: Blocks Only Example"` → `"Smalruby: Blocks Only Example"`
- Compatibility Testing: `"Scratch 3.0 GUI: Compatibility Testing"` → `"Smalruby: Compatibility Testing"`
- Player: `"Scratch 3.0 GUI: Player Example"` → `"Smalruby: Player Example"`

### Test Files

- Updated all test file imports from `@scratch/scratch-vm` to `@smalruby/scratch-vm`
- Affected files: 9 test files including helpers and component tests

### Package Management

- Ran `npm install` to update `package-lock.json` with new package references
- All inter-package dependencies now consistently use `@smalruby` scope

## Implementation Details

- Package names remain as `"scratch-gui"`, `"scratch-vm"`, `"scratch-render"`, and `"scratch-svg-renderer"` (not changed to `"smalruby3-*"`) to maintain compatibility with the upstream Scratch project structure
- Only the package scope changes from `@scratch` to `@smalruby`
- All branding metadata (author, repository, homepage) now correctly references the Smalruby project
- All inter-package dependencies updated to use `@smalruby` scope for internal consistency

## Test Coverage

- Build test: ✅ Confirmed webpack builds successfully with updated titles and dependencies
- Unit tests: ✅ All 72 test suites pass (718 tests passed, 1 skipped)
- Lint check: Existing errors unrelated to these changes

## Related

- Migration analysis: `tmp/scratch-gui-migration-final-analysis.md`
- Based on detailed investigation of gui/smalruby3-gui → gui/smalruby3-editor/packages/scratch-gui migration

🤖 Generated with [Claude Code](https://claude.ai/code)
