### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,103 @@
-# scratch-editor: The Scratch Editor Monorepo
+# smalruby3-editor: The Smalruby 3 Editor Monorepo
+
+This is the development repository for **Smalruby 3**, a Ruby-based visual programming environment forked from [Scratch 3.0](https://github.com/scratchfoundation/scratch-editor).
 
 If you'd like to use Scratch, please visit the [Scratch website](https://scratch.mit.edu/). You can build your own
 Scratch project by pressing "Create" on that website or by visiting <https://scratch.mit.edu/projects/editor/>.
 
-This is a source code repository for the packages that make up the Scratch editor and a few additional support
-packages. Use this if you'd like to learn about how the Scratch editor works or to contribute to its development.
+This is a source code repository for the packages that make up the Smalruby editor and a few additional support
+packages. Use this if you'd like to learn about how the Smalruby editor works or to contribute to its development.
 
 ## What's in this repository?
 
 The `packages` directory in this repository contains:
 
-- `scratch-gui` provides the buttons, menus, and other elements that you interact with when creating and editing a
-  project. It's also the "glue" that brings most of the other modules together at runtime.
+- `scratch-gui`: **Smalruby 3 GUI**. The React-based web interface, customized for Smalruby (e.g., Ruby mode, custom extensions). Forked from `scratch-gui`.
+- `scratch-vm`: **Smalruby 3 VM**. The virtual machine that runs projects, with Opal integration for Ruby execution. Forked from `scratch-vm`.
 - `scratch-render` draws backdrops, sprites, and clones on the stage.
-- `scratch-svg-renderer` processes SVG (vector) images for use with Scratch projects.
-- `scratch-vm` is the virtual machine that runs Scratch projects.
+- `scratch-svg-renderer` processes SVG (vector) images for use with projects.
 
 _Please add to this list as more packages are migrated to the monorepo._
 
 Each package has its own `README.md` file with more information about that package.
 
+## Development
+
+### Installation
+
+To install dependencies for all packages in the monorepo:
+
+```bash
+npm install
+```
+
+**Note**: We strictly recommend using the Docker environment for development to ensure consistency. Please refer to the [root README](../../README.md) for Docker instructions.
+
+### Build
+
+To build all packages:
+
+```bash
+npm run build
+```
+
+To build in development mode (faster, with source maps):
+
+```bash
+npm run build:dev
+```
+
+### Running the Development Server
+
+To start the GUI development server (typically on http://localhost:8601):
+
+```bash
+npm start
+```
+
+### Testing
+
+To run all tests (lint, unit, integration):
+
+```bash
+npm test
+```
+
+To run unit tests only:
+
+```bash
+npm run test:unit
+```
+
+To run integration tests only:
+
+```bash
+npm run test:integration
+```
+
+## Smalruby Specific Features
+
+### Ruby Mode
+Smalruby 3 integrates [Opal](https://opalrb.com/) to convert Ruby code into JavaScript that runs within the Scratch VM. The `scratch-vm` package handles this execution logic, while `scratch-gui` provides the Ruby code editor (using Ace Editor) and UI toggles.
+
+### Google Drive Integration
+Smalruby 3 supports loading and saving projects directly to Google Drive.
+For setup instructions, please see [Google Drive Setup Guide](packages/scratch-gui/docs/google-drive-setup.md).
+
 ## Monorepo migration
 
 ### What's going on?
 
-We're migrating the Scratch editor packages into this monorepo. This will allow us to manage all the packages that
-make up the Scratch editor in one place, making  it easier to manage dependencies and make changes that affect
-multiple packages.
+We're migrating the Smalruby editor packages into this monorepo, following the upstream Scratch Editor structure. This allows us to manage all packages in one place.
 
 ### Why are there only a few packages in this repo?
 
-We're migrating packages in stages. The current plan, which is subject to change, has us migrating repositories in
-four batches. We plan to complete the migration within 2025.
-
-### What will happen to the existing repositories?
-
-The existing repositories will be archived and made read-only. Those repositories contain valuable work and
-information, including but not limited to issues and pull requests. We plan to keep that information available for
-reference, and to selectively migrate it to this new repository.
+We're migrating packages in stages.
 
 ## Thank you!
 
-Scratch would not be what it is today without help from the global community of Scratchers and open-source
-contributors. Thank you for your contributions and support. _[Scratch on!](https://scratch.mit.edu/projects/65347738/fullscreen/)_
+Smalruby is based on Scratch from the Scratch Foundation.
+Scratch would not be what it is today without help from the global community of Scratchers and open-source contributors. Thank you for your contributions and support. _[Scratch on!](https://scratch.mit.edu/projects/65347738/fullscreen/)_
 
 ## Donate
 


### PR DESCRIPTION
Updated README.md to reflect the structure and workflow of smalruby3-editor (monorepo).
- Changed title to smalruby3-editor
- Described packages (scratch-gui, scratch-vm)
- Added development commands
- Added Smalruby specific features (Ruby mode, Google Drive)