### PR TITLE
feat: add contenthash to production build and remove unused HTML files

### DIFF
--- a/packages/scratch-gui/test/integration/blocks-standalone.test.js
+++ b/packages/scratch-gui/test/integration/blocks-standalone.test.js
@@ -25,7 +25,8 @@ let driver;
 
 // A test suite cloned from `blocks.test.js` which acts as a way to check that the
 // standalone way of initialization is working
-describe('Working with the blocks', () => {
+// NOTE: Skipped in Smalruby as standalone.html is not built (not used in Smalruby)
+describe.skip('Working with the blocks', () => {
     beforeAll(() => {
         driver = getDriver();
     });

--- a/packages/scratch-gui/test/integration/blocks.test.js
+++ b/packages/scratch-gui/test/integration/blocks.test.js
@@ -275,7 +275,8 @@ describe('Working with the blocks', () => {
     });
 
     // Regression test for switching between editor/player causing toolbox to stop updating
-    test('"See inside" after being on project page re-initializing variables', async () => {
+    // NOTE: Skipped in Smalruby as player.html is not built (not used in Smalruby)
+    test.skip('"See inside" after being on project page re-initializing variables', async () => {
         const playerUri = path.resolve(__dirname, '../../build/player.html');
         await loadUri(playerUri);
         await clickText('See inside');

--- a/packages/scratch-gui/webpack.config.js
+++ b/packages/scratch-gui/webpack.config.js
@@ -195,11 +195,12 @@ const buildConfig = baseConfig.clone()
     .enableDevServer(process.env.PORT || 8601)
     .merge({
         entry: {
-            gui: './src/playground/index.jsx',
-            guistandalone: './src/playground/standalone.jsx',
-            blocksonly: './src/playground/blocks-only.jsx',
-            compatibilitytesting: './src/playground/compatibility-testing.jsx',
-            player: './src/playground/player.jsx'
+            gui: './src/playground/index.jsx'
+            // Removed unused entry points to reduce build time:
+            // guistandalone: './src/playground/standalone.jsx',
+            // blocksonly: './src/playground/blocks-only.jsx',
+            // compatibilitytesting: './src/playground/compatibility-testing.jsx',
+            // player: './src/playground/player.jsx'
         },
         output: {
             path: path.resolve(__dirname, 'build'),
@@ -219,42 +220,43 @@ const buildConfig = baseConfig.clone()
         originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
         pwa: process.env.NODE_ENV === 'production'
     }))
-    .addPlugin(new HtmlWebpackPlugin({
-        ...commonHtmlWebpackPluginOptions,
-        chunks: ['guistandalone'],
-        filename: 'standalone.html',
-        template: 'src/playground/index.ejs',
-        title: 'Smalruby: Standalone Mode',
-        originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
-        pwa: process.env.NODE_ENV === 'production'
-    }))
-    .addPlugin(new HtmlWebpackPlugin({
-        ...commonHtmlWebpackPluginOptions,
-        chunks: ['blocksonly'],
-        filename: 'blocks-only.html',
-        template: 'src/playground/index.ejs',
-        title: 'Smalruby: Blocks Only Example',
-        originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
-        pwa: process.env.NODE_ENV === 'production'
-    }))
-    .addPlugin(new HtmlWebpackPlugin({
-        ...commonHtmlWebpackPluginOptions,
-        chunks: ['compatibilitytesting'],
-        filename: 'compatibility-testing.html',
-        template: 'src/playground/index.ejs',
-        title: 'Smalruby: Compatibility Testing',
-        originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
-        pwa: process.env.NODE_ENV === 'production'
-    }))
-    .addPlugin(new HtmlWebpackPlugin({
-        ...commonHtmlWebpackPluginOptions,
-        chunks: ['player'],
-        filename: 'player.html',
-        template: 'src/playground/index.ejs',
-        title: 'Smalruby: Player Example',
-        originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
-        pwa: process.env.NODE_ENV === 'production'
-    }))
+    // Removed unused HTML files to reduce build time:
+    // .addPlugin(new HtmlWebpackPlugin({
+    //     ...commonHtmlWebpackPluginOptions,
+    //     chunks: ['guistandalone'],
+    //     filename: 'standalone.html',
+    //     template: 'src/playground/index.ejs',
+    //     title: 'Smalruby: Standalone Mode',
+    //     originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
+    //     pwa: process.env.NODE_ENV === 'production'
+    // }))
+    // .addPlugin(new HtmlWebpackPlugin({
+    //     ...commonHtmlWebpackPluginOptions,
+    //     chunks: ['blocksonly'],
+    //     filename: 'blocks-only.html',
+    //     template: 'src/playground/index.ejs',
+    //     title: 'Smalruby: Blocks Only Example',
+    //     originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
+    //     pwa: process.env.NODE_ENV === 'production'
+    // }))
+    // .addPlugin(new HtmlWebpackPlugin({
+    //     ...commonHtmlWebpackPluginOptions,
+    //     chunks: ['compatibilitytesting'],
+    //     filename: 'compatibility-testing.html',
+    //     template: 'src/playground/index.ejs',
+    //     title: 'Smalruby: Compatibility Testing',
+    //     originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
+    //     pwa: process.env.NODE_ENV === 'production'
+    // }))
+    // .addPlugin(new HtmlWebpackPlugin({
+    //     ...commonHtmlWebpackPluginOptions,
+    //     chunks: ['player'],
+    //     filename: 'player.html',
+    //     template: 'src/playground/index.ejs',
+    //     title: 'Smalruby: Player Example',
+    //     originTrials: JSON.parse(fs.readFileSync('origin-trials.json')),
+    //     pwa: process.env.NODE_ENV === 'production'
+    // }))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [
             {
@@ -279,7 +281,9 @@ const buildWithPwaConfig = buildConfig.clone()
             exclude: [
                 /\.DS_Store/
             ],
-            maximumFileSizeToCacheInBytes: 64 * 1024 * 1024
+            maximumFileSizeToCacheInBytes: 64 * 1024 * 1024,
+            // Don't add revision to files that already have hash in filename
+            dontCacheBustURLsMatching: /\.[0-9a-f]{8,}\./
         })
     )
     .addPlugin(
@@ -310,6 +314,7 @@ const distWithHtmlConfig = buildConfig.clone()
     .merge({
         devtool: false, // Disable source maps for production
         output: {
+            filename: '[name].[contenthash].js', // Add contenthash for cache busting
             path: path.resolve(__dirname, 'dist'),
             clean: false
         },
@@ -331,7 +336,9 @@ const distWithHtmlConfig = buildConfig.clone()
             exclude: [
                 /\.DS_Store/
             ],
-            maximumFileSizeToCacheInBytes: 64 * 1024 * 1024
+            maximumFileSizeToCacheInBytes: 64 * 1024 * 1024,
+            // Don't add revision to files that already have hash in filename
+            dontCacheBustURLsMatching: /\.[0-9a-f]{8,}\./
         })
     )
     .addPlugin(


### PR DESCRIPTION
## Summary

PWA のキャッシュ更新問題を解決するため、Production ビルドで contenthash を使用するように変更しました。また、使用していない HTML ファイルのビルドを停止しました。

## Changes Made

### 1. Production ビルドに contenthash を追加

- `distWithHtmlConfig` の output に `filename: '[name].[contenthash].js'` を追加
- ファイル内容が変わると URL も変わるため、ブラウザキャッシュが自動的に無効化されます
- Development ビルドは `gui.js` のまま（デバッグしやすくするため）

### 2. Workbox の設定改善

- `dontCacheBustURLsMatching: /\.[0-9a-f]{8,}\./` を追加
- ハッシュ付きファイルには workbox の revision を追加しないようにしました

### 3. 不要なファイルのビルド停止

以下のファイルをビルドしないように変更（スモウルビーでは使用していないため）:
- `standalone.html` / `guistandalone.js`
- `blocks-only.html` / `blocksonly.js`
- `compatibility-testing.html` / `compatibilitytesting.js`
- `player.html` / `player.js`

### 4. テストの修正

削除したファイルに依存する Integration テストをスキップするように変更:
- `test/integration/blocks-standalone.test.js` - 全体をスキップ
- `test/integration/blocks.test.js` - player.html を使うテストをスキップ

## Test Coverage

### ✅ Unit Tests
- Test Suites: 73 passed
- Tests: 713 passed, 1 skipped

### ✅ Lint
- 0 errors, 351 warnings (既存の warnings)

### ✅ Integration Tests
- Test Suites: 39 passed, 6 skipped
- Tests: 147 passed, 29 skipped
- 削除したファイルに依存するテストは正常にスキップ
- `extension_koshien.test.js` の失敗は環境的な問題（今回の変更とは無関係）

## Build Verification

### Development Build
```bash
npm run build:dev
```
✅ `gui.js` (ハッシュなし) が生成されることを確認

### Production Build
```bash
npm run build
```
✅ `gui.4cb1b9e0005e6321e029.js` (ハッシュあり) が生成されることを確認
✅ `index.html` に正しい script タグが挿入されることを確認
✅ 不要なファイルが生成されないことを確認

## Related Issues

Closes #47

## Deployment Notes

この変更をデプロイすると:
1. 新しいバージョンでは `gui.[contenthash].js` のようなファイル名になります
2. ユーザーは自動的に最新版のファイルを取得できます
3. Service Worker のキャッシュも自動的に更新されます

## Upstream Compatibility

不要なファイルはコメントアウトのみで削除していないため、upstream の変更を
取り込みやすくしています。

🤖 Generated with [Claude Code](https://claude.ai/code)
