### PR TITLE
feat: add feedback link to send reports via Google Form

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -72,6 +72,27 @@
     border-bottom: 0 !important;
 }
 
+.tab-list-container {
+    display: flex;
+    align-items: flex-end;
+    height: $stage-menu-height;
+}
+
+.feedback-link {
+    margin-left: auto;
+    padding: 0 0.75rem 0.25rem;
+    font-size: 0.65rem;
+    color: $text-primary-transparent;
+    text-decoration: none;
+    white-space: nowrap;
+    align-self: flex-end;
+}
+
+.feedback-link:hover {
+    color: $text-primary;
+    text-decoration: underline;
+}
+
 .tab {
     flex-grow: 1;
     height: 80%;

--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -80,7 +80,7 @@
 
 .feedback-link {
     margin-left: auto;
-    padding: 0 0.75rem 0.25rem;
+    padding: 0 3.75rem 0.25rem;
     font-size: 0.65rem;
     color: $text-primary-transparent;
     text-decoration: none;

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -267,6 +267,10 @@ const GUIComponent = props => {
 
     const handleFeedbackClick = useCallback(e => {
         e.preventDefault();
+        // Open a blank window first to avoid popup blockers
+        const popup = window.open('', '_blank');
+        if (!popup) return;
+
         const confirmed = window.confirm( // eslint-disable-line no-alert
             intl.formatMessage({
                 id: 'gui.smalruby3.feedbackConfirm',
@@ -274,11 +278,10 @@ const GUIComponent = props => {
             })
         );
         if (confirmed) {
-            window.open(
-                'https://docs.google.com/forms/d/e/1FAIpQLSemSOgv8TlJXF6vmFzVm5yUdcNZVMEKBcBcsKHnbW0RFmU3sg/viewform?usp=dialog',
-                '_blank',
-                'noopener,noreferrer'
-            );
+            popup.location.href = 'https://docs.google.com/forms/d/e/1FAIpQLSemSOgv8TlJXF6vmFzVm5yUdcNZVMEKBcBcsKHnbW0RFmU3sg/viewform?usp=dialog';
+            popup.opener = null;
+        } else {
+            popup.close();
         }
     }, [intl]);
 

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -265,6 +265,23 @@ const GUIComponent = props => {
         onRequestCloseDebugModal();
     }, [onDebugModalClose, onRequestCloseDebugModal]);
 
+    const handleFeedbackClick = useCallback(e => {
+        e.preventDefault();
+        const confirmed = window.confirm( // eslint-disable-line no-alert
+            intl.formatMessage({
+                id: 'gui.smalruby3.feedbackConfirm',
+                defaultMessage: 'スモウルビーへのフィードバックを送信するための外部サイトを開きます'
+            })
+        );
+        if (confirmed) {
+            window.open(
+                'https://docs.google.com/forms/d/e/1FAIpQLSemSOgv8TlJXF6vmFzVm5yUdcNZVMEKBcBcsKHnbW0RFmU3sg/viewform?usp=dialog',
+                '_blank',
+                'noopener,noreferrer'
+            );
+        }
+    }, [intl]);
+
     if (isRendererSupported === null) {
         isRendererSupported = Renderer.isSupported();
     }
@@ -449,6 +466,7 @@ const GUIComponent = props => {
                                 focusTabOnClick={false}
                             >
                                 <Box
+                                    className={styles.tabListContainer}
                                     role="region"
                                     aria-label={intl.formatMessage(ariaMessages.tabList)}
                                 >
@@ -528,6 +546,19 @@ const GUIComponent = props => {
                                             />
                                         </Tab>
                                     </TabList>
+                                    <a
+                                        className={styles.feedbackLink}
+                                        href="https://docs.google.com/forms/d/e/1FAIpQLSemSOgv8TlJXF6vmFzVm5yUdcNZVMEKBcBcsKHnbW0RFmU3sg/viewform?usp=dialog"
+                                        rel="noopener noreferrer"
+                                        target="_blank"
+                                        onClick={handleFeedbackClick}
+                                    >
+                                        <FormattedMessage
+                                            defaultMessage="Send feedback"
+                                            description="Link to send feedback"
+                                            id="gui.smalruby3.gui.feedback"
+                                        />
+                                    </a>
                                 </Box>
                                 <TabPanel
                                     className={tabClassNames.tabPanel}

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -269,7 +269,7 @@ const GUIComponent = props => {
         const confirmed = window.confirm( // eslint-disable-line no-alert
             intl.formatMessage({
                 id: 'gui.smalruby3.feedbackConfirm',
-                defaultMessage: 'スモウルビーへのフィードバックを送信するための外部サイトを開きます'
+                defaultMessage: 'スモウルビーをよりよくするためのフィードバック（ご意見）を送信する外部サイトを開きます。よろしいですか？'
             })
         );
         if (!confirmed) {

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -266,22 +266,14 @@ const GUIComponent = props => {
     }, [onDebugModalClose, onRequestCloseDebugModal]);
 
     const handleFeedbackClick = useCallback(e => {
-        e.preventDefault();
-        // Open a blank window first to avoid popup blockers
-        const popup = window.open('', '_blank');
-        if (!popup) return;
-
         const confirmed = window.confirm( // eslint-disable-line no-alert
             intl.formatMessage({
                 id: 'gui.smalruby3.feedbackConfirm',
                 defaultMessage: 'スモウルビーへのフィードバックを送信するための外部サイトを開きます'
             })
         );
-        if (confirmed) {
-            popup.location.href = 'https://docs.google.com/forms/d/e/1FAIpQLSemSOgv8TlJXF6vmFzVm5yUdcNZVMEKBcBcsKHnbW0RFmU3sg/viewform?usp=dialog';
-            popup.opener = null;
-        } else {
-            popup.close();
+        if (!confirmed) {
+            e.preventDefault();
         }
     }, [intl]);
 

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -99,7 +99,7 @@ export default {
     'gui.menuBar.koshienCannotChangeRubyVersion': 'The Ruby version cannot be changed when the Koshien extension is loaded.',
 
     'gui.smalruby3.gui.feedback': 'Send feedback',
-    'gui.smalruby3.feedbackConfirm': 'Opens an external site to send feedback to Smalruby.',
+    'gui.smalruby3.feedbackConfirm': 'You are about to open an external site to send feedback to help us improve Smalruby. Is it okay?',
 
     // Block Display Modal - Block Messages
     // Motion blocks

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -98,6 +98,9 @@ export default {
     'gui.menuBar.koshienEntryForm': 'Entry Form',
     'gui.menuBar.koshienCannotChangeRubyVersion': 'The Ruby version cannot be changed when the Koshien extension is loaded.',
 
+    'gui.smalruby3.gui.feedback': 'Send feedback',
+    'gui.smalruby3.feedbackConfirm': 'Opens an external site to send feedback to Smalruby.',
+
     // Block Display Modal - Block Messages
     // Motion blocks
     'gui.smalruby3.blockDisplayModal.motion_movesteps': 'move (10) steps',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -155,12 +155,12 @@ export default {
     'gui.smalruby3.blockDisplayModal.copyUrl': 'URLのこぴー',
     'gui.smalruby3.blockDisplayModal.saveToFile': 'ふぁいるにせってい',
     'gui.menuBar.blockDisplay': 'ブロックひょうじ...',
-        'gui.menuBar.learn': 'まなぶ',
+    'gui.menuBar.learn': 'まなぶ',
     
-        'gui.smalruby3.gui.feedback': 'フィードバックをそうしん',
-        'gui.smalruby3.feedbackConfirm': 'スモウルビーへのフィードバックをそうしんするためのがいぶサイトをひらきます',
+    'gui.smalruby3.gui.feedback': 'フィードバックをそうしん',
+    'gui.smalruby3.feedbackConfirm': 'スモウルビーへのフィードバックをそうしんするためのがいぶサイトをひらきます',
     
-        // Block Display Modal - Block Messages (Hiragana)
+    // Block Display Modal - Block Messages (Hiragana)
     // Motion blocks
     'gui.smalruby3.blockDisplayModal.motion_movesteps': '(10) ほうごかす',
     'gui.smalruby3.blockDisplayModal.motion_turnright': '↻ (15) どまわす',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -155,9 +155,13 @@ export default {
     'gui.smalruby3.blockDisplayModal.copyUrl': 'URLのこぴー',
     'gui.smalruby3.blockDisplayModal.saveToFile': 'ふぁいるにせってい',
     'gui.menuBar.blockDisplay': 'ブロックひょうじ...',
-    'gui.menuBar.learn': 'まなぶ',
-
-    // Block Display Modal - Block Messages (Hiragana)
+        'gui.menuBar.learn': 'まなぶ',
+    
+        'gui.smalruby3.gui.feedback': 'フィードバックをそうしん',
+        'gui.smalruby3.feedbackConfirm': 'スモウルビーへのフィードバックをそうしんするためのがいぶサイトをひらきます',
+    
+        // Block Display Modal - Block Messages
+     (Hiragana)
     // Motion blocks
     'gui.smalruby3.blockDisplayModal.motion_movesteps': '(10) ほうごかす',
     'gui.smalruby3.blockDisplayModal.motion_turnright': '↻ (15) どまわす',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -158,7 +158,7 @@ export default {
     'gui.menuBar.learn': 'まなぶ',
     
     'gui.smalruby3.gui.feedback': 'フィードバックをそうしん',
-    'gui.smalruby3.feedbackConfirm': 'スモウルビーへのフィードバックをそうしんするためのがいぶサイトをひらきます',
+    'gui.smalruby3.feedbackConfirm': 'スモウルビーをよりよくするためのフィードバック（ごいけん）をそうしんするがいぶサイトをひらきます。よろしいですか？',
     
     // Block Display Modal - Block Messages (Hiragana)
     // Motion blocks

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -160,8 +160,7 @@ export default {
         'gui.smalruby3.gui.feedback': 'フィードバックをそうしん',
         'gui.smalruby3.feedbackConfirm': 'スモウルビーへのフィードバックをそうしんするためのがいぶサイトをひらきます',
     
-        // Block Display Modal - Block Messages
-     (Hiragana)
+        // Block Display Modal - Block Messages (Hiragana)
     // Motion blocks
     'gui.smalruby3.blockDisplayModal.motion_movesteps': '(10) ほうごかす',
     'gui.smalruby3.blockDisplayModal.motion_turnright': '↻ (15) どまわす',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -157,6 +157,9 @@ export default {
     'gui.menuBar.blockDisplay': 'ブロック表示...',
     'gui.menuBar.tutorials': 'チュートリアル',
 
+    'gui.smalruby3.gui.feedback': 'フィードバックを送信',
+    'gui.smalruby3.feedbackConfirm': 'スモウルビーへのフィードバックを送信するための外部サイトを開きます',
+
     // Block Display Modal - Block Messages
     // Motion blocks
     'gui.smalruby3.blockDisplayModal.motion_movesteps': '(10) 歩動かす',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -158,7 +158,7 @@ export default {
     'gui.menuBar.tutorials': 'チュートリアル',
 
     'gui.smalruby3.gui.feedback': 'フィードバックを送信',
-    'gui.smalruby3.feedbackConfirm': 'スモウルビーへのフィードバックを送信するための外部サイトを開きます',
+    'gui.smalruby3.feedbackConfirm': 'スモウルビーをよりよくするためのフィードバック（ご意見）を送信する外部サイトを開きます。よろしいですか？',
 
     // Block Display Modal - Block Messages
     // Motion blocks

--- a/packages/scratch-gui/test/integration/feedback-link.test.js
+++ b/packages/scratch-gui/test/integration/feedback-link.test.js
@@ -1,0 +1,28 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    findByText,
+    getDriver,
+    loadUri
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Feedback link', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('Feedback link should be displayed', async () => {
+        await loadUri(uri);
+        const el = await findByText('Send feedback');
+        expect(await el.isDisplayed()).toBe(true);
+    });
+});


### PR DESCRIPTION
Adds a feedback link to the tab list area that opens a Google Form for user reports.

Closes #140