### PR TITLE
feat: support return statement in method definitions

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -137,6 +137,10 @@ export default function (Generator) {
     };
 
     Generator.control_stop = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment && comment.includes('@ruby:syntax:return')) {
+            return '';
+        }
         const target = Generator.quote_(Generator.getFieldValue(block, 'STOP_OPTION') || 'all');
         return `stop(${target})\n`;
     };

--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -54,9 +54,9 @@ export default function (Generator) {
         }
 
         // Check if this is a return value assignment
-        if (comment && comment.startsWith('@ruby:return:')) {
+        if (comment && comment.includes('@ruby:return:')) {
             // Check if it is an evacuation block (has a number at the end)
-            if (/^@ruby:return:\w+:\d+$/.test(comment)) {
+            if (/@ruby:return:\w+:\d+/.test(comment)) {
                 return '';
             }
 
@@ -64,10 +64,15 @@ export default function (Generator) {
                 // Marker block with no value, suppress output
                 return '';
             }
+
+            const value = Generator.valueToCode(block, 'VALUE', Generator.ORDER_NONE) || '0';
+            if (comment.includes('@ruby:syntax:return')) {
+                return `return ${Generator.nosToCode(value)}\n`;
+            }
+
             // Check if this is the last block in procedure definition
             if (block._isLastReturnInProcedure) {
                 // Output just the value (implicit return)
-                const value = Generator.valueToCode(block, 'VALUE', Generator.ORDER_NONE) || '0';
                 return `${Generator.nosToCode(value)}\n`;
             }
             // Not the last block, output normal variable assignment

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/core.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/core.js
@@ -142,6 +142,49 @@ const CoreHandlers = {
         return block;
     },
 
+    _onReturn (node) {
+        if (!this._context.currentProcedureName) {
+            throw new RubyToBlocksConverterError(node, 'return can only be used in method definition');
+        }
+
+        const procedureName = this._context.currentProcedureName;
+        const returnValue = this._process(node.children[0], true);
+        const variable = this._lookupOrCreateVariable(`@_return_${procedureName}_`);
+        const assignBlock = this._createBlock('data_setvariableto', 'statement', {
+            fields: {
+                VARIABLE: {
+                    name: 'VARIABLE',
+                    id: variable.id,
+                    value: variable.name,
+                    variableType: variable.type
+                }
+            }
+        });
+        const commentText = `@ruby:syntax:return, @ruby:return:${procedureName}`;
+        assignBlock.comment = this._createComment(commentText, assignBlock.id);
+        this._addTextInput(
+            assignBlock, 'VALUE', this._isNumber(returnValue) ? returnValue.toString() : returnValue, '0'
+        );
+
+        // Check if this is an early return (not at the end of the method)
+        // Note: In registerOnDefs, we check if the last block has @ruby:syntax:return.
+        // If we're not the last block, we need to stop the script.
+        const stopBlock = this._createBlock('control_stop', 'terminate', {
+            fields: {
+                STOP_OPTION: {
+                    name: 'STOP_OPTION',
+                    value: 'this script'
+                }
+            }
+        });
+        stopBlock.comment = this._createComment('@ruby:syntax:return', stopBlock.id);
+
+        assignBlock.next = stopBlock.id;
+        stopBlock.parent = assignBlock.id;
+
+        return [assignBlock, stopBlock];
+    },
+
     _processCondition (node) {
         let cond = this._process(node, true);
         const split = this._splitPreBlocksAndValue(cond);

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/context-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/context-utils.js
@@ -33,6 +33,7 @@ const ContextUtils = {
             scopeStack: [],
             scopeCounter: 1,
             currentScopeIndex: 1,
+            currentProcedureName: null,
             nodeToBlockMap: new Map(),
             lineToNodeMap: new Map(),
             containerNodeRanges: [], // Store {startLine, endLine} for container nodes (block, begin, kwbegin)

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
@@ -219,20 +219,28 @@ const MyBlocksConverter = {
             // Process method body - use _process instead of _processStatement
             // because the last expression can be a value (which will be wrapped in return assignment)
             const savedInMyBlockDefinition = converter._context.inMyBlockDefinition;
+            const savedCurrentProcedureName = converter._context.currentProcedureName;
             converter._context.inMyBlockDefinition = true;
+            converter._context.currentProcedureName = procedureName;
             let body = converter._process(node.children[3], false);
             if (!_.isArray(body)) {
                 body = [body];
             }
             converter._context.inMyBlockDefinition = savedInMyBlockDefinition;
+            converter._context.currentProcedureName = savedCurrentProcedureName;
 
             converter._exitScope();
 
             if (body.length > 0) {
                 const lastIdx = body.length - 1;
-                const last = body[lastIdx];
+                let last = body[lastIdx];
+                if (_.isArray(last)) {
+                    last = last[last.length - 1];
+                }
+                const lastCommentText = last.comment ? converter._context.comments[last.comment].text : '';
                 if (converter._isValueBlock(last) &&
-                    !(last instanceof Primitive && (last.type === 'self' || last.type === 'nil'))) {
+                    !(last instanceof Primitive && (last.type === 'self' || last.type === 'nil')) &&
+                    !lastCommentText.includes('@ruby:syntax:return')) {
                     const variable = converter._lookupOrCreateVariable(`@_return_${procedureName}_`);
                     const returnBlock = converter._createBlock('data_setvariableto', 'statement', {
                         fields: {

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -91,4 +91,33 @@ describe('Ruby Round Trip', () => {
         expectRoundTrip('!touching?("_edge_")');
         expectRoundTrip('if touching?("_edge_")\n  move(10)\nend');
     });
+
+    test('return statement in method', () => {
+        expectRoundTrip(`
+def self.add(a, b)
+  return a + b
+end
+`.trim());
+
+        expectRoundTrip(`
+def self.div(a, b)
+  if b == 0
+    return 0
+  end
+  return a / b
+end
+`.trim());
+
+        expectRoundTrip(`
+def self.check(x)
+  if x < 0
+    return "negative"
+  end
+  if x == 0
+    return "zero"
+  end
+  return "positive"
+end
+`.trim());
+    });
 });


### PR DESCRIPTION
This PR implements support for the 'return' statement in Ruby method definitions.

It includes:
- An AST handler for the 'return' statement in the Ruby-to-blocks converter.
- Context management for method names during conversion.
- Logic to suppress unnecessary blocks and comments during block-to-Ruby generation.
- Round-trip integration tests.

closes #137
