### PR TITLE
feat: add network filter error detection for meshV2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,11 @@ MESH_EVENT_BATCH_INTERVAL_MS=1000
 # Default: 15000 (15 seconds)
 MESH_PERIODIC_DATA_SYNC_INTERVAL_MS=15000
 
+# Test mode: Simulate network filter blocking (HTTP 503)
+# Set to "true" to simulate i-Filter or proxy blocking for testing network filter error detection
+# Default: false (disabled)
+# MESH_NETWORK_FILTER=true
+
 # Debug logging (comma-separated categories, e.g., scratch-vm:*)
 DEBUG=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - MESH_AWS_REGION
       - MESH_DATA_UPDATE_INTERVAL_MS
       - MESH_EVENT_BATCH_INTERVAL_MS
+      - MESH_NETWORK_FILTER
     working_dir: /app
     shm_size: '4gb'
     command: npm start

--- a/packages/scratch-gui/src/components/connection-modal/connection-modal.css
+++ b/packages/scratch-gui/src/components/connection-modal/connection-modal.css
@@ -462,7 +462,7 @@
     font-family: monospace;
     font-size: 0.6rem;
     white-space: pre-wrap;
-    margin: 0 0 1rem 0;
+    margin: 0 0 0.4rem 0;
     padding: 0.5rem;
     background-color: white;
     border: 1px solid #e0e0e0;

--- a/packages/scratch-gui/src/components/connection-modal/connection-modal.css
+++ b/packages/scratch-gui/src/components/connection-modal/connection-modal.css
@@ -446,3 +446,55 @@
     height: 60%;
     width: inherit;
 }
+
+/* === Smalruby: Start of network filter detection feature === */
+/* Styles for network filter error message display */
+.network-info {
+    margin: 1rem 0;
+    padding: 1rem;
+    background-color: #f5f5f5;
+    border-radius: 0.5rem;
+    border: 1px solid #ddd;
+    width: 90%;
+}
+
+.network-info-text {
+    font-family: monospace;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    margin: 0 0 1rem 0;
+    padding: 0.5rem;
+    background-color: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 0.25rem;
+    overflow-x: auto;
+}
+
+.copy-button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-family: inherit;
+    transition: background-color 0.2s;
+}
+
+.copy-button:hover {
+    background-color: #45a049;
+}
+
+.copy-button:active {
+    background-color: #3d8b40;
+}
+
+.copy-button img {
+    width: 1rem;
+    height: 1rem;
+}
+/* === Smalruby: End of network filter detection feature === */

--- a/packages/scratch-gui/src/components/connection-modal/connection-modal.css
+++ b/packages/scratch-gui/src/components/connection-modal/connection-modal.css
@@ -450,8 +450,8 @@
 /* === Smalruby: Start of network filter detection feature === */
 /* Styles for network filter error message display */
 .network-info {
-    margin: 1rem 0;
-    padding: 1rem;
+    margin: 0.4rem 0;
+    padding: 0.4rem;
     background-color: #f5f5f5;
     border-radius: 0.5rem;
     border: 1px solid #ddd;
@@ -460,7 +460,7 @@
 
 .network-info-text {
     font-family: monospace;
-    font-size: 0.85rem;
+    font-size: 0.6rem;
     white-space: pre-wrap;
     margin: 0 0 1rem 0;
     padding: 0.5rem;

--- a/packages/scratch-gui/src/components/connection-modal/connection-modal.css
+++ b/packages/scratch-gui/src/components/connection-modal/connection-modal.css
@@ -468,6 +468,7 @@
     border: 1px solid #e0e0e0;
     border-radius: 0.25rem;
     overflow-x: auto;
+    text-align: left;
 }
 
 .copy-button {

--- a/packages/scratch-gui/src/components/connection-modal/connection-modal.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/connection-modal.jsx
@@ -13,7 +13,7 @@ import ErrorStep from './error-step.jsx';
 import UnavailableStep from './unavailable-step.jsx';
 import UpdatePeripheralStep from './update-peripheral-step.jsx';
 // === Smalruby: Start of network filter detection feature ===
-import NetworkFilteredStep from './network-filtered-step.jsx';
+import MeshV2NetworkFilteredStep from './mesh-v2-network-filtered-step.jsx';
 // === Smalruby: End of network filter detection feature ===
 
 import styles from './connection-modal.css';
@@ -63,7 +63,7 @@ const ConnectionModalComponent = props => {
             {props.phase === PHASES.error && <ErrorStep {...props} />}
             {props.phase === PHASES.unavailable && <UnavailableStep {...props} />}
             {/* === Smalruby: Start of network filter detection feature === */}
-            {props.phase === PHASES.networkFiltered && <NetworkFilteredStep {...props} />}
+            {props.phase === PHASES.networkFiltered && <MeshV2NetworkFilteredStep {...props} />}
             {/* === Smalruby: End of network filter detection feature === */}
             {props.phase === PHASES.updatePeripheral && <UpdatePeripheralStep {...props} />}
         </Box>

--- a/packages/scratch-gui/src/components/connection-modal/connection-modal.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/connection-modal.jsx
@@ -12,6 +12,9 @@ import ConnectedStep from './connected-step.jsx';
 import ErrorStep from './error-step.jsx';
 import UnavailableStep from './unavailable-step.jsx';
 import UpdatePeripheralStep from './update-peripheral-step.jsx';
+// === Smalruby: Start of network filter detection feature ===
+import NetworkFilteredStep from './network-filtered-step.jsx';
+// === Smalruby: End of network filter detection feature ===
 
 import styles from './connection-modal.css';
 
@@ -21,6 +24,9 @@ const PHASES = keyMirror({
     connected: null,
     error: null,
     unavailable: null,
+    // === Smalruby: Start of network filter detection feature ===
+    networkFiltered: null,
+    // === Smalruby: End of network filter detection feature ===
     updatePeripheral: null
 });
 
@@ -56,6 +62,9 @@ const ConnectionModalComponent = props => {
             {props.phase === PHASES.connected && <ConnectedStep {...props} />}
             {props.phase === PHASES.error && <ErrorStep {...props} />}
             {props.phase === PHASES.unavailable && <UnavailableStep {...props} />}
+            {/* === Smalruby: Start of network filter detection feature === */}
+            {props.phase === PHASES.networkFiltered && <NetworkFilteredStep {...props} />}
+            {/* === Smalruby: End of network filter detection feature === */}
             {props.phase === PHASES.updatePeripheral && <UpdatePeripheralStep {...props} />}
         </Box>
     </Modal>);

--- a/packages/scratch-gui/src/components/connection-modal/icons/copy.svg
+++ b/packages/scratch-gui/src/components/connection-modal/icons/copy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+</svg>

--- a/packages/scratch-gui/src/components/connection-modal/mesh-v2-network-filtered-step.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/mesh-v2-network-filtered-step.jsx
@@ -1,6 +1,7 @@
-// === Smalruby: Network filter detection feature ===
-// This component displays a message when meshV2 is blocked by network filter (HTTP 503)
-// such as i-Filter proxy in schools or enterprises.
+// === Smalruby: MeshV2 network filter detection feature ===
+// This component is specific to meshV2 extension and displays an error message
+// when the extension is blocked by network filter (HTTP 503) such as i-Filter proxy
+// in schools or enterprises.
 
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
@@ -15,7 +16,7 @@ import copyIcon from './icons/copy.svg';
 
 import styles from './connection-modal.css';
 
-const NetworkFilteredStep = props => {
+const MeshV2NetworkFilteredStep = props => {
     const [copied, setCopied] = React.useState(false);
 
     const networkInfoMessage = `スモウルビーのメッシュ機能を使うため、ネットワークの制限を解除してください。
@@ -137,11 +138,11 @@ URL: https://graphql.api.smalruby.app/, wss://graphql.api.smalruby.app/`;
     );
 };
 
-NetworkFilteredStep.propTypes = {
+MeshV2NetworkFilteredStep.propTypes = {
     onHelp: PropTypes.func,
     onScanning: PropTypes.func
 };
 
-export default NetworkFilteredStep;
+export default MeshV2NetworkFilteredStep;
 
-// === Smalruby: End of network filter detection feature ===
+// === Smalruby: End of MeshV2 network filter detection feature ===

--- a/packages/scratch-gui/src/components/connection-modal/mesh-v2-network-filtered-step.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/mesh-v2-network-filtered-step.jsx
@@ -10,7 +10,6 @@ import React from 'react';
 
 import Box from '../box/box.jsx';
 import Dots from './dots.jsx';
-import helpIcon from './icons/help.svg';
 import backIcon from './icons/back.svg';
 import copyIcon from './icons/copy.svg';
 
@@ -120,16 +119,12 @@ URL: https://graphql.api.smalruby.app/, wss://graphql.api.smalruby.app/`;
                     </button>
                     <button
                         className={styles.connectionButton}
-                        onClick={props.onHelp}
+                        onClick={props.onUseLegacyMesh}
                     >
-                        <img
-                            className={styles.buttonIconLeft}
-                            src={helpIcon}
-                        />
                         <FormattedMessage
-                            defaultMessage="Help"
-                            description="Button to view help content"
-                            id="gui.connection.networkFiltered.helpbutton"
+                            defaultMessage="Use legacy mesh"
+                            description="Button to use legacy mesh extension"
+                            id="gui.connection.networkFiltered.useLegacyMeshButton"
                         />
                     </button>
                 </Box>
@@ -139,8 +134,8 @@ URL: https://graphql.api.smalruby.app/, wss://graphql.api.smalruby.app/`;
 };
 
 MeshV2NetworkFilteredStep.propTypes = {
-    onHelp: PropTypes.func,
-    onScanning: PropTypes.func
+    onScanning: PropTypes.func,
+    onUseLegacyMesh: PropTypes.func
 };
 
 export default MeshV2NetworkFilteredStep;

--- a/packages/scratch-gui/src/components/connection-modal/network-filtered-step.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/network-filtered-step.jsx
@@ -56,20 +56,13 @@ URL: https://graphql.api.smalruby.app/, wss://graphql.api.smalruby.app/`;
 
     return (
         <Box className={styles.body}>
-            <Box className={styles.activityArea}>
-                <Box className={styles.centeredRow}>
-                    <div className={styles.peripheralActivity}>
-                        <img
-                            className={styles.peripheralActivityIcon}
-                            src={props.connectionIconURL}
-                        />
-                    </div>
-                </Box>
-            </Box>
             <Box className={styles.bottomArea}>
                 <div className={classNames(styles.bottomAreaItem, styles.instructions)}>
                     <FormattedMessage
-                        defaultMessage="ネットワークの制限により、現在、あたらしいメッシュ機能が使えません。{br}ネットワーク管理者に次の情報を伝え、制限の解除をご依頼ください。"
+                        defaultMessage={
+                            'The new mesh feature is unavailable.{br}' +
+                            'Please ask your network administrator to remove the restriction.'
+                        }
                         description="Message when mesh v2 is blocked by network filter"
                         id="gui.connection.networkFiltered.message"
                         values={{
@@ -145,7 +138,6 @@ URL: https://graphql.api.smalruby.app/, wss://graphql.api.smalruby.app/`;
 };
 
 NetworkFilteredStep.propTypes = {
-    connectionIconURL: PropTypes.string.isRequired,
     onHelp: PropTypes.func,
     onScanning: PropTypes.func
 };

--- a/packages/scratch-gui/src/components/connection-modal/network-filtered-step.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/network-filtered-step.jsx
@@ -1,0 +1,155 @@
+// === Smalruby: Network filter detection feature ===
+// This component displays a message when meshV2 is blocked by network filter (HTTP 503)
+// such as i-Filter proxy in schools or enterprises.
+
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import React from 'react';
+
+import Box from '../box/box.jsx';
+import Dots from './dots.jsx';
+import helpIcon from './icons/help.svg';
+import backIcon from './icons/back.svg';
+import copyIcon from './icons/copy.svg';
+
+import styles from './connection-modal.css';
+
+const NetworkFilteredStep = props => {
+    const [copied, setCopied] = React.useState(false);
+
+    const networkInfoMessage = `スモウルビーのメッシュ機能を使うため、ネットワークの制限を解除してください。
+
+利用するネットワークの情報
+プロトコル: https, wss (WebSocket)
+ホスト: api.smalruby.app, graphql.api.smalruby.app
+URL: https://graphql.api.smalruby.app/, wss://graphql.api.smalruby.app/`;
+
+    const handleCopy = React.useCallback(() => {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(networkInfoMessage)
+                .then(() => {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                })
+                .catch(() => {
+                    // Silently fail - user can manually copy
+                });
+        } else {
+            // Fallback for older browsers
+            const textArea = document.createElement('textarea');
+            textArea.value = networkInfoMessage;
+            textArea.style.position = 'fixed';
+            textArea.style.left = '-999999px';
+            document.body.appendChild(textArea);
+            textArea.select();
+            try {
+                document.execCommand('copy');
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+            } catch (e) {
+                // Silently fail - user can manually copy
+            }
+            document.body.removeChild(textArea);
+        }
+    }, [networkInfoMessage]);
+
+    return (
+        <Box className={styles.body}>
+            <Box className={styles.activityArea}>
+                <Box className={styles.centeredRow}>
+                    <div className={styles.peripheralActivity}>
+                        <img
+                            className={styles.peripheralActivityIcon}
+                            src={props.connectionIconURL}
+                        />
+                    </div>
+                </Box>
+            </Box>
+            <Box className={styles.bottomArea}>
+                <div className={classNames(styles.bottomAreaItem, styles.instructions)}>
+                    <FormattedMessage
+                        defaultMessage="ネットワークの制限により、現在、あたらしいメッシュ機能が使えません。{br}ネットワーク管理者に次の情報を伝え、制限の解除をご依頼ください。"
+                        description="Message when mesh v2 is blocked by network filter"
+                        id="gui.connection.networkFiltered.message"
+                        values={{
+                            br: <br />
+                        }}
+                    />
+                </div>
+                <div className={classNames(styles.bottomAreaItem, styles.networkInfo)}>
+                    <pre className={styles.networkInfoText}>
+                        {networkInfoMessage}
+                    </pre>
+                    <button
+                        className={styles.copyButton}
+                        onClick={handleCopy}
+                    >
+                        <img
+                            className={styles.buttonIconLeft}
+                            src={copyIcon}
+                        />
+                        {copied ? (
+                            <FormattedMessage
+                                defaultMessage="Copied!"
+                                description="Message shown after copying to clipboard"
+                                id="gui.connection.networkFiltered.copied"
+                            />
+                        ) : (
+                            <FormattedMessage
+                                defaultMessage="Copy to clipboard"
+                                description="Button to copy network info to clipboard"
+                                id="gui.connection.networkFiltered.copyButton"
+                            />
+                        )}
+                    </button>
+                </div>
+                <Dots
+                    error
+                    className={styles.bottomAreaItem}
+                    total={3}
+                />
+                <Box className={classNames(styles.bottomAreaItem, styles.buttonRow)}>
+                    <button
+                        className={styles.connectionButton}
+                        onClick={props.onScanning}
+                    >
+                        <img
+                            className={classNames(styles.buttonIconLeft, styles.buttonIconBack)}
+                            src={backIcon}
+                        />
+                        <FormattedMessage
+                            defaultMessage="Try again"
+                            description="Button to retry connection"
+                            id="gui.connection.networkFiltered.tryagainbutton"
+                        />
+                    </button>
+                    <button
+                        className={styles.connectionButton}
+                        onClick={props.onHelp}
+                    >
+                        <img
+                            className={styles.buttonIconLeft}
+                            src={helpIcon}
+                        />
+                        <FormattedMessage
+                            defaultMessage="Help"
+                            description="Button to view help content"
+                            id="gui.connection.networkFiltered.helpbutton"
+                        />
+                    </button>
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+NetworkFilteredStep.propTypes = {
+    connectionIconURL: PropTypes.string.isRequired,
+    onHelp: PropTypes.func,
+    onScanning: PropTypes.func
+};
+
+export default NetworkFilteredStep;
+
+// === Smalruby: End of network filter detection feature ===

--- a/packages/scratch-gui/src/containers/connection-modal.jsx
+++ b/packages/scratch-gui/src/containers/connection-modal.jsx
@@ -7,7 +7,8 @@ import analytics from '../lib/analytics';
 import extensionData from '../lib/libraries/extensions/index.jsx';
 import {connect} from 'react-redux';
 
-import {closeConnectionModal} from '../reducers/modals';
+import {closeConnectionModal, openConnectionModal} from '../reducers/modals';
+import {setConnectionModalExtensionId} from '../reducers/connection-modal';
 import {isMicroBitUpdateSupported, selectAndUpdateMicroBit} from '../lib/microbit-update';
 
 class ConnectionModal extends React.Component {
@@ -22,7 +23,8 @@ class ConnectionModal extends React.Component {
             'handleError',
             'handleHelp',
             'handleSendUpdate',
-            'handleUpdatePeripheral'
+            'handleUpdatePeripheral',
+            'handleUseLegacyMesh'
         ]);
         this.state = {
             extension: extensionData.find(ext => ext.extensionId === props.extensionId),
@@ -147,6 +149,25 @@ class ConnectionModal extends React.Component {
         // TODO: get this functionality from the extension
         return selectAndUpdateMicroBit(progressCallback);
     }
+    handleUseLegacyMesh () {
+        // Load legacy mesh extension if not already loaded
+        const meshExtensionId = 'mesh';
+        if (!this.props.vm.extensionManager.isExtensionLoaded(meshExtensionId)) {
+            this.props.vm.extensionManager.loadExtensionURL(meshExtensionId);
+        }
+
+        // Close current modal
+        this.props.onCancel();
+
+        // Open connection modal for mesh extension
+        this.props.onUseLegacyMesh(meshExtensionId);
+
+        analytics.event({
+            category: 'extensions',
+            action: 'use legacy mesh from network filter error',
+            label: this.props.extensionId
+        });
+    }
     render () {
         const canUpdatePeripheral = (this.props.extensionId === 'microbit') && isMicroBitUpdateSupported();
         return (
@@ -172,6 +193,7 @@ class ConnectionModal extends React.Component {
                 onScanning={this.handleScanning}
                 onSendPeripheralUpdate={canUpdatePeripheral ? this.handleSendUpdate : null}
                 onUpdatePeripheral={canUpdatePeripheral ? this.handleUpdatePeripheral : null}
+                onUseLegacyMesh={this.handleUseLegacyMesh}
             />
         );
     }
@@ -180,6 +202,7 @@ class ConnectionModal extends React.Component {
 ConnectionModal.propTypes = {
     extensionId: PropTypes.string.isRequired,
     onCancel: PropTypes.func.isRequired,
+    onUseLegacyMesh: PropTypes.func.isRequired,
     useExternalPeripheralList: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired
 };
@@ -191,6 +214,10 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
     onCancel: () => {
         dispatch(closeConnectionModal());
+    },
+    onUseLegacyMesh: extensionId => {
+        dispatch(setConnectionModalExtensionId(extensionId));
+        dispatch(openConnectionModal());
     }
 });
 

--- a/packages/scratch-gui/src/containers/connection-modal.jsx
+++ b/packages/scratch-gui/src/containers/connection-modal.jsx
@@ -72,7 +72,23 @@ class ConnectionModal extends React.Component {
             this.props.onCancel();
         }
     }
-    handleError () {
+    handleError (event) {
+        // === Smalruby: Start of network filter detection feature ===
+        // Check if this is a network filter error (HTTP 503 from proxy like i-Filter)
+        if (event && event.errorType === 'networkFilter' &&
+            this.props.extensionId === 'meshV2') {
+            this.setState({
+                phase: PHASES.networkFiltered
+            });
+            analytics.event({
+                category: 'extensions',
+                action: 'network filter error',
+                label: this.props.extensionId
+            });
+            return;
+        }
+        // === Smalruby: End of network filter detection feature ===
+
         // Assume errors that come in during scanning phase are the result of not
         // having scratch-link installed.
         if (this.state.phase === PHASES.scanning || this.state.phase === PHASES.unavailable) {

--- a/packages/scratch-gui/src/containers/connection-modal.jsx
+++ b/packages/scratch-gui/src/containers/connection-modal.jsx
@@ -150,23 +150,27 @@ class ConnectionModal extends React.Component {
         return selectAndUpdateMicroBit(progressCallback);
     }
     handleUseLegacyMesh () {
-        // Load legacy mesh extension if not already loaded
         const meshExtensionId = 'mesh';
-        if (!this.props.vm.extensionManager.isExtensionLoaded(meshExtensionId)) {
-            this.props.vm.extensionManager.loadExtensionURL(meshExtensionId);
-        }
-
-        // Close current modal
-        this.props.onCancel();
-
-        // Open connection modal for mesh extension
-        this.props.onUseLegacyMesh(meshExtensionId);
 
         analytics.event({
             category: 'extensions',
             action: 'use legacy mesh from network filter error',
             label: this.props.extensionId
         });
+
+        // Close current modal first
+        this.props.onCancel();
+
+        // Wait for modal to close before loading mesh extension
+        setTimeout(() => {
+            // Load legacy mesh extension if not already loaded
+            if (!this.props.vm.extensionManager.isExtensionLoaded(meshExtensionId)) {
+                this.props.vm.extensionManager.loadExtensionURL(meshExtensionId);
+            }
+
+            // Open connection modal for mesh extension
+            this.props.onUseLegacyMesh(meshExtensionId);
+        }, 300); // Wait 300ms for modal close animation to complete
     }
     render () {
         const canUpdatePeripheral = (this.props.extensionId === 'microbit') && isMicroBitUpdateSupported();

--- a/packages/scratch-gui/src/containers/connection-modal.jsx
+++ b/packages/scratch-gui/src/containers/connection-modal.jsx
@@ -73,7 +73,6 @@ class ConnectionModal extends React.Component {
         }
     }
     handleError (event) {
-        // === Smalruby: Start of network filter detection feature ===
         // Check if this is a network filter error (HTTP 503 from proxy like i-Filter)
         if (event && event.errorType === 'networkFilter' &&
             this.props.extensionId === 'meshV2') {
@@ -87,7 +86,6 @@ class ConnectionModal extends React.Component {
             });
             return;
         }
-        // === Smalruby: End of network filter detection feature ===
 
         // Assume errors that come in during scanning phase are the result of not
         // having scratch-link installed.

--- a/packages/scratch-gui/src/containers/extension-library.jsx
+++ b/packages/scratch-gui/src/containers/extension-library.jsx
@@ -25,6 +25,13 @@ const messages = defineMessages({
         defaultMessage: 'Enter the URL of the extension',
         description: 'Prompt for unoffical extension url',
         id: 'gui.extensionLibrary.extensionUrl'
+    },
+    meshDeprecationWarning: {
+        defaultMessage: 'The legacy mesh extension can only be used until April 30. ' +
+            'If you want to continue using the legacy mesh extension, select OK. ' +
+            'Otherwise, if you want to use the new mesh extension, select Cancel.',
+        description: 'Warning message for legacy mesh extension deprecation',
+        id: 'gui.extensionLibrary.meshDeprecationWarning'
     }
 });
 
@@ -51,12 +58,24 @@ class ExtensionLibrary extends React.PureComponent {
         this.props.onToggleShowAllExtensions(event.target.checked);
     }
     handleItemSelect (item) {
-        const id = item.extensionId;
+        let id = item.extensionId;
         let url = item.extensionURL ? item.extensionURL : id;
         if (!item.disabled && !id) {
             // eslint-disable-next-line no-alert
             url = prompt(this.props.intl.formatMessage(messages.extensionUrl));
         }
+
+        // Special handling for legacy mesh extension
+        if (id === 'mesh' && !item.disabled) {
+            // eslint-disable-next-line no-alert
+            const useLegacyMesh = confirm(this.props.intl.formatMessage(messages.meshDeprecationWarning));
+            if (!useLegacyMesh) {
+                // User selected Cancel - use meshV2 instead
+                id = 'meshV2';
+                url = 'meshV2';
+            }
+        }
+
         if (id && !item.disabled) {
             if (this.props.vm.extensionManager.isExtensionLoaded(url)) {
                 this.props.onCategorySelected(id);

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -215,5 +215,5 @@ export default {
     'gui.connection.networkFiltered.copied': 'Copied!',
     'gui.connection.networkFiltered.copyButton': 'Copy to clipboard',
     'gui.connection.networkFiltered.tryagainbutton': 'Try again',
-    'gui.connection.networkFiltered.helpbutton': 'Help'
+    'gui.connection.networkFiltered.useLegacyMeshButton': 'Use legacy mesh'
 };

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -19,6 +19,7 @@ export default {
     'gui.smalruby3.telemetryOptIn.body2': 'The information we collect includes language selection, blocks usage, and some events like saving, loading, and uploading a project. We DO NOT collect any personal information.',
     'gui.telemetryOptIn.buttonTextNo': 'No, thanks',
     'gui.extensionLibrary.showAllExtensions': 'Show all extensions',
+    'gui.extensionLibrary.meshDeprecationWarning': 'The legacy mesh extension can only be used until April 30. If you want to continue using the legacy mesh extension, select OK. Otherwise, if you want to use the new mesh extension, select Cancel.',
     'gui.smalruby3.rubyToBlocksConverter.couldNotConvertPrimitive': '"{ SOURCE }" could not be converted the block.',
     'gui.smalruby3.rubyToBlocksConverter.wrongInstruction': '"{ SOURCE }" is the wrong instruction.',
     'gui.smalruby3.telemetryOptIn.buttonTextYes': "Yes, I'd like to help improve Smalruby",

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -208,5 +208,12 @@ export default {
     'gui.urlLoader.urlExamplesTitle': 'URL Examples',
     'gui.urlLoader.urlExampleScratch': 'https://scratch.mit.edu/projects/{project_id}/',
     'gui.urlLoader.urlExampleGoogleDrive': 'https://drive.google.com/file/d/{file_id}/view?usp=drive_link',
-    'gui.modal.stop': 'Stop'
+    'gui.modal.stop': 'Stop',
+
+    // Network Filter Error messages
+    'gui.connection.networkFiltered.message': 'The new mesh feature is unavailable.{br}Please ask your network administrator to remove the restriction.',
+    'gui.connection.networkFiltered.copied': 'Copied!',
+    'gui.connection.networkFiltered.copyButton': 'Copy to clipboard',
+    'gui.connection.networkFiltered.tryagainbutton': 'Try again',
+    'gui.connection.networkFiltered.helpbutton': 'Help'
 };

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -271,5 +271,5 @@ export default {
     'gui.connection.networkFiltered.copied': 'コピーしました！',
     'gui.connection.networkFiltered.copyButton': 'クリップボードにコピー',
     'gui.connection.networkFiltered.tryagainbutton': 'もういちどためす',
-    'gui.connection.networkFiltered.helpbutton': 'ヘルプ'
+    'gui.connection.networkFiltered.useLegacyMeshButton': 'じゅうらいのメッシュをつかう'
 };

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -266,5 +266,10 @@ export default {
     'gui.connection.updatePeripheral.microbitMoreUpdateSuccessful': 'MicrobitMoreのアップデートにせいこうしました！',
     'gui.connection.updatePeripheral.microbitMoreTiltToLightUp': 'micro:bitをかたむけて25このLEDをすべててんとうさせるとかんりょうです。',
     'gui.connection.scanning.updatePeripheralButton': 'アップデート',
-    'gui.connection.auto-scanning.updatePeripheralButton': 'アップデート'
+    'gui.connection.auto-scanning.updatePeripheralButton': 'アップデート',
+    'gui.connection.networkFiltered.message': 'あたらしいメッシュきのうがつかえません。{br}ネットワークかんりしゃにせいげんのかいじょをごいらいください。',
+    'gui.connection.networkFiltered.copied': 'コピーしました！',
+    'gui.connection.networkFiltered.copyButton': 'クリップボードにコピー',
+    'gui.connection.networkFiltered.tryagainbutton': 'もういちどためす',
+    'gui.connection.networkFiltered.helpbutton': 'ヘルプ'
 };

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -255,6 +255,7 @@ export default {
     'gui.smalruby3.blockDisplayModal.operator_round': '(　) をししゃごにゅう',
     'gui.smalruby3.blockDisplayModal.operator_mathop': '(　) の [ぜったいち▼]',
     'gui.extensionLibrary.showAllExtensions': 'すべてのかくちょうきのうをひょうじ',
+    'gui.extensionLibrary.meshDeprecationWarning': 'じゅうらいのメッシュかくちょうきのうは4がつ30にちまでしかつかえません。このままじゅうらいのメッシュかくちょうきのうをりようするばあいはOKをせんたくします。そうではなく、あたらしいメッシュかくちょうきのうをつかうばあいはキャンセルをせんたくします。',
 
     // MicroBit More - Tilt gesture labels (override to match microbit extension)
     'mbitMore.gesturesMenu.tiltUp': 'うえにかたむいた',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -266,5 +266,10 @@ export default {
     'gui.connection.updatePeripheral.microbitMoreUpdateSuccessful': 'MicrobitMoreのアップデートに成功しました！',
     'gui.connection.updatePeripheral.microbitMoreTiltToLightUp': 'micro:bitを傾けて25個のLEDをすべて点灯させると完了です。',
     'gui.connection.scanning.updatePeripheralButton': 'アップデート',
-    'gui.connection.auto-scanning.updatePeripheralButton': 'アップデート'
+    'gui.connection.auto-scanning.updatePeripheralButton': 'アップデート',
+    'gui.connection.networkFiltered.message': 'あたらしいメッシュ機能が使えません。{br}ネットワーク管理者に制限の解除をご依頼ください。',
+    'gui.connection.networkFiltered.copied': 'コピーしました！',
+    'gui.connection.networkFiltered.copyButton': 'クリップボードにコピー',
+    'gui.connection.networkFiltered.tryagainbutton': 'もう一度試す',
+    'gui.connection.networkFiltered.helpbutton': 'ヘルプ'
 };

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -255,6 +255,7 @@ export default {
     'gui.smalruby3.blockDisplayModal.operator_round': '(　) を四捨五入',
     'gui.smalruby3.blockDisplayModal.operator_mathop': '(　) の [絶対値▼]',
     'gui.extensionLibrary.showAllExtensions': 'すべての拡張機能を表示',
+    'gui.extensionLibrary.meshDeprecationWarning': '従来のメッシュ拡張機能は4月30日までしか使えません。このまま従来のメッシュ拡張機能を利用する場合はOKを選択します。そうではなく、あたらしいメッシュ拡張機能を使う場合はキャンセルを選択します。',
 
     // MicroBit More - Tilt gesture labels (override to match microbit extension)
     'mbitMore.gesturesMenu.tiltUp': '上に傾いた',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -271,5 +271,5 @@ export default {
     'gui.connection.networkFiltered.copied': 'コピーしました！',
     'gui.connection.networkFiltered.copyButton': 'クリップボードにコピー',
     'gui.connection.networkFiltered.tryagainbutton': 'もう一度試す',
-    'gui.connection.networkFiltered.helpbutton': 'ヘルプ'
+    'gui.connection.networkFiltered.useLegacyMeshButton': '従来のメッシュを使う'
 };

--- a/packages/scratch-gui/webpack.config.js
+++ b/packages/scratch-gui/webpack.config.js
@@ -104,7 +104,8 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`,
         'process.env.MESH_DATA_UPDATE_INTERVAL_MS': `"${process.env.MESH_DATA_UPDATE_INTERVAL_MS || ''}"`,
         'process.env.MESH_EVENT_BATCH_INTERVAL_MS': `"${process.env.MESH_EVENT_BATCH_INTERVAL_MS || ''}"`,
-        'process.env.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS': `"${process.env.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS || ''}"`
+        'process.env.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS': `"${process.env.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS || ''}"`,
+        'process.env.MESH_NETWORK_FILTER': `"${process.env.MESH_NETWORK_FILTER || ''}"`
     }))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
@@ -66,19 +66,16 @@ class Scratch3MeshV2Blocks {
             createClient();
             this.meshService = new MeshV2Service(this, this.nodeId, this.domain);
             this.meshService.setDisconnectCallback(reason => {
-                // === Smalruby: Start of network filter detection feature ===
                 // Check if error is caused by network filter (HTTP 503 from proxy like i-Filter)
                 const errorType = this.meshService &&
                     this.meshService.lastError &&
                     this.meshService.isNetworkFilterError(this.meshService.lastError) ?
                     'networkFilter' :
                     null;
-                // === Smalruby: End of network filter detection feature ===
 
                 if (reason === 'GroupNotFound' || reason === 'expired') {
-                    // === Smalruby: Pass errorType to setConnectionState ===
+                    // Pass errorType to setConnectionState for network filter error handling
                     this.setConnectionState('error', errorType);
-                    // === Smalruby: End ===
                 } else {
                     this.setConnectionState('disconnected');
                 }
@@ -311,13 +308,11 @@ class Scratch3MeshV2Blocks {
             this.runtime.emit(this.runtime.constructor.PERIPHERAL_CONNECTED);
             break;
         case 'error':
-            // === Smalruby: Include errorType in event for GUI to handle network filter errors ===
-            // Emit error event only, do not emit PERIPHERAL_DISCONNECTED
+            // Emit error event with errorType for GUI to handle network filter errors
             this.runtime.emit(this.runtime.constructor.PERIPHERAL_REQUEST_ERROR, {
                 extensionId: Scratch3MeshV2Blocks.EXTENSION_ID,
                 errorType: errorType // 'networkFilter' when blocked by proxy (e.g., i-Filter)
             });
-            // === Smalruby: End ===
             if (prevState === 'connected' && !this.isExplicitDisconnect) {
                 this.runtime.emit(this.runtime.constructor.PERIPHERAL_CONNECTION_LOST_ERROR, {
                     extensionId: Scratch3MeshV2Blocks.EXTENSION_ID

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
@@ -66,8 +66,19 @@ class Scratch3MeshV2Blocks {
             createClient();
             this.meshService = new MeshV2Service(this, this.nodeId, this.domain);
             this.meshService.setDisconnectCallback(reason => {
+                // === Smalruby: Start of network filter detection feature ===
+                // Check if error is caused by network filter (HTTP 503 from proxy like i-Filter)
+                const errorType = this.meshService &&
+                    this.meshService.lastError &&
+                    this.meshService.isNetworkFilterError(this.meshService.lastError) ?
+                    'networkFilter' :
+                    null;
+                // === Smalruby: End of network filter detection feature ===
+
                 if (reason === 'GroupNotFound' || reason === 'expired') {
-                    this.setConnectionState('error');
+                    // === Smalruby: Pass errorType to setConnectionState ===
+                    this.setConnectionState('error', errorType);
+                    // === Smalruby: End ===
                 } else {
                     this.setConnectionState('disconnected');
                 }
@@ -283,10 +294,12 @@ class Scratch3MeshV2Blocks {
     /**
      * Set the connection state and emit appropriate events.
      * @param {string} state - The new connection state ('disconnected', 'scanning', 'connecting', 'connected', 'error')
+     * @param {string|null} errorType - Optional error type ('networkFilter' when blocked by proxy like i-Filter)
      */
-    setConnectionState (state) {
+    setConnectionState (state, errorType = null) {
         const prevState = this.connectionState;
-        log.info(`Mesh V2: Connection state transition: ${prevState} -> ${state}`);
+        const errorInfo = errorType ? ` (errorType: ${errorType})` : '';
+        log.info(`Mesh V2: Connection state transition: ${prevState} -> ${state}${errorInfo}`);
         this.connectionState = state;
 
         if (state !== 'disconnected') {
@@ -298,10 +311,13 @@ class Scratch3MeshV2Blocks {
             this.runtime.emit(this.runtime.constructor.PERIPHERAL_CONNECTED);
             break;
         case 'error':
+            // === Smalruby: Include errorType in event for GUI to handle network filter errors ===
             // Emit error event only, do not emit PERIPHERAL_DISCONNECTED
             this.runtime.emit(this.runtime.constructor.PERIPHERAL_REQUEST_ERROR, {
-                extensionId: Scratch3MeshV2Blocks.EXTENSION_ID
+                extensionId: Scratch3MeshV2Blocks.EXTENSION_ID,
+                errorType: errorType // 'networkFilter' when blocked by proxy (e.g., i-Filter)
             });
+            // === Smalruby: End ===
             if (prevState === 'connected' && !this.isExplicitDisconnect) {
                 this.runtime.emit(this.runtime.constructor.PERIPHERAL_CONNECTION_LOST_ERROR, {
                     extensionId: Scratch3MeshV2Blocks.EXTENSION_ID

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
@@ -241,6 +241,16 @@ class Scratch3MeshV2Blocks {
             /* istanbul ignore next */
             .catch(err => {
                 log.error(`Mesh V2: Scan failed: ${err}`);
+                // Check if error is caused by network filter (HTTP 503)
+                log.debug('Mesh V2: Checking lastError:', this.meshService?.lastError);
+                const errorType = this.meshService &&
+                    this.meshService.lastError &&
+                    this.meshService.isNetworkFilterError(this.meshService.lastError) ?
+                    'networkFilter' :
+                    null;
+                log.info(`Mesh V2: Setting error state with errorType: ${errorType}`);
+                // Set error state to trigger error UI
+                this.setConnectionState('error', errorType);
             });
     }
 

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -155,6 +155,11 @@ class MeshV2Service {
 
         this.disconnectCallback = null;
 
+        // === Smalruby: Start of network filter detection feature ===
+        // Store last error for network filter detection (HTTP 503 from proxy like i-Filter)
+        this.lastError = null;
+        // === Smalruby: End of network filter detection feature ===
+
         // Cost tracking
         this.costTracking = {
             connectionStartTime: null,
@@ -201,6 +206,36 @@ class MeshV2Service {
 
         return null;
     }
+
+    // === Smalruby: Start of network filter detection feature ===
+    /**
+     * Check if the error is caused by network filtering (503 Service Unavailable).
+     * Network filters (e.g., i-Filter proxy) block requests before reaching AppSync
+     * and return HTTP 503. The error payload content is undefined and depends on
+     * the proxy implementation, so we can ONLY rely on the HTTP status code.
+     * @param {Error} error - The error to check.
+     * @returns {boolean} True if the error is caused by network filtering.
+     */
+    isNetworkFilterError (error) {
+        if (!error) return false;
+
+        // Primary check: HTTP status code 503 from network error
+        // This is the ONLY reliable indicator when blocked by proxy (e.g., i-Filter)
+        if (error.networkError && error.networkError.statusCode === 503) {
+            log.info('Mesh V2: Detected network filter error (HTTP 503)');
+            return true;
+        }
+
+        // Fallback: Check for 503 in error message (less reliable)
+        // Some GraphQL clients may include status code in message
+        if (error.message && error.message.includes('503')) {
+            log.info('Mesh V2: Detected network filter error (503 in message)');
+            return true;
+        }
+
+        return false;
+    }
+    // === Smalruby: End of network filter detection feature ===
 
     setDisconnectCallback (callback) {
         this.disconnectCallback = callback;
@@ -335,6 +370,9 @@ class MeshV2Service {
             return group;
         } catch (error) {
             log.error(`Mesh V2: Failed to create group: ${error}`);
+            // === Smalruby: Store error for network filter detection ===
+            this.lastError = error;
+            // === Smalruby: End ===
             throw error;
         }
     }
@@ -360,6 +398,9 @@ class MeshV2Service {
             return groups;
         } catch (error) {
             log.error(`Mesh V2: Failed to list groups: ${error}`);
+            // === Smalruby: Store error for network filter detection ===
+            this.lastError = error;
+            // === Smalruby: End ===
             throw error;
         }
     }
@@ -413,6 +454,9 @@ class MeshV2Service {
             return node;
         } catch (error) {
             log.error(`Mesh V2: Failed to join group: ${error}`);
+            // === Smalruby: Store error for network filter detection ===
+            this.lastError = error;
+            // === Smalruby: End ===
             throw error;
         }
     }

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -155,10 +155,15 @@ class MeshV2Service {
 
         this.disconnectCallback = null;
 
-        // === Smalruby: Start of network filter detection feature ===
         // Store last error for network filter detection (HTTP 503 from proxy like i-Filter)
         this.lastError = null;
-        // === Smalruby: End of network filter detection feature ===
+
+        // Test mode: Simulate network filter (HTTP 503) when MESH_NETWORK_FILTER=true
+        this.simulateNetworkFilter = process.env.MESH_NETWORK_FILTER === 'true';
+        if (this.simulateNetworkFilter) {
+            log.warn('Mesh V2: Network filter test mode enabled (MESH_NETWORK_FILTER=true)');
+            log.warn('Mesh V2: All GraphQL requests will return HTTP 503 for testing');
+        }
 
         // Cost tracking
         this.costTracking = {
@@ -207,7 +212,6 @@ class MeshV2Service {
         return null;
     }
 
-    // === Smalruby: Start of network filter detection feature ===
     /**
      * Check if the error is caused by network filtering (503 Service Unavailable).
      * Network filters (e.g., i-Filter proxy) block requests before reaching AppSync
@@ -235,7 +239,35 @@ class MeshV2Service {
 
         return false;
     }
-    // === Smalruby: End of network filter detection feature ===
+
+    /**
+     * Create a simulated HTTP 503 error for testing network filter detection.
+     * This simulates the error structure returned by i-Filter or similar proxies.
+     * @returns {Error} Error object with HTTP 503 structure.
+     * @private
+     */
+    _createSimulated503Error () {
+        const error = new Error('Network error: Service Unavailable');
+        error.networkError = {
+            statusCode: 503,
+            bodyText: 'Simulated network filter block (MESH_NETWORK_FILTER=true)'
+        };
+        error.graphQLErrors = [];
+        return error;
+    }
+
+    /**
+     * Check if network filter test mode is enabled and throw 503 error if so.
+     * @throws {Error} HTTP 503 error if MESH_NETWORK_FILTER=true.
+     * @private
+     */
+    _checkSimulateNetworkFilter () {
+        if (this.simulateNetworkFilter) {
+            const error = this._createSimulated503Error();
+            this.lastError = error;
+            throw error;
+        }
+    }
 
     setDisconnectCallback (callback) {
         this.disconnectCallback = callback;
@@ -313,6 +345,9 @@ class MeshV2Service {
         if (!this.client) throw new Error('Client not initialized');
 
         try {
+            // Simulate network filter (503) for testing when MESH_NETWORK_FILTER=true
+            this._checkSimulateNetworkFilter();
+
             if (!this.domain) {
                 await this.createDomain();
             }
@@ -370,9 +405,8 @@ class MeshV2Service {
             return group;
         } catch (error) {
             log.error(`Mesh V2: Failed to create group: ${error}`);
-            // === Smalruby: Store error for network filter detection ===
+            // Store error for network filter detection
             this.lastError = error;
-            // === Smalruby: End ===
             throw error;
         }
     }
@@ -381,6 +415,9 @@ class MeshV2Service {
         if (!this.client) throw new Error('Client not initialized');
 
         try {
+            // Simulate network filter (503) for testing when MESH_NETWORK_FILTER=true
+            this._checkSimulateNetworkFilter();
+
             if (!this.domain) {
                 await this.createDomain();
             }
@@ -398,9 +435,8 @@ class MeshV2Service {
             return groups;
         } catch (error) {
             log.error(`Mesh V2: Failed to list groups: ${error}`);
-            // === Smalruby: Store error for network filter detection ===
+            // Store error for network filter detection
             this.lastError = error;
-            // === Smalruby: End ===
             throw error;
         }
     }
@@ -409,6 +445,9 @@ class MeshV2Service {
         if (!this.client) throw new Error('Client not initialized');
 
         try {
+            // Simulate network filter (503) for testing when MESH_NETWORK_FILTER=true
+            this._checkSimulateNetworkFilter();
+
             this.costTracking.mutationCount++;
             this.lastFetchTime = new Date().toISOString();
             log.info(`Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before joinGroup)`);
@@ -454,9 +493,8 @@ class MeshV2Service {
             return node;
         } catch (error) {
             log.error(`Mesh V2: Failed to join group: ${error}`);
-            // === Smalruby: Store error for network filter detection ===
+            // Store error for network filter detection
             this.lastError = error;
-            // === Smalruby: End ===
             throw error;
         }
     }

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -221,7 +221,16 @@ class MeshV2Service {
      * @returns {boolean} True if the error is caused by network filtering.
      */
     isNetworkFilterError (error) {
-        if (!error) return false;
+        if (!error) {
+            log.debug('Mesh V2: isNetworkFilterError called with null/undefined error');
+            return false;
+        }
+
+        log.debug('Mesh V2: Checking if error is network filter error:', {
+            hasNetworkError: !!error.networkError,
+            statusCode: error.networkError?.statusCode,
+            message: error.message
+        });
 
         // Primary check: HTTP status code 503 from network error
         // This is the ONLY reliable indicator when blocked by proxy (e.g., i-Filter)
@@ -237,6 +246,7 @@ class MeshV2Service {
             return true;
         }
 
+        log.debug('Mesh V2: Error is NOT a network filter error');
         return false;
     }
 

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -132,8 +132,8 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.PERIPHERAL_CONNECTED, data =>
             this.emit(Runtime.PERIPHERAL_CONNECTED, data)
         );
-        this.runtime.on(Runtime.PERIPHERAL_REQUEST_ERROR, () =>
-            this.emit(Runtime.PERIPHERAL_REQUEST_ERROR)
+        this.runtime.on(Runtime.PERIPHERAL_REQUEST_ERROR, data =>
+            this.emit(Runtime.PERIPHERAL_REQUEST_ERROR, data)
         );
         this.runtime.on(Runtime.PERIPHERAL_DISCONNECTED, data =>
             this.emit(Runtime.PERIPHERAL_DISCONNECTED, data)

--- a/packages/scratch-vm/test/unit/extension_mesh_v2.js
+++ b/packages/scratch-vm/test/unit/extension_mesh_v2.js
@@ -239,7 +239,7 @@ test('Mesh V2 Blocks', t => {
         st.equal(events.length, 2);
         st.equal(events[0].event, 'PERIPHERAL_REQUEST_ERROR');
         st.equal(events[1].event, 'PERIPHERAL_DISCONNECTED');
-        st.same(events[0].data, {extensionId: 'meshV2'});
+        st.same(events[0].data, {extensionId: 'meshV2', errorType: null});
         st.same(events[1].data, {extensionId: 'meshV2'});
 
         st.end();

--- a/packages/scratch-vm/test/unit/extension_mesh_v2.js
+++ b/packages/scratch-vm/test/unit/extension_mesh_v2.js
@@ -4,6 +4,9 @@ const minilog = require('minilog');
 minilog.suggest.deny('vm', 'debug');
 minilog.suggest.deny('vm', 'info');
 
+// Force network filter test mode to be disabled in unit tests
+process.env.MESH_NETWORK_FILTER = 'false';
+
 const URLSearchParams = require('url').URLSearchParams;
 const MeshV2Blocks = require('../../src/extensions/scratch3_mesh_v2/index.js');
 const Variable = require('../../src/engine/variable');

--- a/packages/scratch-vm/test/unit/extension_mesh_v2_service.js
+++ b/packages/scratch-vm/test/unit/extension_mesh_v2_service.js
@@ -4,6 +4,9 @@ const minilog = require('minilog');
 // Suppress debug logs during tests
 minilog.suggest.deny('vm', 'debug');
 
+// Force network filter test mode to be disabled in unit tests
+process.env.MESH_NETWORK_FILTER = 'false';
+
 const MeshV2Service = require('../../src/extensions/scratch3_mesh_v2/mesh-service');
 const log = require('../../src/util/log');
 

--- a/packages/scratch-vm/test/unit/io_clock.js
+++ b/packages/scratch-vm/test/unit/io_clock.js
@@ -20,18 +20,24 @@ test('cycle', t => {
     const c = new Clock(rt);
 
     t.ok(c.projectTimer() <= 0.1);
+
+    // Wait a small amount of time to ensure currentMSecs will be different
+    // when _step() is called, preventing flaky test failures
     setTimeout(() => {
-        c.resetProjectTimer();
+        rt._step();
+        t.ok(c.projectTimer() > 0);
+
         setTimeout(() => {
-            // The timer shouldn't advance until all threads have been stepped
-            t.ok(c.projectTimer() === 0);
-            c.pause();
-            t.ok(c.projectTimer() === 0);
-            c.resume();
-            t.ok(c.projectTimer() === 0);
-            t.end();
+            c.resetProjectTimer();
+            setTimeout(() => {
+                // The timer shouldn't advance until all threads have been stepped
+                t.ok(c.projectTimer() === 0);
+                c.pause();
+                t.ok(c.projectTimer() === 0);
+                c.resume();
+                t.ok(c.projectTimer() === 0);
+                t.end();
+            }, 100);
         }, 100);
-    }, 100);
-    rt._step();
-    t.ok(c.projectTimer() > 0);
+    }, 10);
 });

--- a/packages/scratch-vm/test/unit/mesh_service_v2_global_vars.js
+++ b/packages/scratch-vm/test/unit/mesh_service_v2_global_vars.js
@@ -4,6 +4,9 @@ const minilog = require('minilog');
 minilog.suggest.deny('vm', 'debug');
 minilog.suggest.deny('vm', 'info');
 
+// Force network filter test mode to be disabled in unit tests
+process.env.MESH_NETWORK_FILTER = 'false';
+
 const MeshV2Service = require('../../src/extensions/scratch3_mesh_v2/mesh-service');
 const Variable = require('../../src/engine/variable');
 


### PR DESCRIPTION
## 概要

meshV2機能がネットワークフィルタ（i-Filter等のプロキシ）によってブロックされた場合（HTTP 503エラー）、ユーザーにネットワーク管理者への問い合わせを促すエラー画面を表示する機能を実装しました。

## 実装内容

### 1. ネットワークフィルタエラー検出

**VM側 (scratch-vm):**
- `mesh-service.js`: HTTP 503エラーを検出する`isNetworkFilterError()`メソッドを追加
- `index.js`: エラー時に`errorType: 'networkFilter'`を含むイベントを発行
- `virtual-machine.js`: PERIPHERAL_REQUEST_ERRORイベントのデータを正しく伝播するように修正（重要なバグ修正）

**GUI側 (scratch-gui):**
- `NetworkFilteredStep`コンポーネント: 専用のエラー画面を新規作成
  - ネットワーク管理者への依頼メッセージ
  - ネットワーク情報（プロトコル、ホスト、URL）の表示
  - クリップボードへのコピー機能
  - 「もう一度試す」「ヘルプ」ボタン
- `connection-modal.jsx`: networkFilteredフェーズのハンドリングを追加

### 2. テストモード

環境変数`MESH_NETWORK_FILTER=true`を設定することで、実際のネットワークフィルタがない環境でも503エラーをシミュレートして動作確認できる機能を追加。

- `mesh-service.js`: テストモード用の503エラー生成ロジック
- `webpack.config.js`: 環境変数の伝播設定
- `.env.example`: テストモードのドキュメント追加

### 3. 国際化対応

- defaultMessageを英語に変更
- 日本語（ja.js）、ひらがな（ja-Hira.js）、英語（en.js）の翻訳を追加
- 5つのメッセージID:
  - `gui.connection.networkFiltered.message`
  - `gui.connection.networkFiltered.copied`
  - `gui.connection.networkFiltered.copyButton`
  - `gui.connection.networkFiltered.tryagainbutton`
  - `gui.connection.networkFiltered.helpbutton`

### 4. スタイリング

- ネットワーク情報メッセージを左寄せに変更（可読性向上）
- コピーボタンのアイコン追加

## テスト方法

### 通常のテスト（実際のネットワークフィルタ環境）

1. i-Filter等のネットワークフィルタが有効な環境でアプリを起動
2. meshV2拡張機能を追加
3. 接続モーダルが表示される
4. ネットワークフィルタエラー画面が表示されることを確認

### テストモードでのテスト

1. `.env`に`MESH_NETWORK_FILTER=true`を設定
2. 開発サーバーを再起動: `docker compose restart app`
3. meshV2拡張機能を追加
4. 接続モーダルでHTTP 503エラーが発生
5. ネットワークフィルタエラー画面が表示される
6. クリップボードへのコピー機能が動作することを確認

## 技術的な詳細

### HTTP 503エラーの検出ロジ��ク

i-Filterなどのプロキシは、許可されていないホストへのアクセスをブロックしてHTTP 503を返します。この時、サーバーからのペイロードは信頼できないため、HTTPステータスコードのみで判定しています。

```javascript
isNetworkFilterError(error) {
    if (error.networkError && error.networkError.statusCode === 503) {
        return true;
    }
    if (error.message && error.message.includes('503')) {
        return true;
    }
    return false;
}
```

### 重要なバグ修正

`virtual-machine.js`で`PERIPHERAL_REQUEST_ERROR`イベントを再発行する際、イベントデータが失われていた問題を修正しました。これにより、`errorType`がGUIまで正しく伝わるようになりました。

```javascript
// Before (バグ):
this.runtime.on(Runtime.PERIPHERAL_REQUEST_ERROR, () =>
    this.emit(Runtime.PERIPHERAL_REQUEST_ERROR)
);

// After (修正後):
this.runtime.on(Runtime.PERIPHERAL_REQUEST_ERROR, data =>
    this.emit(Runtime.PERIPHERAL_REQUEST_ERROR, data)
);
```

## 完了条件

- [x] HTTP 503エラー検出機能の実装
- [x] ネットワークフィルタエラー画面の実装
- [x] クリップボードコピー機能の実装
- [x] テストモードの実装
- [x] 国際化対応（ja, ja-Hira, en）
- [x] lintエラー0件
- [x] ビルド成功

## 関連Issue

Closes #35

🤖 Generated with [Claude Code](https://claude.ai/code)
