### PR TITLE
feat: add >= and <= operator conversion

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -114,6 +114,8 @@ RubyGenerator.init = function (options) {
     this.returnCallCache_ = {}; // Clear return value call cache
     this.emptyCallCache_ = {};
     this.notEqualsCallCache_ = {};
+    this.greaterThanOrEqualCallCache_ = {};
+    this.lessThanOrEqualCallCache_ = {};
     this.version = options && options.version ? options.version : '1';
     if (this.variableDB_) {
         this.variableDB_.reset();

--- a/packages/scratch-gui/src/lib/ruby-generator/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/operators.js
@@ -166,7 +166,7 @@ export default function (Generator) {
                 if (part.startsWith('@ruby:operator:>=:')) {
                     const index = part.substring(18);
                     const order = Generator.ORDER_RELATIONAL;
-                    const operand1 = Generator.valueToCode(block, 'OPERAND1', order);
+                    const operand1 = Generator.valueToCode(block, 'OPERAND1', Generator.ORDER_NONE);
                     if (operand1 === `@ruby:operator:>=:${index}`) {
                         const {lhs, rhs} = Generator.greaterThanOrEqualCallCache_[index];
                         delete Generator.greaterThanOrEqualCallCache_[index];
@@ -175,7 +175,7 @@ export default function (Generator) {
                 } else if (part.startsWith('@ruby:operator:<=:')) {
                     const index = part.substring(18);
                     const order = Generator.ORDER_RELATIONAL;
-                    const operand1 = Generator.valueToCode(block, 'OPERAND1', order);
+                    const operand1 = Generator.valueToCode(block, 'OPERAND1', Generator.ORDER_NONE);
                     if (operand1 === `@ruby:operator:<=:${index}`) {
                         const {lhs, rhs} = Generator.lessThanOrEqualCallCache_[index];
                         delete Generator.lessThanOrEqualCallCache_[index];

--- a/packages/scratch-gui/src/lib/ruby-generator/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/operators.js
@@ -49,6 +49,24 @@ export default function (Generator) {
     };
 
     Generator.operator_gt = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment) {
+            const commentParts = comment.split(/,(?=@ruby:)/);
+            for (const part of commentParts) {
+                if (part.startsWith('@ruby:operator:>=:')) {
+                    const index = part.substring(18);
+                    const order = Generator.ORDER_RELATIONAL;
+                    const operand1 = Generator.valueToCode(block, 'OPERAND1', order) || 0;
+                    const operand2 = Generator.valueToCode(block, 'OPERAND2', order) || 0;
+                    Generator.greaterThanOrEqualCallCache_[index] = {
+                        lhs: Generator.nosToCode(operand1),
+                        rhs: Generator.nosToCode(operand2)
+                    };
+                    return [`@ruby:operator:>=:${index}`, order];
+                }
+            }
+        }
+
         const order = Generator.ORDER_RELATIONAL;
         const operand1 = Generator.valueToCode(block, 'OPERAND1', order) || 0;
         const operand2 = Generator.valueToCode(block, 'OPERAND2', order) || 0;
@@ -56,6 +74,24 @@ export default function (Generator) {
     };
 
     Generator.operator_lt = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment) {
+            const commentParts = comment.split(/,(?=@ruby:)/);
+            for (const part of commentParts) {
+                if (part.startsWith('@ruby:operator:<=:')) {
+                    const index = part.substring(18);
+                    const order = Generator.ORDER_RELATIONAL;
+                    const operand1 = Generator.valueToCode(block, 'OPERAND1', order) || 0;
+                    const operand2 = Generator.valueToCode(block, 'OPERAND2', order) || 0;
+                    Generator.lessThanOrEqualCallCache_[index] = {
+                        lhs: Generator.nosToCode(operand1),
+                        rhs: Generator.nosToCode(operand2)
+                    };
+                    return [`@ruby:operator:<=:${index}`, order];
+                }
+            }
+        }
+
         const order = Generator.ORDER_RELATIONAL;
         const operand1 = Generator.valueToCode(block, 'OPERAND1', order) || 0;
         const operand2 = Generator.valueToCode(block, 'OPERAND2', order) || 0;
@@ -74,6 +110,12 @@ export default function (Generator) {
                     index = part.substring(20);
                 } else if (part.startsWith('@ruby:operator:!=:')) {
                     methodName = '!=';
+                    index = part.substring(18);
+                } else if (part.startsWith('@ruby:operator:>=:')) {
+                    methodName = '>=';
+                    index = part.substring(18);
+                } else if (part.startsWith('@ruby:operator:<=:')) {
+                    methodName = '<=';
                     index = part.substring(18);
                 }
             }
@@ -96,6 +138,10 @@ export default function (Generator) {
                     rhs: Generator.nosToCode(operand2)
                 };
                 return [`@ruby:operator:!=:${index}`, order];
+            } else if (methodName === '>=') {
+                return [`@ruby:operator:>=:${index}`, Generator.ORDER_EQUALS];
+            } else if (methodName === '<=') {
+                return [`@ruby:operator:<=:${index}`, Generator.ORDER_EQUALS];
             }
         }
 
@@ -113,6 +159,32 @@ export default function (Generator) {
     };
 
     Generator.operator_or = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment) {
+            const commentParts = comment.split(/,(?=@ruby:)/);
+            for (const part of commentParts) {
+                if (part.startsWith('@ruby:operator:>=:')) {
+                    const index = part.substring(18);
+                    const order = Generator.ORDER_RELATIONAL;
+                    const operand1 = Generator.valueToCode(block, 'OPERAND1', order);
+                    if (operand1 === `@ruby:operator:>=:${index}`) {
+                        const {lhs, rhs} = Generator.greaterThanOrEqualCallCache_[index];
+                        delete Generator.greaterThanOrEqualCallCache_[index];
+                        return [`${lhs} >= ${rhs}`, order];
+                    }
+                } else if (part.startsWith('@ruby:operator:<=:')) {
+                    const index = part.substring(18);
+                    const order = Generator.ORDER_RELATIONAL;
+                    const operand1 = Generator.valueToCode(block, 'OPERAND1', order);
+                    if (operand1 === `@ruby:operator:<=:${index}`) {
+                        const {lhs, rhs} = Generator.lessThanOrEqualCallCache_[index];
+                        delete Generator.lessThanOrEqualCallCache_[index];
+                        return [`${lhs} <= ${rhs}`, order];
+                    }
+                }
+            }
+        }
+
         const order = Generator.ORDER_LOGICAL_OR;
         const operand1 = Generator.valueToCode(block, 'OPERAND1', order) || 'false';
         const operand2 = Generator.valueToCode(block, 'OPERAND2', order) || 'false';

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js
@@ -323,6 +323,48 @@ const BlockUtils = {
         return block;
     },
 
+    _cloneBlock (block) {
+        if (!this._isBlock(block)) {
+            return block;
+        }
+
+        const newBlock = Object.assign({}, block, {
+            id: Blockly.utils.genUid(),
+            parent: null,
+            next: null,
+            inputs: {},
+            fields: _.cloneDeep(block.fields)
+        });
+        this._context.blocks[newBlock.id] = newBlock;
+        this._context.blockTypes[newBlock.id] = this._context.blockTypes[block.id];
+
+        for (const inputName in block.inputs) {
+            const input = block.inputs[inputName];
+            const childBlock = this._context.blocks[input.block];
+            const shadowBlock = input.shadow ? this._context.blocks[input.shadow] : null;
+
+            const newChildBlock = this._cloneBlock(childBlock);
+            let newShadowBlock = null;
+            if (shadowBlock) {
+                if (shadowBlock === childBlock) {
+                    newShadowBlock = newChildBlock;
+                } else {
+                    newShadowBlock = this._cloneBlock(shadowBlock);
+                }
+            }
+            this._addInput(newBlock, inputName, newChildBlock, newShadowBlock);
+        }
+
+        if (block.next) {
+            const nextBlock = this._context.blocks[block.next];
+            const newNextBlock = this._cloneBlock(nextBlock);
+            newBlock.next = newNextBlock.id;
+            newNextBlock.parent = newBlock.id;
+        }
+
+        return newBlock;
+    },
+
     changeRubyExpression (block, node, source = null) {
         block.node = node;
         const expressionBlock = this._context.blocks[block.inputs.EXPRESSION.block];

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -148,6 +148,46 @@ const OperatorsConverter = {
             return block;
         });
 
+        ['>=', '<='].forEach(operator => {
+            converter.registerOnSend('any', operator, 1, params => {
+                const {receiver, args, name} = params;
+                let rh = args[0];
+                if (_.isArray(rh)) {
+                    if (rh.length !== 1) return null;
+                    rh = rh[0];
+                }
+
+                const index = (converter._context.methodCallIndices[name] || 0) + 1;
+                converter._context.methodCallIndices[name] = index;
+
+                const commentText = `@ruby:operator:${name}:${index}`;
+
+                const receiverValue = converter._isNumber(receiver) ? receiver.toString() : receiver;
+                const rhValue = converter._isNumber(rh) ? rh.toString() : rh;
+
+                const subOpcode = operator === '>=' ? 'operator_gt' : 'operator_lt';
+                const subBlock = converter._createBlock(subOpcode, 'value_boolean');
+                converter._addTextInput(subBlock, 'OPERAND1', receiverValue, '');
+                converter._addTextInput(subBlock, 'OPERAND2', rhValue, '50');
+                subBlock.comment = converter._createComment(commentText, subBlock.id);
+
+                const equalsBlock = converter._createBlock('operator_equals', 'value_boolean');
+                converter._addTextInput(
+                    equalsBlock, 'OPERAND1', converter._cloneBlock(receiverValue), ''
+                );
+                converter._addTextInput(
+                    equalsBlock, 'OPERAND2', converter._cloneBlock(rhValue), '50'
+                );
+                equalsBlock.comment = converter._createComment(commentText, equalsBlock.id);
+
+                const block = converter._createBlock('operator_or', 'value_boolean');
+                converter._addInput(block, 'OPERAND1', subBlock);
+                converter._addInput(block, 'OPERAND2', equalsBlock);
+                block.comment = converter._createComment(commentText, block.id);
+                return block;
+            });
+        });
+
         ['>', '<', '=='].forEach(operator => {
             converter.registerOnSend('any', operator, 1, params => {
                 const {receiver, args} = params;

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
@@ -10,6 +10,8 @@ describe('RubyGenerator/Operators', () => {
         RubyGenerator.functionNames_ = {};
         RubyGenerator.emptyCallCache_ = {};
         RubyGenerator.notEqualsCallCache_ = {};
+        RubyGenerator.greaterThanOrEqualCallCache_ = {};
+        RubyGenerator.lessThanOrEqualCallCache_ = {};
         RubyGenerator.currentTarget = null;
         OperatorsBlocks(RubyGenerator);
     });
@@ -134,6 +136,80 @@ describe('RubyGenerator/Operators', () => {
         });
     });
 
+    describe('operator_gt', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_gt',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            RubyGenerator.nosToCode = jest.fn(v => v);
+            expect(RubyGenerator.operator_gt(block)).toEqual(['1 > 2', RubyGenerator.ORDER_RELATIONAL]);
+        });
+
+        test('with @ruby:operator:>=:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_gt',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:operator:>=:1' };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            RubyGenerator.nosToCode = jest.fn(v => v);
+
+            expect(RubyGenerator.operator_gt(block)).toEqual(['@ruby:operator:>=:1', RubyGenerator.ORDER_RELATIONAL]);
+            expect(RubyGenerator.greaterThanOrEqualCallCache_['1']).toEqual({ lhs: '1', rhs: '2' });
+        });
+    });
+
+    describe('operator_lt', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_lt',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            RubyGenerator.nosToCode = jest.fn(v => v);
+            expect(RubyGenerator.operator_lt(block)).toEqual(['1 < 2', RubyGenerator.ORDER_RELATIONAL]);
+        });
+
+        test('with @ruby:operator:<=:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_lt',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:operator:<=:1' };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            RubyGenerator.nosToCode = jest.fn(v => v);
+
+            expect(RubyGenerator.operator_lt(block)).toEqual(['@ruby:operator:<=:1', RubyGenerator.ORDER_RELATIONAL]);
+            expect(RubyGenerator.lessThanOrEqualCallCache_['1']).toEqual({ lhs: '1', rhs: '2' });
+        });
+    });
+
     describe('operator_equals', () => {
         test('normal', () => {
             const block = {
@@ -168,6 +244,42 @@ describe('RubyGenerator/Operators', () => {
 
             expect(RubyGenerator.operator_equals(block)).toEqual(['@ruby:operator:!=:1', RubyGenerator.ORDER_EQUALS]);
             expect(RubyGenerator.notEqualsCallCache_['1']).toEqual({ lhs: '1', rhs: '2' });
+        });
+
+        test('with @ruby:operator:>=:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_equals',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:operator:>=:1' };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            RubyGenerator.nosToCode = jest.fn(v => v);
+
+            expect(RubyGenerator.operator_equals(block)).toEqual(['@ruby:operator:>=:1', RubyGenerator.ORDER_EQUALS]);
+        });
+
+        test('with @ruby:operator:<=:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_equals',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:operator:<=:1' };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('1')
+                .mockReturnValueOnce('2');
+            RubyGenerator.nosToCode = jest.fn(v => v);
+
+            expect(RubyGenerator.operator_equals(block)).toEqual(['@ruby:operator:<=:1', RubyGenerator.ORDER_EQUALS]);
         });
 
         test('with @ruby:method:empty?', () => {
@@ -214,6 +326,57 @@ describe('RubyGenerator/Operators', () => {
 
             expect(RubyGenerator.operator_equals(block)).toEqual(['list("my list").empty?', RubyGenerator.ORDER_FUNCTION_CALL]);
             expect(RubyGenerator.emptyCallCache_['1']).toBeUndefined();
+        });
+    });
+
+    describe('operator_or', () => {
+        test('normal', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_or',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.valueToCode = jest.fn()
+                .mockReturnValueOnce('true')
+                .mockReturnValueOnce('false');
+            expect(RubyGenerator.operator_or(block)).toEqual(['true || false', RubyGenerator.ORDER_LOGICAL_OR]);
+        });
+
+        test('with @ruby:operator:>=:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_or',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:operator:>=:1' };
+            RubyGenerator.greaterThanOrEqualCallCache_['1'] = { lhs: '1', rhs: '2' };
+            RubyGenerator.valueToCode = jest.fn().mockReturnValueOnce('@ruby:operator:>=:1');
+
+            expect(RubyGenerator.operator_or(block)).toEqual(['1 >= 2', RubyGenerator.ORDER_RELATIONAL]);
+            expect(RubyGenerator.greaterThanOrEqualCallCache_['1']).toBeUndefined();
+        });
+
+        test('with @ruby:operator:<=:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_or',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:operator:<=:1' };
+            RubyGenerator.lessThanOrEqualCallCache_['1'] = { lhs: '1', rhs: '2' };
+            RubyGenerator.valueToCode = jest.fn().mockReturnValueOnce('@ruby:operator:<=:1');
+
+            expect(RubyGenerator.operator_or(block)).toEqual(['1 <= 2', RubyGenerator.ORDER_RELATIONAL]);
+            expect(RubyGenerator.lessThanOrEqualCallCache_['1']).toBeUndefined();
         });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
@@ -782,6 +782,234 @@ describe('RubyToBlocksConverter/Operators', () => {
         convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
 
+    test('operator_ge', () => {
+        code = '1 >= 50';
+        expected = [
+            {
+                opcode: 'operator_or',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_gt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('1')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:>=:1',
+                                minimized: true
+                            }
+                        }
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: {
+                            opcode: 'operator_equals',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('1')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:>=:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ],
+                comment: {
+                    text: '@ruby:operator:>=:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'x >= y';
+        expected = [
+            {
+                opcode: 'operator_or',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_gt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: rubyToExpected(converter, target, 'x')[0],
+                                    shadow: expectedInfo.makeText('')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: rubyToExpected(converter, target, 'y')[0],
+                                    shadow: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:>=:1',
+                                minimized: true
+                            }
+                        }
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: {
+                            opcode: 'operator_equals',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: rubyToExpected(converter, target, 'x')[0],
+                                    shadow: expectedInfo.makeText('')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: rubyToExpected(converter, target, 'y')[0],
+                                    shadow: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:>=:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ],
+                comment: {
+                    text: '@ruby:operator:>=:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('operator_le', () => {
+        code = '1 <= 50';
+        expected = [
+            {
+                opcode: 'operator_or',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_lt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('1')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:<=:1',
+                                minimized: true
+                            }
+                        }
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: {
+                            opcode: 'operator_equals',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('1')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:<=:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ],
+                comment: {
+                    text: '@ruby:operator:<=:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'x <= y';
+        expected = [
+            {
+                opcode: 'operator_or',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_lt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: rubyToExpected(converter, target, 'x')[0],
+                                    shadow: expectedInfo.makeText('')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: rubyToExpected(converter, target, 'y')[0],
+                                    shadow: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:<=:1',
+                                minimized: true
+                            }
+                        }
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: {
+                            opcode: 'operator_equals',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: rubyToExpected(converter, target, 'x')[0],
+                                    shadow: expectedInfo.makeText('')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: rubyToExpected(converter, target, 'y')[0],
+                                    shadow: expectedInfo.makeText('50')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:operator:<=:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ],
+                comment: {
+                    text: '@ruby:operator:<=:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
     test('operator_and', () => {
         code = '1 < x && x < 10';
         expected = [

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -1,0 +1,75 @@
+import Blocks from '@smalruby/scratch-vm/src/engine/blocks';
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import RubyGenerator from '../../../../src/lib/ruby-generator';
+
+describe('Ruby Round Trip', () => {
+    let converter;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null);
+    });
+
+    const expectRoundTrip = (code, expectedRuby = null) => {
+        const result = converter.targetCodeToBlocks(null, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(result).toBeTruthy();
+
+        const blocks = new Blocks();
+        blocks.forceNoGlow = true;
+        Object.keys(converter.blocks).forEach(blockId => {
+            blocks.createBlock(converter.blocks[blockId]);
+        });
+
+        const variables = {};
+        [converter.variables, converter._context.localVariables].forEach(vars => {
+            Object.values(vars).forEach(v => {
+                variables[v.id] = v;
+            });
+        });
+
+        const lists = {};
+        Object.values(converter.lists).forEach(v => {
+            lists[v.id] = v;
+        });
+
+        const target = {
+            id: 'target-id',
+            blocks: blocks,
+            variables: variables,
+            lists: lists,
+            comments: converter._context.comments,
+            isStage: false,
+            // Mocking some methods needed by RubyGenerator or Blocks
+            lookupVariableById: id => variables[id],
+            lookupVariableByNameAndType: (name, type) => {
+                return Object.values(variables).find(v => v.name === name && v.type === type);
+            }
+        };
+
+        RubyGenerator.init();
+        RubyGenerator.currentTarget = target;
+        
+        const generatedRuby = RubyGenerator.targetToCode(target);
+        expect(generatedRuby.trim()).toEqual((expectedRuby || code).trim());
+    };
+
+    test('operator >=', () => {
+        expectRoundTrip('1 >= 50');
+        expectRoundTrip('@x >= @y');
+        expectRoundTrip('1.2 >= 3.4');
+        expectRoundTrip('1 + 2 >= 3 * 4');
+    });
+
+    test('operator <=', () => {
+        expectRoundTrip('1 <= 50');
+        expectRoundTrip('@x <= @y');
+        expectRoundTrip('1.2 <= 3.4');
+        expectRoundTrip('1 + 2 <= 3 * 4');
+    });
+
+    test('mixed operators', () => {
+        expectRoundTrip('@x >= @y && @a <= @b');
+        expectRoundTrip('@x >= @y || @a <= @b');
+        expectRoundTrip('!(@x >= @y)');
+    });
+});


### PR DESCRIPTION
This PR implements the mutual conversion between Ruby and instruction blocks for the comparison operators `>=` and `<=`.

### Changes
- Implemented `>=` and `<=` handlers in `ruby-to-blocks-converter`.
  - `x >= y` is converted to `(x > y) || (x == y)`.
  - `x <= y` is converted to `(x < y) || (x == y)`.
  - Added `@ruby:operator:>=:N` and `@ruby:operator:<=:N` comments to allow round-trip conversion.
- Implemented support for these operators in `ruby-generator`.
- Added unit tests for both converter and generator.
- Added round-trip tests to verify the consistency.
- Added `_cloneBlock` utility to `BlockUtils` to support operand duplication.

closes #127
