### PR TITLE
feat: reposition value report bubble in Ruby mode

### DIFF
--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -116,25 +116,38 @@ const RubyToolbar = props => {
     }, [intl]);
 
     const handleSearch = useCallback(() => {
+        if (props.onDismissBubble) {
+            props.onDismissBubble();
+        }
         if (props.editorRef) {
             // Trigger Monaco Editor's search action
             props.editorRef.trigger('keyboard', 'actions.find', null);
         }
-    }, [props.editorRef]);
+    }, [props]);
 
     const handleUndo = useCallback(() => {
+        if (props.onDismissBubble) {
+            props.onDismissBubble();
+        }
         if (props.editorRef) {
             props.editorRef.trigger('keyboard', 'undo', null);
         }
-    }, [props.editorRef]);
+    }, [props]);
 
     const handleRedo = useCallback(() => {
+        if (props.onDismissBubble) {
+            props.onDismissBubble();
+        }
         if (props.editorRef) {
             props.editorRef.trigger('keyboard', 'redo', null);
         }
-    }, [props.editorRef]);
+    }, [props]);
 
     const handlePrevSprite = useCallback(() => {
+        if (props.onDismissBubble) {
+            props.onDismissBubble();
+        }
+
         const sprites = getSortedSprites();
         const currentIndex = getCurrentSpriteIndex();
 
@@ -153,6 +166,10 @@ const RubyToolbar = props => {
     }, [getSortedSprites, getCurrentSpriteIndex, props]);
 
     const handleNextSprite = useCallback(() => {
+        if (props.onDismissBubble) {
+            props.onDismissBubble();
+        }
+
         const sprites = getSortedSprites();
         const currentIndex = getCurrentSpriteIndex();
 
@@ -204,6 +221,9 @@ const RubyToolbar = props => {
     }, []);
 
     const handleSelectTarget = useCallback(targetId => {
+        if (props.onDismissBubble) {
+            props.onDismissBubble();
+        }
         props.onSelectTarget(targetId);
         setCommandValue('');
         setShowDropdown(false);
@@ -225,6 +245,9 @@ const RubyToolbar = props => {
     }, [handleSelectTarget]);
 
     const handleDownload = useCallback(() => {
+        if (props.onDismissBubble) {
+            props.onDismissBubble();
+        }
         // Trigger download Ruby code
         if (props.onDownload) {
             props.onDownload();
@@ -426,6 +449,7 @@ RubyToolbar.propTypes = {
     onSelectTarget: PropTypes.func.isRequired,
     onDownload: PropTypes.func,
     onExecuteLine: PropTypes.func,
+    onDismissBubble: PropTypes.func,
     isRunning: PropTypes.bool,
     canUndo: PropTypes.bool,
     canRedo: PropTypes.bool

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -37,7 +37,8 @@ import {isTimeTravel2020} from '../reducers/time-travel';
 
 import {
     activateTab,
-    SOUNDS_TAB_INDEX
+    SOUNDS_TAB_INDEX,
+    RUBY_TAB_INDEX
 } from '../reducers/editor-tab';
 
 const addFunctionListener = (object, property, callback) => {
@@ -364,6 +365,10 @@ class Blocks extends React.Component {
         this.workspace.glowBlock(data.id, false);
     }
     onVisualReport (data) {
+        // Don't show visual report in Code tab when Ruby tab is active
+        if (this.props.activeTabIndex === RUBY_TAB_INDEX) {
+            return;
+        }
         this.workspace.reportValue(data.id, data.value);
     }
 
@@ -791,6 +796,7 @@ Blocks.propTypes = {
     updateToolboxState: PropTypes.func,
     useCatBlocks: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired,
+    activeTabIndex: PropTypes.number,
     workspaceMetrics: PropTypes.shape({
         targets: PropTypes.objectOf(PropTypes.object)
     }),
@@ -831,6 +837,7 @@ const mapStateToProps = state => ({
     messages: state.locales.messages,
     selectedBlocks: state.scratchGui.blockDisplay.selectedBlocks,
     toolboxXML: state.scratchGui.toolbox.toolboxXML,
+    activeTabIndex: state.scratchGui.editorTab.activeTabIndex,
     customProceduresVisible: state.scratchGui.customProcedures.active,
     workspaceMetrics: state.scratchGui.workspaceMetrics,
     useCatBlocks: isTimeTravel2020(state) || state.scratchGui.settings.theme === CAT_BLOCKS_THEME

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -15,7 +15,7 @@ import {
 import {setRubyVersion} from '../reducers/settings';
 import {showAlertWithTimeout, closeAlertWithId} from '../reducers/alerts';
 import VM from '@smalruby/scratch-vm';
-import {BLOCKS_TAB_INDEX} from '../reducers/editor-tab';
+import {BLOCKS_TAB_INDEX, RUBY_TAB_INDEX} from '../reducers/editor-tab';
 
 import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
 import {targetCodeToBlocks} from '../lib/ruby-to-blocks-converter';
@@ -53,6 +53,8 @@ class RubyTab extends React.Component {
             'handleExecuteLine',
             'handleScriptGlowOn',
             'handleScriptGlowOff',
+            'handleVisualReport',
+            'handleDismissBubble',
             'updateUndoRedoState'
         ]);
         this.mainTooltipId = 'ruby-downloader-tooltip';
@@ -65,6 +67,7 @@ class RubyTab extends React.Component {
         this.downloadCallbackRef = null;
         this.executingLineDecoration = null;
         this.contentChangeListener = null;
+        this.bubbleRef = null;
         this.state = {
             runningBlockId: null,
             executingLine: null,
@@ -78,6 +81,7 @@ class RubyTab extends React.Component {
     componentDidMount () {
         this.props.vm.addListener('SCRIPT_GLOW_ON', this.handleScriptGlowOn);
         this.props.vm.addListener('SCRIPT_GLOW_OFF', this.handleScriptGlowOff);
+        this.props.vm.addListener('VISUAL_REPORT', this.handleVisualReport);
     }
 
     componentDidUpdate (prevProps) {
@@ -90,6 +94,11 @@ class RubyTab extends React.Component {
 
         if (this.props.locale !== prevProps.locale) {
             loadMonacoLocale(this.props.locale);
+        }
+
+        if (prevProps.activeTabIndex === RUBY_TAB_INDEX &&
+            this.props.activeTabIndex !== RUBY_TAB_INDEX) {
+            this.handleDismissBubble();
         }
 
         if (prevProps.isVisible && !this.props.isVisible) {
@@ -163,6 +172,12 @@ class RubyTab extends React.Component {
     componentWillUnmount () {
         this.props.vm.removeListener('SCRIPT_GLOW_ON', this.handleScriptGlowOn);
         this.props.vm.removeListener('SCRIPT_GLOW_OFF', this.handleScriptGlowOff);
+        this.props.vm.removeListener('VISUAL_REPORT', this.handleVisualReport);
+        this.handleDismissBubble();
+        if (this.bubbleRef) {
+            document.body.removeChild(this.bubbleRef);
+            this.bubbleRef = null;
+        }
         this.clearExecutingLineHighlight();
         if (this.resizeObserver) {
             this.resizeObserver.disconnect();
@@ -262,12 +277,18 @@ class RubyTab extends React.Component {
             this.resizeObserver.observe(this.containerRef);
         }
 
-        // Monitor undo/redo stack changes
         this.contentChangeListener = editor.onDidChangeModelContent(() => {
             this.updateUndoRedoState();
         });
 
-        // Set initial undo/redo state
+        editor.onDidChangeCursorPosition(() => {
+            this.handleDismissBubble();
+        });
+
+        editor.onMouseDown(() => {
+            this.handleDismissBubble();
+        });
+
         this.updateUndoRedoState();
     }
 
@@ -379,6 +400,46 @@ class RubyTab extends React.Component {
         if (this.state.runningBlockId === data.id) {
             this.setState({runningBlockId: null, executingLine: null});
             this.clearExecutingLineHighlight();
+        }
+    }
+
+    handleVisualReport (data) {
+        if (this.props.activeTabIndex !== RUBY_TAB_INDEX) {
+            return;
+        }
+
+        const button = document.querySelector('button[aria-label*="カーソル行を実行"]') ||
+                       document.querySelector('button[aria-label*="Execute current line"]') ||
+                       document.querySelector('button[aria-label*="実行を停止"]') ||
+                       document.querySelector('button[aria-label*="Stop execution"]');
+        if (!button) {
+            return;
+        }
+
+        const rect = button.getBoundingClientRect();
+
+        if (!this.bubbleRef) {
+            this.bubbleRef = document.createElement('div');
+            this.bubbleRef.className = styles.valueReportBubble;
+            document.body.appendChild(this.bubbleRef);
+        }
+
+        this.bubbleRef.textContent = String(data.value);
+
+        const x = rect.right + 10;
+        const y = rect.top;
+
+        this.bubbleRef.style.left = `${x}px`;
+        this.bubbleRef.style.top = `${y}px`;
+
+        requestAnimationFrame(() => {
+            this.bubbleRef.classList.add(styles.visible);
+        });
+    }
+
+    handleDismissBubble () {
+        if (this.bubbleRef) {
+            this.bubbleRef.classList.remove(styles.visible);
         }
     }
 
@@ -543,6 +604,7 @@ class RubyTab extends React.Component {
                         onSelectTarget={this.handleSelectTarget}
                         onDownload={this.handleDownload}
                         onExecuteLine={this.handleExecuteLine}
+                        onDismissBubble={this.handleDismissBubble}
                         isRunning={!!this.state.runningBlockId}
                         canUndo={this.state.canUndo}
                         canRedo={this.state.canRedo}
@@ -634,7 +696,8 @@ RubyTab.propTypes = {
     updateRubyCodeTargetState: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired,
     projectTitle: PropTypes.string,
-    locale: PropTypes.string
+    locale: PropTypes.string,
+    activeTabIndex: PropTypes.number
 };
 
 const mapStateToProps = state => ({
@@ -644,7 +707,8 @@ const mapStateToProps = state => ({
     rubyVersion: state.scratchGui.settings.rubyVersion,
     vm: state.scratchGui.vm,
     projectTitle: state.scratchGui.projectTitle,
-    locale: state.locales.locale
+    locale: state.locales.locale,
+    activeTabIndex: state.scratchGui.editorTab.activeTabIndex
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/scratch-gui/src/containers/ruby-tab/ruby-tab.css
+++ b/packages/scratch-gui/src/containers/ruby-tab/ruby-tab.css
@@ -117,12 +117,55 @@ $arrow-rounding: 0.125rem;
     bottom: 0;
 }
 
-/* Override Monaco Editor find widget position to prevent it from being cut off */
+/* Override Monaco Editor find widget position */
 .editorWrapper :global(.monaco-editor .find-widget) {
     right: 48px !important;
 }
 
-/* Executing line highlight */
 .editorWrapper :global(.executing-line) {
     background-color: rgba(133, 92, 214, 0.2) !important;
+}
+
+/* Value report bubble */
+.valueReportBubble {
+    position: fixed;
+    z-index: 1000;
+    background-color: #FFFFFF;
+    border: 1px solid #AAAAAA;
+    border-radius: 4px;
+    padding: 4px 8px;
+    box-sizing: content-box;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    min-width: 50px;
+    max-width: 300px;
+    max-height: 200px;
+    overflow: auto;
+    word-wrap: break-word;
+    word-break: break-all;
+    text-align: center;
+    font-family: "Helvetica Neue", Helvetica, sans-serif;
+    font-size: 0.8em;
+    line-height: 1.2;
+    opacity: 0;
+    transform: translateX(-10px);
+    transition: opacity 0.25s, transform 0.25s;
+    pointer-events: none;
+}
+
+.valueReportBubble.visible {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.valueReportBubble::before {
+    content: '';
+    position: absolute;
+    left: -9px;
+    top: 50%;
+    transform: translateY(-50%) rotate(45deg);
+    width: 16px;
+    height: 16px;
+    background-color: #FFFFFF;
+    border-left: 1px solid #AAAAAA;
+    border-bottom: 1px solid #AAAAAA;
 }


### PR DESCRIPTION
## Summary

Repositioned the value report bubble in Ruby mode from the top-left corner to the right side of the execution button, horizontally aligned.

## Changes Made

### Ruby Tab Bubble Implementation
- Added custom bubble implementation using DOM elements and CSS
- Positioned bubble to the right of execution button with 10px gap
- Vertically aligned with button (top-aligned)
- Left-pointing arrow with vertical centering

### Dismissal Handlers
- Dismiss on Monaco editor cursor position change
- Dismiss on Monaco editor mouse down
- Dismiss on toolbar button clicks (search, undo, redo, sprite navigation, download)
- Dismiss when switching away from Ruby tab

### Tab Isolation
- Ruby tab bubble only shows when Ruby tab is active
- Code tab bubble suppressed when Ruby tab is active
- Prevents both bubbles from showing simultaneously

### Styling
- Matched Code tab bubble styling:
  - `max-height: 200px`
  - `overflow: auto`
  - `word-wrap: break-word`
  - `word-break: break-all`
- Arrow positioned with `top: 50%` and `translateY(-50%)` for vertical centering

## Test Coverage

Manually tested:
- ✅ Short values ("5", "6") display compactly without scrollbars
- ✅ Long strings wrap and scroll correctly within max-height
- ✅ Bubble positioned to right of execution button, horizontally aligned
- ✅ Arrow points correctly at button
- ✅ Bubble dismisses on editor interaction
- ✅ Bubble dismisses on toolbar clicks
- ✅ Bubble dismisses when switching tabs
- ✅ Code tab bubble still works correctly
- ✅ No visual distortion or scrollbar issues

## Related Issues

Fixes the positioning issue where Ruby mode value report bubble appeared at top-left (0px, 27px) instead of near the execution button.
