### PR TITLE
chore: add /notes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ built-monorepo
 
 # Claude Code local settings
 .claude/settings.local.json
+
+/notes


### PR DESCRIPTION
## Summary

- Add `/notes` to `.gitignore` to exclude local notes directory from version control

## Changes Made

- `.gitignore`: Added `/notes` entry

## Test Plan

- No functional changes; verify `.gitignore` is correct after merge
