### PR TITLE
fix: update messages PropType and cleanup debug logs

### DIFF
--- a/packages/scratch-gui/.env.example
+++ b/packages/scratch-gui/.env.example
@@ -1,0 +1,37 @@
+# Google Drive API Configuration
+# See docs/google-drive-setup.md for setup instructions
+
+# Google OAuth 2.0 Client ID (Web Application)
+# Example: 123456789012-abcdefghijklmnopqrstuvwxyz123456.apps.googleusercontent.com
+GOOGLE_CLIENT_ID=your-client-id-here.apps.googleusercontent.com
+
+# Google API Key (for Picker API)
+# Example: AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567
+GOOGLE_API_KEY=your-api-key-here
+
+# Mesh V2 Extension Configuration
+# See https://github.com/smalruby/scratch-vm/tree/develop/ for backend setup
+
+# AppSync GraphQL API Endpoint (Production)
+# Example: https://xxxxx.appsync-api.ap-northeast-1.amazonaws.com/graphql
+MESH_GRAPHQL_ENDPOINT=https://example.appsync-api.ap-northeast-1.amazonaws.com/graphql
+
+# AppSync API Key (Production)
+# Example: da2-xxxxx
+MESH_API_KEY=da2-your-api-key
+
+# AWS Region (Production)
+# Example: ap-northeast-1
+MESH_AWS_REGION=ap-northeast-1
+
+# Data update interval in milliseconds
+# Default: 1000
+MESH_DATA_UPDATE_INTERVAL_MS=1000
+
+# Event batch interval in milliseconds
+# Default: 1000
+MESH_EVENT_BATCH_INTERVAL_MS=1000
+
+# Periodic data sync interval in milliseconds
+# Default: 15000 (15 seconds)
+MESH_PERIODIC_DATA_SYNC_INTERVAL_MS=15000

--- a/packages/scratch-gui/src/components/connection-modal/connection-modal.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/connection-modal.jsx
@@ -42,7 +42,8 @@ const ConnectionModalComponent = props => {
     );
     return (<Modal
         className={styles.modalContent}
-        contentLabel={props.name}
+        contentLabel={typeof props.name === 'string' ? props.name : props.title}
+        headerTitle={props.name}
         headerClassName={styles.header}
         headerImage={props.connectionSmallIconURL}
         id="connectionModal"

--- a/packages/scratch-gui/src/components/modal/modal.jsx
+++ b/packages/scratch-gui/src/components/modal/modal.jsx
@@ -64,7 +64,7 @@ const ModalComponent = props => (
                             src={props.headerImage}
                         />
                     ) : null}
-                    {props.contentLabel}
+                    {props.headerTitle || props.contentLabel}
                 </div>
                 {props.headerActions ? (
                     <div
@@ -123,6 +123,7 @@ ModalComponent.propTypes = {
     headerActions: PropTypes.node,
     headerClassName: PropTypes.string,
     headerImage: PropTypes.string,
+    headerTitle: PropTypes.node,
     isRtl: PropTypes.bool,
     loading: PropTypes.bool,
     onHelp: PropTypes.func,

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -25,6 +25,7 @@ import {injectExtensionBlockMode, injectExtensionCategoryMode} from '../lib/sett
 
 import {connect} from 'react-redux';
 import {updateToolbox} from '../reducers/toolbox';
+import {setScratchBlocks} from '../reducers/block-display';
 import {activateColorPicker} from '../reducers/color-picker';
 import {closeExtensionLibrary, openSoundRecorder, openConnectionModal} from '../reducers/modals';
 import {activateCustomProcedures, deactivateCustomProcedures} from '../reducers/custom-procedures';
@@ -93,6 +94,7 @@ class Blocks extends React.Component {
     }
     componentDidMount () {
         this.ScratchBlocks = VMScratchBlocks(this.props.vm, this.props.useCatBlocks);
+        this.props.onSetScratchBlocks(this.ScratchBlocks);
         this.ScratchBlocks.prompt = this.handlePromptStart;
         this.ScratchBlocks.statusButtonCallback = this.handleConnectionModalStart;
         this.ScratchBlocks.recordSoundCallback = this.handleOpenSoundRecorder;
@@ -600,7 +602,6 @@ class Blocks extends React.Component {
             });
     }
     render () {
-         
         const {
             anyModalVisible,
             canUseCloud,
@@ -614,6 +615,7 @@ class Blocks extends React.Component {
             onActivateColorPicker,
             onOpenConnectionModal,
             onOpenSoundRecorder,
+            onSetScratchBlocks,
             updateToolboxState,
             onActivateCustomProcedures,
             onRequestCloseExtensionLibrary,
@@ -624,7 +626,7 @@ class Blocks extends React.Component {
             workspaceMetrics,
             ...props
         } = this.props;
-         
+
         return (
             <React.Fragment>
                 <DroppableBlocks
@@ -676,13 +678,17 @@ Blocks.propTypes = {
     isRtl: PropTypes.bool,
     isVisible: PropTypes.bool,
     locale: PropTypes.string.isRequired,
-    messages: PropTypes.objectOf(PropTypes.string),
+    messages: PropTypes.objectOf(PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ])),
     onActivateColorPicker: PropTypes.func,
     onActivateCustomProcedures: PropTypes.func,
     onOpenConnectionModal: PropTypes.func,
     onOpenSoundRecorder: PropTypes.func,
     onRequestCloseCustomProcedures: PropTypes.func,
     onRequestCloseExtensionLibrary: PropTypes.func,
+    onSetScratchBlocks: PropTypes.func,
     options: PropTypes.shape({
         media: PropTypes.string,
         zoom: PropTypes.shape({
@@ -760,6 +766,9 @@ const mapDispatchToProps = dispatch => ({
     },
     onRequestCloseCustomProcedures: data => {
         dispatch(deactivateCustomProcedures(data));
+    },
+    onSetScratchBlocks: scratchBlocks => {
+        dispatch(setScratchBlocks(scratchBlocks));
     },
     updateToolboxState: toolboxXML => {
         dispatch(updateToolbox(toolboxXML));

--- a/packages/scratch-gui/src/containers/sprite-selector-item.jsx
+++ b/packages/scratch-gui/src/containers/sprite-selector-item.jsx
@@ -187,7 +187,7 @@ SpriteSelectorItem.propTypes = {
     asset: PropTypes.object,
     costumeURL: PropTypes.string,
     dispatchSetHoveredSprite: PropTypes.func.isRequired,
-    dragPayload: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    dragPayload: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]),
     dragType: PropTypes.string,
     dragging: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/packages/scratch-gui/src/lib/vm-manager-hoc.jsx
+++ b/packages/scratch-gui/src/lib/vm-manager-hoc.jsx
@@ -110,7 +110,10 @@ const vmManagerHOC = function (WrappedComponent) {
         isStarted: PropTypes.bool,
         loadingState: PropTypes.oneOf(LoadingStates),
         locale: PropTypes.string,
-        messages: PropTypes.objectOf(PropTypes.string),
+        messages: PropTypes.objectOf(PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.object
+        ])),
         onError: PropTypes.func,
         onLoadedProject: PropTypes.func,
         onSetProjectUnchanged: PropTypes.func,

--- a/packages/scratch-gui/src/locales/index.js
+++ b/packages/scratch-gui/src/locales/index.js
@@ -4,9 +4,9 @@ import ja from './ja';
 import jaHira from './ja-Hira';
 
 const langs = {
-    "en": en,
-    "ja": ja,
-    "ja-Hira": jaHira
+    'en': en,
+    'ja': ja,
+    'ja-Hira': jaHira
 };
 
 Object.keys(langs).forEach(lang => {

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -2,6 +2,7 @@ export default {
     'gui.modal.reload': '再読み込み',
     'gui.modal.stop': '中止',
     'gui.menuBar.loadFromUrl': 'Scratchから読み込む',
+    'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.meshV2': 'メッシュ',
     'gui.sharedMessages.backdrop': '背景{index}',
     'gui.sharedMessages.costume': 'コスチューム{index}',


### PR DESCRIPTION
This PR fixes the React PropType warning when opening the connection modal by allowing 'messages' prop values to be objects (as transformed by format-message). It also cleans up debug logs and fixes minor lint issues.