### PR TITLE
refactor: improve meshV2 connection modal navigation

### DIFF
--- a/packages/scratch-gui/src/components/connection-modal/scanning-step.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/scanning-step.jsx
@@ -90,6 +90,20 @@ const ScanningStep = props => {
                 total={3}
             />
             <Box className={classNames(styles.bottomAreaItem, styles.buttonRow)}>
+                {/* === Smalruby: Start of back button for meshV2 === */}
+                {props.extensionId === 'meshV2' && props.onBack && (
+                    <button
+                        className={styles.connectionButton}
+                        onClick={props.onBack}
+                    >
+                        <FormattedMessage
+                            defaultMessage="Back"
+                            description="Button to go back to initial step"
+                            id="gui.connection.scanning.backButton"
+                        />
+                    </button>
+                )}
+                {/* === Smalruby: End of back button for meshV2 === */}
                 <button
                     className={styles.connectionButton}
                     onClick={props.onRefresh}
@@ -127,6 +141,8 @@ const ScanningStep = props => {
 
 ScanningStep.propTypes = {
     connectionSmallIconURL: PropTypes.string,
+    extensionId: PropTypes.string,
+    onBack: PropTypes.func,
     onConnecting: PropTypes.func,
     onRefresh: PropTypes.func,
     onUpdatePeripheral: PropTypes.func,

--- a/packages/scratch-gui/src/containers/connection-modal.jsx
+++ b/packages/scratch-gui/src/containers/connection-modal.jsx
@@ -35,7 +35,8 @@ class ConnectionModal extends React.Component {
             // === Smalruby: Start of meshV2 initial step feature ===
             'handleMeshV2CreateGroup',
             'handleMeshV2JoinGroup',
-            'handleMeshV2DomainChange'
+            'handleMeshV2DomainChange',
+            'handleBackToInitial'
             // === Smalruby: End of meshV2 initial step feature ===
         ]);
         // === Smalruby: Start of meshV2 initial step feature ===
@@ -227,6 +228,19 @@ class ConnectionModal extends React.Component {
             label: this.props.extensionId
         });
     }
+    // === Smalruby: Start of meshV2 back button feature ===
+    handleBackToInitial () {
+        // For meshV2, go back to initial step (mesh-v2-initial-step)
+        this.setState({
+            phase: PHASES.meshV2Initial
+        });
+        analytics.event({
+            category: 'extensions',
+            action: 'back to initial step',
+            label: this.props.extensionId
+        });
+    }
+    // === Smalruby: End of meshV2 back button feature ===
     // === Smalruby: End of meshV2 initial step feature ===
     render () {
         const canUpdatePeripheral = ((this.props.extensionId === 'microbit') && isMicroBitUpdateSupported()) ||
@@ -249,6 +263,9 @@ class ConnectionModal extends React.Component {
                 useAutoScan={this.state.extension && this.state.extension.useAutoScan}
                 useExternalPeripheralList={this.props.useExternalPeripheralList}
                 vm={this.props.vm}
+                // === Smalruby: Start of meshV2 back button feature ===
+                onBack={this.props.extensionId === 'meshV2' ? this.handleBackToInitial : null}
+                // === Smalruby: End of meshV2 back button feature ===
                 onCancel={this.handleCancel}
                 onConnected={this.handleConnected}
                 onConnecting={this.handleConnecting}

--- a/packages/scratch-gui/src/containers/scanning-step.jsx
+++ b/packages/scratch-gui/src/containers/scanning-step.jsx
@@ -73,10 +73,12 @@ class ScanningStep extends React.Component {
         return (
             <ScanningStepComponent
                 connectionSmallIconURL={this.props.connectionSmallIconURL}
+                extensionId={this.props.extensionId}
                 peripheralList={this.state.peripheralList}
                 phase={this.state.phase}
                 scanning={this.state.scanning}
                 title={this.props.extensionId}
+                onBack={this.props.onBack}
                 onConnected={this.props.onConnected}
                 onConnecting={this.props.onConnecting}
                 onRefresh={this.handleRefresh}
@@ -89,6 +91,7 @@ class ScanningStep extends React.Component {
 ScanningStep.propTypes = {
     connectionSmallIconURL: PropTypes.string,
     extensionId: PropTypes.string.isRequired,
+    onBack: PropTypes.func,
     onConnected: PropTypes.func.isRequired,
     onConnecting: PropTypes.func.isRequired,
     onUpdatePeripheral: PropTypes.func,

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -220,6 +220,7 @@ export default {
     'gui.modal.stop': 'Stop',
 
     // Network Filter Error messages
+    'gui.connection.scanning.backButton': 'Back',
     'gui.connection.networkFiltered.message': 'The new mesh feature is unavailable.{br}Please ask your network administrator to remove the restriction.',
     'gui.connection.networkFiltered.copied': 'Copied!',
     'gui.connection.networkFiltered.copyButton': 'Copy to clipboard',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -278,6 +278,7 @@ export default {
     'gui.connection.auto-scanning.updatePeripheralButton': 'アップデート',
     'gui.connection.error.updatePeripheralButton': 'アップデート',
     'gui.connection.unavailable.updatePeripheralButton': 'アップデート',
+    'gui.connection.scanning.backButton': 'もどる',
     'gui.connection.networkFiltered.message': 'あたらしいメッシュきのうがつかえません。{br}ネットワークかんりしゃにせいげんのかいじょをごいらいください。',
     'gui.connection.networkFiltered.copied': 'コピーしました！',
     'gui.connection.networkFiltered.copyButton': 'クリップボードにコピー',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -278,6 +278,7 @@ export default {
     'gui.connection.auto-scanning.updatePeripheralButton': 'アップデート',
     'gui.connection.error.updatePeripheralButton': 'アップデート',
     'gui.connection.unavailable.updatePeripheralButton': 'アップデート',
+    'gui.connection.scanning.backButton': '戻る',
     'gui.connection.networkFiltered.message': 'あたらしいメッシュ機能が使えません。{br}ネットワーク管理者に制限の解除をご依頼ください。',
     'gui.connection.networkFiltered.copied': 'コピーしました！',
     'gui.connection.networkFiltered.copyButton': 'クリップボードにコピー',

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
@@ -229,17 +229,6 @@ class Scratch3MeshV2Blocks {
                 domain: group.domain
             }));
 
-            // Add 'Become Host' option
-            peripherals.unshift({
-                peripheralId: MESH_V2_HOST_ID,
-                name: formatMessage({
-                    id: 'mesh.hostPeripheralName',
-                    default: 'Become Mesh Host [{ MESH_ID }]',
-                    description: 'label for becoming Host Mesh in connect modal for Mesh extension'
-                }, {MESH_ID: this.makeMeshIdLabel(this.nodeId)}),
-                rssi: 0
-            });
-
             this.runtime.emit(this.runtime.constructor.PERIPHERAL_LIST_UPDATE, peripherals);
         })
             /* istanbul ignore next */

--- a/packages/scratch-vm/test/unit/extension_mesh_v2.js
+++ b/packages/scratch-vm/test/unit/extension_mesh_v2.js
@@ -104,9 +104,8 @@ test('Mesh V2 Blocks', t => {
         // Since it's async, we need to wait
         setImmediate(() => {
             st.equal(mockRuntime.lastEmittedEvent, 'PERIPHERAL_LIST_UPDATE');
-            st.equal(mockRuntime.lastEmittedData.length, 2); // Host option + 1 valid group
-            st.equal(mockRuntime.lastEmittedData[0].peripheralId, 'meshV2_host');
-            st.equal(mockRuntime.lastEmittedData[1].peripheralId, 'group1');
+            st.equal(mockRuntime.lastEmittedData.length, 1); // 1 valid group (Host option removed)
+            st.equal(mockRuntime.lastEmittedData[0].peripheralId, 'group1');
             st.same(blocks.discoveredGroups, mockGroups);
             st.end();
         });


### PR DESCRIPTION
## 概要

meshV2 接続モーダルのナビゲーションを改善します：

1. **グループ一覧から「Become Host」項目を削除**
   - 初期画面で「ホストになる」機能を提供するため、一覧での重複表示を削除
2. **グループ一覧に「戻る」ボタンを追加**
   - 初期画面に戻れるようにし、ユーザーの選択をやり直せるようにする

## 主な変更点

### VM 側（scratch-vm）
- `scan()` メソッドから「Become Host」項目の追加コードを削除

### GUI 側（scratch-gui）
- `scanning-step.jsx`: 「戻る」ボタンを追加（meshV2 のみ表示）
- `containers/scanning-step.jsx`: onBack プロパティを渡す
- `containers/connection-modal.jsx`: handleBackToInitial メソッド追加
- 国際化メッセージ追加（en, ja, ja-Hira）

## テスト結果

- ✅ meshV2 接続フロー全体が正常に動作
- ✅ 「Become Host」項目がグループ一覧から削除された
- ✅ 「戻る」ボタンで初期画面に戻れる
- ✅ 他の拡張機能（micro:bit）に影響なし
- ✅ 3言語すべてで正しくラベルが表示される
- ✅ Lint 通過
- ✅ ビルド成功

## 関連

- PR #66: meshV2 接続モーダル初期画面の実装
