### PR TITLE
feat: add undo/redo button state control based on Monaco Editor stack

### DIFF
--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -306,7 +306,7 @@ const RubyToolbar = props => {
                     <button
                         className={styles.iconButton}
                         onClick={handleUndo}
-                        disabled={!props.editorRef}
+                        disabled={!props.editorRef || !props.canUndo}
                         aria-label={intl.formatMessage(messages.undo)}
                         title={intl.formatMessage(messages.undo)}
                     >
@@ -318,7 +318,7 @@ const RubyToolbar = props => {
                     <button
                         className={styles.iconButton}
                         onClick={handleRedo}
-                        disabled={!props.editorRef}
+                        disabled={!props.editorRef || !props.canRedo}
                         aria-label={intl.formatMessage(messages.redo)}
                         title={intl.formatMessage(messages.redo)}
                     >
@@ -426,7 +426,9 @@ RubyToolbar.propTypes = {
     onSelectTarget: PropTypes.func.isRequired,
     onDownload: PropTypes.func,
     onExecuteLine: PropTypes.func,
-    isRunning: PropTypes.bool
+    isRunning: PropTypes.bool,
+    canUndo: PropTypes.bool,
+    canRedo: PropTypes.bool
 };
 
 export default RubyToolbar;

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -53,7 +53,8 @@ class RubyTab extends React.Component {
             'getBlockIdForLine',
             'handleExecuteLine',
             'handleScriptGlowOn',
-            'handleScriptGlowOff'
+            'handleScriptGlowOff',
+            'updateUndoRedoState'
         ]);
         this.mainTooltipId = 'ruby-downloader-tooltip';
         this.editorRef = null;
@@ -64,9 +65,12 @@ class RubyTab extends React.Component {
         this.lastProcessedVersion = props.rubyVersion;
         this.downloadCallbackRef = null;
         this.executingLineDecoration = null;
+        this.contentChangeListener = null;
         this.state = {
             runningBlockId: null,
-            executingLine: null
+            executingLine: null,
+            canUndo: false,
+            canRedo: false
         };
 
         loadMonacoLocale(props.locale);
@@ -168,6 +172,10 @@ class RubyTab extends React.Component {
             this.completionProvider.dispose();
             this.completionProvider = null;
         }
+        if (this.contentChangeListener) {
+            this.contentChangeListener.dispose();
+            this.contentChangeListener = null;
+        }
     }
 
     clearErrors () {
@@ -253,6 +261,38 @@ class RubyTab extends React.Component {
                 editor.layout();
             });
             this.resizeObserver.observe(this.containerRef);
+        }
+
+        // Monitor undo/redo stack changes
+        this.contentChangeListener = editor.onDidChangeModelContent(() => {
+            this.updateUndoRedoState();
+        });
+
+        // Set initial undo/redo state
+        this.updateUndoRedoState();
+    }
+
+    updateUndoRedoState () {
+        if (!this.editorRef) {
+            return;
+        }
+
+        const model = this.editorRef.getModel();
+        if (!model) {
+            return;
+        }
+
+        // Access internal _commandManager to check undo/redo stack state
+        // Note: This uses private API which may change in future Monaco Editor versions
+        const commandManager = model._commandManager;
+        if (commandManager) {
+            const canUndo = commandManager.undoStack && commandManager.undoStack.length > 0;
+            const canRedo = commandManager.redoStack && commandManager.redoStack.length > 0;
+
+            this.setState({
+                canUndo,
+                canRedo
+            });
         }
     }
 
@@ -512,6 +552,8 @@ class RubyTab extends React.Component {
                         onDownload={this.handleDownload}
                         onExecuteLine={this.handleExecuteLine}
                         isRunning={!!this.state.runningBlockId}
+                        canUndo={this.state.canUndo}
+                        canRedo={this.state.canRedo}
                     />
                     <div className={styles.editorWrapper}>
                         <Editor

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -282,12 +282,13 @@ class RubyTab extends React.Component {
             return;
         }
 
-        // Access internal _commandManager to check undo/redo stack state
+        // Access internal _undoRedoService to check undo/redo state
         // Note: This uses private API which may change in future Monaco Editor versions
-        const commandManager = model._commandManager;
-        if (commandManager) {
-            const canUndo = commandManager.undoStack && commandManager.undoStack.length > 0;
-            const canRedo = commandManager.redoStack && commandManager.redoStack.length > 0;
+        const undoRedoService = model._undoRedoService;
+        if (undoRedoService && typeof undoRedoService.canUndo === 'function') {
+            const resource = model.uri;
+            const canUndo = undoRedoService.canUndo(resource);
+            const canRedo = undoRedoService.canRedo(resource);
 
             this.setState({
                 canUndo,


### PR DESCRIPTION
## Summary

RubyタブのツールバーのUndo/Redoボタンを、Monaco Editorのundo/redoスタックの状態に基づいて活性/非活性を制御するようにしました。

## Changes Made

### RubyTabコンポーネント ([ruby-tab.jsx](packages/scratch-gui/src/containers/ruby-tab.jsx))
- `canUndo`/`canRedo`の状態を追加
- `updateUndoRedoState()`メソッドを実装し、Monaco Editorの内部API（`_commandManager`）を使用してスタック状態を取得
- `onDidChangeModelContent`イベントでスタック変化を監視
- エディタマウント時に初期状態を設定
- `componentWillUnmount`でリスナーをクリーンアップ
- RubyToolbarに`canUndo`/`canRedo`をpropsとして渡す

### RubyToolbarコンポーネント ([ruby-toolbar.jsx](packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx))
- Undo/Redoボタンの`disabled`属性を`!props.editorRef || !props.canUndo`および`!props.editorRef || !props.canRedo`に変更
- PropTypesに`canUndo`と`canRedo`を追加

## Implementation Details

### Monaco Editorの内部API使用
Monaco Editorは公式APIとしてundo/redoスタックの状態を公開していないため、以下の内部プロパティにアクセスしています：

```javascript
const commandManager = model._commandManager;
const canUndo = commandManager.undoStack && commandManager.undoStack.length > 0;
const canRedo = commandManager.redoStack && commandManager.redoStack.length > 0;
```

**注意**: `_commandManager`は内部実装であり、Monaco Editorのバージョンアップで変更される可能性があります。

### 動作
- エディタのコンテンツが変更されるたびに、undo/redoスタックの状態を確認
- スタックが空の場合、対応するボタンを非活性化
- スタックに履歴がある場合、ボタンを活性化

## Testing

手動テストで以下を確認してください：

1. Rubyタブを開いたとき、Undo/Redoボタンが非活性状態であること
2. コードを入力すると、Undoボタンが活性化されること
3. Undoを実行すると、Redoボタンが活性化されること
4. Undoで最初の状態まで戻ると、Undoボタンが非活性化されること
5. Redoで最新の状態まで進むと、Redoボタンが非活性化されること

## Related Issues

N/A

## Base Branch

このPRは`fix/local-variable-duplicate-registration`ブランチをベースにしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
