### PR TITLE
feat: add GTM support with conditional enabling and smalruby.app deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ GOOGLE_CLIENT_ID=your-client-id-here.apps.googleusercontent.com
 # Example: AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567
 GOOGLE_API_KEY=your-api-key-here
 
+# Google Tag Manager (Analytics)
+# GTM_ID: Google Tag Manager container ID (format: GTM-XXXXXXX)
+# GTM_ENV_AUTH: Environment-specific parameters for staging/preview (leave empty for production)
+#               Format: &gtm_auth=xxx&gtm_preview=env-00&gtm_cookies_win=x
+#               Get from: GTM -> Admin -> Environments -> (environment) -> Get Snippet
+GTM_ID=
+GTM_ENV_AUTH=
+
 # Mesh V2 Extension Configuration
 # See packages/scratch-vm/src/extensions/scratch3_mesh_v2/ for implementation details
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -132,6 +132,8 @@ jobs:
           MESH_DATA_UPDATE_INTERVAL_MS: ${{ vars.MESH_DATA_UPDATE_INTERVAL_MS }}
           MESH_EVENT_BATCH_INTERVAL_MS: ${{ vars.MESH_EVENT_BATCH_INTERVAL_MS }}
           MESH_PERIODIC_DATA_SYNC_INTERVAL_MS: ${{ vars.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS }}
+          GTM_ID: ${{ github.ref == 'refs/heads/develop' && secrets.GTM_ID || '' }}
+          GTM_ENV_AUTH: ${{ github.ref == 'refs/heads/develop' && secrets.GTM_ENV_AUTH || '' }}
         run: npm run build
       - name: Store Build Output
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -162,6 +164,18 @@ jobs:
         with:
           name: test-output-integration
           path: packages/*/test-results/*
+      - name: Prepare deployment files for smalruby.app
+        if: github.ref == 'refs/heads/develop'
+        run: touch packages/scratch-gui/build/.nojekyll
+      - name: Deploy to smalruby.app GitHub Pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        if: github.ref == 'refs/heads/develop'
+        with:
+          deploy_key: ${{ secrets.SMALRUBY_APP_DEPLOY_KEY }}
+          publish_dir: ./packages/scratch-gui/build
+          full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
+          cname: smalruby.app
+          external_repository: smalruby/smalruby.app
       - name: Prepare deployment files
         if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         run: touch packages/scratch-gui/build/.nojekyll
@@ -195,6 +209,8 @@ jobs:
           MESH_DATA_UPDATE_INTERVAL_MS: ${{ vars.MESH_DATA_UPDATE_INTERVAL_MS }}
           MESH_EVENT_BATCH_INTERVAL_MS: ${{ vars.MESH_EVENT_BATCH_INTERVAL_MS }}
           MESH_PERIODIC_DATA_SYNC_INTERVAL_MS: ${{ vars.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS }}
+          GTM_ID: ''
+          GTM_ENV_AUTH: ''
         run: cd packages/scratch-gui && npm exec node ./scripts/postbuild.mjs
       - name: Prepare deployment files for branch GitHub Pages
         if: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - DEBUG
       - GOOGLE_CLIENT_ID
       - GOOGLE_API_KEY
+      - GTM_ID
+      - GTM_ENV_AUTH
       - MESH_GRAPHQL_ENDPOINT
       - MESH_API_KEY
       - MESH_AWS_REGION


### PR DESCRIPTION
## Summary

Google Tag Manager (GTM) サポートと smalruby.app への自動デプロイ機能を実装しました。本番環境（develop ブランチ）のみ GTM を有効化し、PR やブランチプレビューでは GTM を無効化することで GA4 データの汚染を防止します。

## Changes Made

### 1. GTM 環境変数のドキュメント化
**File**: `.env.example`
- GTM_ID と GTM_ENV_AUTH の説明を追加
- 設定方法と用途を記載

### 2. Docker 環境への GTM 対応
**File**: `docker-compose.yml`
- GTM_ID と GTM_ENV_AUTH を環境変数に追加
- ローカル開発環境で GTM の有効/無効を切り替え可能

### 3. CI/CD ワークフローの更新
**File**: `.github/workflows/ci-cd.yml`

#### 条件付き GTM 設定
```yaml
GTM_ID: ${{ github.ref == 'refs/heads/develop' && secrets.GTM_ID || '' }}
GTM_ENV_AUTH: ${{ github.ref == 'refs/heads/develop' && secrets.GTM_ENV_AUTH || '' }}
```
- develop ブランチ: GTM 有効（本番 analytics 収集）
- PR / feature ブランチ: GTM 無効（GA4 汚染防止）

#### smalruby.app への自動デプロイ
- develop ブランチマージ時に smalruby.app へ自動デプロイ
- SMALRUBY_APP_DEPLOY_KEY を使用
- CNAME レコード（smalruby.app）を設定

## Deployment Flow

| ブランチ | デプロイ先 | GTM_ID | 用途 |
|---------|-----------|--------|------|
| `develop` | https://smalruby.app<br>https://smalruby.jp/smalruby3-editor/ | GTM-KKFVD5ZC | 本番 analytics 収集 |
| PR / feature | https://smalruby.jp/smalruby3-editor/{branch}/ | 空（無効） | テストのみ。GA4 汚染防止 |

## Implementation Notes

### GTM インフラストラクチャ（既存）

以下のファイルで GTM サポートは既に実装済み：
- `packages/scratch-gui/src/playground/index.ejs` - GTM スクリプトタグ
- `packages/scratch-gui/webpack.config.js` - GTM 設定
- `packages/scratch-gui/src/lib/analytics.js` - Analytics 抽象化レイヤー

今回の変更は**設定のみ**で、コード変更は不要でした。

### PWA とオフライン対応

Service Worker (Workbox) が自動的にオフラインモードを処理：
- オンライン: GTM スクリプトが正常に読み込まれる
- オフライン: Service Worker がリクエストをインターセプト、失敗を抑制、キャッシュコンテンツを提供
- 追加のエラーハンドリングは不要（Scratch の実装を継承）

## Manual Steps Required

### GitHub Secrets の設定

リポジトリに以下の Secret を追加する必要があります：

1. **Settings → Secrets and variables → Actions → New repository secret**
2. **GTM_ID を追加**:
   - Name: `GTM_ID`
   - Value: `GTM-KKFVD5ZC`

**Note**: GTM_ENV_AUTH は本番環境では空文字列を使用するため設定不要です。

### 既存の Secret

- ✅ `SMALRUBY_APP_DEPLOY_KEY` - 既に設定済み

## Test Plan

### ✅ Before Merge

- [x] ローカルビルドが成功することを確認
- [x] Linting が通ることを確認
- [x] CI/CD ワークフローの構文が正しいことを確認

### ⏳ After Merge (develop)

- [ ] CI/CD パイプラインが成功することを確認
- [ ] https://smalruby.app へのデプロイが成功することを確認
- [ ] GTM スクリプトが正常に読み込まれることを確認（DevTools → Network）
- [ ] dataLayer が存在することを確認（Console で `dataLayer` を実行）
- [ ] Google Tag Manager で analytics イベントが記録されることを確認

### ⏳ Verify GA4 Pollution Prevention

- [ ] PR ビルドで GTM が無効化されることを確認
- [ ] ブランチプレビューで GTM が無効化されることを確認

## Related Issues

Closes #42

## Documentation

詳細な検証手順と設定方法は Issue #42 を参照してください。

---

🤖 Generated with [Claude Code](https://claude.ai/code)
