### PR TITLE
feat(vm): add mesh v1 to v2 migration support

### DIFF
--- a/packages/scratch-vm/src/serialization/mesh-migration.js
+++ b/packages/scratch-vm/src/serialization/mesh-migration.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview
+ * Utilities for migrating projects from the legacy mesh extension to meshV2.
+ */
+
+/**
+ * Detect if the project contains any legacy mesh blocks.
+ * @param {object} projectJSON The project JSON to check.
+ * @returns {boolean} True if legacy mesh blocks are found.
+ */
+const detectMeshV1Blocks = projectJSON => {
+    if (!projectJSON.targets) return false;
+    for (const target of projectJSON.targets) {
+        for (const blockId in target.blocks) {
+            const block = target.blocks[blockId];
+            if (block.opcode && block.opcode.startsWith('mesh_')) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
+
+/**
+ * Migrate the project JSON from legacy mesh to meshV2.
+ * @param {object} projectJSON The project JSON to migrate.
+ * @returns {object} The migrated project JSON.
+ */
+const migrateMeshV1Blocks = projectJSON => {
+    const newProjectJSON = JSON.parse(JSON.stringify(projectJSON));
+
+    // Update extensions
+    if (Array.isArray(newProjectJSON.extensions)) {
+        newProjectJSON.extensions = newProjectJSON.extensions.map(ext => (ext === 'mesh' ? 'meshV2' : ext));
+        if (newProjectJSON.extensions.indexOf('meshV2') === -1) {
+            newProjectJSON.extensions.push('meshV2');
+        }
+    } else {
+        newProjectJSON.extensions = ['meshV2'];
+    }
+
+    // Update opcodes
+    for (const target of newProjectJSON.targets) {
+        for (const blockId in target.blocks) {
+            const block = target.blocks[blockId];
+            if (block.opcode && block.opcode.startsWith('mesh_')) {
+                block.opcode = block.opcode.replace('mesh_', 'meshV2_');
+            }
+        }
+    }
+
+    return newProjectJSON;
+};
+
+module.exports = {
+    detectMeshV1Blocks,
+    migrateMeshV1Blocks
+};

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -18,6 +18,7 @@ const formatMessage = require('format-message');
 
 const Variable = require('./engine/variable');
 const newBlockIds = require('./util/new-block-ids');
+const {detectMeshV1Blocks, migrateMeshV1Blocks} = require('./serialization/mesh-migration');
 
 const {loadCostume} = require('./import/load-costume.js');
 const {loadSound} = require('./import/load-sound.js');
@@ -311,9 +312,10 @@ class VirtualMachine extends EventEmitter {
     /**
      * Load a Scratch project from a .sb, .sb2, .sb3 or json string.
      * @param {string | object} input A json string, object, or ArrayBuffer representing the project to load.
+     * @param {object} options Optional configuration for loading the project.
      * @returns {!Promise} Promise that resolves after targets are installed.
      */
-    loadProject (input) {
+    loadProject (input, options = {}) {
         if (typeof input === 'object' && !(input instanceof ArrayBuffer) &&
           !ArrayBuffer.isView(input)) {
             // If the input is an object and not any ArrayBuffer
@@ -358,12 +360,54 @@ class VirtualMachine extends EventEmitter {
             });
 
         return validationPromise
-            .then(validatedInput => this.deserializeProject(validatedInput[0], validatedInput[1]))
+            .then(validatedInput => {
+                // smalruby: mesh V1 to V2 migration
+                let projectJSON = validatedInput[0];
+                if (options.migrateMeshV1ToV2) {
+                    projectJSON = migrateMeshV1Blocks(projectJSON);
+                }
+                return this.deserializeProject(projectJSON, validatedInput[1]);
+            })
             .then(() => this.runtime.handleProjectLoaded())
             .catch(error => {
                 // Intentionally rejecting here (want errors to be handled by caller)
                 if (Object.prototype.hasOwnProperty.call(error, 'validationError')) {
                     return Promise.reject(JSON.stringify(error));
+                }
+                return Promise.reject(error);
+            });
+    }
+
+    /**
+     * Check if a project contains any legacy mesh blocks.
+     * @param {string | object} input A json string, object, or ArrayBuffer representing the project to check.
+     * @returns {Promise<boolean>} Promise that resolves to true if legacy mesh blocks are found.
+     */
+    hasMeshV1Project (input) {
+        if (typeof input === 'object' && !(input instanceof ArrayBuffer) &&
+          !ArrayBuffer.isView(input)) {
+            input = JSON.stringify(input);
+        }
+
+        return new Promise((resolve, reject) => {
+            const validate = require('scratch-parser');
+            validate(input, false, (error, res) => {
+                if (error) return reject(error);
+                resolve(detectMeshV1Blocks(res[0]));
+            });
+        })
+            .catch(error => {
+                const {SB1File, ValidationError} = require('scratch-sb1-converter');
+
+                try {
+                    const sb1 = new SB1File(input);
+                    return Promise.resolve(detectMeshV1Blocks(sb1.json));
+                } catch (sb1Error) {
+                    if (sb1Error instanceof ValidationError) {
+                        // The input does not validate as a Scratch 1 file.
+                    } else {
+                        return Promise.reject(sb1Error);
+                    }
                 }
                 return Promise.reject(error);
             });

--- a/packages/scratch-vm/test/fixtures/mesh_v1_project.json
+++ b/packages/scratch-vm/test/fixtures/mesh_v1_project.json
@@ -1,0 +1,39 @@
+{
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "blocks": {
+        "block1": {
+          "opcode": "mesh_sendBroadcast",
+          "next": null,
+          "parent": null,
+          "inputs": {},
+          "fields": {},
+          "shadow": false,
+          "topLevel": true
+        }
+      },
+      "comments": {},
+      "currentCostume": 0,
+      "costumes": [],
+      "sounds": [],
+      "volume": 100,
+      "layerOrder": 0,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null
+    }
+  ],
+  "monitors": [],
+  "extensions": ["mesh"],
+  "meta": {
+    "semver": "3.0.0",
+    "vm": "0.2.0",
+    "agent": "Smalruby"
+  }
+}

--- a/packages/scratch-vm/test/fixtures/mesh_v1_project.json
+++ b/packages/scratch-vm/test/fixtures/mesh_v1_project.json
@@ -1,4 +1,5 @@
 {
+  "objName": "Stage",
   "targets": [
     {
       "isStage": true,
@@ -19,7 +20,16 @@
       },
       "comments": {},
       "currentCostume": 0,
-      "costumes": [],
+      "costumes": [
+        {
+          "assetId": "cd21514d0531fdffb22204e0ec5ed84a",
+          "name": "backdrop1",
+          "md5ext": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+          "dataFormat": "svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
       "sounds": [],
       "volume": 100,
       "layerOrder": 0,

--- a/packages/scratch-vm/test/fixtures/mesh_v2_project.json
+++ b/packages/scratch-vm/test/fixtures/mesh_v2_project.json
@@ -1,4 +1,5 @@
 {
+  "objName": "Stage",
   "targets": [
     {
       "isStage": true,
@@ -19,7 +20,16 @@
       },
       "comments": {},
       "currentCostume": 0,
-      "costumes": [],
+      "costumes": [
+        {
+          "assetId": "cd21514d0531fdffb22204e0ec5ed84a",
+          "name": "backdrop1",
+          "md5ext": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+          "dataFormat": "svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
       "sounds": [],
       "volume": 100,
       "layerOrder": 0,

--- a/packages/scratch-vm/test/fixtures/mesh_v2_project.json
+++ b/packages/scratch-vm/test/fixtures/mesh_v2_project.json
@@ -1,0 +1,39 @@
+{
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "blocks": {
+        "block1": {
+          "opcode": "meshV2_sendBroadcast",
+          "next": null,
+          "parent": null,
+          "inputs": {},
+          "fields": {},
+          "shadow": false,
+          "topLevel": true
+        }
+      },
+      "comments": {},
+      "currentCostume": 0,
+      "costumes": [],
+      "sounds": [],
+      "volume": 100,
+      "layerOrder": 0,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null
+    }
+  ],
+  "monitors": [],
+  "extensions": ["meshV2"],
+  "meta": {
+    "semver": "3.0.0",
+    "vm": "0.2.0",
+    "agent": "Smalruby"
+  }
+}

--- a/packages/scratch-vm/test/integration/extensions/mesh-v1-migration.test.js
+++ b/packages/scratch-vm/test/integration/extensions/mesh-v1-migration.test.js
@@ -1,0 +1,45 @@
+const path = require('path');
+const test = require('tap').test;
+const readFileToBuffer = require('../../fixtures/readProjectFile').readFileToBuffer;
+const VirtualMachine = require('../../../src/index');
+
+test('mesh v1 to v2 migration integration', t => {
+    const vm = new VirtualMachine();
+    const project = readFileToBuffer(path.resolve(__dirname, '../../fixtures/mesh_v1_project.json'));
+
+    return vm.loadProject(project, {migrateMeshV1ToV2: true})
+        .then(() => {
+            const targets = vm.runtime.targets;
+            let foundMeshV2 = false;
+            targets.forEach(target => {
+                const blockIds = Object.keys(target.blocks._blocks);
+                blockIds.forEach(blockId => {
+                    const block = target.blocks._blocks[blockId];
+                    if (block.opcode && block.opcode.startsWith('mesh_')) {
+                        t.fail(`Found legacy mesh block: ${block.opcode}`);
+                    }
+                    if (block.opcode && block.opcode.startsWith('meshV2_')) {
+                        foundMeshV2 = true;
+                    }
+                });
+            });
+            t.ok(foundMeshV2, 'Found at least one meshV2 block after migration');
+            t.end();
+        });
+});
+
+test('hasMeshV1Project detection', t => {
+    const vm = new VirtualMachine();
+    const meshV1Project = readFileToBuffer(path.resolve(__dirname, '../../fixtures/mesh_v1_project.json'));
+    const meshV2Project = readFileToBuffer(path.resolve(__dirname, '../../fixtures/mesh_v2_project.json'));
+
+    return vm.hasMeshV1Project(meshV1Project)
+        .then(hasMeshV1 => {
+            t.equal(hasMeshV1, true, 'detects mesh v1 project');
+            return vm.hasMeshV1Project(meshV2Project);
+        })
+        .then(hasMeshV1 => {
+            t.equal(hasMeshV1, false, 'does not detect mesh v1 in v2 project');
+            t.end();
+        });
+});

--- a/packages/scratch-vm/test/unit/mesh_migration.js
+++ b/packages/scratch-vm/test/unit/mesh_migration.js
@@ -1,0 +1,40 @@
+const test = require('tap').test;
+const path = require('path');
+const fs = require('fs');
+const {detectMeshV1Blocks, migrateMeshV1Blocks} = require('../../src/serialization/mesh-migration');
+
+const meshV1Project = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../fixtures/mesh_v1_project.json'), 'utf8'));
+const meshV2Project = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../fixtures/mesh_v2_project.json'), 'utf8'));
+
+test('detectMeshV1Blocks', t => {
+    t.equal(detectMeshV1Blocks(meshV1Project), true, 'detects mesh v1 blocks');
+    t.equal(detectMeshV1Blocks(meshV2Project), false, 'does not detect mesh v1 blocks in v2 project');
+    t.equal(detectMeshV1Blocks({targets: []}), false, 'does not detect mesh v1 blocks in empty project');
+    t.end();
+});
+
+test('migrateMeshV1Blocks', t => {
+    const migrated = migrateMeshV1Blocks(meshV1Project);
+
+    t.not(migrated, meshV1Project, 'returns a new object');
+
+    // Check extensions
+    t.ok(migrated.extensions.includes('meshV2'), 'extensions includes meshV2');
+    t.notOk(migrated.extensions.includes('mesh'), 'extensions does not include mesh');
+
+    // Check opcodes
+    let foundMeshV2 = false;
+    migrated.targets.forEach(target => {
+        Object.values(target.blocks).forEach(block => {
+            if (typeof block.opcode === 'string') {
+                t.notOk(block.opcode.startsWith('mesh_'), `opcode ${block.opcode} should not start with mesh_`);
+                if (block.opcode.startsWith('meshV2_')) {
+                    foundMeshV2 = true;
+                }
+            }
+        });
+    });
+    t.ok(foundMeshV2, 'found at least one meshV2 block');
+
+    t.end();
+});


### PR DESCRIPTION
This PR adds support for migrating legacy mesh extension blocks (v1) to the new meshV2 extension. It includes utilities for detecting and migrating blocks, and updates the VirtualMachine to handle migration during project loading when requested.