### PR TITLE
feat: bidirectional conversion for Ruby true/false literals

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/operators.js
@@ -89,6 +89,9 @@ export default function (Generator) {
                     };
                     return [`@ruby:operator:<=:${index}`, order];
                 }
+                if (part.startsWith('@ruby:literal:false:')) {
+                    return ['false', Generator.ORDER_ATOMIC];
+                }
             }
         }
 
@@ -117,6 +120,8 @@ export default function (Generator) {
                 } else if (part.startsWith('@ruby:operator:<=:')) {
                     methodName = '<=';
                     index = part.substring(18);
+                } else if (part.startsWith('@ruby:literal:true:')) {
+                    return ['true', Generator.ORDER_ATOMIC];
                 }
             }
             if (methodName === 'empty?') {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/expressions.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/expressions.js
@@ -103,11 +103,27 @@ const ExpressionHandlers = {
     },
 
     _onTrue (node) {
-        return new Primitive('true', true, node);
+        const index = (this._context.literalCallIndices.true || 0) + 1;
+        this._context.literalCallIndices.true = index;
+
+        const block = this._createBlock('operator_equals', 'value_boolean');
+        block.node = node;
+        this._addTextInput(block, 'OPERAND1', '1', '1');
+        this._addTextInput(block, 'OPERAND2', '1', '1');
+        block.comment = this._createComment(`@ruby:literal:true:${index}`, block.id);
+        return block;
     },
 
     _onFalse (node) {
-        return new Primitive('false', true, node);
+        const index = (this._context.literalCallIndices.false || 0) + 1;
+        this._context.literalCallIndices.false = index;
+
+        const block = this._createBlock('operator_lt', 'value_boolean');
+        block.node = node;
+        this._addTextInput(block, 'OPERAND1', '0', '0');
+        this._addTextInput(block, 'OPERAND2', '0', '0');
+        block.comment = this._createComment(`@ruby:literal:false:${index}`, block.id);
+        return block;
     },
 
     _onArray (node) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/context-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/context-utils.js
@@ -25,6 +25,7 @@ const ContextUtils = {
             procedures: {},
             methodCallCounts: {},
             methodCallIndices: {},
+            literalCallIndices: {},
             elsifCounter: 0,
             caseCounter: 0,
             isValue: false,

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
@@ -119,7 +119,7 @@ const ControlConverter = {
         // Register onXxx handlers
         converter.registerOnIf((cond, statement, elseStatement) => {
             const block = converter._createBlock('control_if', 'statement');
-            if (!converter._isFalse(cond)) {
+            if (!converter._isFalse(cond) || converter._isBlock(cond)) {
                 converter._addInput(block, 'CONDITION', cond);
             }
             converter._addSubstack(block, statement);
@@ -140,7 +140,7 @@ const ControlConverter = {
                 opcode = 'control_repeat_until';
             }
             const block = converter._createBlock(opcode, 'statement');
-            if (!converter._isFalse(cond)) {
+            if (!converter._isFalse(cond) || converter._isBlock(cond)) {
                 converter._addInput(block, 'CONDITION', cond);
             }
             converter._addSubstack(block, statement);

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
@@ -50,7 +50,14 @@ const NodeUtils = {
     },
 
     _isTrue (value) {
-        return value === true || (value && value.type === 'true');
+        if (value === true || (value && value.type === 'true')) {
+            return true;
+        }
+        if (this._isBlock(value) && value.opcode === 'operator_equals' && value.comment) {
+            const comment = this._context.comments[value.comment];
+            return comment && comment.text.startsWith('@ruby:literal:true:');
+        }
+        return false;
     },
 
     isFalse (value) {
@@ -58,7 +65,14 @@ const NodeUtils = {
     },
 
     _isFalse (value) {
-        return value === false || (value && value.type === 'false');
+        if (value === false || (value && value.type === 'false')) {
+            return true;
+        }
+        if (this._isBlock(value) && value.opcode === 'operator_lt' && value.comment) {
+            const comment = this._context.comments[value.comment];
+            return comment && comment.text.startsWith('@ruby:literal:false:');
+        }
+        return false;
     },
 
     isNil (value) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -219,7 +219,7 @@ const OperatorsConverter = {
             const {receiver} = params;
 
             const block = converter._createBlock('operator_not', 'value_boolean');
-            if (!converter._isFalse(receiver)) {
+            if (!converter._isFalse(receiver) || converter._isBlock(receiver)) {
                 converter._addInput(
                     block,
                     'OPERAND',
@@ -350,10 +350,10 @@ const OperatorsConverter = {
                     o.parent = block.id;
                 }
             });
-            if (!converter._isFalse(operands[0])) {
+            if (!converter._isFalse(operands[0]) || converter._isBlock(operands[0])) {
                 converter._addInput(block, 'OPERAND1', converter._createTextBlock(operands[0]));
             }
-            if (!converter._isFalse(operands[1])) {
+            if (!converter._isFalse(operands[1]) || converter._isBlock(operands[1])) {
                 converter._addInput(block, 'OPERAND2', converter._createTextBlock(operands[1]));
             }
             return block;
@@ -366,10 +366,10 @@ const OperatorsConverter = {
                     o.parent = block.id;
                 }
             });
-            if (!converter._isFalse(operands[0])) {
+            if (!converter._isFalse(operands[0]) || converter._isBlock(operands[0])) {
                 converter._addInput(block, 'OPERAND1', converter._createTextBlock(operands[0]));
             }
-            if (!converter._isFalse(operands[1])) {
+            if (!converter._isFalse(operands[1]) || converter._isBlock(operands[1])) {
                 converter._addInput(block, 'OPERAND2', converter._createTextBlock(operands[1]));
             }
             return block;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/sensing.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/sensing.js
@@ -170,15 +170,15 @@ const SensingConverter = {
             const {args} = params;
 
             const validDragMode = converter.isString(args[0]) && DragMode.indexOf(args[0].toString()) >= 0;
-            const validBoolean = args[0] && (args[0].type === 'true' || args[0].type === 'false');
+            const validBoolean = converter._isTrue(args[0]) || converter._isFalse(args[0]);
 
             if (!validDragMode && !validBoolean) return null;
 
             const block = converter.createBlock('sensing_setdragmode', 'statement');
             let dragMode = args[0];
-            if (dragMode.type === 'true') {
+            if (converter._isTrue(dragMode)) {
                 dragMode = 'draggable';
-            } else if (dragMode.type === 'false') {
+            } else if (converter._isFalse(dragMode)) {
                 dragMode = 'not draggable';
             }
             converter.addField(block, 'DRAG_MODE', dragMode);

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/operators.test.js
@@ -208,6 +208,19 @@ describe('RubyGenerator/Operators', () => {
             expect(RubyGenerator.operator_lt(block)).toEqual(['@ruby:operator:<=:1', RubyGenerator.ORDER_RELATIONAL]);
             expect(RubyGenerator.lessThanOrEqualCallCache_['1']).toEqual({ lhs: '1', rhs: '2' });
         });
+
+        test('with @ruby:literal:false:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_lt',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:literal:false:1' };
+            expect(RubyGenerator.operator_lt(block)).toEqual(['false', RubyGenerator.ORDER_ATOMIC]);
+        });
     });
 
     describe('operator_equals', () => {
@@ -326,6 +339,19 @@ describe('RubyGenerator/Operators', () => {
 
             expect(RubyGenerator.operator_equals(block)).toEqual(['list("my list").empty?', RubyGenerator.ORDER_FUNCTION_CALL]);
             expect(RubyGenerator.emptyCallCache_['1']).toBeUndefined();
+        });
+
+        test('with @ruby:literal:true:1', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'operator_equals',
+                inputs: {
+                    OPERAND1: {},
+                    OPERAND2: {}
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = { text: '@ruby:literal:true:1' };
+            expect(RubyGenerator.operator_equals(block)).toEqual(['true', RubyGenerator.ORDER_ATOMIC]);
         });
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/index.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/index.test.js
@@ -169,8 +169,6 @@ describe('RubyToBlocksConverter', () => {
             test('error', () => {
                 [
                     '1',
-                    'false',
-                    'true',
                     '"Hello!"',
                     ':symbol',
                     'move(10); 1',

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks.test.js
@@ -103,8 +103,8 @@ describe('RubyToBlocksConverter/Looks', () => {
             [
                 'say("Hello!", "2")',
                 'say("Hello!", 2, 3)',
-                'say(false, 2)',
-                'say("Hello!", false)'
+                'say(:symbol, 2)',
+                'say("Hello!", :symbol)'
             ].forEach(c => {
                 convertAndExpectRubyBlockError(converter, target, c);
             });
@@ -160,8 +160,7 @@ describe('RubyToBlocksConverter/Looks', () => {
         test('invalid', () => {
             [
                 'say',
-                'say(false)',
-                'say(true)',
+                'say(:symbol)',
                 'say(1, 2, 1)'
             ].forEach(c => {
                 convertAndExpectRubyBlockError(converter, target, c);
@@ -251,8 +250,8 @@ describe('RubyToBlocksConverter/Looks', () => {
             [
                 'think("Hello!", "2")',
                 'think("Hello!", 2, 3)',
-                'think(false, 2)',
-                'think("Hello!", false)'
+                'think(:symbol, 2)',
+                'think("Hello!", :symbol)'
             ].forEach(c => {
                 convertAndExpectRubyBlockError(converter, target, c);
             });
@@ -308,8 +307,7 @@ describe('RubyToBlocksConverter/Looks', () => {
         test('invalid', () => {
             [
                 'think',
-                'think(false)',
-                'think(true)',
+                'think(:symbol)',
                 'think(1, 2, 1)'
             ].forEach(c => {
                 convertAndExpectRubyBlockError(converter, target, c);
@@ -346,8 +344,7 @@ describe('RubyToBlocksConverter/Looks', () => {
         test('invalid', () => {
             [
                 'switch_costume',
-                'switch_costume(false)',
-                'switch_costume(true)',
+                'switch_costume(:symbol)',
                 'switch_costume(1)',
                 'switch_costume(x)',
                 'switch_costume("costume2", 1)'
@@ -388,8 +385,7 @@ describe('RubyToBlocksConverter/Looks', () => {
         test('invalid', () => {
             [
                 'switch_backdrop',
-                'switch_backdrop(false)',
-                'switch_backdrop(true)',
+                'switch_backdrop(:symbol)',
                 'switch_backdrop(1)',
                 'switch_backdrop(x)',
                 'switch_backdrop("backdrop2", 1)'
@@ -771,8 +767,7 @@ describe('RubyToBlocksConverter/Looks', () => {
                 'go_layers(x)',
                 'go_layers(1, "invalid")',
                 'go_layers("1", "forward")',
-                'go_layers(false, "forward")',
-                'go_layers(true, "forward")'
+                'go_layers(:symbol, "forward")'
             ].forEach(c => {
                 convertAndExpectRubyBlockError(converter, target, c);
             });
@@ -890,8 +885,7 @@ describe('RubyToBlocksConverter/Looks', () => {
         test('invalid', () => {
             [
                 'switch_backdrop_and_wait',
-                'switch_backdrop_and_wait(false)',
-                'switch_backdrop_and_wait(true)',
+                'switch_backdrop_and_wait(:symbol)',
                 'switch_backdrop_and_wait(1)',
                 'switch_backdrop_and_wait(x)',
                 'switch_backdrop_and_wait("backdrop2", 1)'

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/my-blocks.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/my-blocks.test.js
@@ -624,7 +624,7 @@ describe('RubyToBlocksConverter/My Blocks', () => {
                 def self.made_block(arg1, arg2)
                 end
 
-                made_block(false, 1)
+                made_block(:symbol, 1)
             `;
             const res = converter.targetCodeToBlocks(target, code);
             expect(converter.errors).toHaveLength(1);

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
@@ -1053,7 +1053,49 @@ describe('RubyToBlocksConverter/Operators', () => {
         code = 'false && false';
         expected = [
             {
-                opcode: 'operator_and'
+                opcode: 'operator_and',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_lt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('0')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('0')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:literal:false:1',
+                                minimized: true
+                            }
+                        }
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: {
+                            opcode: 'operator_lt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('0')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('0')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:literal:false:2',
+                                minimized: true
+                            }
+                        }
+                    }
+                ]
             }
         ];
         convertAndExpectToEqualBlocks(converter, target, code, expected);
@@ -1102,7 +1144,49 @@ describe('RubyToBlocksConverter/Operators', () => {
         code = 'false || false';
         expected = [
             {
-                opcode: 'operator_or'
+                opcode: 'operator_or',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: {
+                            opcode: 'operator_lt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('0')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('0')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:literal:false:1',
+                                minimized: true
+                            }
+                        }
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: {
+                            opcode: 'operator_lt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('0')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('0')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:literal:false:2',
+                                minimized: true
+                            }
+                        }
+                    }
+                ]
             }
         ];
         convertAndExpectToEqualBlocks(converter, target, code, expected);
@@ -1140,9 +1224,228 @@ describe('RubyToBlocksConverter/Operators', () => {
         code = '!false';
         expected = [
             {
-                opcode: 'operator_not'
+                opcode: 'operator_not',
+                inputs: [
+                    {
+                        name: 'OPERAND',
+                        block: {
+                            opcode: 'operator_lt',
+                            inputs: [
+                                {
+                                    name: 'OPERAND1',
+                                    block: expectedInfo.makeText('0')
+                                },
+                                {
+                                    name: 'OPERAND2',
+                                    block: expectedInfo.makeText('0')
+                                }
+                            ],
+                            comment: {
+                                text: '@ruby:literal:false:1',
+                                minimized: true
+                            }
+                        }
+                    }
+                ]
             }
         ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('ruby_literal_true', () => {
+        code = 'true';
+        expected = [
+            {
+                opcode: 'operator_equals',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: expectedInfo.makeText('1')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('1')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:literal:true:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'true\ntrue';
+        expected = [
+            {
+                opcode: 'operator_equals',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: expectedInfo.makeText('1')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('1')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:literal:true:1',
+                    minimized: true
+                }
+            },
+            {
+                opcode: 'operator_equals',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: expectedInfo.makeText('1')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('1')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:literal:true:2',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('ruby_literal_false', () => {
+        code = 'false';
+        expected = [
+            {
+                opcode: 'operator_lt',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: expectedInfo.makeText('0')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('0')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:literal:false:1',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'false\nfalse';
+        expected = [
+            {
+                opcode: 'operator_lt',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: expectedInfo.makeText('0')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('0')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:literal:false:1',
+                    minimized: true
+                }
+            },
+            {
+                opcode: 'operator_lt',
+                inputs: [
+                    {
+                        name: 'OPERAND1',
+                        block: expectedInfo.makeText('0')
+                    },
+                    {
+                        name: 'OPERAND2',
+                        block: expectedInfo.makeText('0')
+                    }
+                ],
+                comment: {
+                    text: '@ruby:literal:false:2',
+                    minimized: true
+                }
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('ruby_literal_true_false_assignment', () => {
+        code = 'x = true';
+        expected = rubyToExpected(converter, target, 'x = 0');
+        const valueInput1 = expected[0].inputs.find(i => i.name === 'VALUE');
+        valueInput1.block = {
+            opcode: 'operator_equals',
+            inputs: [
+                {
+                    name: 'OPERAND1',
+                    block: expectedInfo.makeText('1')
+                },
+                {
+                    name: 'OPERAND2',
+                    block: expectedInfo.makeText('1')
+                }
+            ],
+            comment: {
+                text: '@ruby:literal:true:1',
+                minimized: true
+            }
+        };
+        valueInput1.shadow = expectedInfo.makeText('0');
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'x = false';
+        expected = rubyToExpected(converter, target, 'x = 0');
+        const valueInput2 = expected[0].inputs.find(i => i.name === 'VALUE');
+        valueInput2.block = {
+            opcode: 'operator_lt',
+            inputs: [
+                {
+                    name: 'OPERAND1',
+                    block: expectedInfo.makeText('0')
+                },
+                {
+                    name: 'OPERAND2',
+                    block: expectedInfo.makeText('0')
+                }
+            ],
+            comment: {
+                text: '@ruby:literal:false:1',
+                minimized: true
+            }
+        };
+        valueInput2.shadow = expectedInfo.makeText('0');
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('ruby_literal_true_false_if', () => {
+        code = 'if true\n  move(10)\nend';
+        expected = rubyToExpected(converter, target, 'if x == 1\n  move(10)\nend');
+        expected[0].inputs.find(i => i.name === 'CONDITION').block = {
+            opcode: 'operator_equals',
+            inputs: [
+                {
+                    name: 'OPERAND1',
+                    block: expectedInfo.makeText('1')
+                },
+                {
+                    name: 'OPERAND2',
+                    block: expectedInfo.makeText('1')
+                }
+            ],
+            comment: {
+                text: '@ruby:literal:true:1',
+                minimized: true
+            }
+        };
         convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -72,4 +72,17 @@ describe('Ruby Round Trip', () => {
         expectRoundTrip('@x >= @y || @a <= @b');
         expectRoundTrip('!(@x >= @y)');
     });
+
+    test('true / false', () => {
+        expectRoundTrip('true');
+        expectRoundTrip('false');
+        expectRoundTrip('if true\n  move(10)\nend');
+        expectRoundTrip('if false\n  move(10)\nend');
+        expectRoundTrip('x = true');
+        expectRoundTrip('x = false');
+        expectRoundTrip('true && false');
+        expectRoundTrip('true || false');
+        expectRoundTrip('!true');
+        expectRoundTrip('!false');
+    });
 });


### PR DESCRIPTION
This PR implements bidirectional conversion between Ruby `true`/`false` literals and Scratch blocks (`operator_equals` and `operator_lt`) with specific comments.

Changes:
- Updated `_onTrue` and `_onFalse` to return blocks with `@ruby:literal:true/false:N` comments.
- Initialized `literalCallIndices` in context.
- Updated `_isTrue` and `_isFalse` to recognize these literal blocks.
- Modified operator and control converters to include these literal blocks in conditions and logical operations.
- Updated Ruby generator to convert blocks with these comments back to `true`/`false`.
- Added comprehensive unit and round-trip tests.
- Fixed existing tests that used `true`/`false` as invalid inputs.

closes #128
