### PR TITLE
fix: preserve float literals (x.0) in Ruby↔block conversion

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/math.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/math.js
@@ -5,7 +5,16 @@
  */
 export default function (Generator) {
     Generator.math_number = function (block) {
-        let n = Number(Generator.getFieldValue(block, 'NUM'));
+        const raw = Generator.getFieldValue(block, 'NUM');
+        // Preserve float notation like "1.0" that would otherwise become integer 1
+        if (typeof raw === 'string' && raw.includes('.')) {
+            const n = Number(raw);
+            if (!isNaN(n) && Number.isInteger(n)) {
+                const order = n < 0 ? Generator.ORDER_UNARY_SIGN : Generator.ORDER_ATOMIC;
+                return [raw, order];
+            }
+        }
+        let n = Number(raw);
         if (isNaN(n)) {
             n = 0;
         }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js
@@ -100,7 +100,13 @@ const BlockUtils = {
 
     _createNumberBlock (opcode, value) {
         if (this._isNumber(value) || value === '') {
-            return this._createFieldBlock(opcode, 'NUM', value.toString());
+            let numStr;
+            if (this._isPrimitive(value) && value.type === 'float' && Number.isInteger(value.value)) {
+                numStr = value.value.toFixed(1);
+            } else {
+                numStr = value.toString();
+            }
+            return this._createFieldBlock(opcode, 'NUM', numStr);
         }
         return value;
     },

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/index.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/index.test.js
@@ -1,6 +1,46 @@
 import RubyGenerator from '../../../../src/lib/ruby-generator';
+import MathBlocks from '../../../../src/lib/ruby-generator/math';
 
 describe('RubyGenerator', () => {
+    describe('math_number', () => {
+        beforeEach(() => {
+            MathBlocks(RubyGenerator);
+        });
+
+        const makeBlock = numFieldValue => ({
+            id: 'block-id',
+            opcode: 'math_number',
+            fields: {
+                NUM: {name: 'NUM', value: numFieldValue}
+            }
+        });
+
+        test('integer field value returns number', () => {
+            const [result] = RubyGenerator.math_number(makeBlock('1'));
+            expect(result).toBe(1);
+        });
+
+        test('float field value with integer appearance (1.0) preserves decimal notation', () => {
+            const [result] = RubyGenerator.math_number(makeBlock('1.0'));
+            expect(result).toBe('1.0');
+        });
+
+        test('non-integer float field value (3.14) returns number', () => {
+            const [result] = RubyGenerator.math_number(makeBlock('3.14'));
+            expect(result).toBe(3.14);
+        });
+
+        test('negative float with integer appearance (-1.0) preserves decimal notation', () => {
+            const [result] = RubyGenerator.math_number(makeBlock('-1.0'));
+            expect(result).toBe('-1.0');
+        });
+
+        test('zero float (0.0) preserves decimal notation', () => {
+            const [result] = RubyGenerator.math_number(makeBlock('0.0'));
+            expect(result).toBe('0.0');
+        });
+    });
+
     describe('quote_', () => {
         test('should escape double quotes', () => {
             const result = RubyGenerator.quote_('"');

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/core-prism.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/core-prism.test.js
@@ -50,4 +50,26 @@ describe('RubyToBlocksConverter Core (Prism)', () => {
         expect(converter.errors).toHaveLength(1);
         expect(converter.errors[0].text).toContain('could not be converted');
     });
+
+    test('float literal 1.0 should be stored as "1.0" in NUM field', async () => {
+        const code = 'move(1.0)';
+        const converter = await targetCodeToBlocks(vm, target, code);
+        expect(converter.result).toBeTruthy();
+        const blocks = Object.values(converter.blocks);
+        const moveBlock = blocks.find(b => b.opcode === 'motion_movesteps');
+        expect(moveBlock).toBeDefined();
+        const stepsBlock = converter.blocks[moveBlock.inputs.STEPS.block];
+        expect(stepsBlock.fields.NUM.value).toBe('1.0');
+    });
+
+    test('float literal 3435.0 should be stored as "3435.0" in NUM field', async () => {
+        const code = 'move(3435.0)';
+        const converter = await targetCodeToBlocks(vm, target, code);
+        expect(converter.result).toBeTruthy();
+        const blocks = Object.values(converter.blocks);
+        const moveBlock = blocks.find(b => b.opcode === 'motion_movesteps');
+        expect(moveBlock).toBeDefined();
+        const stepsBlock = converter.blocks[moveBlock.inputs.STEPS.block];
+        expect(stepsBlock.fields.NUM.value).toBe('3435.0');
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -120,4 +120,16 @@ def self.check(x)
 end
 `.trim());
     });
+
+    test('float literals with integer appearance (x.0) are preserved', async () => {
+        await expectRoundTrip('1.0 + 1.0');
+        await expectRoundTrip('move(1.0)');
+        await expectRoundTrip('move(3435.0)');
+        await expectRoundTrip('1.0 + 2.0');
+        await expectRoundTrip('273.0 - 1.0');
+    });
+
+    test('complex expression with float literals is preserved', async () => {
+        await expectRoundTrip('1.0 / ((1.0 / 3435.0) * Math.log(20.0) + 1.0 / 298.0) - 273.0');
+    });
 });


### PR DESCRIPTION
## Summary

- float リテラル `1.0` のような小数点以下がゼロの値が、Ruby→ブロック→Rubyの変換で `1` に丸められる問題を修正（#148）
- Phase 1: `ruby-generator/math.js` の `math_number` 関数を修正
- Phase 2以降: `ruby-to-blocks-converter/block-utils.js` の `_createNumberBlock` 修正、round-trip テスト追加予定

## Changes

### `math_number` generator の修正

NUM フィールドが `"1.0"` のような文字列の場合、`Number("1.0") = 1` になり float 情報が失われていた。  
`.` を含み、かつ整数値に変換される文字列はそのまま文字列として返すよう修正。

### テスト追加

`test/unit/lib/ruby-generator/index.test.js` に `math_number` のユニットテストを追加:
- `"1"` → 数値 `1`（変更なし）
- `"1.0"` → 文字列 `"1.0"`（float保持）
- `"3.14"` → 数値 `3.14`（変更なし）
- `"-1.0"` → 文字列 `"-1.0"`（float保持）
- `"0.0"` → 文字列 `"0.0"`（float保持）

## Test plan

- [x] Unit tests pass: `jest test/unit/lib/ruby-generator/index.test.js`
- [x] Lint passes
- [ ] Phase 2: `_createNumberBlock` 修正（次コミット予定）
- [ ] Phase Final: round-trip tests

Closes #148
