### PR TITLE
fix: ensure 'end' and trailing empty lines are executable in Ruby tab

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/core.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/core.js
@@ -16,7 +16,6 @@ const CoreHandlers = {
             return Opal.nil;
         }
         node = node.$to_ast();
-        this._context.currentNode = node;
 
         // Track depth for lineToNodeMap
         const depth = this._context.processDepth || 0;
@@ -90,6 +89,9 @@ const CoreHandlers = {
             this._context.methodCallIndices = {};
         }
 
+        const previousNode = this._context.currentNode;
+        this._context.currentNode = node;
+
         const handlerName = '_' + _.camelCase(`on_${node.type}`); // eslint-disable-line prefer-template
         let result;
         if (_.isFunction(this[handlerName])) {
@@ -98,7 +100,15 @@ const CoreHandlers = {
             throw new RubyToBlocksConverterError(node, `not supported node type: ${node.type}`);
         }
 
+        if (result && !this._context.nodeToBlockMap.has(node)) {
+            const blockId = this._getBlockIdFromResult(result);
+            if (blockId) {
+                this._context.nodeToBlockMap.set(node, blockId);
+            }
+        }
+
         this._context.isValue = savedIsValue;
+        this._context.currentNode = previousNode;
         this._context.processDepth = depth; // Restore depth after processing
         return result;
     },
@@ -152,6 +162,16 @@ const CoreHandlers = {
             );
         }
         return cond;
+    },
+
+    _getBlockIdFromResult (result) {
+        if (this._isBlock(result)) {
+            return result.id;
+        }
+        if (_.isArray(result) && result.length > 0 && this._isBlock(result[result.length - 1])) {
+            return result[result.length - 1].id;
+        }
+        return null;
     },
 
     _onBegin (node) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -671,6 +671,12 @@ class RubyToBlocksConverter {
                     return line;
                 }
             }
+
+            // Fallback: Check if this line is contained in some node that has a block
+            const fallbackEntry = this._findContainingNode(line);
+            if (fallbackEntry) {
+                return line;
+            }
         }
         return null;
     }

--- a/packages/scratch-gui/test/integration/execute-line.test.js
+++ b/packages/scratch-gui/test/integration/execute-line.test.js
@@ -1,0 +1,96 @@
+import path from 'path';
+import webdriver from 'selenium-webdriver';
+import SeleniumHelper from '../helpers/selenium-helper';
+import RubyHelper from '../helpers/ruby-helper';
+
+const {By, until} = webdriver;
+const seleniumHelper = new SeleniumHelper();
+const {
+    clickText,
+    clickXpath,
+    getDriver,
+    loadUri,
+    waitForLoadingFinished
+} = seleniumHelper;
+
+const rubyHelper = new RubyHelper(seleniumHelper);
+const {
+    fillInRubyProgram
+} = rubyHelper;
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Ruby cursor line execution', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('Execute if-end block from the end line', async () => {
+        await loadUri(uri);
+        await driver.sleep(2000);
+
+        await clickText('Ruby', '*[@role="tab"]');
+        const code = [
+            'text = "hello"',
+            'if text.empty?',
+            '  say("empty")',
+            'end'
+        ].join('\n');
+        await fillInRubyProgram(code);
+
+        // Set cursor to line 4 (end line)
+        await driver.executeScript('window.monacoEditor.setPosition({lineNumber: 4, column: 1});');
+
+        // Click "Execute current line" button
+        const executeButtonXpath = '//button[contains(@title, "Execute current line") or contains(@title, "カーソル行を実行")]';
+        await clickXpath(executeButtonXpath);
+
+        // Verify that it doesn't show "This line cannot be executed" alert
+        const cannotExecuteAlertXpath = '//span[contains(text(), "This line cannot be executed") or contains(text(), "この行は実行できません")]';
+        let alertFound = false;
+        try {
+            await driver.wait(until.elementLocated(By.xpath(cannotExecuteAlertXpath)), 2000);
+            alertFound = true;
+        } catch (e) {
+            // Success: alert not found
+        }
+        expect(alertFound).toBe(false);
+    });
+
+    test('Execute if-end block from a trailing empty line', async () => {
+        await loadUri(uri);
+        await driver.sleep(2000);
+
+        await clickText('Ruby', '*[@role="tab"]');
+        const code = [
+            'if true',
+            '  say("hi")',
+            'end',
+            '',
+            ''
+        ].join('\n');
+        await fillInRubyProgram(code);
+
+        // Set cursor to line 5 (empty line)
+        await driver.executeScript('window.monacoEditor.setPosition({lineNumber: 5, column: 1});');
+
+        const executeButtonXpath = '//button[contains(@title, "Execute current line") or contains(@title, "カーソル行を実行")]';
+        await clickXpath(executeButtonXpath);
+
+        const cannotExecuteAlertXpath = '//span[contains(text(), "This line cannot be executed") or contains(text(), "この行は実行できません")]';
+        let alertFound = false;
+        try {
+            await driver.wait(until.elementLocated(By.xpath(cannotExecuteAlertXpath)), 2000);
+            alertFound = true;
+        } catch (e) {
+            // Success: alert not found
+        }
+        expect(alertFound).toBe(false);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/get-block-id-for-line.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/get-block-id-for-line.test.js
@@ -1,0 +1,88 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+
+describe('RubyToBlocksConverter.getBlockIdForLine', () => {
+    let converter;
+    let target;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null);
+        target = {
+            isStage: false,
+            variables: {},
+            blocks: {
+                _blocks: {},
+                deleteBlock: jest.fn(),
+                createBlock: jest.fn(),
+                getBlock: (id) => converter.blocks[id]
+            },
+            lookupVariableByNameAndType: jest.fn(),
+            createVariable: jest.fn(),
+            deleteVariable: jest.fn()
+        };
+        converter.vm = {
+            runtime: {
+                getTargetForStage: () => ({
+                    lookupVariableByNameAndType: jest.fn(),
+                    createVariable: jest.fn(),
+                    variables: {}
+                })
+            },
+            extensionManager: {
+                isExtensionLoaded: () => true
+            },
+            emitWorkspaceUpdate: jest.fn()
+        };
+    });
+
+    test('should return block ID for end line of if statement', () => {
+        const code = [
+            'text = "ハロー！"',
+            'if text.empty?',
+            '  say("empty")',
+            'end'
+        ].join('\n');
+        
+        const result = converter.targetCodeToBlocks(target, code);
+        if (!result) {
+            console.error(converter.errors);
+        }
+        expect(result).toBeTruthy();
+        
+        const line4BlockId = converter.getBlockIdForLine(4);
+        expect(line4BlockId).not.toBeNull();
+        expect(line4BlockId).toBeDefined();
+
+        // Line 2 (if) and Line 4 (end) should return the same block ID
+        const line2BlockId = converter.getBlockIdForLine(2);
+        expect(line2BlockId).toBe(line4BlockId);
+    });
+
+    test('should return block ID for trailing empty lines after if statement', () => {
+        const code = [
+            'text = "ハロー！"',
+            'if text.empty?',
+            '  say("true")',
+            'end',
+            '',
+            ''
+        ].join('\n');
+        
+        const result = converter.targetCodeToBlocks(target, code);
+        if (!result) {
+            console.error(converter.errors);
+        }
+        expect(result).toBeTruthy();
+        
+        // Line 4 (end)
+        const line4BlockId = converter.getBlockIdForLine(4);
+        expect(line4BlockId).not.toBeNull();
+
+        // Line 5 (empty)
+        const line5BlockId = converter.getBlockIdForLine(5);
+        expect(line5BlockId).toBe(line4BlockId);
+
+        // Line 6 (empty)
+        const line6BlockId = converter.getBlockIdForLine(6);
+        expect(line6BlockId).toBe(line4BlockId);
+    });
+});


### PR DESCRIPTION
Fixes #115.

Highlights:
- Corrected node-to-block mapping by saving and restoring 'currentNode' in the '_process' function.
- Implemented fallback mapping in '_process' for complex nodes.
- Improved '_findNearestExecutableLine' robustness by including containing node checks during backward search.
- Added comprehensive unit and integration tests to verify executability of 'end' and trailing empty lines.