### PR TITLE
fix: Rubyタブ Monaco Editorのコンテキストメニュー「貼り付け」が動作しない問題を修正

### DIFF
--- a/.gemini/commands/start-implementation.toml
+++ b/.gemini/commands/start-implementation.toml
@@ -16,4 +16,5 @@ After implementation: lint, commit, push, and create a PR.
 Unless specified otherwise, the default PR target branch is `develop`.
 The PR repository must be `smalruby/smalruby3-editor`; never create PRs against the `upstream` repository.
 When creating a PR, to avoid issues with escaping the body string, write the body content to a temporary file first and specify that file using the `-F` or `--body-file` flag with the `gh` command.
+The PR body includes `closes <Issue ID>` to close the issue when the PR is merged.
 """

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -68,6 +68,8 @@ class RubyTab extends React.Component {
         this.downloadCallbackRef = null;
         this.executingLineDecoration = null;
         this.contentChangeListener = null;
+        this.pasteMutationObserver = null;
+        this.bodyMutationObserver = null;
         this.bubbleRef = null;
         this.state = {
             runningBlockId: null,
@@ -193,6 +195,14 @@ class RubyTab extends React.Component {
             this.contentChangeListener.dispose();
             this.contentChangeListener = null;
         }
+        if (this.pasteMutationObserver) {
+            this.pasteMutationObserver.disconnect();
+            this.pasteMutationObserver = null;
+        }
+        if (this.bodyMutationObserver) {
+            this.bodyMutationObserver.disconnect();
+            this.bodyMutationObserver = null;
+        }
     }
 
     clearErrors () {
@@ -259,6 +269,65 @@ class RubyTab extends React.Component {
 
         window.monacoEditor = editor;
         window.monaco = monaco;
+
+        // Custom paste action for Monaco Editor v0.55.1 standalone environment
+        editor.addAction({
+            id: 'smalruby.paste',
+            label: this.props.intl.formatMessage({
+                id: 'gui.rubyTab.paste',
+                defaultMessage: 'Paste'
+            }),
+            contextMenuGroupId: '9_cutcopypaste',
+            contextMenuOrder: 4,
+            precondition: '!editorReadonly',
+            run: async ed => {
+                try {
+                    const text = await navigator.clipboard.readText();
+                    if (text) {
+                        ed.trigger('keyboard', 'type', {text});
+                    }
+                } catch (err) {
+                    // eslint-disable-next-line no-console
+                    console.error('Smalruby custom paste error:', err);
+                }
+            }
+        });
+
+        // Hide original Paste action in Monaco Editor v0.55.1 context menu
+        // Shadow Root is used for context views in some environments
+        const setupPasteMutationObserver = host => {
+            if (this.pasteMutationObserver) return;
+            this.pasteMutationObserver = new MutationObserver(() => {
+                const menuItems = host.shadowRoot.querySelectorAll(
+                    '.action-item[aria-label="Paste"], .action-item[aria-label="貼り付け"]'
+                );
+                if (menuItems.length >= 2) {
+                    menuItems[0].style.display = 'none';
+                }
+            });
+            this.pasteMutationObserver.observe(host.shadowRoot, {
+                childList: true,
+                subtree: true
+            });
+        };
+
+        const shadowRootHost = document.querySelector('.shadow-root-host');
+        if (shadowRootHost && shadowRootHost.shadowRoot) {
+            setupPasteMutationObserver(shadowRootHost);
+        } else {
+            this.bodyMutationObserver = new MutationObserver(() => {
+                const host = document.querySelector('.shadow-root-host');
+                if (host && host.shadowRoot) {
+                    setupPasteMutationObserver(host);
+                    this.bodyMutationObserver.disconnect();
+                    this.bodyMutationObserver = null;
+                }
+            });
+            this.bodyMutationObserver.observe(document.body, {
+                childList: true,
+                subtree: true
+            });
+        }
 
         // Register Smalruby language
         monaco.languages.register({id: 'smalruby'});

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -293,16 +293,37 @@ class RubyTab extends React.Component {
             }
         });
 
-        // Hide original Paste action in Monaco Editor v0.55.1 context menu
-        // Shadow Root is used for context views in some environments
+        // Hide original (broken) Paste action in Monaco Editor v0.55.1 context menu.
+        // Monaco renders context menus in a Shadow DOM (.shadow-root-host).
+        // The aria-label is on .action-label (child), NOT on .action-item itself.
+        // We inject a persistent <style> to hide duplicate paste items, and use a
+        // MutationObserver to re-apply hiding after each menu open/close cycle.
         const setupPasteMutationObserver = host => {
             if (this.pasteMutationObserver) return;
+
+            // Inject a persistent <style> into the shadow root to hide original paste item.
+            // CSS :has() selector targets .action-item that contains the broken paste label.
+            // We hide the first one (original Monaco) and keep the second (our custom action).
+            const style = document.createElement('style');
+            style.textContent = `
+                .action-item:has(.action-label[aria-label="Paste"]):first-of-type,
+                .action-item:has(.action-label[aria-label="貼り付け"]):first-of-type {
+                    display: none !important;
+                }
+            `;
+            host.shadowRoot.appendChild(style);
+
             this.pasteMutationObserver = new MutationObserver(() => {
-                const menuItems = host.shadowRoot.querySelectorAll(
-                    '.action-item[aria-label="Paste"], .action-item[aria-label="貼り付け"]'
-                );
-                if (menuItems.length >= 2) {
-                    menuItems[0].style.display = 'none';
+                // Find all paste-labeled items via the correct selector (aria-label on .action-label)
+                const pasteLabels = Array.from(host.shadowRoot.querySelectorAll(
+                    '.action-label[aria-label="Paste"], .action-label[aria-label="貼り付け"]'
+                ));
+                if (pasteLabels.length >= 2) {
+                    // Hide the first item (original broken Monaco paste action)
+                    const firstPasteItem = pasteLabels[0].closest('.action-item');
+                    if (firstPasteItem) {
+                        firstPasteItem.style.display = 'none';
+                    }
                 }
             });
             this.pasteMutationObserver.observe(host.shadowRoot, {

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -296,40 +296,38 @@ class RubyTab extends React.Component {
         // Hide original (broken) Paste action in Monaco Editor v0.55.1 context menu.
         // Monaco renders context menus in a Shadow DOM (.shadow-root-host).
         // The aria-label is on .action-label (child), NOT on .action-item itself.
-        // We inject a persistent <style> to hide duplicate paste items, and use a
-        // MutationObserver to re-apply hiding after each menu open/close cycle.
+        // We use a MutationObserver to hide the broken original paste item each time
+        // the menu opens. We also call hideDuplicatePaste() immediately on setup because
+        // the shadow host may be created lazily (on first right-click), at which point
+        // menu items are already in the DOM before the observer starts watching.
+        const hideDuplicatePaste = shadowRoot => {
+            const pasteLabels = Array.from(shadowRoot.querySelectorAll(
+                '.action-label[aria-label="Paste"], .action-label[aria-label="貼り付け"]'
+            ));
+            if (pasteLabels.length >= 2) {
+                // Hide the first item (original broken Monaco paste action)
+                const firstPasteItem = pasteLabels[0].closest('.action-item');
+                if (firstPasteItem) {
+                    firstPasteItem.style.display = 'none';
+                }
+            }
+        };
+
         const setupPasteMutationObserver = host => {
             if (this.pasteMutationObserver) return;
 
-            // Inject a persistent <style> into the shadow root to hide original paste item.
-            // CSS :has() selector targets .action-item that contains the broken paste label.
-            // We hide the first one (original Monaco) and keep the second (our custom action).
-            const style = document.createElement('style');
-            style.textContent = `
-                .action-item:has(.action-label[aria-label="Paste"]):first-of-type,
-                .action-item:has(.action-label[aria-label="貼り付け"]):first-of-type {
-                    display: none !important;
-                }
-            `;
-            host.shadowRoot.appendChild(style);
-
             this.pasteMutationObserver = new MutationObserver(() => {
-                // Find all paste-labeled items via the correct selector (aria-label on .action-label)
-                const pasteLabels = Array.from(host.shadowRoot.querySelectorAll(
-                    '.action-label[aria-label="Paste"], .action-label[aria-label="貼り付け"]'
-                ));
-                if (pasteLabels.length >= 2) {
-                    // Hide the first item (original broken Monaco paste action)
-                    const firstPasteItem = pasteLabels[0].closest('.action-item');
-                    if (firstPasteItem) {
-                        firstPasteItem.style.display = 'none';
-                    }
-                }
+                hideDuplicatePaste(host.shadowRoot);
             });
             this.pasteMutationObserver.observe(host.shadowRoot, {
                 childList: true,
                 subtree: true
             });
+
+            // Run immediately in case menu items are already in the DOM
+            // (this happens when the shadow host is created on first right-click,
+            // at which point all items are added before our observer starts watching)
+            hideDuplicatePaste(host.shadowRoot);
         };
 
         const shadowRootHost = document.querySelector('.shadow-root-host');

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -6,6 +6,7 @@ export default {
     'gui.smalruby3.crashMessage.description': 'We are so sorry, but it looks like Smalruby has crashed. This bug has been automatically reported to the Smalruby Team. Please refresh your page to try again.',
     'gui.smalruby3.gui.defaultProjectTitle': 'Smalruby Project',
     'gui.smalruby3.gui.rubyTab': 'Ruby',
+    'gui.rubyTab.paste': 'Paste',
     'gui.smalruby3.previewInfo.betawelcome': 'Welcome to the Smalruby 3.0 Beta',
     'gui.smalruby3.previewInfo.label': 'Try Smalruby 3.0',
     'gui.smalruby3.previewInfo.invitation': "We're working on the next generation of Smalruby. We're excited for you to try it!",

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -4,6 +4,7 @@ export default {
     'gui.menuBar.loadFromUrl': 'Scratchからよみこむ',
     'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.rubyVersion': 'ルビー',
+    'gui.rubyTab.paste': 'はりつけ',
     'gui.rubyVersion.v1': 'バージョン1 (しょきせってい)',
     'gui.rubyVersion.v2': 'バージョン2',
     'gui.menuBar.meshV2': 'メッシュ',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -4,6 +4,7 @@ export default {
     'gui.menuBar.loadFromUrl': 'Scratchから読み込む',
     'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.rubyVersion': 'ルビー',
+    'gui.rubyTab.paste': '貼り付け',
     'gui.rubyVersion.v1': 'バージョン1 (初期設定)',
     'gui.rubyVersion.v2': 'バージョン2',
     'gui.menuBar.meshV2': 'メッシュ',

--- a/packages/scratch-gui/test/integration/monaco-paste.test.js
+++ b/packages/scratch-gui/test/integration/monaco-paste.test.js
@@ -1,0 +1,54 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const seleniumHelper = new SeleniumHelper();
+const {
+    getDriver,
+    loadUri,
+    clickText
+} = seleniumHelper;
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Monaco Editor Paste Action', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        if (driver) {
+            await driver.quit();
+        }
+    });
+
+    test('Custom paste action is registered and works', async () => {
+        await loadUri(uri);
+        await clickText('Ruby', '*[@role="tab"]');
+
+        // Wait for Monaco Editor to be ready
+        await driver.wait(async () => {
+            return await driver.executeScript('return !!window.monacoEditor;');
+        }, 10000);
+
+        // Mock clipboard
+        await driver.executeScript('navigator.clipboard.readText = () => Promise.resolve("pasted_text_from_mock");');
+
+        // Trigger the custom action
+        await driver.executeScript(`
+            const action = window.monacoEditor.getAction('smalruby.paste');
+            if (action) {
+                return action.run();
+            }
+            throw new Error('Action smalruby.paste not found');
+        `);
+
+        // Wait a bit for async paste
+        await driver.sleep(500);
+
+        // Check if text is pasted
+        const code = await driver.executeScript('return window.monacoEditor.getValue();');
+        expect(code).toContain('pasted_text_from_mock');
+    });
+});


### PR DESCRIPTION
fix: Rubyタブ Monaco Editorのコンテキストメニュー「貼り付け」が動作しない問題を修正

Monaco Editor v0.55.1のStandalone環境でコンテキストメニューの「貼り付け」が動作しない問題を修正しました。

## 変更内容
- `packages/scratch-gui/src/containers/ruby-tab.jsx` の `handleEditorDidMount` 内で `editor.addAction()` を使用し、カスタムPasteアクション（id: 'smalruby.paste'）を追加しました。
- Monaco内部のフォーカス問題とサービス不足を回避するため、`navigator.clipboard.readText()` を直接使用するようにしました。
- `MutationObserver` を使用して、Shadow DOM内の壊れた標準の「貼り付け」項目を非表示にするようにしました。
- 英語、日本語、ひらがなロケールに「貼り付け」の翻訳を追加しました。
- 新規インテグレーションテスト `packages/scratch-gui/test/integration/monaco-paste.test.js` を追加しました。

closes #125
