### PR TITLE
fix(gui): improve menu bar layout by separating MeshV2 and Koshien items

### DIFF
--- a/.gemini/commands/commit-local-changes.toml
+++ b/.gemini/commands/commit-local-changes.toml
@@ -1,0 +1,11 @@
+# .gemini/commands/commit-local-changes.toml
+
+description="ローカルの修正をコミットする"
+prompt = """
+Understand my local changes.
+もし現在のブランチが develop であれば、新しいブランチを作成する。
+lint, commit, push.
+まだ PR を作成していなければ PR を作成する。
+
+Use the `gh` command to fetch issue content and interact with GitHub.
+"""

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -1002,6 +1002,9 @@ class MenuBar extends React.Component {
                                 <FormattedMessage {...ariaMessages.debug} />
                             </span>
                         </div>
+                    </div>
+                    <Divider className={classNames(styles.divider)} />
+                    <div className={styles.fileGroup}>
                         {(() => {
                             const meshV2Status = this.getMeshV2Status();
                             if (!meshV2Status.loaded) return null;


### PR DESCRIPTION
This PR improves the menu bar layout by:
- Adding a `Divider` before the MeshV2 and Smalruby Koshien items.
- Wrapping these items in a separate `fileGroup` div.

This helps visually separate these specialized tools from the standard menu items.

Changes:
- Modified `packages/scratch-gui/src/components/menu-bar/menu-bar.jsx`
- Added `.gemini/commands/commit-local-changes.toml`
