### PR TITLE
feat: Ruby class 構文の改良 — クラス名保持と class 内バリデーション

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -47,9 +47,10 @@ Produce a structured design and **present it to the user for approval** before c
 ### Commit & PR Strategy
 
 - After each phase completes: run lint → commit → push
-- After the **first push**: create a PR
+- After the **first push**: create a PR with Implementation Steps as a checkbox list
 - Subsequent phases push to the same PR
-- This allows fine-grained progress tracking
+- After each push (except the first): update the PR body to check off the completed phase's checkbox
+- This allows fine-grained progress tracking via PR checkboxes
 
 ### Design Template
 
@@ -71,6 +72,7 @@ One-paragraph description of what the feature does and why.
 3. **[PASS]** lint + unit test confirmation
 4. **[COMMIT & PUSH]** `<type>: <description>`
 5. **[MAKE PR]** (first push only)
+6. **[UPDATE PR]** Check off this phase's checkbox in PR body (after second push onward)
 
 (Repeat for each phase)
 
@@ -106,7 +108,7 @@ cat > /tmp/design-issue-body.md <<'EOF'
 <list>
 
 ## Implementation Steps
-<numbered list>
+<checkbox list using `- [ ]` markdown syntax>
 
 ## Test Plan
 <list>

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -162,7 +162,9 @@ RubyGenerator.finish = function (code, options) {
     // even when @ruby:class comment is present.
     // For version 2, @ruby:class takes priority over withSpriteNew.
     if (classComment && this.version !== '1') {
-        code = this._wrapWithClass(code, classComment);
+        code = this._wrapWithClass(
+            code, classComment, options && options.withSpriteNew
+        );
     } else if (options && options.withSpriteNew) {
         const spriteNewCode = this.spriteNew(this.currentTarget);
         if (code.length > 0) {
@@ -183,7 +185,7 @@ RubyGenerator.finish = function (code, options) {
     return s + code;
 };
 
-RubyGenerator._wrapWithClass = function (code, classComment) {
+RubyGenerator._wrapWithClass = function (code, classComment, forFileOutput) {
     const target = this.currentTarget;
     let className;
     const setLines = [];
@@ -239,10 +241,45 @@ RubyGenerator._wrapWithClass = function (code, classComment) {
         setCode += '\n';
     }
 
+    let outsideCode = '';
+    if (forFileOutput && code.length > 0) {
+        // Split code into top-level sections (separated by blank lines)
+        // and separate hat/def blocks from non-hat code
+        const sections = code.split(/\n\n/);
+        const insideSections = [];
+        const outsideSections = [];
+        for (const section of sections) {
+            const trimmed = section.trim();
+            if (trimmed.length === 0) continue;
+            if (/^self\.when\(/.test(trimmed) ||
+                /^def /.test(trimmed)) {
+                insideSections.push(section);
+            } else {
+                outsideSections.push(section);
+            }
+        }
+        code = insideSections.join('\n\n');
+        if (code.length > 0 && !code.endsWith('\n')) {
+            code += '\n';
+        }
+        if (outsideSections.length > 0) {
+            const commented = outsideSections
+                .join('\n\n')
+                .split('\n')
+                .map(line => (line.trim().length > 0 ? `# ${line}` : ''))
+                .join('\n');
+            outsideCode = `\n${commented}\n`;
+        }
+    }
+
     if (code.length > 0) {
         code = this.prefixLines(code, this.INDENT);
     }
     code = `class ${className}\n${setCode}${code}end\n`;
+
+    if (outsideCode.length > 0) {
+        code += outsideCode;
+    }
 
     return code;
 };

--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -189,13 +189,30 @@ RubyGenerator._wrapWithClass = function (code, classComment) {
     const setLines = [];
 
     // Parse attribute list from @ruby:class:attr1,attr2,...
+    // Support name=ClassName format for preserving class names
     let allowedAttributes = [];
+    let explicitClassName = null;
     if (classComment.startsWith('@ruby:class:')) {
         const attrPart = classComment.slice('@ruby:class:'.length);
         allowedAttributes = attrPart.split(',');
+
+        // Check for name=ClassName in the first attribute
+        const nameAttrIndex = allowedAttributes.findIndex(a => a.startsWith('name='));
+        if (nameAttrIndex >= 0) {
+            explicitClassName = allowedAttributes[nameAttrIndex].slice('name='.length);
+            // Replace name=ClassName with plain 'name' for attribute processing
+            allowedAttributes[nameAttrIndex] = 'name';
+        }
     }
 
-    if (allowedAttributes.indexOf('name') >= 0) {
+    if (explicitClassName) {
+        // Use the explicit class name from name=ClassName
+        className = explicitClassName;
+        const spriteName = target.sprite.name;
+        if (spriteName !== className) {
+            setLines.push(`set_name ${this.quote_(spriteName)}`);
+        }
+    } else if (allowedAttributes.indexOf('name') >= 0) {
         const spriteName = target.sprite.name;
         if (/^[A-Z]/.test(spriteName)) {
             className = spriteName;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -345,9 +345,16 @@ class RubyToBlocksConverter extends Visitor {
         attributeNames.sort((a, b) => ATTR_ORDER.indexOf(a) - ATTR_ORDER.indexOf(b));
 
         // Generate comment text
+        // For non-Sprite\d+ class names, use name=ClassName format to preserve the class name
         let commentText;
         if (attributeNames.length > 0) {
-            commentText = `@ruby:class:${attributeNames.join(',')}`;
+            const commentParts = attributeNames.map(attr => {
+                if (attr === 'name' && !isSpriteIndexName) {
+                    return `name=${className}`;
+                }
+                return attr;
+            });
+            commentText = `@ruby:class:${commentParts.join(',')}`;
         } else {
             commentText = '@ruby:class';
         }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -71,7 +71,15 @@ class RubyToBlocksConverter extends Visitor {
         super();
         this.vm = vm;
         this.version = options && options.version ? options.version : 1;
-        this._translator = message => message.defaultMessage;
+        this._translator = (message, values) => {
+            let text = message.defaultMessage;
+            if (values) {
+                Object.keys(values).forEach(key => {
+                    text = text.replace(new RegExp(`\\{\\s*${key}\\s*\\}`, 'g'), values[key]);
+                });
+            }
+            return text;
+        };
         this._receiverToMethods = {};
         this._receiverToMyBlocks = {};
         this._onIfHandlers = [];
@@ -157,7 +165,7 @@ class RubyToBlocksConverter extends Visitor {
                             block.node,
                             this._translator(
                                 messages.couldNotConvertPrimitive,
-                                {SOURCE: this._getSource(block.node)}
+                                {SOURCE: this._truncateSource(this._getSource(block.node))}
                             )
                         );
                     } else {
@@ -179,7 +187,7 @@ class RubyToBlocksConverter extends Visitor {
                             block.node,
                             this._translator(
                                 messages.wrongInstruction,
-                                {SOURCE: this._getSource(block.node)}
+                                {SOURCE: this._truncateSource(this._getSource(block.node))}
                             )
                         );
                     }
@@ -400,17 +408,14 @@ class RubyToBlocksConverter extends Visitor {
                 if (!block || !block.opcode) continue;
                 const blockType = this._getBlockType(block);
                 if (blockType !== 'hat' && block.opcode !== 'procedures_definition') {
-                    let src = this._getSource(node);
-                    const newlineIndex = src.indexOf('\n');
-                    if (newlineIndex >= 0) {
-                        src = `${src.slice(0, newlineIndex)}...`;
-                    }
-                    if (src.length > 40) {
-                        src = `${src.slice(0, 40)}...`;
-                    }
+                    const errorNode = block.node || node;
+                    const src = this._truncateSource(this._getSource(errorNode));
                     throw new RubyToBlocksConverterError(
-                        node,
-                        `"${src}" is the wrong instruction.`
+                        errorNode,
+                        this._translator(
+                            messages.wrongInstruction,
+                            {SOURCE: src}
+                        )
                     );
                 }
             }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -33,6 +33,12 @@ const messages = defineMessages({
         defaultMessage: '"{ VARIABLE }", can\'t change variable scope',
         description: 'Error message when trying to change variable scope from global to instance or vice versa',
         id: 'gui.smalruby3.rubyToBlocksConverter.cannotChangeVariableScope'
+    },
+    wrongInstructionInClass: {
+        defaultMessage: '"{ SOURCE }" cannot be placed directly inside a class definition.' +
+            ' Use it inside an event block (e.g. when_flag_clicked) or a method definition (def).',
+        description: 'Error message when a non-hat/non-def block is placed directly in a class body',
+        id: 'gui.smalruby3.rubyToBlocksConverter.wrongInstructionInClass'
     }
 });
 
@@ -393,13 +399,18 @@ class RubyToBlocksConverter extends Visitor {
 
             // Visit filtered statements manually
             const blocks = [];
+            const blockToStmt = new Map();
             for (const stmt of filteredStatements) {
                 this._context.methodCallIndices = {};
                 const block = this.visit(stmt);
                 if (Array.isArray(block)) {
-                    block.forEach(b => blocks.push(b));
+                    block.forEach(b => {
+                        blocks.push(b);
+                        blockToStmt.set(b, stmt);
+                    });
                 } else if (block !== null && typeof block !== 'undefined') {
                     blocks.push(block);
+                    blockToStmt.set(block, stmt);
                 }
             }
 
@@ -408,12 +419,12 @@ class RubyToBlocksConverter extends Visitor {
                 if (!block || !block.opcode) continue;
                 const blockType = this._getBlockType(block);
                 if (blockType !== 'hat' && block.opcode !== 'procedures_definition') {
-                    const errorNode = block.node || node;
+                    const errorNode = block.node || blockToStmt.get(block) || node;
                     const src = this._truncateSource(this._getSource(errorNode));
                     throw new RubyToBlocksConverterError(
                         errorNode,
                         this._translator(
-                            messages.wrongInstruction,
+                            messages.wrongInstructionInClass,
                             {SOURCE: src}
                         )
                     );

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -394,6 +394,20 @@ class RubyToBlocksConverter extends Visitor {
                     blocks.push(block);
                 }
             }
+
+            // Validate: only hat blocks and procedures_definition are allowed at class top-level
+            for (const block of blocks) {
+                if (!block || !block.opcode) continue;
+                const blockType = this._getBlockType(block);
+                if (blockType !== 'hat' && block.opcode !== 'procedures_definition') {
+                    const src = this._getSource(node);
+                    throw new RubyToBlocksConverterError(
+                        node,
+                        `"${src}" is the wrong instruction.`
+                    );
+                }
+            }
+
             return blocks;
         }
         return [];

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -400,7 +400,14 @@ class RubyToBlocksConverter extends Visitor {
                 if (!block || !block.opcode) continue;
                 const blockType = this._getBlockType(block);
                 if (blockType !== 'hat' && block.opcode !== 'procedures_definition') {
-                    const src = this._getSource(node);
+                    let src = this._getSource(node);
+                    const newlineIndex = src.indexOf('\n');
+                    if (newlineIndex >= 0) {
+                        src = `${src.slice(0, newlineIndex)}...`;
+                    }
+                    if (src.length > 40) {
+                        src = `${src.slice(0, 40)}...`;
+                    }
                     throw new RubyToBlocksConverterError(
                         node,
                         `"${src}" is the wrong instruction.`

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/my-blocks.js
@@ -360,7 +360,8 @@ const MyBlocksConverter = {
                             }
                         }
                     }
-                    const msg = `${bNode ? bNode.source : ''} is the wrong instruction.`;
+                    const src = converter._truncateSource(bNode ? bNode.source : '');
+                    const msg = `"${src}" is the wrong instruction.`;
                     throw new RubyToBlocksConverterError(bNode, msg);
                 }
             });

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
@@ -288,6 +288,18 @@ const NodeUtils = {
         return this._context.sourceCode.slice(startOffset, startOffset + length);
     },
 
+    _truncateSource (src, maxLength = 40) {
+        if (!src) return src;
+        const newlineIndex = src.indexOf('\n');
+        if (newlineIndex >= 0) {
+            src = `${src.slice(0, newlineIndex)}...`;
+        }
+        if (src.length > maxLength) {
+            src = `${src.slice(0, maxLength)}...`;
+        }
+        return src;
+    },
+
     _getLineForOffset (byteOffset) {
         if (typeof byteOffset !== 'number' || !this._context.sourceCode) {
             return 1;
@@ -384,7 +396,7 @@ const NodeUtils = {
             column: column,
             type: 'error',
             text: message,
-            source: source
+            source: this._truncateSource(source)
         };
     }
 };

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -29,6 +29,7 @@ export default {
     'gui.extensionLibrary.koshienOnlyAvailableForRubyV1': 'The Koshien extension is only available for Ruby v1',
     'gui.smalruby3.rubyToBlocksConverter.couldNotConvertPrimitive': '"{ SOURCE }" could not be converted the block.',
     'gui.smalruby3.rubyToBlocksConverter.wrongInstruction': '"{ SOURCE }" is the wrong instruction.',
+    'gui.smalruby3.rubyToBlocksConverter.wrongInstructionInClass': '"{ SOURCE }" cannot be placed directly inside a class definition. Use it inside an event block (e.g. when_flag_clicked) or a method definition (def).',
     'gui.smalruby3.telemetryOptIn.buttonTextYes': "Yes, I'd like to help improve Smalruby",
     'gui.smalruby3.extension.mesh.name': 'Old Mesh',
     'gui.smalruby3.extension.mesh.description': 'Allowing users to interact over a computer network.',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -87,6 +87,7 @@ export default {
     'gui.telemetryOptIn.buttonTextNo': 'いいえ、けっこうです。',
     'gui.smalruby3.rubyToBlocksConverter.couldNotConvertPrimitive': '「{ SOURCE }」はブロックにへんかんできません。',
     'gui.smalruby3.rubyToBlocksConverter.wrongInstruction': '「{ SOURCE }」はめいれいがまちがっています。',
+    'gui.smalruby3.rubyToBlocksConverter.wrongInstructionInClass': '「{ SOURCE }」はclassていぎのなかにちょくせつおくことはできません。イベントブロック（れい: when_flag_clicked）やメソッドていぎ（def）のなかでつかってください。',
     'gui.smalruby3.telemetryOptIn.buttonTextYes': 'はい、スモウルビーのかいぜんにきょうりょくします。',
     'gui.smalruby3.extension.mesh.name': 'じゅうらいのメッシュ',
     'gui.smalruby3.extension.mesh.description': 'ネットワークじょうでユーザーかんのやりとりを おこなう。',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -87,6 +87,7 @@ export default {
     'gui.telemetryOptIn.buttonTextNo': 'いいえ、結構です。',
     'gui.smalruby3.rubyToBlocksConverter.couldNotConvertPrimitive': '「{ SOURCE }」はブロックに変換できません。',
     'gui.smalruby3.rubyToBlocksConverter.wrongInstruction': '「{ SOURCE }」は命令がまちがっています。',
+    'gui.smalruby3.rubyToBlocksConverter.wrongInstructionInClass': '「{ SOURCE }」はclass定義の中に直接置くことはできません。イベントブロック（例: when_flag_clicked）やメソッド定義（def）の中で使ってください。',
     'gui.smalruby3.telemetryOptIn.buttonTextYes': 'はい、スモウルビーの改善に協力します。',
     'gui.smalruby3.extension.mesh.name': '従来のメッシュ',
     'gui.smalruby3.extension.mesh.description': 'ネットワーク上でユーザー間のやりとりを行う。',

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
@@ -90,6 +90,60 @@ describe('RubyGenerator/Class', () => {
             expect(result).toContain('set_name "ネコ"');
         });
 
+        test('@ruby:class:name=Cat with different sprite name generates set_name', () => {
+            const {target, runtime} = makeMockTarget('ネコ', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name=Cat'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Cat');
+            expect(result).not.toContain('class Sprite1');
+            // When class name (Cat) differs from sprite name (ネコ), set_name should be generated
+            expect(result).toContain('set_name "ネコ"');
+            expect(result).not.toContain('# @ruby:class');
+        });
+
+        test('@ruby:class:name=Cat with same sprite name does not generate set_name', () => {
+            const {target, runtime} = makeMockTarget('Cat', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name=Cat'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Cat');
+            expect(result).not.toContain('set_name');
+        });
+
+        test('@ruby:class:name=Cat,x,y uses Cat and generates set_xxx', () => {
+            const {target, runtime} = makeMockTarget('ネコ', 1);
+            target.runtime = runtime;
+            target.x = 100;
+            target.y = -50;
+            target.direction = 180;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name=Cat,x,y'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Cat');
+            expect(result).toContain('set_name "ネコ"');
+            expect(result).toContain('set_x 100');
+            expect(result).toContain('set_y -50');
+            expect(result).not.toContain('set_direction');
+        });
+
         test('no @ruby:class comment does not wrap with class', () => {
             RubyGenerator.cache_.targetCommentTexts = [];
 

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
@@ -374,6 +374,40 @@ describe('RubyGenerator/Class', () => {
         });
     });
 
+    describe('top-level code outside class (version 2 file output)', () => {
+        test('non-hat code after class end is commented out in version 2 file output', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            // hat code + non-hat code (separated by blank line as in real output)
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n\nmove(10)\n';
+            const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+            expect(result).toContain('class Sprite1');
+            // hat code should be inside class
+            expect(result).toContain('  self.when(:flag_clicked) do');
+            // non-hat code should be outside class and commented out
+            expect(result).toMatch(/^# move\(10\)$/m);
+        });
+
+        test('non-hat code is not commented out in Ruby tab (no withSpriteNew)', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n\nmove(10)\n';
+            const result = RubyGenerator.finish(code, {});
+
+            expect(result).toContain('class Sprite1');
+            // In Ruby tab (no withSpriteNew), non-hat code should be inside class, not commented
+            expect(result).toContain('  move(10)');
+            expect(result).not.toMatch(/^# move\(10\)$/m);
+        });
+    });
+
     describe('withSpriteNew (version 1 file output)', () => {
         test('@ruby:class with withSpriteNew uses Sprite.new instead of class', () => {
             RubyGenerator.init({version: '1'});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class-error-message.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class-error-message.test.js
@@ -16,6 +16,15 @@ describe('Class error message', () => {
         expect(converter.errors[0].text).toMatch(/when_key_pressed/);
     });
 
+    test('non-hat block inside class mentions class definition in error', async () => {
+        const code = 'class Sprite1\n  move(10)\nend';
+        await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors.length).toBeGreaterThan(0);
+        expect(converter.errors[0].text).toMatch(/move\(10\)/);
+        expect(converter.errors[0].text).toMatch(/class definition/);
+        expect(converter.errors[0].text).toMatch(/event block|when_flag_clicked|def/);
+    });
+
     test('error message does not contain newlines', async () => {
         const code = 'class Sprite1\n  self.when(:flag_clicked) do\n    move(10)\n  end\n  move(10)\nend';
         await converter.targetCodeToBlocks(target, code);

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class-error-message.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class-error-message.test.js
@@ -1,0 +1,42 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+
+describe('Class error message', () => {
+    let converter;
+    const target = null;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null);
+    });
+
+    test('invalid key inside class reports the statement, not the class', async () => {
+        const code = 'class Sprite1\n  when_key_pressed("invalid") do\n  end\nend';
+        await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors.length).toBeGreaterThan(0);
+        expect(converter.errors[0].text).not.toMatch(/class Sprite1/);
+        expect(converter.errors[0].text).toMatch(/when_key_pressed/);
+    });
+
+    test('error message does not contain newlines', async () => {
+        const code = 'class Sprite1\n  self.when(:flag_clicked) do\n    move(10)\n  end\n  move(10)\nend';
+        await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors.length).toBeGreaterThan(0);
+        expect(converter.errors[0].text).not.toMatch(/\n/);
+    });
+
+    test('error source is truncated', async () => {
+        const code = 'when_key_pressed("invalid") do\nend';
+        await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors.length).toBeGreaterThan(0);
+        expect(converter.errors[0].source).not.toMatch(/\n/);
+        expect(converter.errors[0].source).toMatch(/\.\.\.$/);
+    });
+
+    test('top-level wrongInstruction error has SOURCE expanded', async () => {
+        const code = 'when_key_pressed("invalid") do\nend';
+        await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors.length).toBeGreaterThan(0);
+        // {SOURCE} placeholder should be replaced with actual source
+        expect(converter.errors[0].text).not.toMatch(/\{SOURCE\}/);
+        expect(converter.errors[0].text).toMatch(/when_key_pressed/);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -508,6 +508,22 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(converter.errors.length).toBeGreaterThan(0);
         });
 
+        test('error message truncates at newline', async () => {
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                  move(10)
+                end
+            `;
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors.length).toBeGreaterThan(0);
+            const errorText = converter.errors[0].text;
+            expect(errorText).not.toMatch(/\n/);
+            expect(errorText).toMatch(/\.\.\."/);
+        });
+
         test('hat block inside class is allowed', async () => {
             code = `
                 class Sprite1

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -508,7 +508,7 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(converter.errors.length).toBeGreaterThan(0);
         });
 
-        test('error message truncates at newline', async () => {
+        test('error message reports the specific statement, not the class', async () => {
             code = `
                 class Sprite1
                   self.when(:flag_clicked) do
@@ -521,7 +521,9 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(converter.errors.length).toBeGreaterThan(0);
             const errorText = converter.errors[0].text;
             expect(errorText).not.toMatch(/\n/);
-            expect(errorText).toMatch(/\.\.\."/);
+            expect(errorText).toMatch(/move\(10\)/);
+            expect(errorText).not.toMatch(/class Sprite1/);
+            expect(errorText).toMatch(/class definition/);
         });
 
         test('hat block inside class is allowed', async () => {

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -115,7 +115,7 @@ describe('RubyToBlocksConverter/Class', () => {
     });
 
     describe('class name and set_name', () => {
-        test('class Cat changes sprite name and generates @ruby:class:name', async () => {
+        test('class Cat changes sprite name and generates @ruby:class:name=Cat', async () => {
             code = `
                 class Cat
                   self.when(:flag_clicked) do
@@ -130,11 +130,11 @@ describe('RubyToBlocksConverter/Class', () => {
             `);
             await convertAndExpectToEqualBlocks(converter, target, code, expected);
 
-            // @ruby:class:name comment should be created
+            // @ruby:class:name=Cat comment should be created
             const comments = converter._context.comments;
             const targetComments = Object.values(comments).filter(c => c.blockId === null);
             expect(targetComments).toHaveLength(1);
-            expect(targetComments[0].text).toEqual('@ruby:class:name');
+            expect(targetComments[0].text).toEqual('@ruby:class:name=Cat');
 
             // classInfo should record the new name
             expect(converter._context.classInfo).toBeDefined();
@@ -335,7 +335,7 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(blockOpcodes).not.toContain('ruby_statement');
         });
 
-        test('class Cat with set_x generates @ruby:class:name,x', async () => {
+        test('class Cat with set_x generates @ruby:class:name=Cat,x', async () => {
             code = `
                 class Cat
                   set_x 100
@@ -352,7 +352,7 @@ describe('RubyToBlocksConverter/Class', () => {
             const comments = converter._context.comments;
             const targetComments = Object.values(comments).filter(c => c.blockId === null);
             expect(targetComments).toHaveLength(1);
-            expect(targetComments[0].text).toEqual('@ruby:class:name,x');
+            expect(targetComments[0].text).toEqual('@ruby:class:name=Cat,x');
 
             expect(converter._context.classInfo).toBeDefined();
             expect(converter._context.classInfo.name).toEqual('Cat');
@@ -381,6 +381,96 @@ describe('RubyToBlocksConverter/Class', () => {
 
             expect(converter._context.classInfo).toBeDefined();
             expect(converter._context.classInfo.name).toEqual('ネコ');
+            expect(converter._context.classInfo.x).toEqual(100);
+        });
+
+        test('class Cat with set_name generates @ruby:class:name=Cat', async () => {
+            code = `
+                class Cat
+                  set_name "ネコ"
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            // name=Cat preserves class name; set_name value is in classInfo.name
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:name=Cat');
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('ネコ');
+        });
+
+        test('class Cat without set_name generates @ruby:class:name=Cat', async () => {
+            code = `
+                class Cat
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:name=Cat');
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('Cat');
+        });
+
+        test('class Sprite1 with set_name still generates @ruby:class:name (no name=)', async () => {
+            code = `
+                class Sprite1
+                  set_name "ネコ"
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            // Sprite\d+ pattern should NOT have name= prefix
+            expect(targetComments[0].text).toEqual('@ruby:class:name');
+        });
+
+        test('class Cat with set_x generates @ruby:class:name=Cat,x', async () => {
+            code = `
+                class Cat
+                  set_x 100
+
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            const comments = converter._context.comments;
+            const targetComments = Object.values(comments).filter(c => c.blockId === null);
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toEqual('@ruby:class:name=Cat,x');
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('Cat');
             expect(converter._context.classInfo.x).toEqual(100);
         });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -487,6 +487,72 @@ describe('RubyToBlocksConverter/Class', () => {
         });
     });
 
+    describe('class body validation', () => {
+        test('value block inside class generates error', async () => {
+            code = `
+                class Sprite1
+                  1 + 2
+                end
+            `;
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors.length).toBeGreaterThan(0);
+        });
+
+        test('non-hat statement block inside class generates error', async () => {
+            code = `
+                class Sprite1
+                  move(10)
+                end
+            `;
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors.length).toBeGreaterThan(0);
+        });
+
+        test('hat block inside class is allowed', async () => {
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+        });
+
+        test('def (procedures_definition) inside class is allowed', async () => {
+            code = `
+                class Sprite1
+                  def func
+                    move(10)
+                  end
+
+                  self.when(:flag_clicked) do
+                    func
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+        });
+
+        test('hat block with non-hat statement after it inside class is allowed', async () => {
+            code = `
+                class Sprite1
+                  self.when(:flag_clicked) do
+                    move(10)
+                    bounce_if_on_edge
+                  end
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+        });
+    });
+
     describe('applyTargetBlocks applies classInfo to target', () => {
         let spriteTarget, runtime, vmConverter;
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control3.test.js
@@ -120,7 +120,7 @@ describe('RubyToBlocksConverter/Control', () => {
                 const result = await converter.targetCodeToBlocks(stageTarget, command);
                 expect(result).toBeFalsy();
                 expect(converter.errors).toHaveLength(1);
-                expect(converter.errors[0].text).toMatch(/"\{SOURCE\}" is the wrong instruction\./);
+                expect(converter.errors[0].text).toMatch(/is the wrong instruction\./);
                 converter.reset();
             }
         });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks6.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks6.test.js
@@ -58,7 +58,7 @@ describe('RubyToBlocksConverter/Looks', () => {
                 const res = await converter.targetCodeToBlocks(stageTarget, code);
                 expect(res).toBeFalsy();
                 expect(converter.errors).toHaveLength(1);
-                expect(converter.errors[0].text).toMatch(/"\{SOURCE\}" is the wrong instruction\./);
+                expect(converter.errors[0].text).toMatch(/is the wrong instruction\./);
                 
                 // Reset for next test
                 converter.reset();

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion3.test.js
@@ -245,7 +245,7 @@ describe('RubyToBlocksConverter/Motion', () => {
                 const res = await converter.targetCodeToBlocks(stageTarget, code);
                 expect(res).toBeFalsy();
                 expect(converter.errors).toHaveLength(1);
-                expect(converter.errors[0].text).toMatch(/"\{SOURCE\}" is the wrong instruction\./);
+                expect(converter.errors[0].text).toMatch(/is the wrong instruction\./);
                 
                 // Reset for next test
                 converter.reset();

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -228,6 +228,22 @@ end
             );
         });
 
+        test('class Cat with set_name round trip preserves class name', async () => {
+            await expectClassRoundTrip(
+                `class Cat\n  set_name "ネコ"\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
+                `class Cat\n  set_name "ネコ"\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                {name: 'ネコ'}
+            );
+        });
+
+        test('class Cat with set_name and set_x round trip', async () => {
+            await expectClassRoundTrip(
+                `class Cat\n  set_name "ネコ"\n  set_x 100\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
+                `class Cat\n  set_name "ネコ"\n  set_x 100\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                {name: 'ネコ', x: 100}
+            );
+        });
+
         test('class without set_xxx does not output attributes', async () => {
             // Even though sprite has non-default x,y, they should NOT appear
             // because the class had no set_xxx calls (comment is @ruby:class)

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing5.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing5.test.js
@@ -124,7 +124,7 @@ describe('RubyToBlocksConverter/Sensing', () => {
                 const result = await converter.targetCodeToBlocks(stageTarget, command);
                 expect(result).toBeFalsy();
                 expect(converter.errors).toHaveLength(1);
-                expect(converter.errors[0].text).toMatch(/"\{SOURCE\}" is the wrong instruction\./);
+                expect(converter.errors[0].text).toMatch(/is the wrong instruction\./);
                 converter.reset();
             }
         });


### PR DESCRIPTION
## Summary

Ruby class 構文の改良 — クラス名保持と class 内バリデーション (#156)

- `class Cat` のようなカスタムクラス名がラウンドトリップ後に `Sprite1` に変わってしまう問題を修正
- class 内に hat/def 以外のブロックがあった場合のエラー検出
- version 2 ファイル出力時の class 外コードのコメントアウト

## Implementation Steps

- [x] **Phase 1**: クラス名保持 — Ruby → Blocks (`visitClassNode` の `name=` 対応)
- [x] **Phase 2**: クラス名保持 — Blocks → Ruby (`_wrapWithClass` の `name=` 解析)
- [x] **Phase 3**: class 内ブロックのバリデーション
- [x] **Phase 4**: class 外トップレベル文の version 2 コメントアウト
- [x] **Phase 5**: Integration Tests (post-implementation)

## Test Plan

- Unit tests (TDD): visitClassNode name= 生成、_wrapWithClass name= 解析、バリデーション、コメントアウト
- Round-trip tests: Cat + set_name ラウンドトリップ、バリデーションエラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)
