### PR TITLE
refactor: メッシュV2拡張機能のログ出力を抑制する

### DIFF
--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
@@ -239,7 +239,7 @@ class Scratch3MeshV2Blocks {
             .catch(err => {
                 log.error(`Mesh V2: Scan failed: ${err}`);
                 // Check if error is caused by network filter (HTTP 503)
-                log.debug('Mesh V2: Checking lastError:', this.meshService?.lastError);
+                debug(() => `Mesh V2: Checking lastError: ${this.meshService?.lastError}`);
                 const errorType = this.meshService &&
                     this.meshService.lastError &&
                     this.meshService.isNetworkFilterError(this.meshService.lastError) ?

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
@@ -1,7 +1,10 @@
+/* global process */
 const ArgumentType = require('../../extension-support/argument-type');
 const BlockType = require('../../extension-support/block-type');
 const formatMessage = require('format-message');
 const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
 const {v4: uuidv4} = require('uuid');
 const Variable = require('../../engine/variable');
 const {getDomain, saveDomainToLocalStorage} = require('./utils');
@@ -50,7 +53,7 @@ class Scratch3MeshV2Blocks {
 
     /* istanbul ignore next */
     constructor (runtime) {
-        log.info('Loading NEW Mesh V2 extension (GraphQL)');
+        debug(() => 'Loading NEW Mesh V2 extension (GraphQL)');
         this.runtime = runtime;
         try {
             this.domain = getDomain();
@@ -111,7 +114,7 @@ class Scratch3MeshV2Blocks {
         if (this.meshService) {
             this.meshService.domain = domain;
         }
-        log.info(`Mesh V2: Domain set to ${domain || 'null (auto)'}`);
+        debug(() => `Mesh V2: Domain set to ${domain || 'null (auto)'}`);
         return null;
     }
 
@@ -200,6 +203,7 @@ class Scratch3MeshV2Blocks {
         if (!this.meshService) return;
         this.meshService.listGroups().then(groups => {
             this.discoveredGroups = groups;
+            log.info(`Mesh V2: Listed ${groups.length} groups`);
 
             // Filter out expired groups
             const now = Date.now();
@@ -241,7 +245,7 @@ class Scratch3MeshV2Blocks {
                     this.meshService.isNetworkFilterError(this.meshService.lastError) ?
                     'networkFilter' :
                     null;
-                log.info(`Mesh V2: Setting error state with errorType: ${errorType}`);
+                debug(() => `Mesh V2: Setting error state with errorType: ${errorType}`);
                 // Set error state to trigger error UI
                 this.setConnectionState('error', errorType);
             });

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
@@ -203,7 +203,7 @@ class Scratch3MeshV2Blocks {
         if (!this.meshService) return;
         this.meshService.listGroups().then(groups => {
             this.discoveredGroups = groups;
-            log.info(`Mesh V2: Listed ${groups.length} groups`);
+            debug(() => `Mesh V2: Listed ${groups.length} groups`);
 
             // Filter out expired groups
             const now = Date.now();

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -225,15 +225,14 @@ class MeshV2Service {
      */
     isNetworkFilterError (error) {
         if (!error) {
-            log.debug('Mesh V2: isNetworkFilterError called with null/undefined error');
+            debug(() => 'Mesh V2: isNetworkFilterError called with null/undefined error');
             return false;
         }
 
-        log.debug('Mesh V2: Checking if error is network filter error:', {
-            hasNetworkError: !!error.networkError,
-            statusCode: error.networkError?.statusCode,
-            message: error.message
-        });
+        debug(() => `Mesh V2: Checking if error is network filter error: ` +
+            `hasNetworkError=${!!error.networkError}, ` +
+            `statusCode=${error.networkError?.statusCode}, ` +
+            `message=${error.message}`);
 
         // Primary check: HTTP status code 503 from network error
         // This is the ONLY reliable indicator when blocked by proxy (e.g., i-Filter)
@@ -249,7 +248,7 @@ class MeshV2Service {
             return true;
         }
 
-        log.debug('Mesh V2: Error is NOT a network filter error');
+        debug(() => 'Mesh V2: Error is NOT a network filter error');
         return false;
     }
 
@@ -708,7 +707,7 @@ class MeshV2Service {
             this.lastFetchTime = new Date().toISOString();
         }
 
-        log.debug(`Mesh V2: pollEvents for group ${this.groupId}. since=${this.lastFetchTime}`);
+        debug(() => `Mesh V2: pollEvents for group ${this.groupId}. since=${this.lastFetchTime}`);
 
         try {
             this.costTracking.queryCount++;
@@ -853,7 +852,7 @@ class MeshV2Service {
 
             // まだタイミングが来ていない場合は待機
             if (offsetMs > elapsedMs) {
-                log.debug(`Mesh V2: Waiting for event ${event.name} ` +
+                debug(() => `Mesh V2: Waiting for event ${event.name} ` +
                     `(needs ${offsetMs}ms, elapsed ${elapsedMs}ms)`);
                 break;
             }
@@ -863,7 +862,7 @@ class MeshV2Service {
             if (windowBase === null) {
                 windowBase = offsetMs;
             } else if (offsetMs >= windowBase + 33) {
-                log.debug(`Mesh V2: Window limit reached (33ms). ` +
+                debug(() => `Mesh V2: Window limit reached (33ms). ` +
                     `Remaining events will be processed in next frames.`);
                 break;
             }
@@ -914,7 +913,7 @@ class MeshV2Service {
 
     startEventBatchTimer () {
         this.stopEventBatchTimer();
-        log.debug(`Mesh V2: Starting event batch timer (Interval: ${this.eventBatchInterval}ms)`);
+        debug(() => `Mesh V2: Starting event batch timer (Interval: ${this.eventBatchInterval}ms)`);
         this.eventBatchTimer = setInterval(() => {
             this.processBatchEvents();
         }, this.eventBatchInterval);
@@ -1114,7 +1113,7 @@ class MeshV2Service {
         // This avoids redundant mutations if values change back within the rate-limit interval.
         const filteredData = dataArray.filter(item => this.latestQueuedData[item.key] !== item.value);
 
-        log.debug(`Mesh V2: sendData called with ${dataArray.length} items, ` +
+        debug(() => `Mesh V2: sendData called with ${dataArray.length} items, ` +
             `${filteredData.length} items changed: ${JSON.stringify(filteredData)}`);
 
         if (filteredData.length === 0) {
@@ -1154,7 +1153,7 @@ class MeshV2Service {
         const finalPayload = payload.filter(item => this.lastSentData[item.key] !== item.value);
 
         if (finalPayload.length === 0) {
-            log.debug('Mesh V2: Skipping mutation as all data is already up-to-date on server');
+            debug(() => 'Mesh V2: Skipping mutation as all data is already up-to-date on server');
             return {
                 data: {
                     reportDataByNode: {
@@ -1218,7 +1217,7 @@ class MeshV2Service {
             this.eventQueueStats.duplicatesSkipped++;
             this.reportEventStatsIfNeeded();
 
-            log.debug(`Mesh V2: Event already in queue, skipping: ${eventName}`);
+            debug(() => `Mesh V2: Event already in queue, skipping: ${eventName}`);
             return;
         }
 
@@ -1234,7 +1233,7 @@ class MeshV2Service {
             }
         }
 
-        log.debug(`Mesh V2: Queuing event for sending: ${eventName} ` +
+        debug(() => `Mesh V2: Queuing event for sending: ${eventName} ` +
             `(queue size: ${this.eventQueue.length})`);
 
         // キューに追加（発火日時を記録）

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -596,6 +596,7 @@ class MeshV2Service {
             log.info(`  TOTAL ESTIMATED COST: $${totalCost.toFixed(8)} ` +
                 `(${(totalCost * 1000000).toFixed(2)} per million operations equivalent)`);
             log.info(`  Average cost per second: $${(totalCost / connectionDurationSeconds).toFixed(10)}`);
+            this.costTracking.connectionStartTime = null;
         }
 
         // 統計情報を出力
@@ -1195,6 +1196,9 @@ class MeshV2Service {
             const reason = this.shouldDisconnectOnError(error);
             if (reason) {
                 this.cleanupAndDisconnect(reason);
+                // Do not re-throw: sendData will catch this and would call
+                // cleanupAndDisconnect again, causing duplicate cost summaries.
+                return;
             }
             throw error;
         }

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -1,5 +1,7 @@
 /* global process */
 const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
 const {getClient} = require('./mesh-client');
 const RateLimiter = require('./rate-limiter');
 const BlockUtility = require('../../engine/block-utility');
@@ -55,7 +57,7 @@ const DISCONNECT_ERROR_TYPES = new Set([
 /* istanbul ignore next */
 class MeshV2Service {
     constructor (blocks, meshId, domain) {
-        log.info('Initializing MeshV2Service (GraphQL)');
+        debug(() => 'Initializing MeshV2Service (GraphQL)');
         this.blocks = blocks;
         this.runtime = blocks.runtime;
         this.meshId = meshId;
@@ -192,7 +194,7 @@ class MeshV2Service {
         if (error.graphQLErrors && error.graphQLErrors.length > 0) {
             const errorType = error.graphQLErrors[0].errorType;
             if (DISCONNECT_ERROR_TYPES.has(errorType)) {
-                log.info(`Mesh V2: Disconnecting due to errorType: ${errorType}`);
+                debug(() => `Mesh V2: Disconnecting due to errorType: ${errorType}`);
                 return errorType;
             }
         }
@@ -309,25 +311,25 @@ class MeshV2Service {
 
                 const socket = new WebSocket(wsUrl, 'graphql-ws');
                 const timeout = setTimeout(() => {
-                    log.warn('Mesh V2: WebSocket test timed out');
+                    debug(() => 'Mesh V2: WebSocket test timed out');
                     socket.close();
                     resolve(false);
                 }, 3000); // 3 seconds timeout for test
 
                 socket.onopen = () => {
-                    log.info('Mesh V2: WebSocket test successful');
+                    debug(() => 'Mesh V2: WebSocket test successful');
                     clearTimeout(timeout);
                     socket.close();
                     resolve(true);
                 };
 
                 socket.onerror = err => {
-                    log.warn(`Mesh V2: WebSocket test failed: ${err}`);
+                    debug(() => `Mesh V2: WebSocket test failed: ${err}`);
                     clearTimeout(timeout);
                     resolve(false);
                 };
             } catch (error) {
-                log.warn(`Mesh V2: WebSocket not supported or failed to initialize: ${error}`);
+                debug(() => `Mesh V2: WebSocket not supported or failed to initialize: ${error}`);
                 resolve(false);
             }
         });
@@ -343,7 +345,7 @@ class MeshV2Service {
             });
 
             this.domain = result.data.createDomain;
-            log.info(`Mesh V2: Created domain ${this.domain} from source IP`);
+            debug(() => `Mesh V2: Created domain ${this.domain} from source IP`);
             return this.domain;
         } catch (error) {
             log.error(`Mesh V2: Failed to create domain: ${error}`);
@@ -372,7 +374,7 @@ class MeshV2Service {
 
             this.costTracking.mutationCount++;
             this.lastFetchTime = new Date().toISOString();
-            log.info(`Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before createGroup)`);
+            debug(() => `Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before createGroup)`);
             const result = await this.client.mutate({
                 mutation: CREATE_GROUP,
                 variables: {
@@ -460,7 +462,7 @@ class MeshV2Service {
 
             this.costTracking.mutationCount++;
             this.lastFetchTime = new Date().toISOString();
-            log.info(`Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before joinGroup)`);
+            debug(() => `Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before joinGroup)`);
             const result = await this.client.mutate({
                 mutation: JOIN_GROUP,
                 variables: {
@@ -533,7 +535,7 @@ class MeshV2Service {
                         hostId: hostId
                     }
                 });
-                log.info(`Mesh V2: Dissolved group ${groupId}`);
+                debug(() => `Mesh V2: Dissolved group ${groupId}`);
             } else {
                 this.costTracking.mutationCount++;
                 await this.client.mutate({
@@ -544,7 +546,7 @@ class MeshV2Service {
                         nodeId: nodeId
                     }
                 });
-                log.info(`Mesh V2: Left group ${groupId}`);
+                debug(() => `Mesh V2: Left group ${groupId}`);
             }
         } catch (error) {
             log.error(`Mesh V2: Error during leave/dissolve (background): ${error}`);
@@ -596,7 +598,7 @@ class MeshV2Service {
         // 統計情報を出力
         if (this.eventQueueStats &&
             (this.eventQueueStats.duplicatesSkipped > 0 || this.eventQueueStats.dropped > 0)) {
-            log.info(`Mesh V2: Final Event Queue Stats: ` +
+            debug(() => `Mesh V2: Final Event Queue Stats: ` +
                 `duplicates skipped=${this.eventQueueStats.duplicatesSkipped}, ` +
                 `dropped=${this.eventQueueStats.dropped}`);
         }
@@ -648,7 +650,7 @@ class MeshV2Service {
                     this.handleBatchEvent(message.batchEvent);
                 } else if (message.groupDissolve) {
                     this.costTracking.dissolveReceived++;
-                    log.info('Mesh V2: Group dissolved by host');
+                    debug(() => 'Mesh V2: Group dissolved by host');
                     this.cleanupAndDisconnect();
                 } else {
                     log.warn('Mesh V2: Received message with all fields null');
@@ -672,7 +674,7 @@ class MeshV2Service {
         this.stopPolling();
         if (!this.groupId) return;
 
-        log.info(`Mesh V2: Starting event polling (Interval: ${this.pollingIntervalSeconds}s)`);
+        debug(() => `Mesh V2: Starting event polling (Interval: ${this.pollingIntervalSeconds}s)`);
 
         this.pollingTimer = setInterval(() => {
             this.pollEvents();
@@ -684,7 +686,7 @@ class MeshV2Service {
      */
     stopPolling () {
         if (this.pollingTimer) {
-            log.info('Mesh V2: Stopping event polling');
+            debug(() => 'Mesh V2: Stopping event polling');
             clearInterval(this.pollingTimer);
             this.pollingTimer = null;
         }
@@ -719,7 +721,7 @@ class MeshV2Service {
             if (result.data && result.data.getEventsSince) {
                 const events = result.data.getEventsSince;
                 if (events.length > 0) {
-                    log.info(`Mesh V2: Polled ${events.length} events`);
+                    debug(() => `Mesh V2: Polled ${events.length} events`);
 
                     // Filter out events from self and sort by timestamp to preserve order
                     const otherEvents = events
@@ -771,7 +773,7 @@ class MeshV2Service {
             [];
         if (events.length === 0) return;
 
-        log.info(`Mesh V2: Received ${events.length} events from ${batchEvent.firedByNodeId}`);
+        debug(() => `Mesh V2: Received ${events.length} events from ${batchEvent.firedByNodeId}`);
 
         this._queueEventsForPlayback(events);
     }
@@ -799,7 +801,7 @@ class MeshV2Service {
                 event: event,
                 offsetMs: offsetMs
             });
-            log.info(`Mesh V2: Queued event: ${event.name} ` +
+            debug(() => `Mesh V2: Queued event: ${event.name} ` +
                 `(offset: ${offsetMs}ms, original timestamp: ${event.timestamp})`);
         });
 
@@ -809,7 +811,7 @@ class MeshV2Service {
             this.lastBroadcastOffset = 0;
         }
 
-        log.info(`Mesh V2: Total pending broadcasts: ${this.pendingBroadcasts.length}`);
+        debug(() => `Mesh V2: Total pending broadcasts: ${this.pendingBroadcasts.length}`);
     }
 
     /**
@@ -869,11 +871,11 @@ class MeshV2Service {
 
         // 収集したイベントを処理
         if (eventsToProcess.length > 0) {
-            log.info(`Mesh V2: Broadcasting ${eventsToProcess.length} events ` +
+            debug(() => `Mesh V2: Broadcasting ${eventsToProcess.length} events ` +
                 `(${this.pendingBroadcasts.length} remaining in queue)`);
 
             eventsToProcess.forEach(({event, offsetMs}) => {
-                log.info(`Mesh V2: Broadcasting event: ${event.name} ` +
+                debug(() => `Mesh V2: Broadcasting event: ${event.name} ` +
                     `(offset: ${offsetMs}ms, elapsed: ${elapsedMs}ms)`);
 
                 this.broadcastEvent(event);
@@ -883,7 +885,7 @@ class MeshV2Service {
     }
 
     broadcastEvent (event) {
-        log.info(`Mesh V2: Executing broadcastEvent for: ${event.name}`);
+        debug(() => `Mesh V2: Executing broadcastEvent for: ${event.name}`);
         try {
             const args = {
                 BROADCAST_OPTION: {
@@ -896,7 +898,7 @@ class MeshV2Service {
                 if (!util.sequencer) {
                     util.sequencer = this.runtime.sequencer;
                 }
-                log.info(`Mesh V2: Triggering event_broadcast: ${event.name}`);
+                debug(() => `Mesh V2: Triggering event_broadcast: ${event.name}`);
                 this.blocks.opcodeFunctions.event_broadcast(args, util);
             } else {
                 log.warn(`Mesh V2: No BlockUtility instance available for broadcast: ${event.name}`);
@@ -926,7 +928,7 @@ class MeshV2Service {
 
         // キューから全イベントを取り出す
         const events = this.eventQueue.splice(0);
-        log.info(`Mesh V2: Processing ${events.length} queued events for sending`);
+        debug(() => `Mesh V2: Processing ${events.length} queued events for sending`);
 
         try {
             // ペイロードサイズ制限を考慮して分割送信（約1,000イベントごと）
@@ -989,7 +991,7 @@ class MeshV2Service {
         this.stopHeartbeat();
         if (!this.groupId) return;
 
-        log.info(`Mesh V2: Starting heartbeat timer (Role: ${this.isHost ? 'Host' : 'Member'}, ` +
+        debug(() => `Mesh V2: Starting heartbeat timer (Role: ${this.isHost ? 'Host' : 'Member'}, ` +
             `Interval: ${this.isHost ? this.hostHeartbeatInterval : this.memberHeartbeatInterval}s)`);
         const interval = (this.isHost ? this.hostHeartbeatInterval : this.memberHeartbeatInterval) * 1000;
 
@@ -1004,7 +1006,7 @@ class MeshV2Service {
 
     stopHeartbeat () {
         if (this.heartbeatTimer) {
-            log.info('Mesh V2: Stopping heartbeat timer');
+            debug(() => 'Mesh V2: Stopping heartbeat timer');
             clearInterval(this.heartbeatTimer);
             this.heartbeatTimer = null;
         }
@@ -1026,7 +1028,7 @@ class MeshV2Service {
             });
 
             this.expiresAt = result.data.renewHeartbeat.expiresAt;
-            log.info(`Mesh V2: Heartbeat renewed. Expires at: ${this.expiresAt}`);
+            debug(() => `Mesh V2: Heartbeat renewed. Expires at: ${this.expiresAt}`);
 
             if (result.data.renewHeartbeat.heartbeatIntervalSeconds) {
                 const newInterval = result.data.renewHeartbeat.heartbeatIntervalSeconds;
@@ -1061,7 +1063,7 @@ class MeshV2Service {
                 }
             });
 
-            log.info('Mesh V2: Member heartbeat sent');
+            debug(() => 'Mesh V2: Member heartbeat sent');
             if (result.data.sendMemberHeartbeat.expiresAt) {
                 this.expiresAt = result.data.sendMemberHeartbeat.expiresAt;
             }
@@ -1195,7 +1197,11 @@ class MeshV2Service {
 
     fireEvent (eventName, payload = '') {
         if (!this.groupId || !this.client) {
-            log.warn(`Mesh V2: Cannot fire event ${eventName} - groupId: ${this.groupId}, client: ${!!this.client}`);
+            if (this.groupId) {
+                log.warn(`Mesh V2: Cannot fire event ${eventName} - client not available`);
+            } else {
+                debug(() => `Mesh V2: Cannot fire event ${eventName} - not connected`);
+            }
             return;
         }
 
@@ -1244,7 +1250,7 @@ class MeshV2Service {
 
         if (elapsed >= 10000 &&
             (this.eventQueueStats.duplicatesSkipped > 0 || this.eventQueueStats.dropped > 0)) {
-            log.info(`Mesh V2: Event Queue Stats (last ${(elapsed / 1000).toFixed(1)}s): ` +
+            debug(() => `Mesh V2: Event Queue Stats (last ${(elapsed / 1000).toFixed(1)}s): ` +
                 `duplicates skipped=${this.eventQueueStats.duplicatesSkipped}, ` +
                 `dropped=${this.eventQueueStats.dropped}, ` +
                 `current queue size=${this.eventQueue.length}`);
@@ -1293,7 +1299,7 @@ class MeshV2Service {
                 });
             });
 
-            log.info(`Mesh V2: Fetched data from ${nodeStatuses.length} nodes`);
+            debug(() => `Mesh V2: Fetched data from ${nodeStatuses.length} nodes`);
         } catch (error) {
             log.error(`Mesh V2: Failed to fetch group data: ${error}`);
         }
@@ -1306,9 +1312,9 @@ class MeshV2Service {
         this.stopPeriodicDataSync();
 
         const interval = this.periodicDataSyncInterval;
-        log.info(`Mesh V2: Starting periodic data sync timer (Interval: ${interval / 1000}s)`);
+        debug(() => `Mesh V2: Starting periodic data sync timer (Interval: ${interval / 1000}s)`);
         this.dataSyncTimer = setInterval(() => {
-            log.info('Mesh V2: Periodic data sync');
+            debug(() => 'Mesh V2: Periodic data sync');
             this.fetchAllNodesData();
         }, interval);
     }
@@ -1318,7 +1324,7 @@ class MeshV2Service {
      */
     stopPeriodicDataSync () {
         if (this.dataSyncTimer) {
-            log.info('Mesh V2: Stopping periodic data sync timer');
+            debug(() => 'Mesh V2: Stopping periodic data sync timer');
             clearInterval(this.dataSyncTimer);
             this.dataSyncTimer = null;
         }
@@ -1354,12 +1360,12 @@ class MeshV2Service {
 
         const allVariables = this.getGlobalVariables();
         if (allVariables.length === 0) {
-            log.info('Mesh V2: No global variables to send');
+            debug(() => 'Mesh V2: No global variables to send');
             return;
         }
 
         await this.sendData(allVariables);
-        log.info(`Mesh V2: Sent ${allVariables.length} global variables`);
+        debug(() => `Mesh V2: Sent ${allVariables.length} global variables`);
     }
 
     getRemoteVariable (name) {

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -175,6 +175,7 @@ class MeshV2Service {
             heartbeatCount: 0, // RENEW_HEARTBEAT, SEND_MEMBER_HEARTBEAT
             reportDataCount: 0, // REPORT_DATA
             fireEventsCount: 0, // FIRE_EVENTS
+            leaveCount: 0, // LEAVE_GROUP or DISSOLVE_GROUP
             dataUpdateReceived: 0, // ON_DATA_UPDATE
             batchEventReceived: 0, // ON_BATCH_EVENT
             dissolveReceived: 0 // ON_GROUP_DISSOLVE
@@ -520,13 +521,16 @@ class MeshV2Service {
         const hostId = this.meshId;
         const nodeId = this.meshId;
 
+        // Count the leave/dissolve mutation before cleanup() outputs the cost summary
+        this.costTracking.mutationCount++;
+        this.costTracking.leaveCount++;
+
         this.cleanupAndDisconnect();
 
         if (!this.client) return;
 
         try {
             if (isHost) {
-                this.costTracking.mutationCount++;
                 await this.client.mutate({
                     mutation: DISSOLVE_GROUP,
                     variables: {
@@ -537,7 +541,6 @@ class MeshV2Service {
                 });
                 debug(() => `Mesh V2: Dissolved group ${groupId}`);
             } else {
-                this.costTracking.mutationCount++;
                 await this.client.mutate({
                     mutation: LEAVE_GROUP,
                     variables: {
@@ -568,8 +571,8 @@ class MeshV2Service {
             const batchEventCost = this.costTracking.batchEventReceived * 0.000002;
             const dissolveCost = this.costTracking.dissolveReceived * 0.000002;
 
-            // Subscription connection cost (1 subscription)
-            const connectionCost = (connectionDurationMinutes / 1000000) * 1 * 0.08;
+            // Subscription connection cost: $0.00000008 per connection-minute (1 subscription)
+            const connectionCost = connectionDurationMinutes * 0.00000008;
 
             const totalCost = queryCost + mutationCost + dataUpdateCost + batchEventCost +
                 dissolveCost + connectionCost;
@@ -581,6 +584,7 @@ class MeshV2Service {
             log.info(`    - Heartbeats: ${this.costTracking.heartbeatCount}`);
             log.info(`    - REPORT_DATA: ${this.costTracking.reportDataCount}`);
             log.info(`    - FIRE_EVENTS: ${this.costTracking.fireEventsCount}`);
+            log.info(`    - LEAVE/DISSOLVE: ${this.costTracking.leaveCount}`);
             log.info(`  Subscription Messages:`);
             log.info(`    - Data Updates: ${this.costTracking.dataUpdateReceived} msgs = ` +
                 `$${dataUpdateCost.toFixed(8)}`);

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -237,14 +237,14 @@ class MeshV2Service {
         // Primary check: HTTP status code 503 from network error
         // This is the ONLY reliable indicator when blocked by proxy (e.g., i-Filter)
         if (error.networkError && error.networkError.statusCode === 503) {
-            log.info('Mesh V2: Detected network filter error (HTTP 503)');
+            debug(() => 'Mesh V2: Detected network filter error (HTTP 503)');
             return true;
         }
 
         // Fallback: Check for 503 in error message (less reliable)
         // Some GraphQL clients may include status code in message
         if (error.message && error.message.includes('503')) {
-            log.info('Mesh V2: Detected network filter error (503 in message)');
+            debug(() => 'Mesh V2: Detected network filter error (503 in message)');
             return true;
         }
 

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -1169,6 +1169,8 @@ class MeshV2Service {
             this.costTracking.mutationCount++;
             this.costTracking.reportDataCount++;
 
+            log.info(`Mesh V2: Sending ${finalPayload.length} data items to group ${this.groupId}`);
+
             // Save Promise to track completion
             this.lastDataSendPromise = this.client.mutate({
                 mutation: REPORT_DATA,

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/rate-limiter.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/rate-limiter.js
@@ -1,4 +1,6 @@
-const log = require('../../util/log');
+/* global process */
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
 
 /* istanbul ignore next */
 class RateLimiter {
@@ -43,7 +45,7 @@ class RateLimiter {
                 this.queue.push({data, resolve, reject, sendFunction});
             }
 
-            log.debug(`RateLimiter: ${this.enableMerge ? 'Processed' : 'Added'} to queue ` +
+            debug(() => `RateLimiter: ${this.enableMerge ? 'Processed' : 'Added'} to queue ` +
                 `(size: ${this.queue.length}, enableMerge: ${this.enableMerge})`);
 
             this.processQueue();
@@ -68,7 +70,7 @@ class RateLimiter {
                 const existingData = queueItem.data;
                 const mergedData = this.mergeData(existingData, dataArray);
 
-                log.debug(`RateLimiter: Merging data - ` +
+                debug(() => `RateLimiter: Merging data - ` +
                     `before: ${JSON.stringify(existingData)}, ` +
                     `after: ${JSON.stringify(mergedData)}`);
 
@@ -116,7 +118,7 @@ class RateLimiter {
 
         // Output statistics every 10 seconds
         if (elapsed >= 10000) {
-            log.info(`RateLimiter Stats (last ${(elapsed / 1000).toFixed(1)}s): ` +
+            debug(() => `RateLimiter Stats (last ${(elapsed / 1000).toFixed(1)}s): ` +
                 `sent=${this.stats.totalSent}, merged=${this.stats.totalMerged}, ` +
                 `queue=${this.queue.length}`);
 
@@ -195,7 +197,7 @@ class RateLimiter {
 
             const item = this.queue.shift();
             this.requestCount++;
-            log.debug(`RateLimiter: Sending request #${this.requestCount} ` +
+            debug(() => `RateLimiter: Sending request #${this.requestCount} ` +
                 `(queue remaining: ${this.queue.length})`);
 
             try {

--- a/packages/scratch-vm/webpack.config.js
+++ b/packages/scratch-vm/webpack.config.js
@@ -67,6 +67,7 @@ const webBuilder = new ScratchWebpackConfigBuilder(common)
         }
     })
     .addPlugin(new webpack.DefinePlugin({
+        'process.env.DEBUG': JSON.stringify(process.env.DEBUG),
         'process.env.MESH_GRAPHQL_ENDPOINT': JSON.stringify(process.env.MESH_GRAPHQL_ENDPOINT),
         'process.env.MESH_API_KEY': JSON.stringify(process.env.MESH_API_KEY),
         'process.env.MESH_AWS_REGION': JSON.stringify(process.env.MESH_AWS_REGION),


### PR DESCRIPTION
## Summary

- `scratch3_mesh_v2` の大量のデバッグログを整理し、通常使用時のコンソールノイズを削減する
- `debug-logger.js` ユーティリティを導入し、`DEBUG` 環境変数がビルド時に設定されている場合のみ詳細ログを出力するよう制御
- ユーザー操作の主要イベント（グループ作成・参加・一覧取得・AppSync実送信・コスト計算）の `info` ログは維持

## Changes Made

### Phase 1: `webpack.config.js`
- `DefinePlugin` に `process.env.DEBUG` を追加（既存commit）

### Phase 2: `debug-logger.js` + `mesh-service.js`
- `src/util/debug-logger.js` を新規作成（`DEBUG` フラグが有効な場合のみ `log.debug()` を出力）
- `mesh-service.js` の内部ログ（初期化・タイマー管理・WebSocketテスト・polling・heartbeat・イベントキュー詳細など）を `debug()` に変更
- `fireEvent` 未接続時: `groupId` なし→ `debug`、`groupId` あり（clientなし）→ `log.warn` に分岐

### Phase 3: `index.js`
- `debug-logger.js` を導入
- 内部ログ（拡張機能ロード・ドメイン設定・エラー状態遷移）を `debug()` に変更
- `scan()` の `listGroups()` 成功後に `log.info('Mesh V2: Listed N groups')` を追加

## Test Coverage

- lint: パス
- unit tests: 847件パス
- build:dev: 成功
- integration tests: 193件パス

## Related Issues

Closes #130
