### PR TITLE
feat: add version control for Ruby code generation (v1/v2)

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/settings-menu.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/settings-menu.jsx
@@ -11,9 +11,11 @@ import PreferenceMenu from './preference-menu.jsx';
 
 import {DEFAULT_MODE, HIGH_CONTRAST_MODE, colorModeMap} from '../../lib/settings/color-mode/index.js';
 import {themeMap} from '../../lib/settings/theme/index.js';
+import {rubyVersionMap} from '../../lib/settings/ruby-version/index.js';
 import {persistColorMode} from '../../lib/settings/color-mode/persistence.js';
 import {persistTheme} from '../../lib/settings/theme/persistence.js';
-import {setColorMode, setTheme} from '../../reducers/settings.js';
+import {persistRubyVersion} from '../../lib/settings/ruby-version/persistence.js';
+import {setColorMode, setTheme, setRubyVersion} from '../../reducers/settings.js';
 
 import menuBarStyles from './menu-bar.css';
 import styles from './settings-menu.css';
@@ -21,8 +23,16 @@ import styles from './settings-menu.css';
 import dropdownCaret from './dropdown-caret.svg';
 import settingsIcon from './icon--settings.svg';
 import themeIcon from '../../lib/assets/icon--theme.svg';
+import rubyIcon from '../../containers/ruby-tab/icon--ruby.svg';
 import blockDisplayIcon from './block-display-icon.png';
-import {colorModeMenuOpen, themeMenuOpen, openColorModeMenu, openThemeMenu} from '../../reducers/menus.js';
+import {
+    colorModeMenuOpen,
+    themeMenuOpen,
+    rubyVersionMenuOpen,
+    openColorModeMenu,
+    openThemeMenu,
+    openRubyVersionMenu
+} from '../../reducers/menus.js';
 
 const enabledColorModes = [DEFAULT_MODE, HIGH_CONTRAST_MODE];
 
@@ -34,10 +44,14 @@ const SettingsMenu = ({
     isRtl,
     isColorModeMenuOpen,
     isThemeMenuOpen,
+    isRubyVersionMenuOpen,
     activeColorMode,
+    activeRubyVersion,
     onChangeColorMode,
+    onChangeRubyVersion,
     onRequestOpenColorMode,
     onRequestOpenTheme,
+    onRequestOpenRubyVersion,
     onOpenBlockDisplayModal,
     activeTheme,
     onChangeTheme,
@@ -104,6 +118,21 @@ const SettingsMenu = ({
                             onRequestCloseSettings={onRequestClose}
                             onRequestOpen={onRequestOpenTheme}
                         />}
+                    <PreferenceMenu
+                        open={isRubyVersionMenuOpen}
+                        itemsMap={rubyVersionMap}
+                        onChange={onChangeRubyVersion}
+                        defaultMenuIconSrc={rubyIcon}
+                        submenuLabel={{
+                            defaultMessage: 'Ruby',
+                            description: 'Ruby version sub-menu',
+                            id: 'gui.menuBar.rubyVersion'
+                        }}
+                        selectedItemKey={activeRubyVersion}
+                        isRtl={isRtl}
+                        onRequestCloseSettings={onRequestClose}
+                        onRequestOpen={onRequestOpenRubyVersion}
+                    />
                     {canChangeColorMode && <PreferenceMenu
                         open={isColorModeMenuOpen}
                         itemsMap={enabledColorModesMap}
@@ -147,10 +176,14 @@ SettingsMenu.propTypes = {
     onChangeColorMode: PropTypes.func,
     onRequestOpenColorMode: PropTypes.func,
     isColorModeMenuOpen: PropTypes.bool,
+    isRubyVersionMenuOpen: PropTypes.bool,
     onOpenBlockDisplayModal: PropTypes.func,
     activeTheme: PropTypes.string,
+    activeRubyVersion: PropTypes.number,
     onChangeTheme: PropTypes.func,
+    onChangeRubyVersion: PropTypes.func,
     onRequestOpenTheme: PropTypes.func,
+    onRequestOpenRubyVersion: PropTypes.func,
     isThemeMenuOpen: PropTypes.bool,
     onRequestClose: PropTypes.func,
     onRequestOpen: PropTypes.func,
@@ -160,8 +193,10 @@ SettingsMenu.propTypes = {
 const mapStateToProps = state => ({
     activeColorMode: state.scratchGui.settings.colorMode,
     activeTheme: state.scratchGui.settings.theme,
+    activeRubyVersion: state.scratchGui.settings.rubyVersion,
     isColorModeMenuOpen: colorModeMenuOpen(state),
-    isThemeMenuOpen: themeMenuOpen(state)
+    isThemeMenuOpen: themeMenuOpen(state),
+    isRubyVersionMenuOpen: rubyVersionMenuOpen(state)
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
@@ -170,6 +205,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     },
     onRequestOpenTheme: () => {
         dispatch(openThemeMenu());
+    },
+    onRequestOpenRubyVersion: () => {
+        dispatch(openRubyVersionMenu());
     },
     onOpenBlockDisplayModal: () => {
         ownProps.onOpenBlockDisplayModal();
@@ -183,6 +221,11 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         dispatch(setTheme(theme));
         ownProps.onRequestClose();
         persistTheme(theme);
+    },
+    onChangeRubyVersion: rubyVersion => {
+        dispatch(setRubyVersion(rubyVersion));
+        ownProps.onRequestClose();
+        persistRubyVersion(rubyVersion);
     }
 });
 

--- a/packages/scratch-gui/src/components/menu-bar/settings-menu.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/settings-menu.jsx
@@ -11,7 +11,7 @@ import PreferenceMenu from './preference-menu.jsx';
 
 import {DEFAULT_MODE, HIGH_CONTRAST_MODE, colorModeMap} from '../../lib/settings/color-mode/index.js';
 import {themeMap} from '../../lib/settings/theme/index.js';
-import {rubyVersionMap} from '../../lib/settings/ruby-version/index.js';
+import {rubyVersionMap, messages as rubyVersionMessages} from '../../lib/settings/ruby-version/index.js';
 import {persistColorMode} from '../../lib/settings/color-mode/persistence.js';
 import {persistTheme} from '../../lib/settings/theme/persistence.js';
 import {persistRubyVersion} from '../../lib/settings/ruby-version/persistence.js';
@@ -118,21 +118,6 @@ const SettingsMenu = ({
                             onRequestCloseSettings={onRequestClose}
                             onRequestOpen={onRequestOpenTheme}
                         />}
-                    <PreferenceMenu
-                        open={isRubyVersionMenuOpen}
-                        itemsMap={rubyVersionMap}
-                        onChange={onChangeRubyVersion}
-                        defaultMenuIconSrc={rubyIcon}
-                        submenuLabel={{
-                            defaultMessage: 'Ruby',
-                            description: 'Ruby version sub-menu',
-                            id: 'gui.menuBar.rubyVersion'
-                        }}
-                        selectedItemKey={activeRubyVersion}
-                        isRtl={isRtl}
-                        onRequestCloseSettings={onRequestClose}
-                        onRequestOpen={onRequestOpenRubyVersion}
-                    />
                     {canChangeColorMode && <PreferenceMenu
                         open={isColorModeMenuOpen}
                         itemsMap={enabledColorModesMap}
@@ -147,6 +132,17 @@ const SettingsMenu = ({
                         onRequestCloseSettings={onRequestClose}
                         onRequestOpen={onRequestOpenColorMode}
                     />}
+                    <PreferenceMenu
+                        open={isRubyVersionMenuOpen}
+                        itemsMap={rubyVersionMap}
+                        onChange={onChangeRubyVersion}
+                        defaultMenuIconSrc={rubyIcon}
+                        submenuLabel={rubyVersionMessages.rubyMenu}
+                        selectedItemKey={activeRubyVersion}
+                        isRtl={isRtl}
+                        onRequestCloseSettings={onRequestClose}
+                        onRequestOpen={onRequestOpenRubyVersion}
+                    />
                     <MenuItem onClick={onOpenBlockDisplayModal}>
                         <div className={styles.option}>
                             <img
@@ -179,7 +175,7 @@ SettingsMenu.propTypes = {
     isRubyVersionMenuOpen: PropTypes.bool,
     onOpenBlockDisplayModal: PropTypes.func,
     activeTheme: PropTypes.string,
-    activeRubyVersion: PropTypes.number,
+    activeRubyVersion: PropTypes.string,
     onChangeTheme: PropTypes.func,
     onChangeRubyVersion: PropTypes.func,
     onRequestOpenTheme: PropTypes.func,

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -13,7 +13,7 @@ import {
     updateRubyFontSize
 } from '../reducers/ruby-code';
 import {setRubyVersion} from '../reducers/settings';
-import {showStandardAlert} from '../reducers/alerts';
+import {showStandardAlert, closeAlertWithId} from '../reducers/alerts';
 import VM from '@smalruby/scratch-vm';
 import {BLOCKS_TAB_INDEX} from '../reducers/editor-tab';
 
@@ -75,8 +75,6 @@ class RubyTab extends React.Component {
         if (prevProps.isVisible && !this.props.isVisible) {
             if (this.editorRef && this.monacoRef) {
                 this.clearErrors();
-                // Close any active widgets (peek view, hover, etc.)
-                this.editorRef.trigger('source', 'closeMarkersNavigation');
             }
         }
 
@@ -155,10 +153,14 @@ class RubyTab extends React.Component {
     clearErrors () {
         if (this.editorRef && this.monacoRef) {
             this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
+            // Close any active widgets (peek view, hover, etc.)
+            this.editorRef.trigger('source', 'closeMarkersNavigation');
         }
         if (this.props.rubyCode.errors.length > 0) {
             this.props.updateRubyCodeErrorsState([]);
         }
+        this.props.onDismissAlert('convertRubyToBlocksError');
+        this.props.onDismissAlert('rubyVersionChangeFailed');
     }
 
     showErrors (errors) {
@@ -411,6 +413,7 @@ RubyTab.propTypes = {
     onFontSizeChange: PropTypes.func,
     onRevertRubyVersion: PropTypes.func,
     onShowAlert: PropTypes.func,
+    onDismissAlert: PropTypes.func,
     rubyCode: rubyCodeShape,
     rubyVersion: PropTypes.string,
     targetCodeToBlocks: PropTypes.func,
@@ -437,6 +440,7 @@ const mapDispatchToProps = dispatch => ({
     updateRubyCodeTargetState: (target, version) => dispatch(updateRubyCodeTarget(target, version)),
     onRevertRubyVersion: version => dispatch(setRubyVersion(version)),
     onShowAlert: alertId => dispatch(showStandardAlert(alertId)),
+    onDismissAlert: alertId => dispatch(closeAlertWithId(alertId)),
     onRequestCloseFile: () => dispatch(closeFileMenu()),
     onSetAiSaveStatus: status => dispatch(setAiSaveStatus(status)),
     onClearAiSaveStatus: () => dispatch(clearAiSaveStatus()),

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -421,7 +421,7 @@ RubyTab.propTypes = {
     onRevertRubyVersion: PropTypes.func,
     onShowAlert: PropTypes.func,
     rubyCode: rubyCodeShape,
-    rubyVersion: PropTypes.number,
+    rubyVersion: PropTypes.string,
     targetCodeToBlocks: PropTypes.func,
     updateRubyCodeTargetState: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired,

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -74,16 +74,14 @@ class RubyTab extends React.Component {
 
         if (prevProps.isVisible && !this.props.isVisible) {
             if (this.editorRef && this.monacoRef) {
-                this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
+                this.clearErrors();
                 // Close any active widgets (peek view, hover, etc.)
                 this.editorRef.trigger('source', 'closeMarkersNavigation');
             }
         }
 
         if (this.props.rubyCode.code !== prevProps.rubyCode.code && !this.props.rubyCode.modified) {
-            if (this.editorRef && this.monacoRef) {
-                this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
-            }
+            this.clearErrors();
         }
 
         if (this.props.rubyCode.errors !== prevProps.rubyCode.errors) {
@@ -102,9 +100,7 @@ class RubyTab extends React.Component {
                     converter.apply().then(() => {
                         modified = false;
 
-                        if (this.editorRef && this.monacoRef) {
-                            this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
-                        }
+                        this.clearErrors();
 
                         if (!modified) {
                             const editingTargetChanged = this.props.editingTarget &&
@@ -156,6 +152,15 @@ class RubyTab extends React.Component {
         }
     }
 
+    clearErrors () {
+        if (this.editorRef && this.monacoRef) {
+            this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
+        }
+        if (this.props.rubyCode.errors.length > 0) {
+            this.props.updateRubyCodeErrorsState([]);
+        }
+    }
+
     showErrors (errors) {
         if (this.editorRef && this.monacoRef) {
             const markers = errors.map(err => ({
@@ -182,10 +187,7 @@ class RubyTab extends React.Component {
             const converter = this.props.targetCodeToBlocks(this.props.intl);
             if (converter.result) {
                 converter.apply().then(() => {
-                    if (this.editorRef && this.monacoRef) {
-                        this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
-                    }
-                    this.props.updateRubyCodeErrorsState([]);
+                    this.clearErrors();
                     this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
                 });
             } else {
@@ -195,10 +197,7 @@ class RubyTab extends React.Component {
                 this.showErrors(converter.errors);
             }
         } else {
-            if (this.editorRef && this.monacoRef) {
-                this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
-            }
-            this.props.updateRubyCodeErrorsState([]);
+            this.clearErrors();
             this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
         }
     }

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -82,20 +82,7 @@ class RubyTab extends React.Component {
         }
 
         if (this.props.rubyCode.errors !== prevProps.rubyCode.errors) {
-            if (this.editorRef && this.monacoRef) {
-                const markers = this.props.rubyCode.errors.map(err => ({
-                    startLineNumber: err.row + 1,
-                    startColumn: err.column + 1,
-                    endLineNumber: err.row + 1,
-                    endColumn: (err.source ? err.column + err.source.length + 1 : 1000),
-                    message: err.text,
-                    severity: this.monacoRef.MarkerSeverity.Error
-                }));
-                this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', markers);
-                if (markers.length > 0) {
-                    this.editorRef.trigger('source', 'editor.action.marker.next');
-                }
-            }
+            this.showErrors(this.props.rubyCode.errors);
         }
 
         let modified = this.props.rubyCode.modified;
@@ -134,21 +121,7 @@ class RubyTab extends React.Component {
                     });
                     return;
                 }
-                const error = converter.errors[0];
-                if (this.editorRef && this.monacoRef) {
-                    const markers = converter.errors.map(err => ({
-                        startLineNumber: err.row + 1,
-                        startColumn: err.column + 1,
-                        endLineNumber: err.row + 1,
-                        endColumn: (err.source ? err.column + err.source.length + 1 : 1000),
-                        message: err.text,
-                        severity: this.monacoRef.MarkerSeverity.Error
-                    }));
-                    this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', markers);
-                    this.editorRef.setPosition({lineNumber: error.row + 1, column: error.column + 1});
-                    this.editorRef.focus();
-                    this.editorRef.trigger('source', 'editor.action.marker.next');
-                }
+                this.showErrors(converter.errors);
             }
         }
 
@@ -178,6 +151,26 @@ class RubyTab extends React.Component {
         }
     }
 
+    showErrors (errors) {
+        if (this.editorRef && this.monacoRef) {
+            const markers = errors.map(err => ({
+                startLineNumber: err.row + 1,
+                startColumn: err.column + 1,
+                endLineNumber: err.row + 1,
+                endColumn: (err.source ? err.column + err.source.length + 1 : 1000),
+                message: err.text,
+                severity: this.monacoRef.MarkerSeverity.Error
+            }));
+            this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', markers);
+            if (markers.length > 0) {
+                const error = errors[0];
+                this.editorRef.setPosition({lineNumber: error.row + 1, column: error.column + 1});
+                this.editorRef.focus();
+                this.editorRef.trigger('source', 'editor.action.marker.next');
+            }
+        }
+    }
+
     handleRubyVersionChange (oldVersion, newVersion) {
         if (this.props.rubyCode.modified) {
             const converter = this.props.targetCodeToBlocks(this.props.intl);
@@ -188,23 +181,7 @@ class RubyTab extends React.Component {
             } else {
                 this.props.onRevertRubyVersion(oldVersion);
                 this.props.onShowAlert('rubyVersionChangeFailed');
-                if (this.editorRef && this.monacoRef) {
-                    const markers = converter.errors.map(err => ({
-                        startLineNumber: err.row + 1,
-                        startColumn: err.column + 1,
-                        endLineNumber: err.row + 1,
-                        endColumn: (err.source ? err.column + err.source.length + 1 : 1000),
-                        message: err.text,
-                        severity: this.monacoRef.MarkerSeverity.Error
-                    }));
-                    this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', markers);
-                    this.editorRef.setPosition({
-                        lineNumber: converter.errors[0].row + 1,
-                        column: converter.errors[0].column + 1
-                    });
-                    this.editorRef.focus();
-                    this.editorRef.trigger('source', 'editor.action.marker.next');
-                }
+                this.showErrors(converter.errors);
             }
         } else {
             this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -8,6 +8,7 @@ import Editor from '@monaco-editor/react';
 import {
     rubyCodeShape,
     updateRubyCode,
+    updateRubyCodeErrors,
     updateRubyCodeTarget,
     updateRubyFontSize
 } from '../reducers/ruby-code';
@@ -184,6 +185,7 @@ class RubyTab extends React.Component {
                     if (this.editorRef && this.monacoRef) {
                         this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
                     }
+                    this.props.updateRubyCodeErrorsState([]);
                     this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
                 });
             } else {
@@ -196,6 +198,7 @@ class RubyTab extends React.Component {
             if (this.editorRef && this.monacoRef) {
                 this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
             }
+            this.props.updateRubyCodeErrorsState([]);
             this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
         }
     }
@@ -412,6 +415,7 @@ RubyTab.propTypes = {
     rubyCode: rubyCodeShape,
     rubyVersion: PropTypes.string,
     targetCodeToBlocks: PropTypes.func,
+    updateRubyCodeErrorsState: PropTypes.func,
     updateRubyCodeTargetState: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired,
     projectTitle: PropTypes.string,
@@ -430,6 +434,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onChange: code => dispatch(updateRubyCode(code)),
+    updateRubyCodeErrorsState: errors => dispatch(updateRubyCodeErrors(errors)),
     updateRubyCodeTargetState: (target, version) => dispatch(updateRubyCodeTarget(target, version)),
     onRevertRubyVersion: version => dispatch(setRubyVersion(version)),
     onShowAlert: alertId => dispatch(showStandardAlert(alertId)),

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -54,12 +54,16 @@ class RubyTab extends React.Component {
         this.containerRef = null;
         this.resizeObserver = null;
         this.completionProvider = null;
+        this.lastProcessedVersion = props.rubyVersion;
 
         loadMonacoLocale(props.locale);
     }
 
     componentDidUpdate (prevProps) {
         if (this.props.rubyVersion !== prevProps.rubyVersion) {
+            if (this.props.rubyVersion === this.lastProcessedVersion) {
+                return;
+            }
             this.handleRubyVersionChange(prevProps.rubyVersion, this.props.rubyVersion);
         }
 
@@ -172,6 +176,7 @@ class RubyTab extends React.Component {
     }
 
     handleRubyVersionChange (oldVersion, newVersion) {
+        this.lastProcessedVersion = newVersion;
         if (this.props.rubyCode.modified) {
             const converter = this.props.targetCodeToBlocks(this.props.intl);
             if (converter.result) {
@@ -179,6 +184,7 @@ class RubyTab extends React.Component {
                     this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
                 });
             } else {
+                this.lastProcessedVersion = oldVersion;
                 this.props.onRevertRubyVersion(oldVersion);
                 this.props.onShowAlert('rubyVersionChangeFailed');
                 this.showErrors(converter.errors);

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -181,6 +181,9 @@ class RubyTab extends React.Component {
             const converter = this.props.targetCodeToBlocks(this.props.intl);
             if (converter.result) {
                 converter.apply().then(() => {
+                    if (this.editorRef && this.monacoRef) {
+                        this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
+                    }
                     this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
                 });
             } else {
@@ -190,6 +193,9 @@ class RubyTab extends React.Component {
                 this.showErrors(converter.errors);
             }
         } else {
+            if (this.editorRef && this.monacoRef) {
+                this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
+            }
             this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
         }
     }

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -13,7 +13,7 @@ import {
     updateRubyFontSize
 } from '../reducers/ruby-code';
 import {setRubyVersion} from '../reducers/settings';
-import {showStandardAlert, closeAlertWithId} from '../reducers/alerts';
+import {showAlertWithTimeout, closeAlertWithId} from '../reducers/alerts';
 import VM from '@smalruby/scratch-vm';
 import {BLOCKS_TAB_INDEX} from '../reducers/editor-tab';
 
@@ -439,7 +439,7 @@ const mapDispatchToProps = dispatch => ({
     updateRubyCodeErrorsState: errors => dispatch(updateRubyCodeErrors(errors)),
     updateRubyCodeTargetState: (target, version) => dispatch(updateRubyCodeTarget(target, version)),
     onRevertRubyVersion: version => dispatch(setRubyVersion(version)),
-    onShowAlert: alertId => dispatch(showStandardAlert(alertId)),
+    onShowAlert: alertId => showAlertWithTimeout(dispatch, alertId),
     onDismissAlert: alertId => dispatch(closeAlertWithId(alertId)),
     onRequestCloseFile: () => dispatch(closeFileMenu()),
     onSetAiSaveStatus: status => dispatch(setAiSaveStatus(status)),

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -11,6 +11,8 @@ import {
     updateRubyCodeTarget,
     updateRubyFontSize
 } from '../reducers/ruby-code';
+import {setRubyVersion} from '../reducers/settings';
+import {showStandardAlert} from '../reducers/alerts';
 import VM from '@smalruby/scratch-vm';
 import {BLOCKS_TAB_INDEX} from '../reducers/editor-tab';
 
@@ -57,6 +59,10 @@ class RubyTab extends React.Component {
     }
 
     componentDidUpdate (prevProps) {
+        if (this.props.rubyVersion !== prevProps.rubyVersion) {
+            this.handleRubyVersionChange(prevProps.rubyVersion, this.props.rubyVersion);
+        }
+
         if (this.props.locale !== prevProps.locale) {
             loadMonacoLocale(this.props.locale);
         }
@@ -109,9 +115,13 @@ class RubyTab extends React.Component {
                         }
 
                         if (!modified) {
-                            if ((this.props.isVisible && !prevProps.isVisible) ||
-                                (this.props.editingTarget && this.props.editingTarget !== prevProps.editingTarget)) {
-                                this.props.updateRubyCodeTargetState(this.props.vm.editingTarget);
+                            const editingTargetChanged = this.props.editingTarget &&
+                                this.props.editingTarget !== prevProps.editingTarget;
+                            if ((this.props.isVisible && !prevProps.isVisible) || editingTargetChanged) {
+                                this.props.updateRubyCodeTargetState(
+                                    this.props.vm.editingTarget,
+                                    this.props.rubyVersion
+                                );
                             }
                         }
 
@@ -143,9 +153,10 @@ class RubyTab extends React.Component {
         }
 
         if (!modified) {
-            if ((this.props.isVisible && !prevProps.isVisible) ||
-                (this.props.editingTarget && this.props.editingTarget !== prevProps.editingTarget)) {
-                this.props.updateRubyCodeTargetState(this.props.vm.editingTarget);
+            const editingTargetChanged = this.props.editingTarget &&
+                this.props.editingTarget !== prevProps.editingTarget;
+            if ((this.props.isVisible && !prevProps.isVisible) || editingTargetChanged) {
+                this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, this.props.rubyVersion);
             }
         }
 
@@ -164,6 +175,39 @@ class RubyTab extends React.Component {
         if (this.completionProvider) {
             this.completionProvider.dispose();
             this.completionProvider = null;
+        }
+    }
+
+    handleRubyVersionChange (oldVersion, newVersion) {
+        if (this.props.rubyCode.modified) {
+            const converter = this.props.targetCodeToBlocks(this.props.intl);
+            if (converter.result) {
+                converter.apply().then(() => {
+                    this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
+                });
+            } else {
+                this.props.onRevertRubyVersion(oldVersion);
+                this.props.onShowAlert('rubyVersionChangeFailed');
+                if (this.editorRef && this.monacoRef) {
+                    const markers = converter.errors.map(err => ({
+                        startLineNumber: err.row + 1,
+                        startColumn: err.column + 1,
+                        endLineNumber: err.row + 1,
+                        endColumn: (err.source ? err.column + err.source.length + 1 : 1000),
+                        message: err.text,
+                        severity: this.monacoRef.MarkerSeverity.Error
+                    }));
+                    this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', markers);
+                    this.editorRef.setPosition({
+                        lineNumber: converter.errors[0].row + 1,
+                        column: converter.errors[0].column + 1
+                    });
+                    this.editorRef.focus();
+                    this.editorRef.trigger('source', 'editor.action.marker.next');
+                }
+            }
+        } else {
+            this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
         }
     }
 
@@ -374,7 +418,10 @@ RubyTab.propTypes = {
     onSetAiSaveStatus: PropTypes.func,
     onClearAiSaveStatus: PropTypes.func,
     onFontSizeChange: PropTypes.func,
+    onRevertRubyVersion: PropTypes.func,
+    onShowAlert: PropTypes.func,
     rubyCode: rubyCodeShape,
+    rubyVersion: PropTypes.number,
     targetCodeToBlocks: PropTypes.func,
     updateRubyCodeTargetState: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired,
@@ -386,6 +433,7 @@ const mapStateToProps = state => ({
     blocksTabVisible: state.scratchGui.editorTab.activeTabIndex === BLOCKS_TAB_INDEX,
     editingTarget: state.scratchGui.targets.editingTarget,
     rubyCode: state.scratchGui.rubyCode,
+    rubyVersion: state.scratchGui.settings.rubyVersion,
     vm: state.scratchGui.vm,
     projectTitle: state.scratchGui.projectTitle,
     locale: state.locales.locale
@@ -393,7 +441,9 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onChange: code => dispatch(updateRubyCode(code)),
-    updateRubyCodeTargetState: target => dispatch(updateRubyCodeTarget(target)),
+    updateRubyCodeTargetState: (target, version) => dispatch(updateRubyCodeTarget(target, version)),
+    onRevertRubyVersion: version => dispatch(setRubyVersion(version)),
+    onShowAlert: alertId => dispatch(showStandardAlert(alertId)),
     onRequestCloseFile: () => dispatch(closeFileMenu()),
     onSetAiSaveStatus: status => dispatch(setAiSaveStatus(status)),
     onClearAiSaveStatus: () => dispatch(clearAiSaveStatus()),

--- a/packages/scratch-gui/src/lib/alerts/index.jsx
+++ b/packages/scratch-gui/src/lib/alerts/index.jsx
@@ -32,6 +32,20 @@ const alerts = [
         maxDisplaySecs: 5
     },
     {
+        alertId: 'rubyVersionChangeFailed',
+        clearList: ['rubyVersionChangeFailed'],
+        closeButton: true,
+        content: (
+            <FormattedMessage
+                defaultMessage="Cannot change Ruby version: Please fix Ruby code errors first."
+                description="Message indicating that Ruby version change failed due to Ruby code errors"
+                id="gui.smalruby3.alerts.rubyVersionChangeFailed"
+            />
+        ),
+        level: AlertLevels.WARN,
+        maxDisplaySecs: 5
+    },
+    {
         alertId: 'createSuccess',
         alertType: AlertTypes.STANDARD,
         clearList: ['createSuccess', 'creating', 'createCopySuccess', 'creatingCopy',

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -109,9 +109,10 @@ RubyGenerator.ORDER_AND_OR = 21;           // and or
 RubyGenerator.ORDER_NONE = 99;             // (...)
 /* eslint-enable no-multi-spaces */
 
-RubyGenerator.init = function (_options) {
+RubyGenerator.init = function (options) {
     this.definitions_ = {};
     this.returnCallCache_ = {}; // Clear return value call cache
+    this.version = options && options.version ? options.version : 1;
     if (this.variableDB_) {
         this.variableDB_.reset();
     } else {

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -112,7 +112,7 @@ RubyGenerator.ORDER_NONE = 99;             // (...)
 RubyGenerator.init = function (options) {
     this.definitions_ = {};
     this.returnCallCache_ = {}; // Clear return value call cache
-    this.version = options && options.version ? options.version : 1;
+    this.version = options && options.version ? options.version : '1';
     if (this.variableDB_) {
         this.variableDB_.reset();
     } else {

--- a/packages/scratch-gui/src/lib/ruby-generator/procedure.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/procedure.js
@@ -118,7 +118,7 @@ export default function (Generator) {
         if (isCall) {
             return `${methodName}${argsString}\n`;
         }
-        if (Generator.version === 2) {
+        if (Generator.version.toString() === '2') {
             return `def ${methodName}${argsString}\n`;
         }
         return `def self.${methodName}${argsString}\n`;

--- a/packages/scratch-gui/src/lib/ruby-generator/procedure.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/procedure.js
@@ -118,6 +118,9 @@ export default function (Generator) {
         if (isCall) {
             return `${methodName}${argsString}\n`;
         }
+        if (Generator.version === 2) {
+            return `def ${methodName}${argsString}\n`;
+        }
         return `def self.${methodName}${argsString}\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter-hoc.jsx
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter-hoc.jsx
@@ -92,7 +92,7 @@ const RubyToBlocksConverterHOC = function (WrappedComponent) {
         onHighlightTarget: PropTypes.func,
         onShowConvertRubyToBlocksErrorAlert: PropTypes.func,
         rubyCode: rubyCodeShape,
-        rubyVersion: PropTypes.number,
+        rubyVersion: PropTypes.string,
         updateRubyCodeErrorsState: PropTypes.func,
         vm: PropTypes.instanceOf(VM)
     };

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter-hoc.jsx
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter-hoc.jsx
@@ -45,7 +45,8 @@ const RubyToBlocksConverterHOC = function (WrappedComponent) {
                     this.props.vm,
                     this.props.rubyCode.target,
                     this.props.rubyCode.code,
-                    intl
+                    intl,
+                    {version: this.props.rubyVersion}
                 );
                 if (!converter.result) {
                     this.props.vm.setEditingTarget(this.props.rubyCode.target.id);
@@ -91,6 +92,7 @@ const RubyToBlocksConverterHOC = function (WrappedComponent) {
         onHighlightTarget: PropTypes.func,
         onShowConvertRubyToBlocksErrorAlert: PropTypes.func,
         rubyCode: rubyCodeShape,
+        rubyVersion: PropTypes.number,
         updateRubyCodeErrorsState: PropTypes.func,
         vm: PropTypes.instanceOf(VM)
     };
@@ -98,6 +100,7 @@ const RubyToBlocksConverterHOC = function (WrappedComponent) {
     const mapStateToProps = state => ({
         editingTarget: state.scratchGui.targets.editingTarget,
         rubyCode: state.scratchGui.rubyCode,
+        rubyVersion: state.scratchGui.settings.rubyVersion,
         vm: state.scratchGui.vm
     });
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -93,8 +93,9 @@ const getExtensionIdForOpcode = function (opcode) {
  * Class for a block converter that translates ruby code into the blocks.
  */
 class RubyToBlocksConverter {
-    constructor (vm) {
+    constructor (vm, options) {
         this.vm = vm;
+        this.version = options && options.version ? options.version : 1;
         this._translator = message => message.defaultMessage;
         this._receiverToMethods = {};
         this._receiverToMyBlocks = {};
@@ -2042,8 +2043,8 @@ const NullRubyToBlocksConverter = {
     apply: () => Promise.resolve()
 };
 
-const targetCodeToBlocks = function (vm, target, code, intl) {
-    const converter = new RubyToBlocksConverter(vm);
+const targetCodeToBlocks = function (vm, target, code, intl, options) {
+    const converter = new RubyToBlocksConverter(vm, options);
     if (intl) {
         converter.setTranslatorFunction(intl.formatMessage);
     }

--- a/packages/scratch-gui/src/lib/settings/ruby-version/index.js
+++ b/packages/scratch-gui/src/lib/settings/ruby-version/index.js
@@ -1,18 +1,23 @@
 import {defineMessages} from 'react-intl';
 
-const VERSION_1 = 1;
-const VERSION_2 = 2;
+const VERSION_1 = '1';
+const VERSION_2 = '2';
 
 const messages = defineMessages({
     [VERSION_1]: {
         id: 'gui.rubyVersion.v1',
-        defaultMessage: 'v1',
+        defaultMessage: 'v1 (default)',
         description: 'label for legacy Ruby version (v1)'
     },
     [VERSION_2]: {
         id: 'gui.rubyVersion.v2',
         defaultMessage: 'v2',
         description: 'label for standard Ruby version (v2)'
+    },
+    rubyMenu: {
+        id: 'gui.menuBar.rubyVersion',
+        defaultMessage: 'Ruby',
+        description: 'Ruby version sub-menu'
     }
 });
 
@@ -28,5 +33,6 @@ const rubyVersionMap = {
 export {
     VERSION_1,
     VERSION_2,
-    rubyVersionMap
+    rubyVersionMap,
+    messages
 };

--- a/packages/scratch-gui/src/lib/settings/ruby-version/index.js
+++ b/packages/scratch-gui/src/lib/settings/ruby-version/index.js
@@ -1,0 +1,32 @@
+import {defineMessages} from 'react-intl';
+
+const VERSION_1 = 1;
+const VERSION_2 = 2;
+
+const messages = defineMessages({
+    [VERSION_1]: {
+        id: 'gui.rubyVersion.v1',
+        defaultMessage: 'v1',
+        description: 'label for legacy Ruby version (v1)'
+    },
+    [VERSION_2]: {
+        id: 'gui.rubyVersion.v2',
+        defaultMessage: 'v2',
+        description: 'label for standard Ruby version (v2)'
+    }
+});
+
+const rubyVersionMap = {
+    [VERSION_1]: {
+        label: messages[VERSION_1]
+    },
+    [VERSION_2]: {
+        label: messages[VERSION_2]
+    }
+};
+
+export {
+    VERSION_1,
+    VERSION_2,
+    rubyVersionMap
+};

--- a/packages/scratch-gui/src/lib/settings/ruby-version/persistence.js
+++ b/packages/scratch-gui/src/lib/settings/ruby-version/persistence.js
@@ -1,0 +1,37 @@
+import cookie from 'cookie';
+
+import {VERSION_1, VERSION_2} from '.';
+
+const COOKIE_KEY = 'smalruby:rubyVersion';
+const VERSION_SWITCH_DATE = new Date('2026-04-01T00:00:00Z');
+
+const isValidRubyVersion = version => [VERSION_1, VERSION_2].includes(Number(version));
+
+const getDefaultVersion = () => {
+    const now = new Date();
+    return now >= VERSION_SWITCH_DATE ? VERSION_2 : VERSION_1;
+};
+
+const detectRubyVersion = () => {
+    const obj = cookie.parse(document.cookie) || {};
+    const rubyVersionCookie = obj[COOKIE_KEY];
+
+    if (isValidRubyVersion(rubyVersionCookie)) return Number(rubyVersionCookie);
+
+    // No cookie set. Fall back to date-based default
+    return getDefaultVersion();
+};
+
+const persistRubyVersion = version => {
+    if (!isValidRubyVersion(version)) {
+        throw new Error(`Invalid ruby version: ${version}`);
+    }
+
+    const expires = new Date(new Date().setFullYear(new Date().getFullYear() + 1)).toUTCString();
+    document.cookie = `${COOKIE_KEY}=${version};expires=${expires};path=/`;
+};
+
+export {
+    detectRubyVersion,
+    persistRubyVersion
+};

--- a/packages/scratch-gui/src/lib/settings/ruby-version/persistence.js
+++ b/packages/scratch-gui/src/lib/settings/ruby-version/persistence.js
@@ -1,11 +1,9 @@
-import cookie from 'cookie';
-
 import {VERSION_1, VERSION_2} from '.';
 
-const COOKIE_KEY = 'smalruby:rubyVersion';
+const STORAGE_KEY = 'smalruby:rubyVersion';
 const VERSION_SWITCH_DATE = new Date('2026-04-01T00:00:00Z');
 
-const isValidRubyVersion = version => [VERSION_1, VERSION_2].includes(Number(version));
+const isValidRubyVersion = version => [VERSION_1, VERSION_2].includes(version);
 
 const getDefaultVersion = () => {
     const now = new Date();
@@ -13,12 +11,15 @@ const getDefaultVersion = () => {
 };
 
 const detectRubyVersion = () => {
-    const obj = cookie.parse(document.cookie) || {};
-    const rubyVersionCookie = obj[COOKIE_KEY];
+    if (typeof window === 'undefined' || !window.localStorage) {
+        return getDefaultVersion();
+    }
 
-    if (isValidRubyVersion(rubyVersionCookie)) return Number(rubyVersionCookie);
+    const rubyVersion = window.localStorage.getItem(STORAGE_KEY);
 
-    // No cookie set. Fall back to date-based default
+    if (isValidRubyVersion(rubyVersion)) return rubyVersion;
+
+    // No preference set. Fall back to date-based default
     return getDefaultVersion();
 };
 
@@ -27,8 +28,9 @@ const persistRubyVersion = version => {
         throw new Error(`Invalid ruby version: ${version}`);
     }
 
-    const expires = new Date(new Date().setFullYear(new Date().getFullYear() + 1)).toUTCString();
-    document.cookie = `${COOKIE_KEY}=${version};expires=${expires};path=/`;
+    if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(STORAGE_KEY, version);
+    }
 };
 
 export {

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -3,6 +3,9 @@ export default {
     'gui.modal.stop': 'ちゅうし',
     'gui.menuBar.loadFromUrl': 'Scratchからよみこむ',
     'gui.menuBar.colorMode': 'カラーモード',
+    'gui.menuBar.rubyVersion': 'ルビー',
+    'gui.rubyVersion.v1': 'バージョン1 (しょきせってい)',
+    'gui.rubyVersion.v2': 'バージョン2',
     'gui.menuBar.meshV2': 'メッシュ',
     'gui.sharedMessages.backdrop': 'はいけい{index}',
     'gui.sharedMessages.costume': 'コスチューム{index}',
@@ -26,6 +29,7 @@ export default {
     'gui.menuBar.koshienEntryForm': 'さんかもうしこみ',
     'gui.menuBar.aiSaving': 'ルビーをほぞんちゅう...',
     'gui.menuBar.aiSaved': 'ルビーがほぞんされました。',
+    'gui.smalruby3.alerts.rubyVersionChangeFailed': 'ルビーのバージョンをへんこうできません：さきにルビーのコードのエラーをなおしてください。',
     'gui.stageHeader.stageSizeMiddle': 'ちゅうサイズのステージにきりかえる',
 
     'gui.koshienTestModal.title': 'スモウルビーこうしえんのAIをためす',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -3,6 +3,9 @@ export default {
     'gui.modal.stop': '中止',
     'gui.menuBar.loadFromUrl': 'Scratchから読み込む',
     'gui.menuBar.colorMode': 'カラーモード',
+    'gui.menuBar.rubyVersion': 'ルビー',
+    'gui.rubyVersion.v1': 'バージョン1 (初期設定)',
+    'gui.rubyVersion.v2': 'バージョン2',
     'gui.menuBar.meshV2': 'メッシュ',
     'gui.sharedMessages.backdrop': '背景{index}',
     'gui.sharedMessages.costume': 'コスチューム{index}',
@@ -26,6 +29,7 @@ export default {
     'gui.menuBar.koshienEntryForm': '参加申し込み',
     'gui.menuBar.aiSaving': 'ルビーを保存中...',
     'gui.menuBar.aiSaved': 'ルビーが保存されました。',
+    'gui.smalruby3.alerts.rubyVersionChangeFailed': 'ルビーのバージョンを変更できません：先にルビーのコードのエラーを直してください。',
     'gui.stageHeader.stageSizeMiddle': '中サイズのステージに切り替える',
 
     'gui.koshienTestModal.title': 'スモウルビー甲子園のAIを試す',

--- a/packages/scratch-gui/src/reducers/menus.js
+++ b/packages/scratch-gui/src/reducers/menus.js
@@ -11,6 +11,7 @@ const MENU_MODE = 'modeMenu';
 const MENU_SETTINGS = 'settingsMenu';
 const MENU_COLOR_MODE = 'colorModeMenu';
 const MENU_THEME = 'themeMenu';
+const MENU_RUBY_VERSION = 'rubyVersionMenu';
 const MENU_KOSHIEN = 'koshienMenu';
 const MENU_MESH_V2 = 'meshV2Menu';
 
@@ -56,6 +57,7 @@ const rootMenu = new Menu('root')
             .addChild(new Menu(MENU_LANGUAGE))
             .addChild(new Menu(MENU_COLOR_MODE))
             .addChild(new Menu(MENU_THEME))
+            .addChild(new Menu(MENU_RUBY_VERSION))
     )
     .addChild(new Menu(MENU_FILE))
     .addChild(new Menu(MENU_EDIT))
@@ -78,6 +80,7 @@ const initialState = {
     [MENU_SETTINGS]: false,
     [MENU_COLOR_MODE]: false,
     [MENU_THEME]: false,
+    [MENU_RUBY_VERSION]: false,
     [MENU_KOSHIEN]: false,
     [MENU_MESH_V2]: false
 };
@@ -159,6 +162,10 @@ const openThemeMenu = () => openMenu(MENU_THEME);
 const closeThemeMenu = () => closeMenu(MENU_THEME);
 const themeMenuOpen = state => state.scratchGui.menus[MENU_THEME];
 
+const openRubyVersionMenu = () => openMenu(MENU_RUBY_VERSION);
+const closeRubyVersionMenu = () => closeMenu(MENU_RUBY_VERSION);
+const rubyVersionMenuOpen = state => state.scratchGui.menus[MENU_RUBY_VERSION];
+
 const openKoshienMenu = () => openMenu(MENU_KOSHIEN);
 const closeKoshienMenu = () => closeMenu(MENU_KOSHIEN);
 const koshienMenuOpen = state => state.scratchGui.menus[MENU_KOSHIEN];
@@ -200,6 +207,9 @@ export {
     openThemeMenu,
     closeThemeMenu,
     themeMenuOpen,
+    openRubyVersionMenu,
+    closeRubyVersionMenu,
+    rubyVersionMenuOpen,
     openKoshienMenu,
     closeKoshienMenu,
     koshienMenuOpen,

--- a/packages/scratch-gui/src/reducers/ruby-code.js
+++ b/packages/scratch-gui/src/reducers/ruby-code.js
@@ -59,7 +59,7 @@ const reducer = function (state, action) {
         return Object.assign({}, state, {
             modified: false,
             target: action.target,
-            code: RubyGenerator.targetToCode(action.target),
+            code: RubyGenerator.targetToCode(action.target, {version: action.version}),
             errors: [],
             markers: []
         });
@@ -93,10 +93,11 @@ const updateRubyCode = function (code) {
     };
 };
 
-const updateRubyCodeTarget = function (target) {
+const updateRubyCodeTarget = function (target, version) {
     return {
         type: UPDATE_RUBYCODE_TARGET,
-        target: target
+        target: target,
+        version: version
     };
 };
 

--- a/packages/scratch-gui/src/reducers/settings.js
+++ b/packages/scratch-gui/src/reducers/settings.js
@@ -1,12 +1,15 @@
 import {detectColorMode} from '../lib/settings/color-mode/persistence';
 import {detectTheme} from '../lib/settings/theme/persistence';
+import {detectRubyVersion} from '../lib/settings/ruby-version/persistence';
 
 const SET_COLOR_MODE = 'scratch-gui/settings/SET_COLOR_MODE';
 const SET_THEME = 'scratch-gui/settings/SET_THEME';
+const SET_RUBY_VERSION = 'scratch-gui/settings/SET_RUBY_VERSION';
 
 const initialState = {
     colorMode: detectColorMode(),
-    theme: detectTheme()
+    theme: detectTheme(),
+    rubyVersion: detectRubyVersion()
 };
 
 const reducer = (state = initialState, action) => {
@@ -15,6 +18,8 @@ const reducer = (state = initialState, action) => {
         return {...state, colorMode: action.colorMode};
     case SET_THEME:
         return {...state, theme: action.theme};
+    case SET_RUBY_VERSION:
+        return {...state, rubyVersion: action.rubyVersion};
     default:
         return state;
     }
@@ -30,9 +35,15 @@ const setTheme = theme => ({
     theme
 });
 
+const setRubyVersion = rubyVersion => ({
+    type: SET_RUBY_VERSION,
+    rubyVersion
+});
+
 export {
     reducer as default,
     initialState as settingsInitialState,
     setColorMode,
-    setTheme
+    setTheme,
+    setRubyVersion
 };

--- a/packages/scratch-gui/test/unit/lib/ruby-generator-version.test.jsx
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator-version.test.jsx
@@ -1,0 +1,71 @@
+import RubyGenerator from '../../../src/lib/ruby-generator';
+
+describe('RubyGenerator Versioning', () => {
+    let renderedTarget;
+
+    beforeEach(() => {
+        RubyGenerator.cache_ = {};
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.functionNames_ = {};
+
+        renderedTarget = {
+            id: 'target1',
+            sprite: {
+                name: 'Sprite1'
+            },
+            comments: {},
+            variables: {},
+            blocks: {
+                getScripts: () => ['block1'],
+                getBlock: (id) => {
+                    if (id === 'block1') {
+                        return {
+                            id: 'block1',
+                            opcode: 'procedures_definition',
+                            inputs: {
+                                custom_block: {
+                                    block: 'block2'
+                                }
+                            },
+                            next: null
+                        };
+                    }
+                    if (id === 'block2') {
+                        return {
+                            id: 'block2',
+                            opcode: 'procedures_prototype',
+                            mutation: {
+                                proccode: 'my_method'
+                            },
+                            inputs: {}
+                        };
+                    }
+                    return null;
+                },
+                getInputs: (block) => block.inputs || {},
+                getProcedureParamNamesIdsAndDefaults: () => [[], [], []]
+            },
+            runtime: {
+                getTargetForStage: () => null
+            }
+        };
+        RubyGenerator.currentTarget = renderedTarget;
+    });
+
+    test('v1 generates def self.method_name', () => {
+        const code = RubyGenerator.targetToCode(renderedTarget, {version: 1});
+        expect(code).toContain('def self.my_method');
+        expect(code).not.toContain('def my_method');
+    });
+
+    test('v2 generates def method_name', () => {
+        const code = RubyGenerator.targetToCode(renderedTarget, {version: 2});
+        expect(code).toContain('def my_method');
+        expect(code).not.toContain('def self.my_method');
+    });
+
+    test('default (no version) generates def self.method_name', () => {
+        const code = RubyGenerator.targetToCode(renderedTarget);
+        expect(code).toContain('def self.my_method');
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-generator-version.test.jsx
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator-version.test.jsx
@@ -53,13 +53,13 @@ describe('RubyGenerator Versioning', () => {
     });
 
     test('v1 generates def self.method_name', () => {
-        const code = RubyGenerator.targetToCode(renderedTarget, {version: 1});
+        const code = RubyGenerator.targetToCode(renderedTarget, {version: '1'});
         expect(code).toContain('def self.my_method');
         expect(code).not.toContain('def my_method');
     });
 
     test('v2 generates def method_name', () => {
-        const code = RubyGenerator.targetToCode(renderedTarget, {version: 2});
+        const code = RubyGenerator.targetToCode(renderedTarget, {version: '2'});
         expect(code).toContain('def my_method');
         expect(code).not.toContain('def self.my_method');
     });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter-version.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter-version.test.js
@@ -1,0 +1,47 @@
+import {targetCodeToBlocks} from '../../../src/lib/ruby-to-blocks-converter';
+
+describe('RubyToBlocksConverter Versioning', () => {
+    let vm;
+    let target;
+
+    beforeEach(() => {
+        vm = {
+            runtime: {
+                getTargetForStage: () => ({
+                    variables: {},
+                    lookupVariableByNameAndType: () => null
+                })
+            }
+        };
+        target = {
+            isStage: false,
+            variables: {},
+            lookupVariableByNameAndType: () => null,
+            blocks: {
+                getProcedureParamNamesIdsAndDefaults: () => [[], [], []]
+            }
+        };
+    });
+
+    test('converts v1 (def self.method_name) to blocks', () => {
+        const code = `def self.my_method
+end`;
+        const converter = targetCodeToBlocks(vm, target, code);
+        expect(converter.result).toBe(true);
+        expect(converter.errors).toHaveLength(0);
+        
+        const blocks = Object.values(converter.blocks);
+        expect(blocks.some(b => b.opcode === 'procedures_definition')).toBe(true);
+    });
+
+    test('converts v2 (def method_name) to blocks', () => {
+        const code = `def my_method
+end`;
+        const converter = targetCodeToBlocks(vm, target, code);
+        expect(converter.result).toBe(true);
+        expect(converter.errors).toHaveLength(0);
+
+        const blocks = Object.values(converter.blocks);
+        expect(blocks.some(b => b.opcode === 'procedures_definition')).toBe(true);
+    });
+});

--- a/packages/scratch-gui/test/unit/util/ruby-versions.test.js
+++ b/packages/scratch-gui/test/unit/util/ruby-versions.test.js
@@ -1,0 +1,74 @@
+import {VERSION_1, VERSION_2} from '../../../src/lib/settings/ruby-version';
+import {detectRubyVersion, persistRubyVersion} from '../../../src/lib/settings/ruby-version/persistence';
+
+describe('ruby versions', () => {
+    const originalCookie = window.document.cookie;
+    const originalDate = global.Date;
+
+    beforeEach(() => {
+        // Clear cookies
+        const cookies = window.document.cookie.split(';');
+        for (let i = 0; i < cookies.length; i++) {
+            const cookie = cookies[i];
+            const eqPos = cookie.indexOf('=');
+            const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
+            window.document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+        }
+    });
+
+    afterAll(() => {
+        window.document.cookie = originalCookie;
+        global.Date = originalDate;
+    });
+
+    describe('persistence', () => {
+        test('returns the version stored in a cookie', () => {
+            window.document.cookie = 'smalruby:rubyVersion=2';
+            const version = detectRubyVersion();
+            expect(version).toEqual(VERSION_2);
+        });
+
+        test('returns v1 before 2026-04-01 when no cookie', () => {
+            const mockDate = new Date('2026-03-31T23:59:59Z');
+            global.Date = class extends Date {
+                constructor (arg) {
+                    if (arg) return new originalDate(arg);
+                    return mockDate;
+                }
+                static now () {
+                    return mockDate.getTime();
+                }
+            };
+
+            const version = detectRubyVersion();
+            expect(version).toEqual(VERSION_1);
+        });
+
+        test('returns v2 after 2026-04-01 when no cookie', () => {
+            const mockDate = new Date('2026-04-01T00:00:01Z');
+            global.Date = class extends Date {
+                constructor (arg) {
+                    if (arg) return new originalDate(arg);
+                    return mockDate;
+                }
+                static now () {
+                    return mockDate.getTime();
+                }
+            };
+
+            const version = detectRubyVersion();
+            expect(version).toEqual(VERSION_2);
+        });
+
+        test('persists version to cookie', () => {
+            persistRubyVersion(VERSION_2);
+            // jsdom's document.cookie might not behave exactly like a real browser
+            // but detectRubyVersion should be able to read what persistRubyVersion wrote.
+            expect(detectRubyVersion()).toEqual(VERSION_2);
+        });
+
+        test('throws error for invalid version', () => {
+            expect(() => persistRubyVersion(3)).toThrow('Invalid ruby version: 3');
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/util/ruby-versions.test.js
+++ b/packages/scratch-gui/test/unit/util/ruby-versions.test.js
@@ -2,33 +2,24 @@ import {VERSION_1, VERSION_2} from '../../../src/lib/settings/ruby-version';
 import {detectRubyVersion, persistRubyVersion} from '../../../src/lib/settings/ruby-version/persistence';
 
 describe('ruby versions', () => {
-    const originalCookie = window.document.cookie;
     const originalDate = global.Date;
 
     beforeEach(() => {
-        // Clear cookies
-        const cookies = window.document.cookie.split(';');
-        for (let i = 0; i < cookies.length; i++) {
-            const cookie = cookies[i];
-            const eqPos = cookie.indexOf('=');
-            const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
-            window.document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
-        }
+        window.localStorage.clear();
     });
 
     afterAll(() => {
-        window.document.cookie = originalCookie;
         global.Date = originalDate;
     });
 
     describe('persistence', () => {
-        test('returns the version stored in a cookie', () => {
-            window.document.cookie = 'smalruby:rubyVersion=2';
+        test('returns the version stored in localStorage', () => {
+            window.localStorage.setItem('smalruby:rubyVersion', '2');
             const version = detectRubyVersion();
             expect(version).toEqual(VERSION_2);
         });
 
-        test('returns v1 before 2026-04-01 when no cookie', () => {
+        test('returns v1 before 2026-04-01 when no preference', () => {
             const mockDate = new Date('2026-03-31T23:59:59Z');
             global.Date = class extends Date {
                 constructor (arg) {
@@ -44,7 +35,7 @@ describe('ruby versions', () => {
             expect(version).toEqual(VERSION_1);
         });
 
-        test('returns v2 after 2026-04-01 when no cookie', () => {
+        test('returns v2 after 2026-04-01 when no preference', () => {
             const mockDate = new Date('2026-04-01T00:00:01Z');
             global.Date = class extends Date {
                 constructor (arg) {
@@ -60,15 +51,14 @@ describe('ruby versions', () => {
             expect(version).toEqual(VERSION_2);
         });
 
-        test('persists version to cookie', () => {
+        test('persists version to localStorage', () => {
             persistRubyVersion(VERSION_2);
-            // jsdom's document.cookie might not behave exactly like a real browser
-            // but detectRubyVersion should be able to read what persistRubyVersion wrote.
+            expect(window.localStorage.getItem('smalruby:rubyVersion')).toEqual('2');
             expect(detectRubyVersion()).toEqual(VERSION_2);
         });
 
         test('throws error for invalid version', () => {
-            expect(() => persistRubyVersion(3)).toThrow('Invalid ruby version: 3');
+            expect(() => persistRubyVersion('3')).toThrow('Invalid ruby version: 3');
         });
     });
 });


### PR DESCRIPTION
Implement version control for Ruby code generation (v1 and v2).

## Changes

- Add Ruby version selection to Settings menu.
- Support v1 (legacy: `def self.method_name`) and v2 (standard: `def method_name`) formats.
- Persist version preference in Web Storage (`localStorage`) using key `smalruby:rubyVersion`.
- Date-based default version: v1 before 2026/04/01, v2 after.
- Handle version switching with Ruby code validation and error alerts.
- Auto-dismiss error alerts when Ruby code is corrected or version change is successful.
- Refactored `RubyTab` to deduplicate error handling and clearing logic.
- Standardized Ruby version as a string ('1' or '2') to align with `PreferenceMenu` and resolve PropType warnings.
- Update Ruby generator and Ruby-to-blocks converter to be version-aware.
- Support translations for `en`, `ja`, and `ja-Hira`.
- Add unit tests for persistence, generator, and converter.

Closes #80