### PR TITLE
fix: restore group name display in meshV2 connection modal

### DIFF
--- a/packages/scratch-gui/src/components/connection-modal/connected-step.jsx
+++ b/packages/scratch-gui/src/components/connection-modal/connected-step.jsx
@@ -26,11 +26,15 @@ const ConnectedStep = props => (
         </Box>
         <Box className={styles.bottomArea}>
             <Box className={classNames(styles.bottomAreaItem, styles.instructions)}>
-                <FormattedMessage
-                    defaultMessage="Connected"
-                    description="Message indicating that a device was connected"
-                    id="gui.connection.connected"
-                />
+                {/* === Smalruby: Start of meshV2 connected message feature === */}
+                {props.connectedMessage || (
+                    <FormattedMessage
+                        defaultMessage="Connected"
+                        description="Message indicating that a device was connected"
+                        id="gui.connection.connected"
+                    />
+                )}
+                {/* === Smalruby: End of meshV2 connected message feature === */}
             </Box>
             <Dots
                 success
@@ -64,6 +68,9 @@ const ConnectedStep = props => (
 );
 
 ConnectedStep.propTypes = {
+    // === Smalruby: Start of meshV2 connected message feature ===
+    connectedMessage: PropTypes.string,
+    // === Smalruby: End of meshV2 connected message feature ===
     connectionIconURL: PropTypes.string.isRequired,
     onCancel: PropTypes.func,
     onDisconnect: PropTypes.func

--- a/packages/scratch-gui/src/containers/connection-modal.jsx
+++ b/packages/scratch-gui/src/containers/connection-modal.jsx
@@ -47,7 +47,10 @@ class ConnectionModal extends React.Component {
         // === Smalruby: End of meshV2 initial step feature ===
         this.state = {
             extension: extensionData.find(ext => ext.extensionId === props.extensionId),
-            phase: initialPhase
+            phase: initialPhase,
+            // === Smalruby: Start of meshV2 connected message feature ===
+            connectedMessage: props.vm.getPeripheralConnectedMessage(props.extensionId)
+            // === Smalruby: End of meshV2 connected message feature ===
         };
     }
     componentDidMount () {
@@ -126,7 +129,10 @@ class ConnectionModal extends React.Component {
     }
     handleConnected () {
         this.setState({
-            phase: PHASES.connected
+            phase: PHASES.connected,
+            // === Smalruby: Start of meshV2 connected message feature ===
+            connectedMessage: this.props.vm.getPeripheralConnectedMessage(this.props.extensionId)
+            // === Smalruby: End of meshV2 connected message feature ===
         });
         analytics.event({
             category: 'extensions',
@@ -249,6 +255,9 @@ class ConnectionModal extends React.Component {
             <ConnectionModalComponent
                 connectingMessage={this.state.extension && this.state.extension.connectingMessage}
                 connectionIconURL={this.state.extension && this.state.extension.connectionIconURL}
+                // === Smalruby: Start of meshV2 connected message feature ===
+                connectedMessage={this.state.connectedMessage}
+                // === Smalruby: End of meshV2 connected message feature ===
                 connectionSmallIconURL={this.state.extension && this.state.extension.connectionSmallIconURL}
                 connectionTipIconURL={this.state.extension && this.state.extension.connectionTipIconURL}
                 // === Smalruby: Start of meshV2 initial step feature ===

--- a/packages/scratch-gui/test/unit/components/connected-step.test.jsx
+++ b/packages/scratch-gui/test/unit/components/connected-step.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import {renderWithIntl} from '../../helpers/intl-helpers.jsx';
+import ConnectedStep from '../../../src/components/connection-modal/connected-step.jsx';
+
+const defaultProps = (overrides = {}) => ({
+    connectionIconURL: 'icon.png',
+    onCancel: jest.fn(),
+    onDisconnect: jest.fn(),
+    ...overrides
+});
+
+describe('ConnectedStep component', () => {
+    test('shows default "Connected" message when connectedMessage prop is not provided', () => {
+        const {container} = renderWithIntl(
+            <ConnectedStep {...defaultProps()} />
+        );
+        expect(container.textContent).toContain('Connected');
+    });
+
+    test('shows custom connectedMessage when prop is provided', () => {
+        const {container} = renderWithIntl(
+            <ConnectedStep
+                {...defaultProps()}
+                connectedMessage="Registered Host Mesh [ABC]"
+            />
+        );
+        expect(container.textContent).toContain('Registered Host Mesh [ABC]');
+        expect(container.textContent).not.toContain('Connected');
+    });
+
+    test('shows default "Connected" message when connectedMessage is empty string', () => {
+        const {container} = renderWithIntl(
+            <ConnectedStep
+                {...defaultProps()}
+                connectedMessage=""
+            />
+        );
+        expect(container.textContent).toContain('Connected');
+    });
+});

--- a/packages/scratch-gui/test/unit/containers/connection-modal-connected-message.test.jsx
+++ b/packages/scratch-gui/test/unit/containers/connection-modal-connected-message.test.jsx
@@ -1,0 +1,189 @@
+/**
+ * Integration-style unit test for meshV2 connected message display.
+ *
+ * Tests the full flow: ConnectionModal container receives PERIPHERAL_CONNECTED
+ * event → state.connectedMessage updated → ConnectedStep displays the message.
+ *
+ * This is a regression test for issue #132:
+ * "meshV2 connection modal does not show group name after connecting"
+ */
+
+import React from 'react';
+import {render, act} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {Provider} from 'react-redux';
+import {IntlProvider} from 'react-intl';
+import configureStore from 'redux-mock-store';
+import ConnectionModal from '../../../src/containers/connection-modal.jsx';
+
+// Use the real ConnectionModalComponent but mock sub-steps to avoid full render complexity
+jest.mock('../../../src/components/connection-modal/connection-modal.jsx', () => {
+    const React = require('react');
+    const ConnectedStep = require('../../../src/components/connection-modal/connected-step.jsx').default;
+    const PHASES = {
+        scanning: 'scanning',
+        connecting: 'connecting',
+        connected: 'connected',
+        error: 'error',
+        unavailable: 'unavailable',
+        networkFiltered: 'networkFiltered',
+        meshV2Initial: 'meshV2Initial',
+        updatePeripheral: 'updatePeripheral'
+    };
+    const MockConnectionModalComponent = props => (
+        <div data-testid="modal">
+            {props.phase === PHASES.connected && (
+                <ConnectedStep
+                    connectedMessage={props.connectedMessage}
+                    connectionIconURL={props.connectionIconURL || 'icon.png'}
+                    onCancel={props.onCancel}
+                    onDisconnect={props.onDisconnect}
+                />
+            )}
+        </div>
+    );
+    MockConnectionModalComponent.displayName = 'MockConnectionModalComponent';
+    MockConnectionModalComponent.defaultProps = {connectingMessage: 'Connecting'};
+    return {
+        __esModule: true,
+        default: MockConnectionModalComponent,
+        PHASES
+    };
+});
+
+jest.mock('../../../src/lib/analytics', () => ({event: jest.fn()}));
+
+jest.mock('../../../src/lib/libraries/extensions/index.jsx', () => [
+    {
+        extensionId: 'meshV2',
+        name: 'Mesh V2',
+        connectionIconURL: 'icon.png',
+        connectionSmallIconURL: 'small-icon.png',
+        connectionTipIconURL: 'tip-icon.png',
+        connectingMessage: 'Connecting...',
+        useAutoScan: false
+    }
+]);
+
+jest.mock('../../../src/reducers/modals', () => ({
+    closeConnectionModal: jest.fn(() => ({type: 'CLOSE_CONNECTION_MODAL'})),
+    setConnectionModalExtensionId: jest.fn(() => ({type: 'SET_EXTENSION_ID'})),
+    openConnectionModal: jest.fn(() => ({type: 'OPEN_CONNECTION_MODAL'}))
+}));
+jest.mock('../../../src/reducers/mesh-v2', () => ({
+    setDomain: jest.fn(() => ({type: 'SET_DOMAIN'}))
+}));
+jest.mock('../../../src/lib/microbit-update', () => ({
+    isMicroBitUpdateSupported: jest.fn(() => false),
+    selectAndUpdateMicroBit: jest.fn()
+}));
+jest.mock('../../../src/lib/microbit-more-update', () => ({
+    isMicroBitUpdateSupported: jest.fn(() => false),
+    selectAndUpdateMicroBit: jest.fn()
+}));
+
+const mockStore = configureStore();
+
+const createMockVm = ({isConnected = false, connectedMessage = null} = {}) => {
+    const listeners = {};
+    const vm = {
+        on: jest.fn((event, handler) => {
+            listeners[event] = handler;
+        }),
+        removeListener: jest.fn(),
+        getPeripheralIsConnected: jest.fn(() => isConnected),
+        getPeripheralConnectedMessage: jest.fn(() => connectedMessage),
+        connectPeripheral: jest.fn(),
+        disconnectPeripheral: jest.fn(),
+        runtime: {
+            peripheralExtensions: {
+                meshV2: {setDomain: jest.fn()}
+            }
+        },
+        extensionManager: {
+            isExtensionLoaded: jest.fn(() => false),
+            loadExtensionURL: jest.fn()
+        },
+        emit (event, ...args) {
+            if (listeners[event]) {
+                listeners[event](...args);
+            }
+        }
+    };
+    return vm;
+};
+
+const renderModal = (vm) => {
+    const store = mockStore({
+        scratchGui: {
+            connectionModal: {extensionId: 'meshV2'},
+            meshV2: {domain: ''}
+        }
+    });
+    return render(
+        <IntlProvider
+            locale="en"
+            messages={{}}
+        >
+            <Provider store={store}>
+                <ConnectionModal vm={vm} />
+            </Provider>
+        </IntlProvider>
+    );
+};
+
+describe('meshV2 connected message display (regression: issue #132)', () => {
+    test('displays group name after creating a group (registeredHost)', () => {
+        const vm = createMockVm({isConnected: false, connectedMessage: null});
+        const {getByText, queryByText} = renderModal(vm);
+
+        // Initially not in connected phase, so "Connected" text is not shown
+        expect(queryByText('Connected')).toBeNull();
+
+        // Simulate: user creates a group → VM connects → emits PERIPHERAL_CONNECTED
+        vm.getPeripheralConnectedMessage.mockReturnValue('Registered Host Mesh [ABC-123]');
+        act(() => {
+            vm.emit('PERIPHERAL_CONNECTED');
+        });
+
+        // After connection, the group name should be displayed
+        expect(getByText('Registered Host Mesh [ABC-123]')).toBeInTheDocument();
+        expect(queryByText('Connected')).toBeNull();
+    });
+
+    test('displays group name after joining a group (joinedMesh)', () => {
+        const vm = createMockVm({isConnected: false, connectedMessage: null});
+        const {getByText, queryByText} = renderModal(vm);
+
+        // Simulate: user joins a group → VM connects → emits PERIPHERAL_CONNECTED
+        vm.getPeripheralConnectedMessage.mockReturnValue('Joined Mesh [XYZ-789]');
+        act(() => {
+            vm.emit('PERIPHERAL_CONNECTED');
+        });
+
+        // After connection, the joined group name should be displayed
+        expect(getByText('Joined Mesh [XYZ-789]')).toBeInTheDocument();
+        expect(queryByText('Connected')).toBeNull();
+    });
+
+    test('displays default "Connected" when already connected without a connectedMessage', () => {
+        // When the modal opens while already connected but no message is available
+        const vm = createMockVm({isConnected: true, connectedMessage: null});
+        const {getByText} = renderModal(vm);
+
+        // Should fall back to "Connected"
+        expect(getByText('Connected')).toBeInTheDocument();
+    });
+
+    test('displays group name when modal opens while already connected', () => {
+        // When the modal opens while already connected with an existing message
+        const vm = createMockVm({
+            isConnected: true,
+            connectedMessage: 'Registered Host Mesh [EXISTING]'
+        });
+        const {getByText, queryByText} = renderModal(vm);
+
+        expect(getByText('Registered Host Mesh [EXISTING]')).toBeInTheDocument();
+        expect(queryByText('Connected')).toBeNull();
+    });
+});

--- a/packages/scratch-gui/test/unit/containers/connection-modal.test.jsx
+++ b/packages/scratch-gui/test/unit/containers/connection-modal.test.jsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import {render, act} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {Provider} from 'react-redux';
+import configureStore from 'redux-mock-store';
+import ConnectionModal from '../../../src/containers/connection-modal.jsx';
+
+// Mock the ConnectionModalComponent to capture props
+jest.mock('../../../src/components/connection-modal/connection-modal.jsx', () => {
+    const React = require('react');
+    const PHASES = {
+        scanning: 'scanning',
+        connecting: 'connecting',
+        connected: 'connected',
+        error: 'error',
+        unavailable: 'unavailable',
+        networkFiltered: 'networkFiltered',
+        meshV2Initial: 'meshV2Initial',
+        updatePeripheral: 'updatePeripheral'
+    };
+    const MockComponent = props => (
+        <div data-testid="connection-modal-component">
+            <div data-testid="connected-message">{props.connectedMessage}</div>
+            <div data-testid="phase">{props.phase}</div>
+        </div>
+    );
+    MockComponent.displayName = 'MockConnectionModalComponent';
+    MockComponent.defaultProps = {connectingMessage: 'Connecting'};
+    return {
+        __esModule: true,
+        default: MockComponent,
+        PHASES
+    };
+});
+
+// Mock analytics
+jest.mock('../../../src/lib/analytics', () => ({
+    event: jest.fn()
+}));
+
+// Mock extension data
+jest.mock('../../../src/lib/libraries/extensions/index.jsx', () => [
+    {
+        extensionId: 'meshV2',
+        name: 'Mesh V2',
+        connectionIconURL: 'icon.png',
+        connectionSmallIconURL: 'small-icon.png',
+        connectionTipIconURL: 'tip-icon.png',
+        connectingMessage: 'Connecting...',
+        useAutoScan: false
+    }
+]);
+
+// Mock reducers
+jest.mock('../../../src/reducers/modals', () => ({
+    closeConnectionModal: jest.fn(() => ({type: 'CLOSE_CONNECTION_MODAL'})),
+    setConnectionModalExtensionId: jest.fn(() => ({type: 'SET_EXTENSION_ID'})),
+    openConnectionModal: jest.fn(() => ({type: 'OPEN_CONNECTION_MODAL'}))
+}));
+jest.mock('../../../src/reducers/mesh-v2', () => ({
+    setDomain: jest.fn(() => ({type: 'SET_DOMAIN'}))
+}));
+
+// Mock microbit-update
+jest.mock('../../../src/lib/microbit-update', () => ({
+    isMicroBitUpdateSupported: jest.fn(() => false),
+    selectAndUpdateMicroBit: jest.fn()
+}));
+jest.mock('../../../src/lib/microbit-more-update', () => ({
+    isMicroBitUpdateSupported: jest.fn(() => false),
+    selectAndUpdateMicroBit: jest.fn()
+}));
+
+const mockStore = configureStore();
+
+const createStore = ({extensionId = 'meshV2', domain = ''} = {}) =>
+    mockStore({
+        scratchGui: {
+            connectionModal: {extensionId},
+            meshV2: {domain}
+        }
+    });
+
+const createMockVm = ({isConnected = false, connectedMessage = null} = {}) => {
+    const listeners = {};
+    const vm = {
+        on: jest.fn((event, handler) => {
+            listeners[event] = handler;
+        }),
+        removeListener: jest.fn(),
+        getPeripheralIsConnected: jest.fn(() => isConnected),
+        getPeripheralConnectedMessage: jest.fn(() => connectedMessage),
+        connectPeripheral: jest.fn(),
+        disconnectPeripheral: jest.fn(),
+        runtime: {
+            peripheralExtensions: {
+                meshV2: {setDomain: jest.fn()}
+            }
+        },
+        extensionManager: {
+            isExtensionLoaded: jest.fn(() => false),
+            loadExtensionURL: jest.fn()
+        },
+        emit (event, ...args) {
+            if (listeners[event]) {
+                listeners[event](...args);
+            }
+        }
+    };
+    return vm;
+};
+
+const renderWithStore = (vm, storeOptions = {}) => {
+    const store = createStore(storeOptions);
+    return render(
+        <Provider store={store}>
+            <ConnectionModal vm={vm} />
+        </Provider>
+    );
+};
+
+describe('ConnectionModal container', () => {
+    describe('state.connectedMessage initialization', () => {
+        test('initializes connectedMessage from vm.getPeripheralConnectedMessage when already connected', () => {
+            const vm = createMockVm({
+                isConnected: true,
+                connectedMessage: 'Registered Host Mesh [ABC]'
+            });
+            const {getByTestId} = renderWithStore(vm);
+
+            expect(vm.getPeripheralConnectedMessage).toHaveBeenCalledWith('meshV2');
+            expect(getByTestId('connected-message').textContent).toBe('Registered Host Mesh [ABC]');
+        });
+
+        test('initializes connectedMessage as empty string when not connected', () => {
+            const vm = createMockVm({isConnected: false, connectedMessage: null});
+            const {getByTestId} = renderWithStore(vm);
+
+            expect(getByTestId('connected-message').textContent).toBe('');
+        });
+    });
+
+    describe('handleConnected updates connectedMessage', () => {
+        test('updates connectedMessage from vm after PERIPHERAL_CONNECTED event', () => {
+            const vm = createMockVm({
+                isConnected: false,
+                connectedMessage: null
+            });
+            const {getByTestId} = renderWithStore(vm);
+
+            // Initially no connected message
+            expect(getByTestId('connected-message').textContent).toBe('');
+
+            // Simulate connection: update mock to return message, then emit event
+            vm.getPeripheralConnectedMessage.mockReturnValue('Joined Mesh [XYZ]');
+            act(() => {
+                vm.emit('PERIPHERAL_CONNECTED');
+            });
+
+            expect(vm.getPeripheralConnectedMessage).toHaveBeenCalledWith('meshV2');
+            expect(getByTestId('connected-message').textContent).toBe('Joined Mesh [XYZ]');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- meshV2でグループ作成・参加後の接続ダイアログにグループ名が表示されない問題を修正
- モノレポ移行時に失われた `connectedMessage` の仕組みを復元

## Root Cause

VM側（`connectedMessage()` メソッド、`getPeripheralConnectedMessage()` API）は正しく実装済みだったが、GUI側が以下3点を失っていた：

1. `ConnectionModal` コンテナの `state.connectedMessage` 管理
2. `handleConnected` での `connectedMessage` 更新
3. `ConnectedStep` コンポーネントでのカスタムメッセージ表示

## Changes Made

- `packages/scratch-gui/src/containers/connection-modal.jsx`
  - constructor で `state.connectedMessage` を `vm.getPeripheralConnectedMessage()` で初期化
  - `handleConnected` で接続時に `connectedMessage` を更新
  - `ConnectionModalComponent` へ `connectedMessage` prop を渡す

- `packages/scratch-gui/src/components/connection-modal/connected-step.jsx`
  - `connectedMessage` prop を受け取り、提供された場合はカスタムメッセージを表示
  - 提供されない場合は従来の "Connected" メッセージにフォールバック
  - `connectedMessage: PropTypes.string` を propTypes に追加

## Test Coverage

- `test/unit/containers/connection-modal.test.jsx` を新規追加
  - `state.connectedMessage` が接続済み時に初期化されること
  - 未接続時は空文字で初期化されること
  - `PERIPHERAL_CONNECTED` イベント後に `connectedMessage` が更新されること

- `test/unit/components/connected-step.test.jsx` を新規追加
  - `connectedMessage` なしの時は "Connected" を表示すること
  - `connectedMessage` がある時はカスタムメッセージを表示すること
  - 空文字の時は "Connected" にフォールバックすること

## Related Issues

Closes #132
