### PR TITLE
feat: implement empty? conversion between Ruby and blocks

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: design
+description: Investigate the codebase based on requirements, produce a detailed design, and create a GitHub Issue. Use when planning a new feature or immediately before starting implementation.
+argument-hint: "[feature description or issue number]"
+disable-model-invocation: true
+---
+
+# /design - Investigate & Design, then Create GitHub Issue
+
+Investigate the codebase for `$ARGUMENTS`, produce a detailed design, and create a GitHub Issue.
+
+## Phase 1: Requirement Clarification
+
+- Parse the feature name and goal from `$ARGUMENTS` or conversation context
+- If `$ARGUMENTS` is a GitHub issue number, fetch it first:
+  ```
+  gh issue view <number> --repo smalruby/smalruby3-editor
+  ```
+- If the requirement is unclear, ask one clarifying question before proceeding
+- Read relevant memory files (`project_overview`, `style_and_conventions`) for context
+
+## Phase 2: Codebase Investigation
+
+Investigate relevant parts of the codebase efficiently using Serena symbolic tools.
+
+1. **Identify affected packages** under `packages/` (scratch-gui, scratch-vm, etc.)
+2. **Explore related symbols and files**
+   - Use `get_symbols_overview`, `find_symbol`, `search_for_pattern` to locate related code
+   - Read only the bodies of symbols directly relevant to the feature
+   - Note key file paths, class/function names, and existing patterns
+3. **Identify constraints and risks**
+   - Cross-package dependencies
+   - Upstream Scratch code areas (harder to modify safely)
+   - Existing tests that may be affected
+
+## Phase 3: Design
+
+Produce a structured design and **present it to the user for approval** before creating the Issue.
+
+### TDD Policy
+
+- Plan implementation using **Test-Driven Development (TDD)**:
+  - For each phase: **[RED]** write failing unit test first → **[GREEN]** implement to pass → **[PASS]** confirm
+  - UI-related features take too long to test interactively, so **only unit tests follow TDD**
+  - **Integration tests are written after implementation** (for regression detection), not before
+
+### Commit & PR Strategy
+
+- After each phase completes: run lint → commit → push
+- After the **first push**: create a PR
+- Subsequent phases push to the same PR
+- This allows fine-grained progress tracking
+
+### Design Template
+
+```markdown
+## Feature: <name>
+
+### Goal
+One-paragraph description of what the feature does and why.
+
+### Affected Files
+- `path/to/file` — reason
+
+### Implementation Steps（TDD + Commit Strategy）
+
+**Phase N: <phase name>**
+
+1. **[RED]** Add/update unit tests (confirm they fail)
+2. **[GREEN]** Implement to make tests pass
+3. **[PASS]** lint + unit test confirmation
+4. **[COMMIT & PUSH]** `<type>: <description>`
+5. **[MAKE PR]** (first push only)
+
+(Repeat for each phase)
+
+**Phase Final: Integration Tests（post-implementation）**
+
+- Write integration tests for regression detection
+- lint + all tests (unit + integration) pass
+- **[COMMIT & PUSH]** `test: add integration tests for <feature>`
+
+### Test Plan
+
+| Type | Timing | Target |
+|------|--------|--------|
+| Unit tests (TDD) | Before implementation (RED → GREEN) | core logic |
+| Integration tests | After implementation | round-trip, UI behavior |
+
+### Risks & Open Questions
+- ...
+```
+
+Wait for explicit user approval ("looks good", "OK", "yes", etc.) before proceeding to Phase 4.
+
+## Phase 4: GitHub Issue Creation
+
+After user approves the design, create the GitHub Issue using a temporary file:
+
+```bash
+cat > /tmp/design-issue-body.md <<'EOF'
+## Goal
+<goal>
+
+## Affected Files
+<list>
+
+## Implementation Steps
+<numbered list>
+
+## Test Plan
+<list>
+
+## Risks & Open Questions
+<list>
+EOF
+
+gh issue create \
+  --repo smalruby/smalruby3-editor \
+  --title "<type>: <short description>" \
+  --body-file /tmp/design-issue-body.md
+
+rm /tmp/design-issue-body.md
+```
+
+Issue title must follow Conventional Commits style (`feat:`, `fix:`, `refactor:`, etc.).
+
+## Final Report (Japanese)
+
+Report the result to the user in Japanese:
+- Show the created issue URL
+- Briefly summarize what was designed and created
+- Note any open questions that need follow-up
+
+---
+
+**Important**: Do NOT start implementation. This skill only investigates, designs, and creates the Issue.

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -112,6 +112,7 @@ RubyGenerator.ORDER_NONE = 99;             // (...)
 RubyGenerator.init = function (options) {
     this.definitions_ = {};
     this.returnCallCache_ = {}; // Clear return value call cache
+    this.emptyCallCache_ = {};
     this.version = options && options.version ? options.version : '1';
     if (this.variableDB_) {
         this.variableDB_.reset();

--- a/packages/scratch-gui/src/lib/ruby-generator/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/operators.js
@@ -147,7 +147,8 @@ export default function (Generator) {
                 }
             }
             if (methodName === 'empty?') {
-                const str = Generator.valueToCode(block, 'STRING', Generator.ORDER_FUNCTION_CALL) || Generator.quote_('');
+                const str = Generator.valueToCode(block, 'STRING', Generator.ORDER_FUNCTION_CALL) ||
+                    Generator.quote_('');
                 Generator.emptyCallCache_[index] = str;
                 return [`@ruby:method:empty?:${index}`, Generator.ORDER_FUNCTION_CALL];
             }

--- a/packages/scratch-gui/src/lib/ruby-generator/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/operators.js
@@ -63,6 +63,30 @@ export default function (Generator) {
     };
 
     Generator.operator_equals = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment) {
+            const commentParts = comment.split(/,(?=@ruby:)/);
+            let methodName = null;
+            let index = null;
+            for (const part of commentParts) {
+                if (part.startsWith('@ruby:method:empty?:')) {
+                    methodName = 'empty?';
+                    index = part.substring(20);
+                }
+            }
+            if (methodName === 'empty?') {
+                const operand1 = Generator.valueToCode(block, 'OPERAND1', Generator.ORDER_EQUALS);
+                if (operand1 === `@ruby:method:empty?:${index}`) {
+                    const operand2 = Generator.valueToCode(block, 'OPERAND2', Generator.ORDER_EQUALS);
+                    if (Generator.nosToCode(operand2) === 0) {
+                        const receiver = Generator.emptyCallCache_[index];
+                        delete Generator.emptyCallCache_[index];
+                        return [`${receiver}.empty?`, Generator.ORDER_FUNCTION_CALL];
+                    }
+                }
+            }
+        }
+
         const order = Generator.ORDER_EQUALS;
         const operand1 = Generator.valueToCode(block, 'OPERAND1', order) || 0;
         const operand2 = Generator.valueToCode(block, 'OPERAND2', order) || 0;
@@ -111,6 +135,24 @@ export default function (Generator) {
     };
 
     Generator.operator_length = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment) {
+            const commentParts = comment.split(/,(?=@ruby:)/);
+            let methodName = null;
+            let index = null;
+            for (const part of commentParts) {
+                if (part.startsWith('@ruby:method:empty?:')) {
+                    methodName = 'empty?';
+                    index = part.substring(20);
+                }
+            }
+            if (methodName === 'empty?') {
+                const str = Generator.valueToCode(block, 'STRING', Generator.ORDER_FUNCTION_CALL) || Generator.quote_('');
+                Generator.emptyCallCache_[index] = str;
+                return [`@ruby:method:empty?:${index}`, Generator.ORDER_FUNCTION_CALL];
+            }
+        }
+
         const order = Generator.ORDER_FUNCTION_CALL;
         const str = Generator.valueToCode(block, 'STRING', order) || Generator.quote_('');
         return [`${str}.length`, order];

--- a/packages/scratch-gui/src/lib/ruby-generator/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/operators.js
@@ -6,7 +6,7 @@
 export default function (Generator) {
     Generator.operator_add = function (block) {
         const comment = Generator.getCommentText(block);
-        if (comment === '@ruby:to_i') {
+        if (comment === '@ruby:method:to_i') {
             const value = Generator.valueToCode(block, 'NUM1', Generator.ORDER_FUNCTION_CALL) || 0;
             return [`${value}.to_i`, Generator.ORDER_FUNCTION_CALL];
         }
@@ -91,7 +91,7 @@ export default function (Generator) {
 
     Generator.operator_join = function (block) {
         const comment = Generator.getCommentText(block);
-        if (comment === '@ruby:to_s') {
+        if (comment === '@ruby:method:to_s') {
             const value = Generator.valueToCode(block, 'STRING1', Generator.ORDER_FUNCTION_CALL) ||
                 Generator.quote_('');
             return [`${value}.to_s`, Generator.ORDER_FUNCTION_CALL];

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -38,16 +38,21 @@ const OperatorsConverter = {
         });
 
         converter.registerOnSend(['string', 'block', 'variable'], 'empty?', 0, params => {
-            const {receiver} = params;
+            const {receiver, name} = params;
+
+            const index = (converter._context.methodCallIndices[name] || 0) + 1;
+            converter._context.methodCallIndices[name] = index;
+
+            const commentText = `@ruby:method:${name}:${index}`;
 
             const lengthBlock = converter._createBlock('operator_length', 'value');
             converter._addTextInput(lengthBlock, 'STRING', receiver, 'apple');
-            lengthBlock.comment = converter._createComment('@ruby:method:empty?', lengthBlock.id);
+            lengthBlock.comment = converter._createComment(commentText, lengthBlock.id);
 
             const block = converter._createBlock('operator_equals', 'value_boolean');
             converter._addInput(block, 'OPERAND1', lengthBlock, converter._createTextBlock(''));
             converter._addTextInput(block, 'OPERAND2', '0', '50');
-            block.comment = converter._createComment('@ruby:method:empty?', block.id);
+            block.comment = converter._createComment(commentText, block.id);
             return block;
         });
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -37,6 +37,20 @@ const OperatorsConverter = {
             return block;
         });
 
+        converter.registerOnSend(['string', 'block', 'variable'], 'empty?', 0, params => {
+            const {receiver} = params;
+
+            const lengthBlock = converter._createBlock('operator_length', 'value');
+            converter._addTextInput(lengthBlock, 'STRING', receiver, 'apple');
+            lengthBlock.comment = converter._createComment('@ruby:method:empty?', lengthBlock.id);
+
+            const block = converter._createBlock('operator_equals', 'value_boolean');
+            converter._addInput(block, 'OPERAND1', lengthBlock, converter._createTextBlock(''));
+            converter._addTextInput(block, 'OPERAND2', '0', '50');
+            block.comment = converter._createComment('@ruby:method:empty?', block.id);
+            return block;
+        });
+
         converter.registerOnSend(['string', 'block'], 'include?', 1, params => {
             const {receiver, args} = params;
             if (!converter._isStringOrBlock(args[0])) return null;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -29,7 +29,7 @@ const OperatorsConverter = {
             return block;
         });
 
-        converter.registerOnSend(['string', 'block'], 'length', 0, params => {
+        converter.registerOnSend(['string', 'block', 'variable'], 'length', 0, params => {
             const {receiver} = params;
 
             const block = converter._createBlock('operator_length', 'value');

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -155,7 +155,7 @@ const OperatorsConverter = {
                 converter._addTextInput(block, 'STRING1', receiver, '');
             }
             converter._addTextInput(block, 'STRING2', '', '');
-            block.comment = converter._createComment('@ruby:to_s', block.id);
+            block.comment = converter._createComment('@ruby:method:to_s', block.id);
             return block;
         });
 
@@ -169,7 +169,7 @@ const OperatorsConverter = {
                 converter._addNumberInput(block, 'NUM1', 'math_number', receiver, '');
             }
             converter._addNumberInput(block, 'NUM2', 'math_number', 0, '');
-            block.comment = converter._createComment('@ruby:to_i', block.id);
+            block.comment = converter._createComment('@ruby:method:to_i', block.id);
             return block;
         });
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
@@ -182,7 +182,10 @@ const VariablesConverter = {
 
         converter.registerOnSend('variable', 'length', 0, params => {
             const {receiver} = params;
-            return converter._changeBlock(receiver, 'data_lengthoflist', 'value');
+            if (converter._isBlock(receiver) && converter.isListBlock(receiver)) {
+                return converter._changeBlock(receiver, 'data_lengthoflist', 'value');
+            }
+            return null;
         });
 
         converter.registerOnSend('variable', 'include?', 1, params => {

--- a/packages/scratch-gui/test/integration/empty-conversion.test.js
+++ b/packages/scratch-gui/test/integration/empty-conversion.test.js
@@ -1,0 +1,103 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+import RubyHelper from '../helpers/ruby-helper';
+import {
+    EDIT_MENU_XPATH
+} from '../helpers/menu-xpaths';
+
+const seleniumHelper = new SeleniumHelper();
+const {
+    clickText,
+    clickXpath,
+    getDriver,
+    loadUri
+} = seleniumHelper;
+const rubyHelper = new RubyHelper(seleniumHelper);
+const {
+    fillInRubyProgram,
+    currentRubyProgram
+} = rubyHelper;
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('empty? conversion integration', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('empty? round-trip conversion', async () => {
+        await loadUri(uri);
+
+        await clickText('Ruby', '*[@role="tab"]');
+        const rubyCode = [
+            '@text = ""',
+            'if @text.empty?',
+            '  say("empty")',
+            'else',
+            '  say("not empty")',
+            'end',
+            ''
+        ].join('\n');
+        await fillInRubyProgram(rubyCode);
+
+        // Convert to Code tab (Ruby to Blocks)
+        await clickText('Code', '*[@role="tab"]');
+
+        // Convert back to Ruby (Blocks to Ruby)
+        await clickXpath(EDIT_MENU_XPATH);
+        await clickText('Generate Ruby from Code');
+
+        await clickText('Ruby', '*[@role="tab"]');
+
+        const expectedRubyCode = [
+            '@text = ""',
+            'if @text.empty?',
+            '  say("empty")',
+            'else',
+            '  say("not empty")',
+            'end',
+            ''
+        ].join('\n');
+        expect(await currentRubyProgram()).toEqual(expectedRubyCode);
+    });
+
+    test('multiple empty? round-trip conversion', async () => {
+        await loadUri(uri);
+
+        await clickText('Ruby', '*[@role="tab"]');
+        const rubyCode = [
+            '@text1 = ""',
+            '@text2 = "a"',
+            'if @text1.empty? || @text2.empty?',
+            '  say("at least one is empty")',
+            'end',
+            ''
+        ].join('\n');
+        await fillInRubyProgram(rubyCode);
+
+        // Convert to Code tab (Ruby to Blocks)
+        await clickText('Code', '*[@role="tab"]');
+
+        // Convert back to Ruby (Blocks to Ruby)
+        await clickXpath(EDIT_MENU_XPATH);
+        await clickText('Generate Ruby from Code');
+
+        await clickText('Ruby', '*[@role="tab"]');
+
+        const expectedRubyCode = [
+            '@text1 = ""',
+            '@text2 = "a"',
+            'if @text1.empty? || @text2.empty?',
+            '  say("at least one is empty")',
+            'end',
+            ''
+        ].join('\n');
+        expect(await currentRubyProgram()).toEqual(expectedRubyCode);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
@@ -8,6 +8,7 @@ describe('RubyGenerator/Operators', () => {
         };
         RubyGenerator.definitions_ = {};
         RubyGenerator.functionNames_ = {};
+        RubyGenerator.emptyCallCache_ = {};
         RubyGenerator.currentTarget = null;
         OperatorsBlocks(RubyGenerator);
     });
@@ -71,6 +72,75 @@ describe('RubyGenerator/Operators', () => {
             RubyGenerator.valueToCode = jest.fn()
                 .mockReturnValueOnce('x');
             expect(RubyGenerator.operator_join(block)).toEqual(['x.to_s', RubyGenerator.ORDER_FUNCTION_CALL]);
+        });
+    });
+
+    describe('operator_length', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_length',
+                inputs: {
+                    STRING: {}
+                }
+            };
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('"apple"');
+            expect(RubyGenerator.operator_length(block)).toEqual(['"apple".length', RubyGenerator.ORDER_FUNCTION_CALL]);
+        });
+
+        test('with @ruby:method:empty?', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_length',
+                inputs: {
+                    STRING: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:method:empty?:1' };
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('x');
+            expect(RubyGenerator.operator_length(block)).toEqual(['@ruby:method:empty?:1', RubyGenerator.ORDER_FUNCTION_CALL]);
+            expect(RubyGenerator.emptyCallCache_['1']).toEqual('x');
+        });
+    });
+
+    describe('operator_equals', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_equals',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            RubyGenerator.nosToCode = jest.fn(v => v);
+            expect(RubyGenerator.operator_equals(block)).toEqual(['1 == 2', RubyGenerator.ORDER_EQUALS]);
+        });
+
+        test('with @ruby:method:empty?', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_equals',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:method:empty?:1' };
+            RubyGenerator.emptyCallCache_['1'] = 'x';
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('@ruby:method:empty?:1')
+                .mockReturnValueOnce('0');
+            RubyGenerator.nosToCode = jest.fn(v => {
+                if (v === '0') return 0;
+                return v;
+            });
+
+            expect(RubyGenerator.operator_equals(block)).toEqual(['x.empty?', RubyGenerator.ORDER_FUNCTION_CALL]);
+            expect(RubyGenerator.emptyCallCache_['1']).toBeUndefined();
         });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
@@ -1,0 +1,76 @@
+import RubyGenerator from '../../../../src/lib/ruby-generator';
+import OperatorsBlocks from '../../../../src/lib/ruby-generator/operators';
+
+describe('RubyGenerator/Operators', () => {
+    beforeEach(() => {
+        RubyGenerator.cache_ = {
+            comments: {}
+        };
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.functionNames_ = {};
+        RubyGenerator.currentTarget = null;
+        OperatorsBlocks(RubyGenerator);
+    });
+
+    describe('operator_add', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_add',
+                inputs: {
+                    NUM1: {},
+                    NUM2: {}
+                }
+            };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            expect(RubyGenerator.operator_add(block)).toEqual(['1 + 2', RubyGenerator.ORDER_ADDITIVE]);
+        });
+
+        test('with @ruby:method:to_i', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_add',
+                inputs: {
+                    NUM1: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:method:to_i' };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('x');
+            expect(RubyGenerator.operator_add(block)).toEqual(['x.to_i', RubyGenerator.ORDER_FUNCTION_CALL]);
+        });
+    });
+
+    describe('operator_join', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_join',
+                inputs: {
+                    STRING1: {},
+                    STRING2: {}
+                }
+            };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('"hello "')
+                .mockReturnValueOnce('"world"');
+            expect(RubyGenerator.operator_join(block)).toEqual(['"hello " + "world"', RubyGenerator.ORDER_ADDITIVE]);
+        });
+
+        test('with @ruby:method:to_s', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_join',
+                inputs: {
+                    STRING1: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:method:to_s' };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('x');
+            expect(RubyGenerator.operator_join(block)).toEqual(['x.to_s', RubyGenerator.ORDER_FUNCTION_CALL]);
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
@@ -838,6 +838,79 @@ describe('RubyToBlocksConverter/Operators', () => {
         convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
 
+    test('empty?', () => {
+        code = '"apple".empty?';
+        expected = [
+            {
+                opcode: 'operator_equals',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_length',
+                            inputs: [
+                                {
+                                    name: 'STRING',
+                                    block: expectedInfo.makeText('apple')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:method:empty?',
+                                minimized: true
+                            }
+                        },
+                        shadow: expectedInfo.makeText('')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('0')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:method:empty?',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'x.empty?';
+        expected = [
+            {
+                opcode: 'operator_equals',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_length',
+                            inputs: [
+                                {
+                                    name: 'STRING',
+                                    block: rubyToExpected(converter, target, 'x')[0],
+                                    shadow: expectedInfo.makeText('apple')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:method:empty?',
+                                minimized: true
+                            }
+                        },
+                        shadow: expectedInfo.makeText('')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('0')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:method:empty?',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
     test('operator_contains', () => {
         code = '"apple".include?("a")';
         expected = [

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
@@ -855,7 +855,7 @@ describe('RubyToBlocksConverter/Operators', () => {
                                 }
                             ],
                             comment: {
-                                text: '@ruby:method:empty?',
+                                text: '@ruby:method:empty?:1',
                                 minimized: true
                             }
                         },
@@ -867,7 +867,7 @@ describe('RubyToBlocksConverter/Operators', () => {
                     }
                 ],
                 comment: {
-                    text: '@ruby:method:empty?',
+                    text: '@ruby:method:empty?:1',
                     minimized: true
                 }
             }
@@ -891,7 +891,7 @@ describe('RubyToBlocksConverter/Operators', () => {
                                 }
                             ],
                             comment: {
-                                text: '@ruby:method:empty?',
+                                text: '@ruby:method:empty?:1',
                                 minimized: true
                             }
                         },
@@ -903,7 +903,7 @@ describe('RubyToBlocksConverter/Operators', () => {
                     }
                 ],
                 comment: {
-                    text: '@ruby:method:empty?',
+                    text: '@ruby:method:empty?:1',
                     minimized: true
                 }
             }

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
@@ -1068,7 +1068,7 @@ describe('RubyToBlocksConverter/Operators', () => {
                     }
                 ],
                 comment: {
-                    text: '@ruby:to_s',
+                    text: '@ruby:method:to_s',
                     minimized: true
                 }
             }
@@ -1091,7 +1091,7 @@ describe('RubyToBlocksConverter/Operators', () => {
                     }
                 ],
                 comment: {
-                    text: '@ruby:to_s',
+                    text: '@ruby:method:to_s',
                     minimized: true
                 }
             }
@@ -1117,7 +1117,7 @@ describe('RubyToBlocksConverter/Operators', () => {
                     }
                 ],
                 comment: {
-                    text: '@ruby:to_i',
+                    text: '@ruby:method:to_i',
                     minimized: true
                 }
             }
@@ -1140,7 +1140,7 @@ describe('RubyToBlocksConverter/Operators', () => {
                     }
                 ],
                 comment: {
-                    text: '@ruby:to_i',
+                    text: '@ruby:method:to_i',
                     minimized: true
                 }
             }

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables.test.js
@@ -44,6 +44,31 @@ describe('RubyToBlocksConverter/Variables', () => {
                 convertAndExpectToEqualBlocks(converter, target, code, expected);
             });
 
+            test('operator_length', () => {
+                const code = `${varName}.length`;
+                const expected = [
+                    {
+                        opcode: 'operator_length',
+                        inputs: [
+                            {
+                                name: 'STRING',
+                                block: {
+                                    opcode: 'data_variable',
+                                    fields: [
+                                        {
+                                            name: 'VARIABLE',
+                                            variable: varName
+                                        }
+                                    ]
+                                },
+                                shadow: expectedInfo.makeText('apple')
+                            }
+                        ]
+                    }
+                ];
+                convertAndExpectToEqualBlocks(converter, target, code, expected);
+            });
+
             test('operator_letter_of', () => {
                 const code = `${varName}[0]`;
                 const expected = [


### PR DESCRIPTION
Implement empty? conversion between Ruby and blocks, including prerequisite fixes and refactoring of method comments. Fixes #111.