### PR TITLE
refactor(gui): update intermediate variable naming conventions

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -123,18 +123,43 @@ Before considering a task complete and preparing a Pull Request, follow these st
     ```
 3.  **Run Unit Tests**:
     ```bash
+    # all tests
     docker compose run --rm app npm run test:unit
+    # run specific test (scratch-vm or scratch-gui)
+    docker compose run --rm app bash -c "cd /app/packages/scratch-vm && npm exec tap test/path/to/your-test.js"
+    docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm exec jest test/path/to/your-test.js"
     ```
-4.  **Run Integration Tests** (if applicable):
+4.  **Build the application**:
     ```bash
-    docker compose run --rm app npm run test:integration
+    docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run build:dev"
     ```
-5.  **Build Check**: Ensure the project builds successfully.
+5.  **Run Integration Tests** (if applicable):
+    ```bash
+    # all tests
+    docker compose run --rm app npm run test:integration
+    # run specific test (scratch-vm or scratch-gui)
+    docker compose run --rm app bash -c "cd /app/packages/scratch-vm && npm exec tap test/path/to/your-test.js"
+    docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm exec jest test/path/to/your-test.js"
+    ```
+6.  **Debug with browser logs**:
+    ```javascript
+    import SeleniumHelper from '../helpers/selenium-helper';
+    const { getLogs } = new SeleniumHelper();
+
+    test('Your test', async () => {
+        // ... test code ...
+
+        // Get all logs (INFO, WARNING, SEVERE)
+        const logs = await getLogs({ includeAllLevels: true });
+        console.log('Browser logs:', logs);
+    });
+    ```
+7.  **Build Check**: Ensure the project builds successfully.
     ```bash
     docker compose run --rm app npm run build
     ```
-6.  **Git Status**: Check for untracked files and ensure all changes are staged.
-7.  **Commit**: Use Conventional Commits and ensure you are NOT on the `develop` branch.
+8.  **Git Status**: Check for untracked files and ensure all changes are staged.
+9.  **Commit**: Use Conventional Commits and ensure you are NOT on the `develop` branch.
 
 ## Contribution Guidelines
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
@@ -78,9 +78,9 @@ const MyBlocksConverter = {
                 if (callIndex < callCount) {
                     varSuffix = `_${callIndex}`;
 
-                    // Create evacuation block: @_return_name_N = @_return_name
-                    const targetVariable = converter._lookupOrCreateVariable(`@_return_${name}${varSuffix}`);
-                    const sourceVariable = converter._lookupOrCreateVariable(`@_return_${name}`);
+                    // Create evacuation block: @_return_name_N_ = @_return_name_
+                    const targetVariable = converter._lookupOrCreateVariable(`@_return_${name}${varSuffix}_`);
+                    const sourceVariable = converter._lookupOrCreateVariable(`@_return_${name}_`);
 
                     const sourceBlock = converter._createBlock('data_variable', 'value_variable', {
                         fields: {
@@ -113,7 +113,7 @@ const MyBlocksConverter = {
                     resultBlocks.push(evacuationBlock);
                 }
 
-                const variable = converter._lookupOrCreateVariable(`@_return_${name}${varSuffix}`);
+                const variable = converter._lookupOrCreateVariable(`@_return_${name}${varSuffix}_`);
                 const varBlock = converter._createBlock('data_variable', 'value_variable', {
                     fields: {
                         VARIABLE: {
@@ -233,7 +233,7 @@ const MyBlocksConverter = {
                 const last = body[lastIdx];
                 if (converter._isValueBlock(last) &&
                     !(last instanceof Primitive && (last.type === 'self' || last.type === 'nil'))) {
-                    const variable = converter._lookupOrCreateVariable(`@_return_${procedureName}`);
+                    const variable = converter._lookupOrCreateVariable(`@_return_${procedureName}_`);
                     const returnBlock = converter._createBlock('data_setvariableto', 'statement', {
                         fields: {
                             VARIABLE: {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variable-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variable-utils.js
@@ -60,7 +60,7 @@ const VariableUtils = {
 
         if (scope === 'local') {
             // Create transformed name - arguments DO NOT get indexed
-            const transformedName = isArgument ? varName : `${varName}_${scopeIndex}_`;
+            const transformedName = isArgument ? varName : `_${varName}_${scopeIndex}_`;
 
             // Check if this transformed name already exists in global store
             variable = this._context[storeName][transformedName];

--- a/packages/scratch-gui/test/helpers/expect-to-equal-blocks.js
+++ b/packages/scratch-gui/test/helpers/expect-to-equal-blocks.js
@@ -223,7 +223,7 @@ const expectToEqualBlocks = function (converter, expectedBlocksInfo) {
     const context = {
         converter: converter,
         blocks: blocks,
-        variables: converter.variables,
+        variables: Object.assign({}, converter.variables, converter._context.localVariables),
         lists: converter.lists,
         broadcastMsgs: converter.broadcastMsgs
     };
@@ -410,7 +410,7 @@ const rubyToExpected = function (converter, target, code) {
     const context = {
         converter: converter,
         blocks: blocks,
-        variables: converter.variables,
+        variables: Object.assign({}, converter.variables, converter._context.localVariables),
         lists: converter.lists,
         broadcastMsgs: converter.broadcastMsgs
     };

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/method-return.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/method-return.test.js
@@ -140,7 +140,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
                         fields: [
                             {
                                 name: 'VARIABLE',
-                                variable: '@_return_add'
+                                variable: '@_return_add_'
                             }
                         ],
                         inputs: [
@@ -289,13 +289,12 @@ describe('RubyToBlocksConverter/Method Return', () => {
                         ],
                         next: {
                             opcode: 'data_setvariableto',
-                            fields: [
-                                {
-                                    name: 'VARIABLE',
-                                    variable: '@_return_calculate'
-                                }
-                            ],
-                            inputs: [
+                                                    fields: [
+                                                        {
+                                                            name: 'VARIABLE',
+                                                            variable: '@_return_calculate_'
+                                                        }
+                                                    ],                            inputs: [
                                 {
                                     name: 'VALUE',
                                     block: {
@@ -346,7 +345,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
         test('explicit return variable assignment should NOT add @ruby:return comment', () => {
             const code = `
                 def self.add(a, b)
-                  @_return_add = a + b
+                  @_return_add_ = a + b
                 end
             `;
             const expected = [
@@ -379,7 +378,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
                         fields: [
                             {
                                 name: 'VARIABLE',
-                                variable: '@_return_add'
+                                variable: '@_return_add_'
                             }
                         ],
                         inputs: [
@@ -524,7 +523,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
             const evacuationId = firstCall.next;
             const evacuation = blocks[evacuationId];
             expect(evacuation.opcode).toBe('data_setvariableto');
-            expect(evacuation.fields.VARIABLE.value).toBe('_return_add_1');
+            expect(evacuation.fields.VARIABLE.value).toBe('_return_add_1_');
             
             const secondCallId = evacuation.next;
             const secondCall = blocks[secondCallId];
@@ -537,9 +536,9 @@ describe('RubyToBlocksConverter/Method Return', () => {
 
             // Check arguments
             const arg1Id = Object.values(secondCall.inputs)[0].block;
-            expect(blocks[arg1Id].fields.VARIABLE.value).toBe('_return_add_1');
+            expect(blocks[arg1Id].fields.VARIABLE.value).toBe('_return_add_1_');
             expect(thirdCall.inputs.MESSAGE.block).toBeDefined();
-            expect(blocks[thirdCall.inputs.MESSAGE.block].fields.VARIABLE.value).toBe('_return_add');
+            expect(blocks[thirdCall.inputs.MESSAGE.block].fields.VARIABLE.value).toBe('_return_add_');
 
             // Verify Blocks -> Ruby
             await converter.applyTargetBlocks(target);
@@ -679,7 +678,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
 
             const firstEvacuation = blocks[firstCall.next];
             expect(firstEvacuation.opcode).toBe('data_setvariableto');
-            expect(firstEvacuation.fields.VARIABLE.value).toBe('_return_add_1');
+            expect(firstEvacuation.fields.VARIABLE.value).toBe('_return_add_1_');
             expect(converter._context.comments[firstEvacuation.comment].text).toBe('@ruby:return:add:1');
 
             const secondCall = blocks[firstEvacuation.next];
@@ -688,7 +687,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
 
             const secondEvacuation = blocks[secondCall.next];
             expect(secondEvacuation.opcode).toBe('data_setvariableto');
-            expect(secondEvacuation.fields.VARIABLE.value).toBe('_return_add_2');
+            expect(secondEvacuation.fields.VARIABLE.value).toBe('_return_add_2_');
             expect(converter._context.comments[secondEvacuation.comment].text).toBe('@ruby:return:add:2');
 
             const topCall = blocks[secondEvacuation.next];
@@ -704,8 +703,8 @@ describe('RubyToBlocksConverter/Method Return', () => {
             const RubyGenerator = require('../../../../src/lib/ruby-generator').default;
             const generatedRuby = RubyGenerator.targetToCode(target);
             
-            expect(generatedRuby).not.toMatch(/@_return_add_1 = @_return_add/);
-            expect(generatedRuby).not.toMatch(/@_return_add_2 = @_return_add/);
+            expect(generatedRuby).not.toMatch(/@_return_add_1_ = @_return_add_/);
+            expect(generatedRuby).not.toMatch(/@_return_add_2_ = @_return_add_/);
             expect(generatedRuby).toMatch(/say\(add\(add\(2, 5\), add\(4, 6\)\)\)/);
         });
 
@@ -733,7 +732,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
 
             const firstEvacuation = blocks[firstCall.next];
             expect(firstEvacuation.opcode).toBe('data_setvariableto');
-            expect(firstEvacuation.fields.VARIABLE.value).toBe('_return_add_1');
+            expect(firstEvacuation.fields.VARIABLE.value).toBe('_return_add_1_');
 
             // add(@_return_add_1, 3) -> index 2
             const secondCall = blocks[firstEvacuation.next];
@@ -742,7 +741,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
 
             const secondEvacuation = blocks[secondCall.next];
             expect(secondEvacuation.opcode).toBe('data_setvariableto');
-            expect(secondEvacuation.fields.VARIABLE.value).toBe('_return_add_2');
+            expect(secondEvacuation.fields.VARIABLE.value).toBe('_return_add_2_');
 
             // add(@_return_add_2, 4) -> index 3 (last)
             const topCall = blocks[secondEvacuation.next];

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables.test.js
@@ -882,4 +882,41 @@ describe('RubyToBlocksConverter/Variables', () => {
             expect(res).toBeTruthy();
         });
     });
+
+    describe('Pseudo-Local Variable Naming', () => {
+        test('local variable should have leading and trailing underscores and scope index', () => {
+            const code = 'x = 1';
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: '_x_1_'
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: expectedInfo.makeText('1')
+                        }
+                    ]
+                }
+            ];
+            convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('local variable in method should have scope index 2', () => {
+            const code = `
+                def self.test
+                  y = 2
+                end
+            `;
+            const res = converter.targetCodeToBlocks(target, code);
+            expect(res).toBeTruthy();
+            const setVarBlock = Object.values(converter.blocks).find(b => b.opcode === 'data_setvariableto');
+            expect(setVarBlock).toBeDefined();
+            expect(setVarBlock.fields.VARIABLE.value).toBe('_y_2_');
+        });
+    });
 });


### PR DESCRIPTION
Updates the naming conventions for intermediate variables in the Ruby-to-blocks converter:
- Local variables: `foo_1_` -> `_foo_1_`
- Return values: `@_return_foo` -> `@_return_foo_`, `@_return_foo_1` -> `@_return_foo_1_`

Also updates the test helper to correctly verify local variables.