### PR TITLE
feat: Ruby class 構文によるスプライト定義サポート

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,36 @@ After changing environment variables, restart the service:
 docker compose restart app
 ```
 
+## Browser Debugging with Playwright MCP
+
+When verifying behavior in the browser using Playwright MCP, use the `window.smalruby` debug global object exposed by `packages/scratch-gui/src/containers/ruby-tab.jsx`:
+
+```javascript
+// Available after visiting the Ruby tab at least once
+window.smalruby.vm        // Scratch VM instance
+window.smalruby.sprite    // Current editing target (RenderedTarget)
+window.smalruby.blocks    // Current target's blocks
+window.smalruby.comments  // Current target's comments
+window.smalruby.stage     // Stage target
+window.smalruby.runtime   // VM runtime
+
+// Monaco editor instance
+monaco.editor.getEditors()[0]  // Get the first Monaco editor
+```
+
+To access the RubyGenerator (webpack bundled module):
+
+```javascript
+// Obtain webpack require via webpackChunkGUI
+let req;
+window.webpackChunkGUI.push([['__probe__'], {}, r => { req = r; }]);
+// Find RubyGenerator
+for (const id in req.c) {
+    const m = req.c[id]?.exports;
+    if (m?.default?.targetsToCode) { /* found RubyGenerator = m.default */ break; }
+}
+```
+
 ## Testing Philosophy
 
 Follow TDD (Test-Driven Development) approach:

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -487,6 +487,7 @@ class Blocks extends React.Component {
                     this.workspace.cleanUp();
 
                     // Re-calculate the position of the comments.
+                    const firstTopBlock = this.workspace.getTopBlocks(true)[0];
                     this.workspace.getTopComments(false).forEach(comment => {
                         if (comment.blockId) {
                             const block = this.workspace.getBlockById(comment.blockId);
@@ -508,6 +509,21 @@ class Blocks extends React.Component {
                                     targetComments[comment.id].x = x;
                                     targetComments[comment.id].y = y;
                                 }
+                            }
+                        } else if (firstTopBlock) {
+                            // Workspace-level comments (e.g. @ruby:class) have no blockId.
+                            // Place them to the left of the first top block, at the same y.
+                            const blockXY = firstTopBlock.getRelativeToSurfaceXY();
+                            const commentHW = comment.getHeightWidth();
+                            const rtl = this.workspace.RTL;
+                            const x = rtl ? 20 : -commentHW.width - 20;
+                            const y = blockXY.y;
+                            comment.moveTo(x, y);
+
+                            const targetComments = this.props.vm.editingTarget.comments;
+                            if (targetComments && targetComments[comment.id]) {
+                                targetComments[comment.id].x = x;
+                                targetComments[comment.id].y = y;
                             }
                         }
                     });

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -85,6 +85,11 @@ class RubyTab extends React.Component {
         this.props.vm.addListener('SCRIPT_GLOW_ON', this.handleScriptGlowOn);
         this.props.vm.addListener('SCRIPT_GLOW_OFF', this.handleScriptGlowOff);
         this.props.vm.addListener('VISUAL_REPORT', this.handleVisualReport);
+
+        // Expose debug globals for Playwright MCP and browser console
+        window.smalruby = window.smalruby || {};
+        window.smalruby.vm = this.props.vm;
+        this._updateDebugGlobals();
     }
 
     componentDidUpdate (prevProps) {
@@ -173,6 +178,8 @@ class RubyTab extends React.Component {
             // Mark Ruby tab as used for tutorial onboarding
             this.props.onMarkRubyTabUsed();
         }
+
+        this._updateDebugGlobals();
     }
 
     componentWillUnmount () {
@@ -204,6 +211,19 @@ class RubyTab extends React.Component {
             this.bodyMutationObserver.disconnect();
             this.bodyMutationObserver = null;
         }
+    }
+
+    _updateDebugGlobals () {
+        if (!window.smalruby) window.smalruby = {};
+        const vm = this.props.vm;
+        window.smalruby.vm = vm;
+        if (vm.editingTarget) {
+            window.smalruby.sprite = vm.editingTarget;
+            window.smalruby.blocks = vm.editingTarget.blocks;
+            window.smalruby.comments = vm.editingTarget.comments;
+        }
+        window.smalruby.stage = vm.runtime ? vm.runtime.getTargetForStage() : null;
+        window.smalruby.runtime = vm.runtime;
     }
 
     clearErrors () {

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -140,12 +140,27 @@ RubyGenerator.finish = function (code, options) {
     }
 
     const comments = RubyGenerator.getTargetCommentTexts();
-    if (comments.length > 0) {
-        const commentCodes = comments.map(comment => `${this.prefixLines(comment, '# ')}\n`);
+
+    // Detect @ruby:class comments
+    let classComment = null;
+    const otherComments = [];
+    for (const comment of comments) {
+        if (comment === '@ruby:class' || comment === '@ruby:class:name') {
+            classComment = comment;
+        } else {
+            otherComments.push(comment);
+        }
+    }
+
+    // Add non-class target comments
+    if (otherComments.length > 0) {
+        const commentCodes = otherComments.map(comment => `${this.prefixLines(comment, '# ')}\n`);
         code = `${commentCodes.join('\n')}\n${code}`;
     }
 
-    if (options && options.withSpriteNew) {
+    if (classComment) {
+        code = this._wrapWithClass(code, classComment);
+    } else if (options && options.withSpriteNew) {
         const spriteNewCode = this.spriteNew(this.currentTarget);
         if (code.length > 0) {
             code = this.prefixLines(code, this.INDENT);
@@ -163,6 +178,37 @@ RubyGenerator.finish = function (code, options) {
     }
 
     return s + code;
+};
+
+RubyGenerator._wrapWithClass = function (code, classComment) {
+    const target = this.currentTarget;
+    let className;
+    let setNameCode = '';
+
+    if (classComment === '@ruby:class:name') {
+        const spriteName = target.sprite.name;
+        if (/^[A-Z]/.test(spriteName)) {
+            className = spriteName;
+        } else {
+            // Calculate sprite index
+            const sprites = target.runtime.targets.filter(t => !t.isStage);
+            const index = sprites.indexOf(target) + 1;
+            className = `Sprite${index}`;
+            setNameCode = `${this.INDENT}set_name ${this.quote_(spriteName)}\n\n`;
+        }
+    } else {
+        // @ruby:class - use Sprite%index%
+        const sprites = target.runtime.targets.filter(t => !t.isStage);
+        const index = sprites.indexOf(target) + 1;
+        className = `Sprite${index}`;
+    }
+
+    if (code.length > 0) {
+        code = this.prefixLines(code, this.INDENT);
+    }
+    code = `class ${className}\n${setNameCode}${code}end\n`;
+
+    return code;
 };
 
 RubyGenerator.initTargets = function (options) {

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -145,7 +145,7 @@ RubyGenerator.finish = function (code, options) {
     let classComment = null;
     const otherComments = [];
     for (const comment of comments) {
-        if (comment === '@ruby:class' || comment === '@ruby:class:name') {
+        if (comment === '@ruby:class' || comment.startsWith('@ruby:class:')) {
             classComment = comment;
         } else {
             otherComments.push(comment);
@@ -185,7 +185,14 @@ RubyGenerator._wrapWithClass = function (code, classComment) {
     let className;
     const setLines = [];
 
-    if (classComment === '@ruby:class:name') {
+    // Parse attribute list from @ruby:class:attr1,attr2,...
+    let allowedAttributes = [];
+    if (classComment.startsWith('@ruby:class:')) {
+        const attrPart = classComment.slice('@ruby:class:'.length);
+        allowedAttributes = attrPart.split(',');
+    }
+
+    if (allowedAttributes.indexOf('name') >= 0) {
         const spriteName = target.sprite.name;
         if (/^[A-Z]/.test(spriteName)) {
             className = spriteName;
@@ -197,14 +204,14 @@ RubyGenerator._wrapWithClass = function (code, classComment) {
             setLines.push(`set_name ${this.quote_(spriteName)}`);
         }
     } else {
-        // @ruby:class - use Sprite%index%
+        // No name attribute - use Sprite%index%
         const sprites = target.runtime.targets.filter(t => !t.isStage);
         const index = sprites.indexOf(target) + 1;
         className = `Sprite${index}`;
     }
 
-    // Generate set_xxx for non-default sprite attributes
-    this._generateSetXxx(target, setLines);
+    // Generate set_xxx only for listed attributes
+    this._generateSetXxx(target, setLines, allowedAttributes);
 
     let setCode = '';
     if (setLines.length > 0) {
@@ -220,26 +227,26 @@ RubyGenerator._wrapWithClass = function (code, classComment) {
     return code;
 };
 
-RubyGenerator._generateSetXxx = function (target, setLines) {
-    if (target.x !== 0) {
+RubyGenerator._generateSetXxx = function (target, setLines, allowedAttributes) {
+    if (allowedAttributes.indexOf('x') >= 0 && target.x !== 0) {
         setLines.push(`set_x ${target.x}`);
     }
-    if (target.y !== 0) {
+    if (allowedAttributes.indexOf('y') >= 0 && target.y !== 0) {
         setLines.push(`set_y ${target.y}`);
     }
-    if (target.direction !== 90) {
+    if (allowedAttributes.indexOf('direction') >= 0 && target.direction !== 90) {
         setLines.push(`set_direction ${target.direction}`);
     }
-    if (!target.visible) {
+    if (allowedAttributes.indexOf('visible') >= 0 && !target.visible) {
         setLines.push(`set_visible ${!!target.visible}`);
     }
-    if (target.size !== 100) {
+    if (allowedAttributes.indexOf('size') >= 0 && target.size !== 100) {
         setLines.push(`set_size ${target.size}`);
     }
-    if (target.currentCostume > 0) {
+    if (allowedAttributes.indexOf('current_costume') >= 0 && target.currentCostume > 0) {
         setLines.push(`set_current_costume ${target.currentCostume}`);
     }
-    if (target.rotationStyle !== 'all around') {
+    if (allowedAttributes.indexOf('rotation_style') >= 0 && target.rotationStyle !== 'all around') {
         setLines.push(`set_rotation_style ${this.quote_(target.rotationStyle)}`);
     }
 };

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -183,7 +183,7 @@ RubyGenerator.finish = function (code, options) {
 RubyGenerator._wrapWithClass = function (code, classComment) {
     const target = this.currentTarget;
     let className;
-    let setNameCode = '';
+    const setLines = [];
 
     if (classComment === '@ruby:class:name') {
         const spriteName = target.sprite.name;
@@ -194,7 +194,7 @@ RubyGenerator._wrapWithClass = function (code, classComment) {
             const sprites = target.runtime.targets.filter(t => !t.isStage);
             const index = sprites.indexOf(target) + 1;
             className = `Sprite${index}`;
-            setNameCode = `${this.INDENT}set_name ${this.quote_(spriteName)}\n\n`;
+            setLines.push(`set_name ${this.quote_(spriteName)}`);
         }
     } else {
         // @ruby:class - use Sprite%index%
@@ -203,12 +203,45 @@ RubyGenerator._wrapWithClass = function (code, classComment) {
         className = `Sprite${index}`;
     }
 
+    // Generate set_xxx for non-default sprite attributes
+    this._generateSetXxx(target, setLines);
+
+    let setCode = '';
+    if (setLines.length > 0) {
+        setCode = setLines.map(line => `${this.INDENT}${line}\n`).join('');
+        setCode += '\n';
+    }
+
     if (code.length > 0) {
         code = this.prefixLines(code, this.INDENT);
     }
-    code = `class ${className}\n${setNameCode}${code}end\n`;
+    code = `class ${className}\n${setCode}${code}end\n`;
 
     return code;
+};
+
+RubyGenerator._generateSetXxx = function (target, setLines) {
+    if (target.x !== 0) {
+        setLines.push(`set_x ${target.x}`);
+    }
+    if (target.y !== 0) {
+        setLines.push(`set_y ${target.y}`);
+    }
+    if (target.direction !== 90) {
+        setLines.push(`set_direction ${target.direction}`);
+    }
+    if (!target.visible) {
+        setLines.push(`set_visible ${!!target.visible}`);
+    }
+    if (target.size !== 100) {
+        setLines.push(`set_size ${target.size}`);
+    }
+    if (target.currentCostume > 0) {
+        setLines.push(`set_current_costume ${target.currentCostume}`);
+    }
+    if (target.rotationStyle !== 'all around') {
+        setLines.push(`set_rotation_style ${this.quote_(target.rotationStyle)}`);
+    }
 };
 
 RubyGenerator.initTargets = function (options) {

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -158,7 +158,10 @@ RubyGenerator.finish = function (code, options) {
         code = `${commentCodes.join('\n')}\n${code}`;
     }
 
-    if (classComment) {
+    // For version 1 file output (withSpriteNew), use Sprite.new format
+    // even when @ruby:class comment is present.
+    // For version 2, @ruby:class takes priority over withSpriteNew.
+    if (classComment && this.version !== '1') {
         code = this._wrapWithClass(code, classComment);
     } else if (options && options.withSpriteNew) {
         const spriteNewCode = this.spriteNew(this.currentTarget);

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -291,12 +291,66 @@ class RubyToBlocksConverter extends Visitor {
     }
 
     visitClassNode (node) {
-        // Create @ruby:class target comment (blockId=null for sprite-level comment)
-        this._createComment('@ruby:class', null);
+        const className = node.name;
+        const isSpriteIndexName = /^Sprite\d+$/.test(className);
 
-        // Visit class body statements
-        if (node.body) {
-            return this.visit(node.body);
+        // Pre-scan class body for set_name calls
+        let setNameValue = null;
+        if (node.body && node.body.body) {
+            for (const stmt of node.body.body) {
+                if (stmt.constructor.name === 'CallNode' &&
+                    stmt.name === 'set_name' &&
+                    !stmt.receiver &&
+                    stmt.arguments_ &&
+                    stmt.arguments_.arguments_.length === 1) {
+                    const arg = stmt.arguments_.arguments_[0];
+                    if (arg.constructor.name === 'StringNode') {
+                        const unescaped = arg.unescaped;
+                        setNameValue = typeof unescaped === 'object' ? unescaped.value : unescaped;
+                    }
+                }
+            }
+        }
+
+        // Determine comment type and classInfo
+        const hasNameChange = !isSpriteIndexName || setNameValue !== null;
+        const commentText = hasNameChange ? '@ruby:class:name' : '@ruby:class';
+        this._createComment(commentText, null);
+
+        // Store class info in context for later application
+        if (hasNameChange) {
+            this._context.classInfo = {
+                name: setNameValue || className
+            };
+        }
+
+        // Visit class body, filtering out set_name calls
+        if (node.body && node.body.body) {
+            const filteredStatements = node.body.body.filter(stmt => {
+                if (stmt.constructor.name === 'CallNode' &&
+                    stmt.name === 'set_name' &&
+                    !stmt.receiver) {
+                    return false;
+                }
+                return true;
+            });
+
+            if (filteredStatements.length === 0) {
+                return [];
+            }
+
+            // Visit filtered statements manually
+            const blocks = [];
+            for (const stmt of filteredStatements) {
+                this._context.methodCallIndices = {};
+                const block = this.visit(stmt);
+                if (Array.isArray(block)) {
+                    block.forEach(b => blocks.push(b));
+                } else if (block !== null && typeof block !== 'undefined') {
+                    blocks.push(block);
+                }
+            }
+            return blocks;
         }
         return [];
     }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -289,6 +289,17 @@ class RubyToBlocksConverter extends Visitor {
     visitProgramNode (node) {
         return this.visit(node.statements);
     }
+
+    visitClassNode (node) {
+        // Create @ruby:class target comment (blockId=null for sprite-level comment)
+        this._createComment('@ruby:class', null);
+
+        // Visit class body statements
+        if (node.body) {
+            return this.visit(node.body);
+        }
+        return [];
+    }
 }
 
 // Mixin methods

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -309,6 +309,12 @@ class RubyToBlocksConverter extends Visitor {
             set_lists: 'lists'
         };
 
+        // Canonical attribute order for comment text
+        const ATTR_ORDER = [
+            'name', 'x', 'y', 'direction', 'visible', 'size',
+            'current_costume', 'rotation_style', 'costumes', 'variables', 'lists'
+        ];
+
         // Pre-scan class body for set_xxx calls
         const classInfo = {};
         const setMethodNames = new Set();
@@ -330,15 +336,26 @@ class RubyToBlocksConverter extends Visitor {
             }
         }
 
-        // Determine comment type
-        const hasNameChange = !isSpriteIndexName || Object.prototype.hasOwnProperty.call(classInfo, 'name');
-        const hasAnySetMethod = Object.keys(classInfo).length > 0;
-        const commentText = hasNameChange ? '@ruby:class:name' : '@ruby:class';
+        // Collect attribute names for comment
+        const attributeNames = Object.keys(classInfo);
+        if (!isSpriteIndexName && !Object.prototype.hasOwnProperty.call(classInfo, 'name')) {
+            attributeNames.push('name');
+        }
+        // Sort by canonical order
+        attributeNames.sort((a, b) => ATTR_ORDER.indexOf(a) - ATTR_ORDER.indexOf(b));
+
+        // Generate comment text
+        let commentText;
+        if (attributeNames.length > 0) {
+            commentText = `@ruby:class:${attributeNames.join(',')}`;
+        } else {
+            commentText = '@ruby:class';
+        }
         this._createComment(commentText, null);
 
         // Store class info in context
-        if (hasNameChange || hasAnySetMethod) {
-            if (!classInfo.name && !isSpriteIndexName) {
+        if (attributeNames.length > 0) {
+            if (!Object.prototype.hasOwnProperty.call(classInfo, 'name') && !isSpriteIndexName) {
                 classInfo.name = className;
             }
             this._context.classInfo = classInfo;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -294,41 +294,61 @@ class RubyToBlocksConverter extends Visitor {
         const className = node.name;
         const isSpriteIndexName = /^Sprite\d+$/.test(className);
 
-        // Pre-scan class body for set_name calls
-        let setNameValue = null;
+        // Set of recognized set_xxx class methods
+        const SET_METHODS = {
+            set_name: 'name',
+            set_x: 'x',
+            set_y: 'y',
+            set_direction: 'direction',
+            set_visible: 'visible',
+            set_size: 'size',
+            set_current_costume: 'current_costume',
+            set_rotation_style: 'rotation_style',
+            set_costumes: 'costumes',
+            set_variables: 'variables',
+            set_lists: 'lists'
+        };
+
+        // Pre-scan class body for set_xxx calls
+        const classInfo = {};
+        const setMethodNames = new Set();
         if (node.body && node.body.body) {
             for (const stmt of node.body.body) {
                 if (stmt.constructor.name === 'CallNode' &&
-                    stmt.name === 'set_name' &&
+                    SET_METHODS[stmt.name] &&
                     !stmt.receiver &&
                     stmt.arguments_ &&
                     stmt.arguments_.arguments_.length === 1) {
+                    const attrName = SET_METHODS[stmt.name];
                     const arg = stmt.arguments_.arguments_[0];
-                    if (arg.constructor.name === 'StringNode') {
-                        const unescaped = arg.unescaped;
-                        setNameValue = typeof unescaped === 'object' ? unescaped.value : unescaped;
+                    const value = this._extractClassMethodArg(arg);
+                    if (value !== null) {
+                        classInfo[attrName] = value;
+                        setMethodNames.add(stmt.name);
                     }
                 }
             }
         }
 
-        // Determine comment type and classInfo
-        const hasNameChange = !isSpriteIndexName || setNameValue !== null;
+        // Determine comment type
+        const hasNameChange = !isSpriteIndexName || Object.prototype.hasOwnProperty.call(classInfo, 'name');
+        const hasAnySetMethod = Object.keys(classInfo).length > 0;
         const commentText = hasNameChange ? '@ruby:class:name' : '@ruby:class';
         this._createComment(commentText, null);
 
-        // Store class info in context for later application
-        if (hasNameChange) {
-            this._context.classInfo = {
-                name: setNameValue || className
-            };
+        // Store class info in context
+        if (hasNameChange || hasAnySetMethod) {
+            if (!classInfo.name && !isSpriteIndexName) {
+                classInfo.name = className;
+            }
+            this._context.classInfo = classInfo;
         }
 
-        // Visit class body, filtering out set_name calls
+        // Visit class body, filtering out set_xxx calls
         if (node.body && node.body.body) {
             const filteredStatements = node.body.body.filter(stmt => {
                 if (stmt.constructor.name === 'CallNode' &&
-                    stmt.name === 'set_name' &&
+                    setMethodNames.has(stmt.name) &&
                     !stmt.receiver) {
                     return false;
                 }
@@ -353,6 +373,35 @@ class RubyToBlocksConverter extends Visitor {
             return blocks;
         }
         return [];
+    }
+
+    _extractClassMethodArg (argNode) {
+        const type = argNode.constructor.name;
+        switch (type) {
+        case 'StringNode': {
+            const unescaped = argNode.unescaped;
+            return typeof unescaped === 'object' ? unescaped.value : unescaped;
+        }
+        case 'IntegerNode':
+            return argNode.value;
+        case 'FloatNode':
+            return argNode.value;
+        case 'TrueNode':
+            return true;
+        case 'FalseNode':
+            return false;
+        case 'CallNode':
+            // Handle unary minus: e.g., -50
+            if (argNode.name === '-@' && argNode.receiver) {
+                const innerValue = this._extractClassMethodArg(argNode.receiver);
+                if (typeof innerValue === 'number') {
+                    return -innerValue;
+                }
+            }
+            return null;
+        default:
+            return null;
+        }
     }
 }
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/target-applier.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/target-applier.js
@@ -122,6 +122,35 @@ const TargetApplier = {
                 );
             });
 
+            // Apply classInfo attributes to the target
+            const classInfo = this._context.classInfo;
+            if (classInfo) {
+                if (Object.prototype.hasOwnProperty.call(classInfo, 'name')) {
+                    target.sprite.name = classInfo.name;
+                }
+                if (Object.prototype.hasOwnProperty.call(classInfo, 'x')) {
+                    target.x = classInfo.x;
+                }
+                if (Object.prototype.hasOwnProperty.call(classInfo, 'y')) {
+                    target.y = classInfo.y;
+                }
+                if (Object.prototype.hasOwnProperty.call(classInfo, 'direction')) {
+                    target.direction = classInfo.direction;
+                }
+                if (Object.prototype.hasOwnProperty.call(classInfo, 'visible')) {
+                    target.visible = classInfo.visible;
+                }
+                if (Object.prototype.hasOwnProperty.call(classInfo, 'size')) {
+                    target.size = classInfo.size;
+                }
+                if (Object.prototype.hasOwnProperty.call(classInfo, 'current_costume')) {
+                    target.currentCostume = classInfo.current_costume;
+                }
+                if (Object.prototype.hasOwnProperty.call(classInfo, 'rotation_style')) {
+                    target.rotationStyle = classInfo.rotation_style;
+                }
+            }
+
             this.vm.emitWorkspaceUpdate();
         });
     }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/target-applier.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/target-applier.js
@@ -122,36 +122,67 @@ const TargetApplier = {
                 );
             });
 
-            // Apply classInfo attributes to the target
+            // Apply classInfo attributes to the target using VM setter methods
+            // to trigger renderer updates and Redux state changes.
             const classInfo = this._context.classInfo;
             if (classInfo) {
-                if (Object.prototype.hasOwnProperty.call(classInfo, 'name')) {
+                const has = prop => Object.prototype.hasOwnProperty.call(classInfo, prop);
+
+                if (has('name')) {
                     target.sprite.name = classInfo.name;
                 }
-                if (Object.prototype.hasOwnProperty.call(classInfo, 'x')) {
-                    target.x = classInfo.x;
+
+                if (has('x') || has('y')) {
+                    const newX = has('x') ? classInfo.x : target.x;
+                    const newY = has('y') ? classInfo.y : target.y;
+                    if (typeof target.setXY === 'function') {
+                        target.setXY(newX, newY, true);
+                    } else {
+                        target.x = newX;
+                        target.y = newY;
+                    }
                 }
-                if (Object.prototype.hasOwnProperty.call(classInfo, 'y')) {
-                    target.y = classInfo.y;
+                if (has('direction')) {
+                    if (typeof target.setDirection === 'function') {
+                        target.setDirection(classInfo.direction);
+                    } else {
+                        target.direction = classInfo.direction;
+                    }
                 }
-                if (Object.prototype.hasOwnProperty.call(classInfo, 'direction')) {
-                    target.direction = classInfo.direction;
+                if (has('visible')) {
+                    if (typeof target.setVisible === 'function') {
+                        target.setVisible(classInfo.visible);
+                    } else {
+                        target.visible = classInfo.visible;
+                    }
                 }
-                if (Object.prototype.hasOwnProperty.call(classInfo, 'visible')) {
-                    target.visible = classInfo.visible;
+                if (has('size')) {
+                    if (typeof target.setSize === 'function') {
+                        target.setSize(classInfo.size);
+                    } else {
+                        target.size = classInfo.size;
+                    }
                 }
-                if (Object.prototype.hasOwnProperty.call(classInfo, 'size')) {
-                    target.size = classInfo.size;
+                if (has('current_costume')) {
+                    if (typeof target.setCostume === 'function') {
+                        target.setCostume(classInfo.current_costume);
+                    } else {
+                        target.currentCostume = classInfo.current_costume;
+                    }
                 }
-                if (Object.prototype.hasOwnProperty.call(classInfo, 'current_costume')) {
-                    target.currentCostume = classInfo.current_costume;
-                }
-                if (Object.prototype.hasOwnProperty.call(classInfo, 'rotation_style')) {
-                    target.rotationStyle = classInfo.rotation_style;
+                if (has('rotation_style')) {
+                    if (typeof target.setRotationStyle === 'function') {
+                        target.setRotationStyle(classInfo.rotation_style);
+                    } else {
+                        target.rotationStyle = classInfo.rotation_style;
+                    }
                 }
             }
 
             this.vm.emitWorkspaceUpdate();
+            if (classInfo && typeof this.vm.emitTargetsUpdate === 'function') {
+                this.vm.emitTargetsUpdate();
+            }
         });
     }
 };

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
@@ -128,20 +128,20 @@ describe('RubyGenerator/Class', () => {
     });
 
     describe('set_xxx method generation', () => {
-        test('non-default x,y generates set_x and set_y', () => {
+        test('@ruby:class:x,y outputs only set_x and set_y', () => {
             const {target, runtime} = makeMockTarget('Sprite1', 1);
             target.runtime = runtime;
             target.x = 100;
             target.y = -50;
-            target.direction = 90;
-            target.visible = true;
-            target.size = 100;
+            target.direction = 180;
+            target.visible = false;
+            target.size = 50;
             target.currentCostume = 0;
             target.rotationStyle = 'all around';
             target.sprite.costumes = [];
             target.variables = {};
             RubyGenerator.currentTarget_ = target;
-            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:x,y'];
 
             const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
@@ -153,11 +153,11 @@ describe('RubyGenerator/Class', () => {
             expect(result).not.toContain('set_size');
         });
 
-        test('non-default direction generates set_direction', () => {
+        test('@ruby:class:direction outputs only set_direction', () => {
             const {target, runtime} = makeMockTarget('Sprite1', 1);
             target.runtime = runtime;
-            target.x = 0;
-            target.y = 0;
+            target.x = 100;
+            target.y = -50;
             target.direction = 180;
             target.visible = true;
             target.size = 100;
@@ -166,19 +166,21 @@ describe('RubyGenerator/Class', () => {
             target.sprite.costumes = [];
             target.variables = {};
             RubyGenerator.currentTarget_ = target;
-            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:direction'];
 
             const code = 'move(10)\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_direction 180');
+            expect(result).not.toContain('set_x');
+            expect(result).not.toContain('set_y');
         });
 
-        test('visible false generates set_visible', () => {
+        test('@ruby:class:visible outputs set_visible', () => {
             const {target, runtime} = makeMockTarget('Sprite1', 1);
             target.runtime = runtime;
-            target.x = 0;
-            target.y = 0;
+            target.x = 100;
+            target.y = -50;
             target.direction = 90;
             target.visible = false;
             target.size = 100;
@@ -187,15 +189,17 @@ describe('RubyGenerator/Class', () => {
             target.sprite.costumes = [];
             target.variables = {};
             RubyGenerator.currentTarget_ = target;
-            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:visible'];
 
             const code = 'move(10)\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_visible false');
+            expect(result).not.toContain('set_x');
+            expect(result).not.toContain('set_y');
         });
 
-        test('non-default size generates set_size', () => {
+        test('@ruby:class:size outputs set_size', () => {
             const {target, runtime} = makeMockTarget('Sprite1', 1);
             target.runtime = runtime;
             target.x = 0;
@@ -208,7 +212,7 @@ describe('RubyGenerator/Class', () => {
             target.sprite.costumes = [];
             target.variables = {};
             RubyGenerator.currentTarget_ = target;
-            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:size'];
 
             const code = 'move(10)\n';
             const result = RubyGenerator.finish(code, {});
@@ -216,7 +220,7 @@ describe('RubyGenerator/Class', () => {
             expect(result).toContain('set_size 50');
         });
 
-        test('non-default rotation_style generates set_rotation_style', () => {
+        test('@ruby:class:rotation_style outputs set_rotation_style', () => {
             const {target, runtime} = makeMockTarget('Sprite1', 1);
             target.runtime = runtime;
             target.x = 0;
@@ -229,7 +233,7 @@ describe('RubyGenerator/Class', () => {
             target.sprite.costumes = [];
             target.variables = {};
             RubyGenerator.currentTarget_ = target;
-            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:rotation_style'];
 
             const code = 'move(10)\n';
             const result = RubyGenerator.finish(code, {});
@@ -237,16 +241,16 @@ describe('RubyGenerator/Class', () => {
             expect(result).toContain('set_rotation_style "left-right"');
         });
 
-        test('all default values produce no set_xxx', () => {
+        test('@ruby:class without attributes produces no set_xxx even with non-default values', () => {
             const {target, runtime} = makeMockTarget('Sprite1', 1);
             target.runtime = runtime;
-            target.x = 0;
-            target.y = 0;
-            target.direction = 90;
-            target.visible = true;
-            target.size = 100;
-            target.currentCostume = 0;
-            target.rotationStyle = 'all around';
+            target.x = 100;
+            target.y = -50;
+            target.direction = 180;
+            target.visible = false;
+            target.size = 50;
+            target.currentCostume = 2;
+            target.rotationStyle = 'left-right';
             target.sprite.costumes = [];
             target.variables = {};
             RubyGenerator.currentTarget_ = target;
@@ -255,12 +259,64 @@ describe('RubyGenerator/Class', () => {
             const code = 'move(10)\n';
             const result = RubyGenerator.finish(code, {});
 
+            expect(result).toContain('class Sprite1');
             expect(result).not.toContain('set_x');
             expect(result).not.toContain('set_y');
             expect(result).not.toContain('set_direction');
             expect(result).not.toContain('set_visible');
             expect(result).not.toContain('set_size');
+            expect(result).not.toContain('set_current_costume');
             expect(result).not.toContain('set_rotation_style');
+        });
+
+        test('@ruby:class:x,y,direction outputs only listed attributes', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 100;
+            target.y = -50;
+            target.direction = 180;
+            target.visible = false;
+            target.size = 50;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:x,y,direction'];
+
+            const code = 'move(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('set_x 100');
+            expect(result).toContain('set_y -50');
+            expect(result).toContain('set_direction 180');
+            expect(result).not.toContain('set_visible');
+            expect(result).not.toContain('set_size');
+        });
+
+        test('@ruby:class:name,x,y outputs set_name, set_x, set_y', () => {
+            const {target, runtime} = makeMockTarget('ネコ', 1);
+            target.runtime = runtime;
+            target.x = 100;
+            target.y = -50;
+            target.direction = 180;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name,x,y'];
+
+            const code = 'move(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Sprite1');
+            expect(result).toContain('set_name "ネコ"');
+            expect(result).toContain('set_x 100');
+            expect(result).toContain('set_y -50');
+            expect(result).not.toContain('set_direction');
         });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
@@ -1,0 +1,129 @@
+import RubyGenerator from '../../../../src/lib/ruby-generator';
+
+describe('RubyGenerator/Class', () => {
+    beforeEach(() => {
+        RubyGenerator.init({version: '2'});
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.requires_ = {};
+        RubyGenerator.prepares_ = {};
+        // Reset cache
+        RubyGenerator.cache_ = {
+            targetCommentTexts: [],
+            comments: {}
+        };
+    });
+
+    const makeMockTarget = (name, index = 1) => {
+        const targets = [];
+        const stage = {isStage: true};
+        for (let i = 0; i < index; i++) {
+            targets.push({isStage: false, sprite: {name: `OtherSprite${i + 1}`}});
+        }
+        const target = targets[index - 1];
+        target.sprite = {name: name};
+        targets.unshift(stage);
+        return {
+            target,
+            runtime: {targets}
+        };
+    };
+
+    describe('@ruby:class comment wrapping', () => {
+        test('@ruby:class wraps code with class Sprite%index%', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Sprite1');
+            expect(result).toContain('end\n');
+            expect(result).toContain('  self.when(:flag_clicked) do');
+            // Should NOT output @ruby:class as a comment line
+            expect(result).not.toContain('# @ruby:class');
+        });
+
+        test('@ruby:class:name wraps code with class using sprite name (uppercase start)', () => {
+            const {target, runtime} = makeMockTarget('Cat', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Cat');
+            expect(result).not.toContain('set_name');
+            expect(result).not.toContain('# @ruby:class');
+        });
+
+        test('@ruby:class:name with non-uppercase sprite name generates set_name', () => {
+            const {target, runtime} = makeMockTarget('ネコ', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Sprite1');
+            expect(result).toContain('set_name "ネコ"');
+            expect(result).not.toContain('# @ruby:class');
+        });
+
+        test('@ruby:class:name with sprite at index 2', () => {
+            // Create a runtime with multiple sprites
+            const stage = {isStage: true};
+            const sprite1 = {isStage: false, sprite: {name: 'Sprite1'}};
+            const sprite2 = {isStage: false, sprite: {name: 'ネコ'}};
+            const targets = [stage, sprite1, sprite2];
+            sprite2.runtime = {targets};
+            RubyGenerator.currentTarget_ = sprite2;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Sprite2');
+            expect(result).toContain('set_name "ネコ"');
+        });
+
+        test('no @ruby:class comment does not wrap with class', () => {
+            RubyGenerator.cache_.targetCommentTexts = [];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).not.toContain('class ');
+        });
+
+        test('@ruby:class with empty code', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const result = RubyGenerator.finish('', {});
+
+            expect(result).toContain('class Sprite1');
+            expect(result).toContain('end');
+        });
+
+        test('other target comments are preserved alongside @ruby:class', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class', 'some user comment'];
+
+            const code = 'move(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Sprite1');
+            // Other comments should be inside the class
+            expect(result).toContain('# some user comment');
+            expect(result).not.toContain('# @ruby:class');
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
@@ -126,4 +126,141 @@ describe('RubyGenerator/Class', () => {
             expect(result).not.toContain('# @ruby:class');
         });
     });
+
+    describe('set_xxx method generation', () => {
+        test('non-default x,y generates set_x and set_y', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 100;
+            target.y = -50;
+            target.direction = 90;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('set_x 100');
+            expect(result).toContain('set_y -50');
+            expect(result).not.toContain('set_direction');
+            expect(result).not.toContain('set_visible');
+            expect(result).not.toContain('set_size');
+        });
+
+        test('non-default direction generates set_direction', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 0;
+            target.y = 0;
+            target.direction = 180;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'move(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('set_direction 180');
+        });
+
+        test('visible false generates set_visible', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 0;
+            target.y = 0;
+            target.direction = 90;
+            target.visible = false;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'move(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('set_visible false');
+        });
+
+        test('non-default size generates set_size', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 0;
+            target.y = 0;
+            target.direction = 90;
+            target.visible = true;
+            target.size = 50;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'move(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('set_size 50');
+        });
+
+        test('non-default rotation_style generates set_rotation_style', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 0;
+            target.y = 0;
+            target.direction = 90;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'left-right';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'move(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('set_rotation_style "left-right"');
+        });
+
+        test('all default values produce no set_xxx', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 0;
+            target.y = 0;
+            target.direction = 90;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'move(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).not.toContain('set_x');
+            expect(result).not.toContain('set_y');
+            expect(result).not.toContain('set_direction');
+            expect(result).not.toContain('set_visible');
+            expect(result).not.toContain('set_size');
+            expect(result).not.toContain('set_rotation_style');
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
@@ -319,4 +319,83 @@ describe('RubyGenerator/Class', () => {
             expect(result).not.toContain('set_direction');
         });
     });
+
+    describe('withSpriteNew (version 1 file output)', () => {
+        test('@ruby:class with withSpriteNew uses Sprite.new instead of class', () => {
+            RubyGenerator.init({version: '1'});
+            const {target, runtime} = makeMockTarget('ネコ', 1);
+            target.runtime = runtime;
+            target.x = 90;
+            target.y = -50;
+            target.direction = 45;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.isStage = false;
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name,x,y,direction'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '1'});
+
+            expect(result).toContain('Sprite.new("ネコ"');
+            expect(result).toContain('x: 90');
+            expect(result).toContain('y: -50');
+            expect(result).toContain('direction: 45');
+            expect(result).not.toContain('class ');
+            expect(result).not.toContain('set_name');
+            expect(result).not.toContain('set_x');
+        });
+
+        test('@ruby:class without attributes and withSpriteNew uses Sprite.new with defaults', () => {
+            RubyGenerator.init({version: '1'});
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 0;
+            target.y = 0;
+            target.direction = 90;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.isStage = false;
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '1'});
+
+            expect(result).toContain('Sprite.new("Sprite1")');
+            expect(result).not.toContain('class ');
+        });
+
+        test('@ruby:class with version 2 still uses class format even with withSpriteNew', () => {
+            RubyGenerator.init({version: '2'});
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 0;
+            target.y = 0;
+            target.direction = 90;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.isStage = false;
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '2'});
+
+            expect(result).toContain('class Sprite1');
+            expect(result).not.toContain('Sprite.new');
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_lego_boost.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_lego_boost.test.js
@@ -18,7 +18,7 @@ describe('Ruby Roundtrip: LEGO BOOST extension blocks', () => {
         converter = makeConverter(target, runtime);
     });
 
-    test('Ruby -> Code -> Ruby', async () => {
+    test('motor control blocks', async () => {
         await expectRoundTrip(converter, target, dedent`
             boost_motor_turn_on_for("A", 1)
             boost_motor_turn_on_for("B", 1)
@@ -35,7 +35,11 @@ describe('Ruby Roundtrip: LEGO BOOST extension blocks', () => {
             boost_motor_set_direction_for("A", "reverse")
 
             boost_motor_get_position("A")
+        `);
+    });
 
+    test('color sensing blocks', async () => {
+        await expectRoundTrip(converter, target, dedent`
             self.when(:boost_color, "any") do
             end
 
@@ -58,7 +62,11 @@ describe('Ruby Roundtrip: LEGO BOOST extension blocks', () => {
             end
 
             boost_seeing_color?("any")
+        `);
+    });
 
+    test('tilt sensing and light blocks', async () => {
+        await expectRoundTrip(converter, target, dedent`
             self.when(:boost_tilted, "any") do
             end
 

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/operators.test.js
@@ -18,7 +18,7 @@ describe('Ruby Roundtrip: Operators category blocks', () => {
         converter = makeConverter(target, runtime);
     });
 
-    test('Ruby -> Code -> Ruby', async () => {
+    test('arithmetic, comparison and logic operators', async () => {
         await expectRoundTrip(converter, target, dedent`
             0 + 0
 
@@ -43,7 +43,11 @@ describe('Ruby Roundtrip: Operators category blocks', () => {
             false || false
 
             !false
+        `);
+    });
 
+    test('string and type conversion operators', async () => {
+        await expectRoundTrip(converter, target, dedent`
             "apple " + "banana"
 
             "apple"[0]
@@ -67,7 +71,11 @@ describe('Ruby Roundtrip: Operators category blocks', () => {
             0.floor
 
             0.ceil
+        `);
+    });
 
+    test('math functions', async () => {
+        await expectRoundTrip(converter, target, dedent`
             Math.sqrt(0)
 
             Math.sin(0)

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -226,6 +226,12 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(converter._context.classInfo.x).toEqual(100);
             expect(converter._context.classInfo.y).toEqual(-50);
             expect(converter._context.classInfo.direction).toEqual(180);
+
+            // Comment should list the attributes
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:x,y,direction');
         });
 
         test('set_visible false is stored in classInfo', async () => {
@@ -244,6 +250,11 @@ describe('RubyToBlocksConverter/Class', () => {
 
             expect(converter._context.classInfo).toBeDefined();
             expect(converter._context.classInfo.visible).toEqual(false);
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:visible');
         });
 
         test('set_size and set_current_costume are stored in classInfo', async () => {
@@ -264,6 +275,11 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(converter._context.classInfo).toBeDefined();
             expect(converter._context.classInfo.size).toEqual(50);
             expect(converter._context.classInfo.current_costume).toEqual(2);
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:size,current_costume');
         });
 
         test('set_rotation_style is stored in classInfo', async () => {
@@ -282,6 +298,11 @@ describe('RubyToBlocksConverter/Class', () => {
 
             expect(converter._context.classInfo).toBeDefined();
             expect(converter._context.classInfo.rotation_style).toEqual('left-right');
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:rotation_style');
         });
 
         test('set_xxx methods are not converted to blocks', async () => {
@@ -308,6 +329,55 @@ describe('RubyToBlocksConverter/Class', () => {
             const blocks = converter.blocks;
             const blockOpcodes = Object.values(blocks).map(b => b.opcode);
             expect(blockOpcodes).not.toContain('ruby_statement');
+        });
+
+        test('class Cat with set_x generates @ruby:class:name,x', async () => {
+            code = `
+                class Cat
+                  set_x 100
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:name,x');
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('Cat');
+            expect(converter._context.classInfo.x).toEqual(100);
+        });
+
+        test('class Sprite1 with set_name and set_x generates @ruby:class:name,x', async () => {
+            code = `
+                class Sprite1
+                  set_name "ネコ"
+                  set_x 100
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:name,x');
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('ネコ');
+            expect(converter._context.classInfo.x).toEqual(100);
         });
 
         test('set_xxx without class generates error', async () => {

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -204,4 +204,122 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(targetComments[0].text).toEqual('@ruby:class');
         });
     });
+
+    describe('set_xxx class methods', () => {
+        test('set_x, set_y, set_direction are stored in classInfo', async () => {
+            code = `
+                class Sprite1
+                  set_x 100
+                  set_y -50
+                  set_direction 180
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.x).toEqual(100);
+            expect(converter._context.classInfo.y).toEqual(-50);
+            expect(converter._context.classInfo.direction).toEqual(180);
+        });
+
+        test('set_visible false is stored in classInfo', async () => {
+            code = `
+                class Sprite1
+                  set_visible false
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.visible).toEqual(false);
+        });
+
+        test('set_size and set_current_costume are stored in classInfo', async () => {
+            code = `
+                class Sprite1
+                  set_size 50
+                  set_current_costume 2
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.size).toEqual(50);
+            expect(converter._context.classInfo.current_costume).toEqual(2);
+        });
+
+        test('set_rotation_style is stored in classInfo', async () => {
+            code = `
+                class Sprite1
+                  set_rotation_style "left-right"
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.rotation_style).toEqual('left-right');
+        });
+
+        test('set_xxx methods are not converted to blocks', async () => {
+            code = `
+                class Sprite1
+                  set_x 100
+                  set_y -50
+                  set_direction 180
+                  set_visible false
+                  set_size 50
+                  set_current_costume 2
+                  set_rotation_style "left-right"
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            // set_xxx should not create ruby_statement blocks
+            const blocks = converter.blocks;
+            const blockOpcodes = Object.values(blocks).map(b => b.opcode);
+            expect(blockOpcodes).not.toContain('ruby_statement');
+        });
+
+        test('set_xxx without class generates error', async () => {
+            code = `
+                set_x 100
+                self.when(:flag_clicked) do
+                  move(10)
+                end
+            `;
+            // set_x outside class should be treated as unknown call
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors.length).toBeGreaterThan(0);
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -1,0 +1,112 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectToEqualBlocks,
+    rubyToExpected
+} from '../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/Class', () => {
+    let converter;
+    let target;
+    let code;
+    let expected;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null);
+        target = null;
+        code = null;
+        expected = null;
+    });
+
+    describe('basic class syntax', () => {
+        test('class Sprite1 with when_flag_clicked', async () => {
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            expected = await rubyToExpected(converter, target, `
+                self.when(:flag_clicked) do
+                  move(10)
+                end
+            `);
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+            // @ruby:class comment should be created with blockId=null
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class');
+        });
+
+        test('class with multiple event handlers', async () => {
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+
+                  self.when(:key_pressed, "space") do
+                    move(20)
+                  end
+                end
+            `;
+            expected = await rubyToExpected(converter, target, `
+                self.when(:flag_clicked) do
+                  move(10)
+                end
+
+                self.when(:key_pressed, "space") do
+                  move(20)
+                end
+            `);
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class');
+        });
+
+        test('class with top-level statements outside', async () => {
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+
+                bounce_if_on_edge
+            `;
+            expected = await rubyToExpected(converter, target, `
+                self.when(:flag_clicked) do
+                  move(10)
+                end
+
+                bounce_if_on_edge
+            `);
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class');
+        });
+
+        test('empty class', async () => {
+            code = `
+                class Sprite1
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class');
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -3,6 +3,10 @@ import {
     convertAndExpectToEqualBlocks,
     rubyToExpected
 } from '../../../helpers/expect-to-equal-blocks';
+import {
+    makeSpriteTarget,
+    makeConverter
+} from '../../helpers/ruby-roundtrip-helper';
 
 describe('RubyToBlocksConverter/Class', () => {
     let converter;
@@ -390,6 +394,200 @@ describe('RubyToBlocksConverter/Class', () => {
             // set_x outside class should be treated as unknown call
             await converter.targetCodeToBlocks(target, code);
             expect(converter.errors.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('applyTargetBlocks applies classInfo to target', () => {
+        let spriteTarget, runtime, vmConverter;
+
+        beforeEach(() => {
+            ({target: spriteTarget, runtime} = makeSpriteTarget());
+            spriteTarget.sprite = {name: 'スプライト1', costumes: []};
+            vmConverter = makeConverter(spriteTarget, runtime);
+        });
+
+        test('class Sprite1 applies sprite name Sprite1', async () => {
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            // Sprite name should remain 'スプライト1' because class Sprite1 has no name attribute
+            // (Sprite1 matches Sprite%d% pattern, so no name change)
+            expect(spriteTarget.sprite.name).toEqual('スプライト1');
+        });
+
+        test('class Cat applies sprite name Cat', async () => {
+            code = `
+                class Cat
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            expect(spriteTarget.sprite.name).toEqual('Cat');
+        });
+
+        test('set_name applies sprite name', async () => {
+            code = `
+                class Sprite1
+                  set_name "ネコ"
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            expect(spriteTarget.sprite.name).toEqual('ネコ');
+        });
+
+        test('set_x and set_y apply to target', async () => {
+            code = `
+                class Sprite1
+                  set_x 100
+                  set_y -50
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            expect(spriteTarget.x).toEqual(100);
+            expect(spriteTarget.y).toEqual(-50);
+        });
+
+        test('set_direction applies to target', async () => {
+            code = `
+                class Sprite1
+                  set_direction 180
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            expect(spriteTarget.direction).toEqual(180);
+        });
+
+        test('set_visible false applies to target', async () => {
+            spriteTarget.visible = true;
+            code = `
+                class Sprite1
+                  set_visible false
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            expect(spriteTarget.visible).toEqual(false);
+        });
+
+        test('set_size applies to target', async () => {
+            code = `
+                class Sprite1
+                  set_size 50
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            expect(spriteTarget.size).toEqual(50);
+        });
+
+        test('set_rotation_style applies to target', async () => {
+            code = `
+                class Sprite1
+                  set_rotation_style "left-right"
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            expect(spriteTarget.rotationStyle).toEqual('left-right');
+        });
+
+        test('set_current_costume applies to target', async () => {
+            code = `
+                class Sprite1
+                  set_current_costume 2
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            expect(spriteTarget.currentCostume).toEqual(2);
+        });
+
+        test('class without classInfo does not change target attributes', async () => {
+            spriteTarget.x = 10;
+            spriteTarget.y = 20;
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await vmConverter.targetCodeToBlocks(spriteTarget, code);
+            expect(vmConverter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+            await vmConverter.applyTargetBlocks(spriteTarget);
+
+            // x and y should remain unchanged
+            expect(spriteTarget.x).toEqual(10);
+            expect(spriteTarget.y).toEqual(20);
+            expect(spriteTarget.sprite.name).toEqual('スプライト1');
         });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -109,4 +109,99 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(targetComments[0].text).toEqual('@ruby:class');
         });
     });
+
+    describe('class name and set_name', () => {
+        test('class Cat changes sprite name and generates @ruby:class:name', async () => {
+            code = `
+                class Cat
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            expected = await rubyToExpected(converter, target, `
+                self.when(:flag_clicked) do
+                  move(10)
+                end
+            `);
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+            // @ruby:class:name comment should be created
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:name');
+
+            // classInfo should record the new name
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('Cat');
+        });
+
+        test('class Sprite1 with set_name changes sprite name and generates @ruby:class:name', async () => {
+            code = `
+                class Sprite1
+                  set_name "ネコ"
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            expected = await rubyToExpected(converter, target, `
+                self.when(:flag_clicked) do
+                  move(10)
+                end
+            `);
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+            // @ruby:class:name comment should be created
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:name');
+
+            // classInfo should record the set_name value
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('ネコ');
+        });
+
+        test('set_name is not converted to blocks', async () => {
+            code = `
+                class Sprite1
+                  set_name "ネコ"
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            // set_name should not create any blocks
+            const blocks = converter.blocks;
+            const blockOpcodes = Object.values(blocks).map(b => b.opcode);
+            expect(blockOpcodes).not.toContain('ruby_statement');
+        });
+
+        test('class Sprite1 without set_name generates @ruby:class', async () => {
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            // Should be @ruby:class (not @ruby:class:name) since class name matches Sprite%d% pattern
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class');
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -183,10 +183,9 @@ end
             const stage = {isStage: true};
             target.runtime = {targets: [stage, target]};
 
-            RubyGenerator.init();
             RubyGenerator.currentTarget = target;
 
-            const generatedRuby = RubyGenerator.targetToCode(target);
+            const generatedRuby = RubyGenerator.targetToCode(target, {version: '2'});
             expect(generatedRuby.trim()).toEqual((expectedRuby || code).trim());
         };
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -132,4 +132,93 @@ end
     test('complex expression with float literals is preserved', async () => {
         await expectRoundTrip('1.0 / ((1.0 / 3435.0) * Math.log(20.0) + 1.0 / 298.0) - 273.0');
     });
+
+    describe('class syntax round trip', () => {
+        const expectClassRoundTrip = async (code, expectedRuby = null, spriteOptions = {}) => {
+            const result = await converter.targetCodeToBlocks(null, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(result).toBeTruthy();
+
+            const blocks = new Blocks();
+            blocks.forceNoGlow = true;
+            Object.keys(converter.blocks).forEach(blockId => {
+                blocks.createBlock(converter.blocks[blockId]);
+            });
+
+            const variables = {};
+            [converter.variables, converter._context.localVariables].forEach(vars => {
+                Object.values(vars).forEach(v => {
+                    variables[v.id] = v;
+                });
+            });
+
+            const lists = {};
+            Object.values(converter.lists).forEach(v => {
+                lists[v.id] = v;
+            });
+
+            const spriteName = spriteOptions.name || 'Sprite1';
+            const target = {
+                id: 'target-id',
+                blocks: blocks,
+                variables: variables,
+                lists: lists,
+                comments: converter._context.comments,
+                isStage: false,
+                sprite: {name: spriteName, costumes: []},
+                x: spriteOptions.x || 0,
+                y: spriteOptions.y || 0,
+                direction: spriteOptions.direction || 90,
+                visible: spriteOptions.visible !== false,
+                size: spriteOptions.size || 100,
+                currentCostume: spriteOptions.currentCostume || 0,
+                rotationStyle: spriteOptions.rotationStyle || 'all around',
+                lookupVariableById: id => variables[id],
+                lookupVariableByNameAndType: (name, type) => {
+                    return Object.values(variables).find(v => v.name === name && v.type === type);
+                }
+            };
+
+            // Set up runtime.targets mock
+            const stage = {isStage: true};
+            target.runtime = {targets: [stage, target]};
+
+            RubyGenerator.init();
+            RubyGenerator.currentTarget = target;
+
+            const generatedRuby = RubyGenerator.targetToCode(target);
+            expect(generatedRuby.trim()).toEqual((expectedRuby || code).trim());
+        };
+
+        test('basic class Sprite1 round trip', async () => {
+            await expectClassRoundTrip(
+                `class Sprite1\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
+                `class Sprite1\n  when_flag_clicked do\n    move(10)\n  end\nend`
+            );
+        });
+
+        test('class Cat round trip', async () => {
+            await expectClassRoundTrip(
+                `class Cat\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
+                `class Cat\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                {name: 'Cat'}
+            );
+        });
+
+        test('class with set_name round trip', async () => {
+            await expectClassRoundTrip(
+                `class Sprite1\n  set_name "ネコ"\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
+                `class Sprite1\n  set_name "ネコ"\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                {name: 'ネコ'}
+            );
+        });
+
+        test('class with set_x and set_y round trip', async () => {
+            await expectClassRoundTrip(
+                `class Sprite1\n  set_x 100\n  set_y -50\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
+                `class Sprite1\n  set_x 100\n  set_y -50\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                {x: 100, y: -50}
+            );
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -220,5 +220,23 @@ end
                 {x: 100, y: -50}
             );
         });
+
+        test('class with name and set_x round trip', async () => {
+            await expectClassRoundTrip(
+                `class Cat\n  set_x 90\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
+                `class Cat\n  set_x 90\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                {name: 'Cat', x: 90}
+            );
+        });
+
+        test('class without set_xxx does not output attributes', async () => {
+            // Even though sprite has non-default x,y, they should NOT appear
+            // because the class had no set_xxx calls (comment is @ruby:class)
+            await expectClassRoundTrip(
+                `class Sprite1\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
+                `class Sprite1\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                {x: 100, y: -50}
+            );
+        });
     });
 });


### PR DESCRIPTION
## Summary

Ruby タブで `class` 構文によるスプライト定義をサポートするための実装です。

Refs #154

## Changes Made

### Phase 1: 基本 class 構文の Ruby→Blocks 変換
- `visitClassNode` メソッドを `RubyToBlocksConverter` に追加
- class 本体の statements を通常のブロック群として変換
- `@ruby:class` ターゲットコメント（blockId=null）を生成
- 空のクラス、複数イベントハンドラ、class 外のトップレベル文に対応

### Phase 2: class 名・set_name によるスプライト名変更
- `class Cat` のようなカスタムクラス名 → スプライト名として採用
- `set_name "ネコ"` → スプライト名設定
- 大文字始まり → クラス名をそのまま使用、それ以外 → `Sprite%index%` + `set_name`

### Phase 3: set_xxx メソッドによるスプライト属性設定
- `set_x`, `set_y`, `set_direction`, `set_visible`, `set_size`, `set_current_costume`, `set_rotation_style` を classInfo として解析
- 変換時に対応する VM setter メソッドでスプライト属性を実際に更新

### Phase 4: Blocks→Ruby `@ruby:class` コメントから class 構文生成
- `@ruby:class` → `class Sprite1 ... end`
- `@ruby:class:name` → スプライト名に基づくクラス名
- `@ruby:class:x,y,direction` → 指定属性のみ `set_xxx` として出力

### Phase 5: version 2 での set_xxx メソッド生成
- コメントに列挙された属性のみを `set_xxx` として出力
- 属性順序を正規化: `name, x, y, direction, visible, size, current_costume, rotation_style`

### Phase 6: ラウンドトリップテスト
- class 構文 → Blocks → Ruby のラウンドトリップ検証
- `set_xxx` 属性付きラウンドトリップ検証

### 追加修正
- `@ruby:class` コメントをブロック左側に正しく配置
- VM setter メソッド使用による UI 再レンダリング修正
- **version 1 ファイル出力修正**: `@ruby:class` コメント存在時でも version 1 + `withSpriteNew` では `Sprite.new("name", ...)` 形式を使用

## Affected Files

- `packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js` — class 構文パーサー
- `packages/scratch-gui/src/lib/ruby-generator/index.js` — class 構文ジェネレーター
- `packages/scratch-gui/src/containers/ruby-tab.jsx` — デバッグ用グローバル変数追加
- `packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js` — コンバーターテスト (新規)
- `packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js` — ジェネレーターテスト (新規)
- `packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js` — ラウンドトリップテスト更新
- `CLAUDE.md` — ブラウザデバッグ手順追加

## Test Plan

- [x] Phase 1: class 構文基本テスト (4 tests)
- [x] Phase 2: class 名・set_name テスト (5 tests)
- [x] Phase 3: set_xxx メソッドテスト (8 tests)
- [x] Phase 4: Blocks→Ruby class 構文生成テスト (7 tests)
- [x] Phase 5: version 2 set_xxx 生成テスト (8 tests)
- [x] Phase 6: ラウンドトリップテスト (14 tests)
- [x] version 1 ファイル出力テスト (3 tests)
- [x] lint 通過
- [x] 全ユニットテスト通過 (162 suites, 1008 tests)
- [x] Playwright MCP によるブラウザ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
