### PR TITLE
feat: add bidirectional conversion for list.empty? (#113)

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -160,18 +160,24 @@ export default function (Generator) {
     Generator.data_itemoflist = function (block) {
         const index = getListIndex(block);
         const list = getListName(block);
-        return [`${list}[${index}]`, Generator.ORDER_FUNCTION_CAL];
+        return [`${list}[${index}]`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.data_itemnumoflist = function (block) {
         const item = Generator.valueToCode(block, 'ITEM', Generator.ORDER_NONE) || '0';
         const list = getListName(block);
-        return [`${list}.index(${Generator.nosToCode(item)})`, Generator.ORDER_FUNCTION_CAL];
+        return [`${list}.index(${Generator.nosToCode(item)})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.data_lengthoflist = function (block) {
         const list = getListName(block);
-        return [`${list}.length`, Generator.ORDER_FUNCTION_CAL];
+        const comment = Generator.getCommentText(block);
+        if (comment && comment.startsWith('@ruby:method:empty?:')) {
+            const index = comment.substring(20);
+            Generator.emptyCallCache_[index] = list;
+            return [`@ruby:method:empty?:${index}`, Generator.ORDER_FUNCTION_CALL];
+        }
+        return [`${list}.length`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.data_listcontainsitem = function (block) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -45,8 +45,13 @@ const OperatorsConverter = {
 
             const commentText = `@ruby:method:${name}:${index}`;
 
-            const lengthBlock = converter._createBlock('operator_length', 'value');
-            converter._addTextInput(lengthBlock, 'STRING', receiver, 'apple');
+            let lengthBlock;
+            if (converter._isBlock(receiver) && converter.isListBlock(receiver)) {
+                lengthBlock = converter._changeBlock(receiver, 'data_lengthoflist', 'value');
+            } else {
+                lengthBlock = converter._createBlock('operator_length', 'value');
+                converter._addTextInput(lengthBlock, 'STRING', receiver, 'apple');
+            }
             lengthBlock.comment = converter._createComment(commentText, lengthBlock.id);
 
             const block = converter._createBlock('operator_equals', 'value_boolean');

--- a/packages/scratch-gui/test/integration/empty-conversion.test.js
+++ b/packages/scratch-gui/test/integration/empty-conversion.test.js
@@ -100,4 +100,40 @@ describe('empty? conversion integration', () => {
         ].join('\n');
         expect(await currentRubyProgram()).toEqual(expectedRubyCode);
     });
+
+    test('list empty? round-trip conversion', async () => {
+        await loadUri(uri);
+
+        await clickText('Ruby', '*[@role="tab"]');
+        const rubyCode = [
+            'list("@list").clear',
+            'if list("@list").empty?',
+            '  say("empty")',
+            'else',
+            '  say("not empty")',
+            'end',
+            ''
+        ].join('\n');
+        await fillInRubyProgram(rubyCode);
+
+        // Convert to Code tab (Ruby to Blocks)
+        await clickText('Code', '*[@role="tab"]');
+
+        // Convert back to Ruby (Blocks to Ruby)
+        await clickXpath(EDIT_MENU_XPATH);
+        await clickText('Generate Ruby from Code');
+
+        await clickText('Ruby', '*[@role="tab"]');
+
+        const expectedRubyCode = [
+            'list("@list").clear',
+            'if list("@list").empty?',
+            '  say("empty")',
+            'else',
+            '  say("not empty")',
+            'end',
+            ''
+        ].join('\n');
+        expect(await currentRubyProgram()).toEqual(expectedRubyCode);
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/data.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/data.test.js
@@ -1,0 +1,49 @@
+import RubyGenerator from '../../../../src/lib/ruby-generator';
+import DataBlocks from '../../../../src/lib/ruby-generator/data';
+
+describe('RubyGenerator/Data', () => {
+    beforeEach(() => {
+        RubyGenerator.cache_ = {
+            comments: {}
+        };
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.functionNames_ = {};
+        RubyGenerator.emptyCallCache_ = {};
+        RubyGenerator.currentTarget = null;
+        DataBlocks(RubyGenerator);
+    });
+
+    describe('data_lengthoflist', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'data_lengthoflist',
+                fields: {
+                    LIST: {
+                        id: 'list-id',
+                        value: 'my list'
+                    }
+                }
+            };
+            RubyGenerator.listName = jest.fn().mockReturnValue('my list');
+            expect(RubyGenerator.data_lengthoflist(block)).toEqual(['list("my list").length', RubyGenerator.ORDER_FUNCTION_CALL]);
+        });
+
+        test('with @ruby:method:empty?', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'data_lengthoflist',
+                fields: {
+                    LIST: {
+                        id: 'list-id',
+                        value: 'my list'
+                    }
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:method:empty?:1' };
+            RubyGenerator.listName = jest.fn().mockReturnValue('my list');
+            expect(RubyGenerator.data_lengthoflist(block)).toEqual(['@ruby:method:empty?:1', RubyGenerator.ORDER_FUNCTION_CALL]);
+            expect(RubyGenerator.emptyCallCache_['1']).toEqual('list("my list")');
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
@@ -142,5 +142,28 @@ describe('RubyGenerator/Operators', () => {
             expect(RubyGenerator.operator_equals(block)).toEqual(['x.empty?', RubyGenerator.ORDER_FUNCTION_CALL]);
             expect(RubyGenerator.emptyCallCache_['1']).toBeUndefined();
         });
+
+        test('with @ruby:method:empty? for list', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_equals',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:method:empty?:1' };
+            RubyGenerator.emptyCallCache_['1'] = 'list("my list")';
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('@ruby:method:empty?:1')
+                .mockReturnValueOnce('0');
+            RubyGenerator.nosToCode = jest.fn(v => {
+                if (v === '0') return 0;
+                return v;
+            });
+
+            expect(RubyGenerator.operator_equals(block)).toEqual(['list("my list").empty?', RubyGenerator.ORDER_FUNCTION_CALL]);
+            expect(RubyGenerator.emptyCallCache_['1']).toBeUndefined();
+        });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
@@ -909,6 +909,41 @@ describe('RubyToBlocksConverter/Operators', () => {
             }
         ];
         convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'list("@list").empty?';
+        expected = [
+            {
+                opcode: 'operator_equals',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'data_lengthoflist',
+                            fields: [
+                                {
+                                    name: 'LIST',
+                                    list: '@list'
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:method:empty?:1',
+                                minimized: true
+                            }
+                        },
+                        shadow: expectedInfo.makeText('')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('0')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:method:empty?:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
 
     test('operator_contains', () => {


### PR DESCRIPTION
This PR implements bidirectional conversion between Ruby's `list.empty?` and Scratch's `data_lengthoflist` + `operator_equals` blocks.

### Changes:
- **Ruby to Blocks:** Updated `empty?` handler in `operators.js` to detect list blocks and use `data_lengthoflist`.
- **Blocks to Ruby:** Updated `data_lengthoflist` in `data.js` to handle `@ruby:method:empty?` comments and populate `emptyCallCache_`.
- **Refactoring:** Fixed `ORDER_FUNCTION_CAL` typos in `data.js`.
- **Testing:**
    - Added unit tests in `ruby-to-blocks-converter/operators.test.js`.
    - Created `ruby-generator/data.test.js` and added tests for `data_lengthoflist`.
    - Added unit tests in `ruby-generator/operators.test.js`.
    - Added integration test in `empty-conversion.test.js`.

Closes #113