### PR TITLE
feat: show whole shape of blocks when mouse over the flyout

### DIFF
--- a/packages/scratch-gui/src/components/blocks/blocks.css
+++ b/packages/scratch-gui/src/components/blocks/blocks.css
@@ -74,6 +74,30 @@
     border-left: 1px solid $ui-black-transparent;
 }
 
+.blocks :global(.blocklyFlyout:hover) {
+    overflow: visible;
+    clip-path: inset(0 -100vw 0 0);
+    -webkit-clip-path: inset(0 -100vw 0 0);
+}
+
+[dir="rtl"] .blocks :global(.blocklyFlyout:hover) {
+    clip-path: inset(0 0 0 -100vw);
+    -webkit-clip-path: inset(0 0 0 -100vw);
+}
+
+.blocks :global(.blocklyFlyout:hover .blocklyWorkspace) {
+    clip-path: none;
+    -webkit-clip-path: none;
+}
+
+.blocks :global(.blocklyFlyout:hover .blocklyScrollbarBackground:hover) {
+    opacity: 0.4;
+}
+
+.blocks :global(.blocklyFlyout .blocklyFlyoutScrollbar) {
+    margin-left: 4px;
+}
+
 
 .blocks :global(.blocklyBlockDragSurface) {
     /*


### PR DESCRIPTION
### Summary
This PR ports a missing feature that displays the full shape of long blocks when hovering over the flyout palette.

### Implementation Details
- Applied CSS patch to `packages/scratch-gui/src/components/blocks/blocks.css`.
- Added RTL support for the flyout hover effect.
- Improved browser compatibility using `-webkit-clip-path`.
- Adjusted scrollbar opacity and margin for better usability during hover.

### Ported from
Commit `d9f80c994b1e4a5f739b3d7e79ec00ba8c789f11` from the previous repository.