### PR TITLE
feat: add bidirectional conversion for != operator

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -113,6 +113,7 @@ RubyGenerator.init = function (options) {
     this.definitions_ = {};
     this.returnCallCache_ = {}; // Clear return value call cache
     this.emptyCallCache_ = {};
+    this.notEqualsCallCache_ = {};
     this.version = options && options.version ? options.version : '1';
     if (this.variableDB_) {
         this.variableDB_.reset();

--- a/packages/scratch-gui/src/lib/ruby-generator/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/operators.js
@@ -72,6 +72,9 @@ export default function (Generator) {
                 if (part.startsWith('@ruby:method:empty?:')) {
                     methodName = 'empty?';
                     index = part.substring(20);
+                } else if (part.startsWith('@ruby:operator:!=:')) {
+                    methodName = '!=';
+                    index = part.substring(18);
                 }
             }
             if (methodName === 'empty?') {
@@ -84,6 +87,15 @@ export default function (Generator) {
                         return [`${receiver}.empty?`, Generator.ORDER_FUNCTION_CALL];
                     }
                 }
+            } else if (methodName === '!=') {
+                const order = Generator.ORDER_EQUALS;
+                const operand1 = Generator.valueToCode(block, 'OPERAND1', order) || 0;
+                const operand2 = Generator.valueToCode(block, 'OPERAND2', order) || 0;
+                Generator.notEqualsCallCache_[index] = {
+                    lhs: Generator.nosToCode(operand1),
+                    rhs: Generator.nosToCode(operand2)
+                };
+                return [`@ruby:operator:!=:${index}`, order];
             }
         }
 
@@ -108,6 +120,23 @@ export default function (Generator) {
     };
 
     Generator.operator_not = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment) {
+            const commentParts = comment.split(/,(?=@ruby:)/);
+            for (const part of commentParts) {
+                if (part.startsWith('@ruby:operator:!=:')) {
+                    const index = part.substring(18);
+                    const order = Generator.ORDER_NONE;
+                    const operand = Generator.valueToCode(block, 'OPERAND', order);
+                    if (operand === `@ruby:operator:!=:${index}`) {
+                        const {lhs, rhs} = Generator.notEqualsCallCache_[index];
+                        delete Generator.notEqualsCallCache_[index];
+                        return [`${lhs} != ${rhs}`, Generator.ORDER_EQUALS];
+                    }
+                }
+            }
+        }
+
         const order = Generator.ORDER_UNARY_SIGN;
         const operand = Generator.valueToCode(block, 'OPERAND', order) || 'false';
         return [`!${operand}`, order];

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -120,6 +120,34 @@ const OperatorsConverter = {
             return block;
         });
 
+        converter.registerOnSend('any', '!=', 1, params => {
+            const {receiver, args, name} = params;
+            let rh = args[0];
+            if (_.isArray(rh)) {
+                if (rh.length !== 1) return null;
+                rh = rh[0];
+            }
+
+            const index = (converter._context.methodCallIndices[name] || 0) + 1;
+            converter._context.methodCallIndices[name] = index;
+
+            const commentText = `@ruby:operator:${name}:${index}`;
+
+            const equalsBlock = converter._createBlock('operator_equals', 'value_boolean');
+            converter._addTextInput(
+                equalsBlock, 'OPERAND1', converter._isNumber(receiver) ? receiver.toString() : receiver, ''
+            );
+            converter._addTextInput(
+                equalsBlock, 'OPERAND2', converter._isNumber(rh) ? rh.toString() : rh, '50'
+            );
+            equalsBlock.comment = converter._createComment(commentText, equalsBlock.id);
+
+            const block = converter._createBlock('operator_not', 'value_boolean');
+            converter._addInput(block, 'OPERAND', equalsBlock);
+            block.comment = converter._createComment(commentText, block.id);
+            return block;
+        });
+
         ['>', '<', '=='].forEach(operator => {
             converter.registerOnSend('any', operator, 1, params => {
                 const {receiver, args} = params;

--- a/packages/scratch-gui/test/integration/ruby-tab/operators.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab/operators.test.js
@@ -45,6 +45,8 @@ describe('Ruby Tab: Operators category blocks', () => {
 
             "" == 50
 
+            "" != 50
+
             false && false
 
             false || false
@@ -56,6 +58,8 @@ describe('Ruby Tab: Operators category blocks', () => {
             "apple"[0]
 
             "apple".length
+
+            "".empty?
 
             "apple".include?("a")
 

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
@@ -9,6 +9,7 @@ describe('RubyGenerator/Operators', () => {
         RubyGenerator.definitions_ = {};
         RubyGenerator.functionNames_ = {};
         RubyGenerator.emptyCallCache_ = {};
+        RubyGenerator.notEqualsCallCache_ = {};
         RubyGenerator.currentTarget = null;
         OperatorsBlocks(RubyGenerator);
     });
@@ -103,6 +104,36 @@ describe('RubyGenerator/Operators', () => {
         });
     });
 
+    describe('operator_not', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_not',
+                inputs: {
+                    OPERAND: {}
+                }
+            };
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('true');
+            expect(RubyGenerator.operator_not(block)).toEqual(['!true', RubyGenerator.ORDER_UNARY_SIGN]);
+        });
+
+        test('with @ruby:operator:!=:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_not',
+                inputs: {
+                    OPERAND: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:operator:!=:1' };
+            RubyGenerator.notEqualsCallCache_['1'] = { lhs: '1', rhs: '2' };
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('@ruby:operator:!=:1');
+
+            expect(RubyGenerator.operator_not(block)).toEqual(['1 != 2', RubyGenerator.ORDER_EQUALS]);
+            expect(RubyGenerator.notEqualsCallCache_['1']).toBeUndefined();
+        });
+    });
+
     describe('operator_equals', () => {
         test('normal', () => {
             const block = {
@@ -118,6 +149,25 @@ describe('RubyGenerator/Operators', () => {
                 .mockReturnValueOnce('2');
             RubyGenerator.nosToCode = jest.fn(v => v);
             expect(RubyGenerator.operator_equals(block)).toEqual(['1 == 2', RubyGenerator.ORDER_EQUALS]);
+        });
+
+        test('with @ruby:operator:!=:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_equals',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:operator:!=:1' };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            RubyGenerator.nosToCode = jest.fn(v => v);
+
+            expect(RubyGenerator.operator_equals(block)).toEqual(['@ruby:operator:!=:1', RubyGenerator.ORDER_EQUALS]);
+            expect(RubyGenerator.notEqualsCallCache_['1']).toEqual({ lhs: '1', rhs: '2' });
         });
 
         test('with @ruby:method:empty?', () => {

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
@@ -573,6 +573,215 @@ describe('RubyToBlocksConverter/Operators', () => {
         convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
 
+    test('operator_not_equals', () => {
+        code = '1 != 50';
+        expected = [
+            {
+                opcode: 'operator_not',
+                inputs: [
+                    {
+                        name: 'OPERAND',
+                        block: {
+                            opcode: 'operator_equals',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('1')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:!=:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ],
+                comment: {
+                    text: '@ruby:operator:!=:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'x != y';
+        expected = [
+            {
+                opcode: 'operator_not',
+                inputs: [
+                    {
+                        name: 'OPERAND',
+                        block: {
+                            opcode: 'operator_equals',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: rubyToExpected(converter, target, 'x')[0],
+                                    shadow: expectedInfo.makeText('')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: rubyToExpected(converter, target, 'y')[0],
+                                    shadow: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:!=:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ],
+                comment: {
+                    text: '@ruby:operator:!=:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = '1 != 50\n2 != 60';
+        expected = [
+            {
+                opcode: 'operator_not',
+                inputs: [
+                    {
+                        name: 'OPERAND',
+                        block: {
+                            opcode: 'operator_equals',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('1')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:!=:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ],
+                comment: {
+                    text: '@ruby:operator:!=:1',
+                    minimized: true
+                }
+            },
+            {
+                opcode: 'operator_not',
+                inputs: [
+                    {
+                        name: 'OPERAND',
+                        block: {
+                            opcode: 'operator_equals',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('2')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('60')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:!=:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ],
+                comment: {
+                    text: '@ruby:operator:!=:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = '1 != 50 && 2 != 60';
+        expected = [
+            {
+                opcode: 'operator_and',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_not',
+                            inputs: [
+                                {
+                                    name: 'OPERAND',
+                                    block: {
+                                        opcode: 'operator_equals',
+                                        inputs: [
+                                            {
+                                                name: 'OPERAND1',
+                                                block: expectedInfo.makeText('1')
+                                            },
+                                            {
+                                                name: 'OPERAND2',
+                                                block: expectedInfo.makeText('50')
+                                            }
+                                        ],
+                                        comment: {
+                                            text: '@ruby:operator:!=:1',
+                                            minimized: true
+                                        }
+                                    }
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:!=:1',
+                                minimized: true
+                            }
+                        }
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: {
+                            opcode: 'operator_not',
+                            inputs: [
+                                {
+                                    name: 'OPERAND',
+                                    block: {
+                                        opcode: 'operator_equals',
+                                        inputs: [
+                                            {
+                                                name: 'OPERAND1',
+                                                block: expectedInfo.makeText('2')
+                                            },
+                                            {
+                                                name: 'OPERAND2',
+                                                block: expectedInfo.makeText('60')
+                                            }
+                                        ],
+                                        comment: {
+                                            text: '@ruby:operator:!=:2',
+                                            minimized: true
+                                        }
+                                    }
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:!=:2',
+                                minimized: true
+                            }
+                        }
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
     test('operator_and', () => {
         code = '1 < x && x < 10';
         expected = [


### PR DESCRIPTION
Implement bidirectional conversion for Ruby's != operator using @ruby:operator:!=:N comments to mark operator_not and operator_equals blocks. Follows the pattern of empty? method implementation.