### PR TITLE
fix: reject non-boolean blocks in boolean inputs

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
@@ -119,7 +119,7 @@ const ControlConverter = {
         // Register onXxx handlers
         converter.registerOnIf((cond, statement, elseStatement) => {
             const block = converter._createBlock('control_if', 'statement');
-            if (!converter._isFalse(cond) || converter._isBlock(cond)) {
+            if (converter._isFalseOrBooleanBlock(cond)) {
                 converter._addInput(block, 'CONDITION', cond);
             }
             converter._addSubstack(block, statement);
@@ -140,7 +140,7 @@ const ControlConverter = {
                 opcode = 'control_repeat_until';
             }
             const block = converter._createBlock(opcode, 'statement');
-            if (!converter._isFalse(cond) || converter._isBlock(cond)) {
+            if (converter._isFalseOrBooleanBlock(cond)) {
                 converter._addInput(block, 'CONDITION', cond);
             }
             converter._addSubstack(block, statement);

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -217,15 +217,14 @@ const OperatorsConverter = {
 
         converter.registerOnSend(['variable', 'boolean', 'block'], '!', 0, params => {
             const {receiver} = params;
+            if (!converter._isFalseOrBooleanBlock(receiver)) return null;
 
             const block = converter._createBlock('operator_not', 'value_boolean');
-            if (!converter._isFalse(receiver) || converter._isBlock(receiver)) {
-                converter._addInput(
-                    block,
-                    'OPERAND',
-                    converter._createTextBlock(converter._isNumber(receiver) ? receiver.toString() : receiver)
-                );
-            }
+            converter._addInput(
+                block,
+                'OPERAND',
+                converter._createTextBlock(converter._isNumber(receiver) ? receiver.toString() : receiver)
+            );
             return block;
         });
 
@@ -350,10 +349,10 @@ const OperatorsConverter = {
                     o.parent = block.id;
                 }
             });
-            if (!converter._isFalse(operands[0]) || converter._isBlock(operands[0])) {
+            if (converter._isFalseOrBooleanBlock(operands[0])) {
                 converter._addInput(block, 'OPERAND1', converter._createTextBlock(operands[0]));
             }
-            if (!converter._isFalse(operands[1]) || converter._isBlock(operands[1])) {
+            if (converter._isFalseOrBooleanBlock(operands[1])) {
                 converter._addInput(block, 'OPERAND2', converter._createTextBlock(operands[1]));
             }
             return block;
@@ -366,10 +365,10 @@ const OperatorsConverter = {
                     o.parent = block.id;
                 }
             });
-            if (!converter._isFalse(operands[0]) || converter._isBlock(operands[0])) {
+            if (converter._isFalseOrBooleanBlock(operands[0])) {
                 converter._addInput(block, 'OPERAND1', converter._createTextBlock(operands[0]));
             }
-            if (!converter._isFalse(operands[1]) || converter._isBlock(operands[1])) {
+            if (converter._isFalseOrBooleanBlock(operands[1])) {
                 converter._addInput(block, 'OPERAND2', converter._createTextBlock(operands[1]));
             }
             return block;

--- a/packages/scratch-gui/test/helpers/expect-to-equal-blocks.js
+++ b/packages/scratch-gui/test/helpers/expect-to-equal-blocks.js
@@ -245,7 +245,7 @@ const convertAndExpectToEqualBlocks = function (converter, target, code, expecte
 const convertAndExpectRubyBlockError = function (converter, target, code) {
     converter.targetCodeToBlocks(target, code);
     expect(converter.errors).toHaveLength(1);
-    expect(converter.errors[0].text).toMatch(/ is the wrong instruction./);
+    expect(converter.errors[0].text).toMatch(/ is the wrong instruction\.|condition is not boolean: /);
 };
 
 const expectToEqualRubyStatement = function (converter, expectedStatement) {

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators.test.js
@@ -1995,4 +1995,16 @@ describe('RubyToBlocksConverter/Operators', () => {
         ];
         convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
+
+    test('reject non-boolean blocks in boolean inputs', () => {
+        [
+            '!move(10)',
+            'move(10) && touching?("_edge_")',
+            'touching?("_edge_") && move(10)',
+            'move(10) || touching?("_edge_")',
+            'touching?("_edge_") || move(10)'
+        ].forEach(s => {
+            convertAndExpectRubyBlockError(converter, target, s);
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -85,4 +85,10 @@ describe('Ruby Round Trip', () => {
         expectRoundTrip('!true');
         expectRoundTrip('!false');
     });
+
+    test('sensing and boolean operators', () => {
+        expectRoundTrip('touching?("_edge_")');
+        expectRoundTrip('!touching?("_edge_")');
+        expectRoundTrip('if touching?("_edge_")\n  move(10)\nend');
+    });
 });


### PR DESCRIPTION
This PR addresses the issue where non-boolean blocks (like `move(10)`) were incorrectly allowed in boolean inputs of various operators and control blocks.

### Changes:
- Updated `operator_not` handler in `operators.js` to return `null` if the receiver is not a boolean block, triggering a conversion error.
- Updated `operator_and` and `operator_or` handlers in `operators.js` to use `_isFalseOrBooleanBlock` for input validation.
- Updated `onIf` and `onUntil` handlers in `control.js` to use `_isFalseOrBooleanBlock` for condition validation.
- Added unit tests for rejected cases in `operators.test.js`.
- Added round-trip integration tests for sensing and boolean operators in `round-trip.test.js`.
- Updated `convertAndExpectRubyBlockError` helper in `expect-to-equal-blocks.js` to handle both "wrong instruction" and "condition is not boolean" errors.

Closes #135
