### PR TITLE
fix: add missing headerActions prop to extension library modal

### DIFF
--- a/packages/scratch-gui/src/components/library/library.jsx
+++ b/packages/scratch-gui/src/components/library/library.jsx
@@ -342,6 +342,7 @@ class LibraryComponent extends React.Component {
         ));
     }
     constructKey (data) {
+        if (data.extensionId) return data.extensionId;
         return typeof data.name === 'string' ? data.name : data.rawURL;
     }
     scrollToTop () {
@@ -413,6 +414,7 @@ class LibraryComponent extends React.Component {
             <Modal
                 fullScreen
                 contentLabel={this.props.title}
+                headerActions={this.props.headerActions}
                 id={this.props.id}
                 onRequestClose={this.handleClose}
             >
@@ -475,7 +477,7 @@ class LibraryComponent extends React.Component {
 
 LibraryComponent.propTypes = {
     data: PropTypes.arrayOf(
-         
+
         // An item in the library
         PropTypes.shape({
             // @todo remove md5/rawURL prop from library, refactor to use storage
@@ -486,9 +488,10 @@ LibraryComponent.propTypes = {
             ]),
             rawURL: PropTypes.string
         })
-         
+
     ),
     filterable: PropTypes.bool,
+    headerActions: PropTypes.node,
     withCategories: PropTypes.bool,
     id: PropTypes.string.isRequired,
     intl: intlShape.isRequired,


### PR DESCRIPTION
## Summary

Fixed missing "Show all extensions" checkbox in the extension library modal during migration from smalruby3-gui to smalruby3-editor.

Also fixed React duplicate key warning that occurred when opening the extension library.

## Issues Fixed

### 1. Missing "Show all extensions" checkbox

**Problem:**
- The checkbox in the upper-right corner of the extension library modal was not visible
- The `headerActions` prop was defined in `ExtensionLibrary` container but not forwarded to the `Modal` component in `LibraryComponent`

**Solution:**
- Added `headerActions={this.props.headerActions}` to the `Modal` component
- Added `headerActions: PropTypes.node` to `LibraryComponent.propTypes`

### 2. Duplicate key warning

**Problem:**
```
Warning: Encountered two children with the same key, `static/assets/mesh.0cf0a2c574a3010200b5.png`.
Keys should be unique so that components maintain their identity across updates.
```

**Root Cause:**
- Multiple extensions can share the same icon image
- The `constructKey` method in the migrated code used `rawURL` (icon path) as the fallback key
- This caused duplicate keys when extensions shared the same icon

**Solution:**
- Updated `constructKey` to check `extensionId` first before falling back to `name` or `rawURL`
- This ensures each extension has a unique key even when sharing icons

## Implementation Details

### Changes in `packages/scratch-gui/src/components/library/library.jsx`

#### 1. Forward headerActions to Modal (line 416)
```jsx
<Modal
    fullScreen
    contentLabel={this.props.title}
    headerActions={this.props.headerActions}  // Added
    id={this.props.id}
    onRequestClose={this.handleClose}
>
```

#### 2. Add headerActions to PropTypes (line 493)
```jsx
LibraryComponent.propTypes = {
    ...
    filterable: PropTypes.bool,
    headerActions: PropTypes.node,  // Added
    withCategories: PropTypes.bool,
    ...
};
```

#### 3. Fix constructKey method (line 345)
```jsx
constructKey (data) {
    if (data.extensionId) return data.extensionId;  // Added: prioritize extensionId
    return typeof data.name === 'string' ? data.name : data.rawURL;
}
```

## Migration Reference

These changes align with the source code in `gui/smalruby3-gui`:
- `src/containers/extension-library.jsx#L100` - headerActions definition
- `src/components/library/library.jsx#L202` - headerActions forwarding to Modal
- `src/components/library/library.jsx#L159` - constructKey with extensionId check

## Test Coverage

### Manual Testing

1. ✅ Open extension library modal
2. ✅ Verify "Show all extensions" checkbox appears in upper-right corner
3. ✅ Toggle checkbox and verify hidden extensions show/hide correctly
4. ✅ Check browser console - no duplicate key warnings

### Verification Environment

```bash
docker compose up gui
# Access http://localhost:8601
# Open extension library and verify both fixes
```

## Related

Related to #29 - Monorepo migration from smalruby3-gui/scratch-vm to smalruby3-editor

🤖 Generated with [Claude Code](https://claude.ai/code)
