### PR TITLE
fix(gui): adjust comment positioning after returning from Ruby

### DIFF
--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -484,11 +484,9 @@ class Blocks extends React.Component {
                                 }
 
                                 const blockXY = block.getRelativeToSurfaceXY();
-                                const blockHW = block.getHeightWidth();
+                                const commentHW = comment.getHeightWidth();
                                 const rtl = this.workspace.RTL;
-                                const x = rtl ?
-                                    blockXY.x - blockHW.width - 20 - comment.getWidth() :
-                                    blockXY.x + blockHW.width + 20;
+                                const x = rtl ? 20 : -commentHW.width - 20;
                                 const y = blockXY.y;
                                 comment.moveTo(x, y);
 


### PR DESCRIPTION
### Resolves

None

### Proposed Changes

- Adjusted the X coordinate calculation for comments in the `fromRuby` cleanup block in `blocks.jsx`.
- Comments are now positioned at a fixed offset (20 for RTL, -commentWidth - 20 for LTR) relative to the workspace origin or surface? 
  - Actually, it seems it's moving them to a consistent X position when they are re-generated from Ruby code.

### Reason for Changes

- When returning from Ruby to blocks, comments need to be positioned appropriately as the blocks are re-arranged by `workspace.cleanUp()`.

### Test Coverage

- Ran lint: `npm run lint --workspace=packages/scratch-gui` passed.