### PR TITLE
feat: support multiple method calls at same level with return values

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -32,6 +32,11 @@ export default function (Generator) {
 
         // Check if this is a return value assignment
         if (comment && comment.startsWith('@ruby:return:')) {
+            // Check if it is an evacuation block (has a number at the end)
+            if (/^@ruby:return:\w+:\d+$/.test(comment)) {
+                return '';
+            }
+
             if (!hasValueInput) {
                 // Marker block with no value, suppress output
                 return '';

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -177,12 +177,39 @@ class RubyToBlocksConverter {
             lists: {},
             broadcastMsgs: {},
             procedures: {},
+            methodCallCounts: {},
+            methodCallIndices: {},
             isValue: false,
             inMyBlockDefinition: false
         };
         if (this.vm && this.vm.runtime && this.vm.runtime.getTargetForStage) {
             this._loadVariables(this.vm.runtime.getTargetForStage());
         }
+    }
+
+    _countMethodCalls (node) {
+        const counts = {};
+        if (!node || node === Opal.nil) return counts;
+
+        const queue = [node.$to_ast ? node.$to_ast() : node];
+        while (queue.length > 0) {
+            const ast = queue.shift();
+            if (!ast || typeof ast.type !== 'string' || !ast.children) continue;
+
+            if (ast.type === 'send') {
+                const name = ast.children[1].toString();
+                const procedure = this._lookupProcedure(name);
+                if (procedure && procedure.hasReturnValue) {
+                    counts[name] = (counts[name] || 0) + 1;
+                }
+            }
+            ast.children.forEach(child => {
+                if (child && typeof child.type === 'string' && child.children) {
+                    queue.push(child);
+                }
+            });
+        }
+        return counts;
     }
 
     targetCodeToBlocks (target, code) {
@@ -1424,6 +1451,11 @@ class RubyToBlocksConverter {
 
         const savedIsValue = this._context.isValue;
         this._context.isValue = isValue;
+
+        if (!isValue) {
+            this._context.methodCallCounts = this._countMethodCalls(node);
+            this._context.methodCallIndices = {};
+        }
 
         const handlerName = '_' + _.camelCase(`on_${node.type}`); // eslint-disable-line prefer-template
         let result;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
@@ -26,9 +26,19 @@ const MyBlocksConverter = {
                 }
             });
 
+            let callIndex;
+            let callCount;
             // Add comment if procedure has return value and used as value
             if (procedure.hasReturnValue && converter.isValueContext()) {
-                block.comment = converter._createComment(`@ruby:return:${name}`, block.id);
+                callCount = converter._context.methodCallCounts[name] || 0;
+                callIndex = (converter._context.methodCallIndices[name] || 0) + 1;
+                converter._context.methodCallIndices[name] = callIndex;
+
+                let commentText = `@ruby:return:${name}`;
+                if (callIndex < callCount) {
+                    commentText += `:${callIndex}`;
+                }
+                block.comment = converter._createComment(commentText, block.id);
             }
 
             if (Object.prototype.hasOwnProperty.call(converter._context.procedureCallBlocks, procedure.id)) {
@@ -62,7 +72,11 @@ const MyBlocksConverter = {
             // If procedure has return value and used in value context,
             // return [procedures_call, data_variable] for the converter
             if (procedure.hasReturnValue && converter.isValueContext()) {
-                const variable = converter._lookupOrCreateVariable(`@_return_${name}`);
+                let varSuffix = '';
+                if (callIndex < callCount) {
+                    varSuffix = `_${callIndex}`;
+                }
+                const variable = converter._lookupOrCreateVariable(`@_return_${name}${varSuffix}`);
 
                 const varBlock = converter._createBlock('data_variable', 'value_variable', {
                     fields: {
@@ -74,7 +88,8 @@ const MyBlocksConverter = {
                         }
                     }
                 });
-                varBlock.comment = converter._createComment(`@ruby:return:${name}`, varBlock.id);
+                const commentText = converter._context.comments[block.comment].text;
+                varBlock.comment = converter._createComment(commentText, varBlock.id);
 
                 return [block, varBlock];
             }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
@@ -70,14 +70,51 @@ const MyBlocksConverter = {
             });
 
             // If procedure has return value and used in value context,
-            // return [procedures_call, data_variable] for the converter
+            // return [procedures_call, evacuation_block, data_variable] for the converter
             if (procedure.hasReturnValue && converter.isValueContext()) {
+                const commentText = converter._context.comments[block.comment].text;
+                const resultBlocks = [block];
+
                 let varSuffix = '';
                 if (callIndex < callCount) {
                     varSuffix = `_${callIndex}`;
-                }
-                const variable = converter._lookupOrCreateVariable(`@_return_${name}${varSuffix}`);
 
+                    // Create evacuation block: @_return_name_N = @_return_name
+                    const targetVariable = converter._lookupOrCreateVariable(`@_return_${name}${varSuffix}`);
+                    const sourceVariable = converter._lookupOrCreateVariable(`@_return_${name}`);
+
+                    const sourceBlock = converter._createBlock('data_variable', 'value_variable', {
+                        fields: {
+                            VARIABLE: {
+                                name: 'VARIABLE',
+                                id: sourceVariable.id,
+                                value: sourceVariable.name,
+                                variableType: sourceVariable.type
+                            }
+                        }
+                    });
+
+                    const evacuationBlock = converter._createBlock('data_setvariableto', 'statement', {
+                        fields: {
+                            VARIABLE: {
+                                name: 'VARIABLE',
+                                id: targetVariable.id,
+                                value: targetVariable.name,
+                                variableType: targetVariable.type
+                            }
+                        },
+                        inputs: {
+                            VALUE: {
+                                name: 'VALUE',
+                                block: sourceBlock.id
+                            }
+                        }
+                    });
+                    evacuationBlock.comment = converter._createComment(commentText, evacuationBlock.id);
+                    resultBlocks.push(evacuationBlock);
+                }
+
+                const variable = converter._lookupOrCreateVariable(`@_return_${name}${varSuffix}`);
                 const varBlock = converter._createBlock('data_variable', 'value_variable', {
                     fields: {
                         VARIABLE: {
@@ -88,10 +125,10 @@ const MyBlocksConverter = {
                         }
                     }
                 });
-                const commentText = converter._context.comments[block.comment].text;
                 varBlock.comment = converter._createComment(commentText, varBlock.id);
+                resultBlocks.push(varBlock);
 
-                return [block, varBlock];
+                return resultBlocks;
             }
 
             return block;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/method-return.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/method-return.test.js
@@ -514,14 +514,19 @@ describe('RubyToBlocksConverter/Method Return', () => {
 
             const blocks = converter.blocks;
             
-            // Verify the chain: hat -> add(1, 5) -> add(?, 3) -> say(?)
+            // Verify the chain: hat -> add(1, 5) -> evacuation -> add(?, 3) -> say(?)
             const hatBlock = Object.values(blocks).find(b => b.opcode === 'event_whenflagclicked');
             const firstCallId = hatBlock.next;
             const firstCall = blocks[firstCallId];
             expect(firstCall.opcode).toBe('procedures_call');
             expect(firstCall.mutation.proccode).toBe('add %s %s');
             
-            const secondCallId = firstCall.next;
+            const evacuationId = firstCall.next;
+            const evacuation = blocks[evacuationId];
+            expect(evacuation.opcode).toBe('data_setvariableto');
+            expect(evacuation.fields.VARIABLE.value).toBe('_return_add_1');
+            
+            const secondCallId = evacuation.next;
             const secondCall = blocks[secondCallId];
             expect(secondCall.opcode).toBe('procedures_call');
             expect(secondCall.mutation.proccode).toBe('add %s %s');
@@ -648,6 +653,112 @@ describe('RubyToBlocksConverter/Method Return', () => {
             const generatedRuby = RubyGenerator.targetToCode(target);
             
             expect(generatedRuby).toMatch(/say\(add\(calculate\(1\), 2\)\)/);
+        });
+
+        test('evacuation blocks for multiple calls at same level: say(add(add(2, 5), add(4, 6)))', async () => {
+            const code = `
+                def add(a, b)
+                  a + b
+                end
+
+                when_flag_clicked do
+                  say(add(add(2, 5), add(4, 6)))
+                end
+            `;
+            const result = converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+
+            const blocks = converter.blocks;
+
+            // Find blocks by comment to verify their presence and order
+            const firstCall = Object.values(blocks).find(b =>
+                b.opcode === 'procedures_call' &&
+                b.comment && converter._context.comments[b.comment].text === '@ruby:return:add:1'
+            );
+            expect(firstCall).toBeDefined();
+
+            const firstEvacuation = blocks[firstCall.next];
+            expect(firstEvacuation.opcode).toBe('data_setvariableto');
+            expect(firstEvacuation.fields.VARIABLE.value).toBe('_return_add_1');
+            expect(converter._context.comments[firstEvacuation.comment].text).toBe('@ruby:return:add:1');
+
+            const secondCall = blocks[firstEvacuation.next];
+            expect(secondCall.opcode).toBe('procedures_call');
+            expect(converter._context.comments[secondCall.comment].text).toBe('@ruby:return:add:2');
+
+            const secondEvacuation = blocks[secondCall.next];
+            expect(secondEvacuation.opcode).toBe('data_setvariableto');
+            expect(secondEvacuation.fields.VARIABLE.value).toBe('_return_add_2');
+            expect(converter._context.comments[secondEvacuation.comment].text).toBe('@ruby:return:add:2');
+
+            const topCall = blocks[secondEvacuation.next];
+            expect(topCall.opcode).toBe('procedures_call');
+            expect(converter._context.comments[topCall.comment].text).toBe('@ruby:return:add');
+
+            // Top call should NOT have an evacuation block after it
+            const sayBlock = blocks[topCall.next];
+            expect(sayBlock.opcode).toBe('looks_say');
+
+            // Verify Blocks -> Ruby suppresses evacuation blocks
+            await converter.applyTargetBlocks(target);
+            const RubyGenerator = require('../../../../src/lib/ruby-generator').default;
+            const generatedRuby = RubyGenerator.targetToCode(target);
+            
+            expect(generatedRuby).not.toMatch(/@_return_add_1 = @_return_add/);
+            expect(generatedRuby).not.toMatch(/@_return_add_2 = @_return_add/);
+            expect(generatedRuby).toMatch(/say\(add\(add\(2, 5\), add\(4, 6\)\)\)/);
+        });
+
+        test('evacuation blocks for 3-level nesting: say(add(add(add(1, 2), 3), 4))', async () => {
+            const code = `
+                def add(a, b)
+                  a + b
+                end
+
+                when_flag_clicked do
+                  say(add(add(add(1, 2), 3), 4))
+                end
+            `;
+            const result = converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+
+            const blocks = converter.blocks;
+
+            // add(1, 2) -> index 1
+            const firstCall = Object.values(blocks).find(b =>
+                b.opcode === 'procedures_call' &&
+                b.comment && converter._context.comments[b.comment].text === '@ruby:return:add:1'
+            );
+            expect(firstCall).toBeDefined();
+
+            const firstEvacuation = blocks[firstCall.next];
+            expect(firstEvacuation.opcode).toBe('data_setvariableto');
+            expect(firstEvacuation.fields.VARIABLE.value).toBe('_return_add_1');
+
+            // add(@_return_add_1, 3) -> index 2
+            const secondCall = blocks[firstEvacuation.next];
+            expect(secondCall.opcode).toBe('procedures_call');
+            expect(converter._context.comments[secondCall.comment].text).toBe('@ruby:return:add:2');
+
+            const secondEvacuation = blocks[secondCall.next];
+            expect(secondEvacuation.opcode).toBe('data_setvariableto');
+            expect(secondEvacuation.fields.VARIABLE.value).toBe('_return_add_2');
+
+            // add(@_return_add_2, 4) -> index 3 (last)
+            const topCall = blocks[secondEvacuation.next];
+            expect(topCall.opcode).toBe('procedures_call');
+            expect(converter._context.comments[topCall.comment].text).toBe('@ruby:return:add');
+
+            // No evacuation after top call
+            const sayBlock = blocks[topCall.next];
+            expect(sayBlock.opcode).toBe('looks_say');
+
+            // Verify Blocks -> Ruby
+            await converter.applyTargetBlocks(target);
+            const RubyGenerator = require('../../../../src/lib/ruby-generator').default;
+            const generatedRuby = RubyGenerator.targetToCode(target);
+            
+            expect(generatedRuby).toMatch(/say\(add\(add\(add\(1, 2\), 3\), 4\)\)/);
         });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/method-return.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/method-return.test.js
@@ -532,7 +532,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
 
             // Check arguments
             const arg1Id = Object.values(secondCall.inputs)[0].block;
-            expect(blocks[arg1Id].fields.VARIABLE.value).toBe('_return_add');
+            expect(blocks[arg1Id].fields.VARIABLE.value).toBe('_return_add_1');
             expect(thirdCall.inputs.MESSAGE.block).toBeDefined();
             expect(blocks[thirdCall.inputs.MESSAGE.block].fields.VARIABLE.value).toBe('_return_add');
 
@@ -563,7 +563,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
             expect(generatedRuby).toMatch(/say\(add\(add\(add\(1, 2\), 3\), 4\)\)/);
         });
 
-        test('unsupported: multiple calls at same level: say(add(add(1, 5), add(2, 3)))', async () => {
+        test('multiple calls at same level: say(add(add(1, 5), add(2, 3)))', async () => {
             const code = `
                 def add(a, b)
                   a + b
@@ -581,8 +581,73 @@ describe('RubyToBlocksConverter/Method Return', () => {
             const RubyGenerator = require('../../../../src/lib/ruby-generator').default;
             const generatedRuby = RubyGenerator.targetToCode(target);
             
-            // Phase 1 limitation: results in collision
-            expect(generatedRuby).toMatch(/say\(add\(add\(2, 3\), @_return_add\)\)/);
+            expect(generatedRuby).toMatch(/say\(add\(add\(1, 5\), add\(2, 3\)\)\)/);
+        });
+
+        test('complex nested calls: say(add(add(add(1, 2), 3), add(4, 5)))', async () => {
+            const code = `
+                def add(a, b)
+                  a + b
+                end
+
+                when_flag_clicked do
+                  say(add(add(add(1, 2), 3), add(4, 5)))
+                end
+            `;
+            const result = converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+
+            // Verify Blocks -> Ruby
+            await converter.applyTargetBlocks(target);
+            const RubyGenerator = require('../../../../src/lib/ruby-generator').default;
+            const generatedRuby = RubyGenerator.targetToCode(target);
+            
+            expect(generatedRuby).toMatch(/say\(add\(add\(add\(1, 2\), 3\), add\(4, 5\)\)\)/);
+        });
+
+        test('very complex nested calls: say(add(add(add(1, 2), add(3, 4)), add(5, 6)))', async () => {
+            const code = `
+                def add(a, b)
+                  a + b
+                end
+
+                when_flag_clicked do
+                  say(add(add(add(1, 2), add(3, 4)), add(5, 6)))
+                end
+            `;
+            const result = converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+
+            // Verify Blocks -> Ruby
+            await converter.applyTargetBlocks(target);
+            const RubyGenerator = require('../../../../src/lib/ruby-generator').default;
+            const generatedRuby = RubyGenerator.targetToCode(target);
+            
+            expect(generatedRuby).toMatch(/say\(add\(add\(add\(1, 2\), add\(3, 4\)\), add\(5, 6\)\)\)/);
+        });
+
+        test('mixed method names: say(add(calculate(1), 2))', async () => {
+            const code = `
+                def add(a, b)
+                  a + b
+                end
+                def calculate(x)
+                  x * 2
+                end
+
+                when_flag_clicked do
+                  say(add(calculate(1), 2))
+                end
+            `;
+            const result = converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+
+            // Verify Blocks -> Ruby
+            await converter.applyTargetBlocks(target);
+            const RubyGenerator = require('../../../../src/lib/ruby-generator').default;
+            const generatedRuby = RubyGenerator.targetToCode(target);
+            
+            expect(generatedRuby).toMatch(/say\(add\(calculate\(1\), 2\)\)/);
         });
     });
 });


### PR DESCRIPTION
Implements support for multiple method calls with return values at the same level (e.g., say(add(add(1, 5), add(2, 3)))) by using numbered return variables and comments. Fixes #76.