### PR TITLE
fix: resolve TypeError when executing Ruby code with 'wait' command

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js
@@ -62,7 +62,7 @@ const BlockUtils = {
         this._context.blockTypes[block.id] = type;
 
         // Map current node to block ID for line execution feature
-        if (this._context.currentNode && this._context.currentNode !== Opal.nil) {
+        if (!block.shadow && this._context.currentNode && this._context.currentNode !== Opal.nil) {
             this._context.nodeToBlockMap.set(this._context.currentNode, block.id);
         }
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -584,16 +584,25 @@ class RubyToBlocksConverter {
 
         const blockId = this._context.nodeToBlockMap.get(entry.node);
 
-        // If direct mapping exists but node has no block, try fallback
-        if (!blockId) {
+        // If direct mapping exists but node has no block, or block was deleted, try fallback
+        if (!blockId || !this._context.blocks[blockId]) {
             const fallbackEntry = this._findContainingNode(lineNumber);
             if (fallbackEntry) {
                 const fallbackBlockId = this._context.nodeToBlockMap.get(fallbackEntry.node);
-                return fallbackBlockId || null;
+                if (fallbackBlockId && this._context.blocks[fallbackBlockId]) {
+                    return fallbackBlockId;
+                }
             }
+
+            const nearestLine = this._findNearestExecutableLine(lineNumber);
+            if (nearestLine !== null) {
+                return this.getBlockIdForLine(nearestLine);
+            }
+
+            return null;
         }
 
-        return blockId || null;
+        return blockId;
     }
 
     /**

--- a/packages/scratch-vm/src/engine/blocks.js
+++ b/packages/scratch-vm/src/engine/blocks.js
@@ -214,7 +214,9 @@ class Blocks {
         let block = this._blocks[id];
         if (typeof block === 'undefined') return null;
         while (block.parent !== null) {
-            block = this._blocks[block.parent];
+            const parentBlock = this._blocks[block.parent];
+            if (typeof parentBlock === 'undefined') return block.id;
+            block = parentBlock;
         }
         return block.id;
     }


### PR DESCRIPTION
Rubyタブで `wait` 命令（後方互換性のためだけに残されており、命令ブロックに変換されるときに除去される命令）を含むプログラムを実行しようとすると、 `TypeError: Cannot read properties of undefined (reading 'parent')` が発生する不具合を修正しました。

### 原因の分析
1.  **ノードとブロックの誤ったマッピング**: `RubyToBlocksConverter` において、 `wait` 命令のような「命令ブロックとしては存在しないが一時的に `ruby_statement` ブロックとして作成され、後で除去される」命令を処理する際、その命令の引数として作成される影のブロック（ `text` ブロックなど）が `nodeToBlockMap` を上書きしていました。
2.  **除去されたブロックの参照**: `wait` 命令に対応する `ruby_statement` ブロックは除去されますが、影のブロックは `converter.blocks` に残ります。 `getBlockIdForLine` は、この影のブロックのIDを返してしまいます。
3.  **VMでのクラッシュ**: VMの `getTopLevelScript` 関数において、受け取ったブロックIDがVM内に存在しない親ブロック（除去された `ruby_statement`）を参照している場合、その親を辿ろうとして `undefined` のプロパティを参照し、クラッシュしていました。

### 修正内容
1.  **`packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js`**:
    *   `_createBlock` において、影のブロック（ `shadow: true` ）を `nodeToBlockMap` に登録しないように修正しました。
2.  **`packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js`**:
    *   `getBlockIdForLine` において、取得したブロックIDが `this._context.blocks` に存在するか確認する処理を追加しました。 `wait` のように除去されたブロックのIDがマッピングに残っている場合、以前の実行可能ラインを検索するなどのフォールバック処理が正しく行われるようになります。
3.  **`packages/scratch-vm/src/engine/blocks.js`**:
    *   `getTopLevelScript` において、親ブロックのIDが指すブロックが `this._blocks` に存在しない場合にクラッシュしないよう、安全に探索を中断するガードを追加しました。