### PR TITLE
fix: update hoveredTarget propType to resolve invalid prop type warning

### DIFF
--- a/packages/scratch-gui/src/components/sprite-selector/sprite-list.jsx
+++ b/packages/scratch-gui/src/components/sprite-selector/sprite-list.jsx
@@ -112,9 +112,8 @@ SpriteList.propTypes = {
     draggingType: PropTypes.oneOf(Object.keys(DragConstants)),
     editingTarget: PropTypes.string,
     hoveredTarget: PropTypes.shape({
-        hoveredSprite: PropTypes.string,
         receivedBlocks: PropTypes.bool,
-        sprite: PropTypes.string
+        sprite: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     }),
     items: PropTypes.arrayOf(PropTypes.shape({
         costume: PropTypes.shape({

--- a/packages/scratch-gui/src/components/sprite-selector/sprite-selector.jsx
+++ b/packages/scratch-gui/src/components/sprite-selector/sprite-selector.jsx
@@ -149,8 +149,8 @@ const SpriteSelectorComponent = function (props) {
 SpriteSelectorComponent.propTypes = {
     editingTarget: PropTypes.string,
     hoveredTarget: PropTypes.shape({
-        hoveredSprite: PropTypes.string,
-        receivedBlocks: PropTypes.bool
+        receivedBlocks: PropTypes.bool,
+        sprite: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     }),
     onChangeSpriteDirection: PropTypes.func,
     onChangeSpriteName: PropTypes.func,

--- a/packages/scratch-gui/src/components/target-pane/target-pane.jsx
+++ b/packages/scratch-gui/src/components/target-pane/target-pane.jsx
@@ -132,8 +132,8 @@ TargetPane.propTypes = {
     extensionLibraryVisible: PropTypes.bool,
     fileInputRef: PropTypes.func,
     hoveredTarget: PropTypes.shape({
-        hoveredSprite: PropTypes.string,
-        receivedBlocks: PropTypes.bool
+        receivedBlocks: PropTypes.bool,
+        sprite: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     }),
     onActivateBlocksTab: PropTypes.func.isRequired,
     onChangeSpriteDirection: PropTypes.func,


### PR DESCRIPTION
This PR updates the `hoveredTarget` propType in `SpriteList`, `SpriteSelectorComponent`, and `TargetPane` to correctly allow the `sprite` property to be either a string or a number. It also removes the unused `hoveredSprite` property.

This resolves the following warning observed when displaying the costume tab:
`Warning: Failed prop type: Invalid prop hoveredTarget.sprite of type number supplied to SpriteList, expected string.`