### PR TITLE
fix: ensure smalrubot_s1 disconnect cleanup and state transition on errors

### DIFF
--- a/packages/scratch-vm/src/extensions/scratch3_smalrubot_s1/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_smalrubot_s1/index.js
@@ -206,55 +206,90 @@ class Smalrubot {
 
     disconnect () {
         debug(() => 'Smalrubot.disconnect');
+        log.info('[Disconnect] Starting disconnect sequence');
 
         if (this.connectionState === 'disconnected') {
             debug(() => 'Already disconnected.');
+            log.info('[Disconnect] Already in disconnected state, skipping');
             return Promise.resolve();
         }
 
         if (!this.serialPort) {
             debug(() => 'Already disconnected.');
+            log.info('[Disconnect] No serial port, setting state to disconnected');
             this.setConnectionState('disconnected');
             return Promise.resolve();
         }
 
+        log.info('[Disconnect] Stopping all operations before cleanup');
         return this.stopAll()
-            .catch(error => log.error(error))
+            .catch(error => {
+                log.warn('[Disconnect] Error during stopAll (expected during physical disconnect):', error);
+            })
             .then(() => {
+                log.info('[Disconnect] Starting resource cleanup');
                 let promise = Promise.resolve();
+
                 if (this.reader) {
+                    log.info('[Disconnect] Canceling reader');
                     promise = promise
                         .then(() => this.reader.cancel())
                         .then(() => {
+                            log.info('[Disconnect] Reader canceled successfully');
                             this.reader = null;
                         })
-                        .catch(error => log.error(error));
+                        .catch(error => {
+                            log.warn('[Disconnect] Error canceling reader (may already be closed):', error);
+                            this.reader = null;
+                        });
                 }
 
                 if (this.writer) {
+                    log.info('[Disconnect] Closing writer');
                     promise = promise
                         .then(() => this.writer.close())
                         .then(() => {
+                            log.info('[Disconnect] Writer closed successfully');
                             this.writer = null;
                             this.writing = false;
                             this.writeQueue = [];
                         })
-                        .catch(error => log.error(error));
+                        .catch(error => {
+                            log.warn('[Disconnect] Error closing writer (may be in ERRORED state):', error);
+                            this.writer = null;
+                            this.writing = false;
+                            this.writeQueue = [];
+                        });
                 }
 
+                log.info('[Disconnect] Closing serial port');
                 promise = promise
                     .then(() => this.serialPort.close())
                     .then(() => {
+                        log.info('[Disconnect] Serial port closed successfully');
                         this.serialPort = null;
-
-                        this.setConnectionState('disconnected');
+                    })
+                    .catch(error => {
+                        // Port may already be closed due to physical disconnection
+                        // This is expected behavior and should not prevent state transition
+                        log.warn('[Disconnect] Error closing serial port (may already be closed):', error);
+                        this.serialPort = null;
                     });
 
                 return promise;
             })
+            .then(() => {
+                // CRITICAL: Always transition to disconnected state, even if errors occurred
+                // This ensures the GUI reflects the actual state and allows reconnection
+                log.info('[Disconnect] Setting connection state to disconnected');
+                this.setConnectionState('disconnected');
+                log.info('[Disconnect] Disconnect sequence completed successfully');
+            })
             .catch(error => {
-                log.error(error);
-                throw error;
+                // Log any unexpected errors but still ensure state transition
+                log.error('[Disconnect] Unexpected error during disconnect:', error);
+                log.info('[Disconnect] Ensuring state transition despite errors');
+                this.setConnectionState('disconnected');
             });
     }
 
@@ -376,26 +411,36 @@ class Smalrubot {
         const prevConnectionState = this.connectionState;
 
         debug(() => `Set connection state: from=<${prevConnectionState}> to=<${connectionState}>`);
+        log.info(`[SetConnectionState] Transitioning from '${prevConnectionState}' to '${connectionState}'`);
 
         this.connectionState = connectionState;
 
         switch (this.connectionState) {
         case 'scanned':
+            log.info('[SetConnectionState] Emitting PERIPHERAL_LIST_UPDATE event');
             this.emitRuntime('PERIPHERAL_LIST_UPDATE', {0: {peripheralId: 0}});
             break;
         case 'connected':
+            log.info('[SetConnectionState] Emitting PERIPHERAL_CONNECTED event');
             this.emitRuntime('PERIPHERAL_CONNECTED');
             break;
         case 'disconnected':
             if (prevConnectionState === 'connecting') {
+                log.info('[SetConnectionState] Connection failed during connect phase, ' +
+                    'emitting PERIPHERAL_REQUEST_ERROR');
                 this.emitRuntime('PERIPHERAL_REQUEST_ERROR', {
                     extensionId: Scratch3SmalrubotS1Blocks.EXTENSION_ID // eslint-disable-line
                 });
             } else if (prevConnectionState !== 'disconnecting' && prevConnectionState !== 'disconnected') {
+                log.info('[SetConnectionState] Unexpected disconnection detected, ' +
+                    'emitting PERIPHERAL_CONNECTION_LOST_ERROR');
                 this.emitRuntime('PERIPHERAL_CONNECTION_LOST_ERROR', {
                     extensionId: Scratch3SmalrubotS1Blocks.EXTENSION_ID // eslint-disable-line
                 });
+            } else {
+                log.info('[SetConnectionState] Normal disconnection, no error events emitted');
             }
+            log.info('[SetConnectionState] Emitting PERIPHERAL_DISCONNECTED event');
             this.emitRuntime('PERIPHERAL_DISCONNECTED');
             break;
         }
@@ -554,7 +599,8 @@ class SmalrubotS1 extends Smalrubot {
                 return updateSensorValuesLoop();
             })
             .catch(error => {
-                log.error(`Error reading from Smalrubot: reason=<${error}>`);
+                log.error(`[UpdateSensorValues] Error reading from Smalrubot: ${error.name}: ${error.message}`);
+                log.info('[UpdateSensorValues] Physical disconnection detected, initiating disconnect cleanup');
 
                 this.disconnect();
             });

--- a/packages/scratch-vm/test/unit/extension_smalrubot_s1.js
+++ b/packages/scratch-vm/test/unit/extension_smalrubot_s1.js
@@ -1,0 +1,201 @@
+const test = require('tap').test;
+const minilog = require('minilog');
+// Suppress debug and info logs during tests
+minilog.suggest.deny('vm', 'debug');
+minilog.suggest.deny('vm', 'info');
+
+const SmalrubotS1Blocks = require('../../src/extensions/scratch3_smalrubot_s1/index.js');
+
+/**
+ * Create a mock runtime for testing
+ * @returns {object} Mock runtime
+ */
+const createMockRuntime = () => {
+    const runtime = {
+        registerPeripheralExtension: () => {},
+        on: () => {},
+        emit: (event, data) => {
+            runtime.lastEmittedEvent = event;
+            runtime.lastEmittedData = data;
+        },
+        constructor: {
+            PERIPHERAL_LIST_UPDATE: 'PERIPHERAL_LIST_UPDATE',
+            PERIPHERAL_CONNECTED: 'PERIPHERAL_CONNECTED',
+            PERIPHERAL_DISCONNECTED: 'PERIPHERAL_DISCONNECTED',
+            PERIPHERAL_CONNECTION_LOST_ERROR: 'PERIPHERAL_CONNECTION_LOST_ERROR',
+            PERIPHERAL_REQUEST_ERROR: 'PERIPHERAL_REQUEST_ERROR'
+        }
+    };
+    return runtime;
+};
+
+/**
+ * Create a mock serial port with configurable behavior
+ * @param {object} options - Configuration options
+ * @param {boolean} options.closeThrows - Whether close() should throw an error
+ * @returns {object} Mock serial port
+ */
+const createMockSerialPort = ({closeThrows = false} = {}) => {
+    const mockReader = {
+        cancel: () => Promise.resolve(),
+        read: () => new Promise(() => {}) // Never resolves
+    };
+
+    const mockWriter = {
+        close: () => Promise.resolve(),
+        write: () => Promise.resolve()
+    };
+
+    const mockPort = {
+        open: () => Promise.resolve(),
+        close: () => {
+            if (closeThrows) {
+                return Promise.reject(new Error('InvalidStateError: The port is already closed'));
+            }
+            return Promise.resolve();
+        },
+        readable: {
+            getReader: () => mockReader
+        },
+        writable: {
+            getWriter: () => mockWriter
+        }
+    };
+
+    return mockPort;
+};
+
+test('Smalrubot S1 Blocks', t => {
+    // Mock Web Serial API
+    global.navigator = {
+        serial: {
+            requestPort: () => Promise.resolve(createMockSerialPort())
+        }
+    };
+
+    t.test('constructor', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new SmalrubotS1Blocks(mockRuntime);
+        st.type(blocks, SmalrubotS1Blocks);
+        st.ok(blocks.smalrubot);
+        st.end();
+    });
+
+    t.test('getInfo', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new SmalrubotS1Blocks(mockRuntime);
+        const info = blocks.getInfo();
+        st.equal(info.id, 'smalrubotS1');
+        st.equal(info.name, 'Smalrubot S1');
+        st.ok(info.blocks.length > 0);
+        st.equal(info.showStatusButton, true);
+        st.end();
+    });
+
+    t.test('disconnect handles errors gracefully', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new SmalrubotS1Blocks(mockRuntime);
+        const smalrubot = blocks.smalrubot;
+
+        // Set up smalrubot in a connected state with a port that throws on close
+        smalrubot.serialPort = createMockSerialPort({closeThrows: true});
+        smalrubot.reader = {
+            cancel: () => Promise.reject(new Error('Reader already canceled'))
+        };
+        smalrubot.writer = {
+            close: () => Promise.reject(new Error('Cannot close a ERRORED writable stream'))
+        };
+        smalrubot.connectionState = 'connected';
+
+        // Perform disconnect
+        return smalrubot.disconnect()
+            .then(() => {
+                // Verify state transitioned to disconnected despite errors
+                st.equal(smalrubot.connectionState, 'disconnected',
+                    'should transition to disconnected state even when errors occur');
+
+                // Verify resources are cleaned up
+                st.equal(smalrubot.serialPort, null,
+                    'should set serialPort to null');
+                st.equal(smalrubot.reader, null,
+                    'should set reader to null');
+                st.equal(smalrubot.writer, null,
+                    'should set writer to null');
+
+                // Verify PERIPHERAL_DISCONNECTED event was emitted
+                st.equal(mockRuntime.lastEmittedEvent, 'PERIPHERAL_DISCONNECTED',
+                    'should emit PERIPHERAL_DISCONNECTED event');
+
+                st.end();
+            })
+            .catch(err => {
+                st.fail(`disconnect should not throw errors: ${err.message}`);
+                st.end();
+            });
+    });
+
+    t.test('disconnect from already disconnected state', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new SmalrubotS1Blocks(mockRuntime);
+        const smalrubot = blocks.smalrubot;
+
+        // Already in disconnected state
+        smalrubot.connectionState = 'disconnected';
+
+        return smalrubot.disconnect()
+            .then(() => {
+                st.equal(smalrubot.connectionState, 'disconnected',
+                    'should remain in disconnected state');
+                st.end();
+            });
+    });
+
+    t.test('disconnect without serial port', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new SmalrubotS1Blocks(mockRuntime);
+        const smalrubot = blocks.smalrubot;
+
+        // Set connected state but no serial port (edge case)
+        smalrubot.connectionState = 'connected';
+        smalrubot.serialPort = null;
+
+        return smalrubot.disconnect()
+            .then(() => {
+                st.equal(smalrubot.connectionState, 'disconnected',
+                    'should transition to disconnected state');
+                st.end();
+            });
+    });
+
+    t.test('disconnect cleans up all resources', st => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new SmalrubotS1Blocks(mockRuntime);
+        const smalrubot = blocks.smalrubot;
+
+        // Set up smalrubot in a connected state
+        smalrubot.serialPort = createMockSerialPort();
+        smalrubot.reader = {
+            cancel: () => Promise.resolve()
+        };
+        smalrubot.writer = {
+            close: () => Promise.resolve()
+        };
+        smalrubot.writing = true;
+        smalrubot.writeQueue = ['data1', 'data2'];
+        smalrubot.connectionState = 'connected';
+
+        return smalrubot.disconnect()
+            .then(() => {
+                st.equal(smalrubot.serialPort, null, 'should clear serialPort');
+                st.equal(smalrubot.reader, null, 'should clear reader');
+                st.equal(smalrubot.writer, null, 'should clear writer');
+                st.equal(smalrubot.writing, false, 'should reset writing flag');
+                st.same(smalrubot.writeQueue, [], 'should clear writeQueue');
+                st.equal(smalrubot.connectionState, 'disconnected',
+                    'should transition to disconnected state');
+                st.end();
+            });
+    });
+
+    t.end();
+});


### PR DESCRIPTION
## Summary

Fixes critical bug in Smalrubot S1 extension where physical device disconnection during active communication prevented proper cleanup and state transition, requiring page reload to reconnect.

## Problem

When the Smalrubot S1 device is physically disconnected (USB cable unplugged) during active communication:
- ❌ Extension fails to transition to `disconnected` state
- ❌ GUI remains in "connected" state
- ❌ Resources (reader, writer, serialPort) not cleaned up
- ❌ Reconnection impossible without page reload
- ❌ Uncaught exceptions in console

## Root Cause

The `disconnect()` method had insufficient error handling. When `serialPort.close()` threw an `InvalidStateError` (port already closed due to physical disconnection), the error propagated uncaught, preventing `setConnectionState('disconnected')` from executing.

## Solution

### 1. Robust Disconnect Error Handling

- ✅ Wrapped all cleanup operations with proper `.catch()` handlers
- ✅ Ensured `setConnectionState('disconnected')` always executes
- ✅ Changed from throwing errors to logging them
- ✅ Added fallback state transition for unexpected errors

### 2. Comprehensive Debug Logging

Added detailed logging throughout disconnect sequence for integration testing:
- `[Disconnect]` prefix for all disconnect-related logs
- `[UpdateSensorValues]` for error detection
- `[SetConnectionState]` for state transitions and event emissions

### 3. Unit Tests

Created `test/unit/extension_smalrubot_s1.js` with test coverage for:
- Constructor and getInfo
- Disconnect error handling with mock serial port
- State transition despite errors
- Resource cleanup verification
- Edge cases (already disconnected, no serial port)

**Test Results:** ✅ 19/19 tests passed

## Changes Made

### Modified Files

- `packages/scratch-vm/src/extensions/scratch3_smalrubot_s1/index.js`:
  - Enhanced `disconnect()` method with robust error handling (lines 207-285)
  - Added logging to `updateSensorValues()` error handler (lines 556-560)
  - Added logging to `setConnectionState()` for debugging (lines 375-445)

### New Files

- `packages/scratch-vm/test/unit/extension_smalrubot_s1.js`:
  - Basic extension tests (constructor, getInfo)
  - Disconnect error handling tests
  - Resource cleanup tests

## Investigation Notes

**VirtualMachine Event Propagation:**
Confirmed that VirtualMachine already correctly passes through event data for `PERIPHERAL_*` events (fixed in commit ab9e415 for meshV2). No changes needed for error event propagation to GUI.

## Testing

### Unit Tests

\`\`\`bash
docker compose run --rm app bash -c "cd packages/scratch-vm && npx tap test/unit/extension_smalrubot_s1.js"
# Result: 19/19 tests passed ✅
\`\`\`

### Integration Testing Required

⚠️ **User to perform integration testing:**
1. Connect Smalrubot S1 device
2. Start communication (observe sensor values updating)
3. Physically unplug USB cable during active communication
4. Verify:
   - Console shows detailed `[Disconnect]` logs
   - GUI transitions to disconnected state
   - No uncaught exceptions
   - Can reconnect after plugging device back in

**Expected Log Sequence:**
\`\`\`
[UpdateSensorValues] Error reading from Smalrubot: NetworkError: The device has been lost.
[UpdateSensorValues] Physical disconnection detected, initiating disconnect cleanup
[Disconnect] Starting disconnect sequence
[Disconnect] Stopping all operations before cleanup
[Disconnect] Starting resource cleanup
[Disconnect] Canceling reader
[Disconnect] Reader canceled successfully (or warning if already closed)
[Disconnect] Closing writer
[Disconnect] Writer closed successfully (or warning if in ERRORED state)
[Disconnect] Closing serial port
[Disconnect] Serial port closed successfully (or warning if already closed)
[Disconnect] Setting connection state to disconnected
[SetConnectionState] Transitioning from 'connected' to 'disconnected'
[SetConnectionState] Unexpected disconnection detected, emitting PERIPHERAL_CONNECTION_LOST_ERROR
[SetConnectionState] Emitting PERIPHERAL_DISCONNECTED event
[Disconnect] Disconnect sequence completed successfully
\`\`\`

## Regression Testing

✅ All existing unit tests pass:
\`\`\`bash
docker compose run --rm app bash -c "cd packages/scratch-vm && npm run test:unit"
# Result: 74/74 test files passed
\`\`\`

✅ Linting passes:
\`\`\`bash
docker compose run --rm app bash -c "cd packages/scratch-vm && npx eslint src/extensions/scratch3_smalrubot_s1/index.js"
# Result: 0 errors, 2 pre-existing warnings
\`\`\`

## Related Issues

- Fixes #50
- Related to commit ab9e415 (meshV2 error propagation fix)

## Checklist

- ✅ Code follows project conventions
- ✅ ESLint passes (0 new errors)
- ✅ Unit tests added and passing (19/19)
- ✅ Existing tests pass (74/74 test files)
- ✅ Detailed logging added for debugging
- ✅ Commit message follows conventional commits
- ✅ References Issue #50
- ⏳ Integration testing pending (user to perform)

## Future Work

After integration testing confirms the fix:
- Consider reducing log verbosity (remove detailed debug logs)
- Document error handling best practices for Serial-based extensions
- Apply similar pattern to other Serial-based extensions if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
