### PR TITLE
fix: class 内 set_xxx フィルタリングが production ビルドで動作しない

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -238,7 +238,6 @@ RubyGenerator._wrapWithClass = function (code, classComment, forFileOutput) {
     let setCode = '';
     if (setLines.length > 0) {
         setCode = setLines.map(line => `${this.INDENT}${line}\n`).join('');
-        setCode += '\n';
     }
 
     let outsideCode = '';
@@ -275,7 +274,8 @@ RubyGenerator._wrapWithClass = function (code, classComment, forFileOutput) {
     if (code.length > 0) {
         code = this.prefixLines(code, this.INDENT);
     }
-    code = `class ${className}\n${setCode}${code}end\n`;
+    const separator = setCode.length > 0 && code.length > 0 ? '\n' : '';
+    code = `class ${className}\n${setCode}${separator}${code}end\n`;
 
     if (outsideCode.length > 0) {
         code += outsideCode;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -154,9 +154,10 @@ class RubyToBlocksConverter extends Visitor {
             }
             // Link blocks if root is not a begin node (begin nodes handle linking internally)
             // This is needed for cases like "text = gets" where a single statement returns multiple blocks
-            if (root.constructor.name !== 'StatementsNode' &&
-                root.constructor.name !== 'ProgramNode' &&
-                root.constructor.name !== 'BeginNode') {
+            const rootType = this._getNodeTypeName(root);
+            if (rootType !== 'StatementsNode' &&
+                rootType !== 'ProgramNode' &&
+                rootType !== 'BeginNode') {
                 blocks = this._linkBlocks(blocks);
             }
             blocks.forEach(block => {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -300,6 +300,24 @@ class RubyToBlocksConverter extends Visitor {
         return result;
     }
 
+    // Get the node type name using accept()-based sniffing, which is safe
+    // against minification (constructor.name is mangled by esbuild/terser).
+    // Returns e.g. 'CallNode', 'StringNode', 'IntegerNode', etc.
+    _getNodeTypeName (node) {
+        let handlerName = null;
+        const sniffer = new Proxy({}, {
+            get (_target, prop) {
+                if (typeof prop === 'string' && prop.startsWith('visit')) {
+                    handlerName = prop;
+                }
+                return () => {};
+            }
+        });
+        node.accept(sniffer);
+        // handlerName is e.g. 'visitCallNode' -> extract 'CallNode'
+        return handlerName ? handlerName.slice('visit'.length) : null;
+    }
+
     visitProgramNode (node) {
         return this.visit(node.statements);
     }
@@ -334,7 +352,7 @@ class RubyToBlocksConverter extends Visitor {
         const setMethodNames = new Set();
         if (node.body && node.body.body) {
             for (const stmt of node.body.body) {
-                if (stmt.constructor.name === 'CallNode' &&
+                if (this._getNodeTypeName(stmt) === 'CallNode' &&
                     SET_METHODS[stmt.name] &&
                     !stmt.receiver &&
                     stmt.arguments_ &&
@@ -385,7 +403,7 @@ class RubyToBlocksConverter extends Visitor {
         // Visit class body, filtering out set_xxx calls
         if (node.body && node.body.body) {
             const filteredStatements = node.body.body.filter(stmt => {
-                if (stmt.constructor.name === 'CallNode' &&
+                if (this._getNodeTypeName(stmt) === 'CallNode' &&
                     setMethodNames.has(stmt.name) &&
                     !stmt.receiver) {
                     return false;
@@ -437,7 +455,7 @@ class RubyToBlocksConverter extends Visitor {
     }
 
     _extractClassMethodArg (argNode) {
-        const type = argNode.constructor.name;
+        const type = this._getNodeTypeName(argNode);
         switch (type) {
         case 'StringNode': {
             const unescaped = argNode.unescaped;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -485,6 +485,64 @@ describe('RubyToBlocksConverter/Class', () => {
             await converter.targetCodeToBlocks(target, code);
             expect(converter.errors.length).toBeGreaterThan(0);
         });
+
+        test('class with only set_name converts without error', async () => {
+            code = `
+                class Sprite1
+                  set_name "ネコ"
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('ネコ');
+        });
+
+        test('class with only set_x and set_y converts without error', async () => {
+            code = `
+                class Sprite1
+                  set_x 100
+                  set_y -50
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.x).toEqual(100);
+            expect(converter._context.classInfo.y).toEqual(-50);
+        });
+
+        test('class with all set_xxx only converts without error', async () => {
+            code = `
+                class Sprite1
+                  set_name "ネコ"
+                  set_x 100
+                  set_y -50
+                  set_direction 180
+                  set_visible false
+                  set_size 50
+                  set_current_costume 2
+                  set_rotation_style "left-right"
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+
+            expect(converter._context.classInfo).toBeDefined();
+            expect(converter._context.classInfo.name).toEqual('ネコ');
+            expect(converter._context.classInfo.x).toEqual(100);
+            expect(converter._context.classInfo.y).toEqual(-50);
+            expect(converter._context.classInfo.direction).toEqual(180);
+            expect(converter._context.classInfo.visible).toEqual(false);
+            expect(converter._context.classInfo.size).toEqual(50);
+            expect(converter._context.classInfo.current_costume).toEqual(2);
+            expect(converter._context.classInfo.rotation_style).toEqual('left-right');
+        });
     });
 
     describe('class body validation', () => {

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -253,5 +253,29 @@ end
                 {x: 100, y: -50}
             );
         });
+
+        test('class with only set_name round trip', async () => {
+            await expectClassRoundTrip(
+                `class Sprite1\n  set_name "ネコ"\nend`,
+                `class Sprite1\n  set_name "ネコ"\nend`,
+                {name: 'ネコ'}
+            );
+        });
+
+        test('class with only set_x and set_y round trip', async () => {
+            await expectClassRoundTrip(
+                `class Sprite1\n  set_x 100\n  set_y -50\nend`,
+                `class Sprite1\n  set_x 100\n  set_y -50\nend`,
+                {x: 100, y: -50}
+            );
+        });
+
+        test('class with all set_xxx only round trip', async () => {
+            await expectClassRoundTrip(
+                `class Sprite1\n  set_name "ネコ"\n  set_x 100\n  set_y -50\n  set_direction 180\n  set_visible false\n  set_size 50\n  set_current_costume 2\n  set_rotation_style "left-right"\nend`,
+                `class Sprite1\n  set_name "ネコ"\n  set_x 100\n  set_y -50\n  set_direction 180\n  set_visible false\n  set_size 50\n  set_current_costume 2\n  set_rotation_style "left-right"\nend`,
+                {name: 'ネコ', x: 100, y: -50, direction: 180, visible: false, size: 50, currentCostume: 2, rotationStyle: 'left-right'}
+            );
+        });
     });
 });


### PR DESCRIPTION
## Summary

class 内 `set_xxx` メソッド（`set_name`, `set_x`, `set_y`, `set_direction`, `set_visible`, `set_size`, `set_current_costume`, `set_rotation_style`）のフィルタリングが production ビルドで動作しない問題を修正する。

`constructor.name` は esbuild/terser でマングルされるため、`accept()` ベースの Proxy sniffer パターンで安全にノードタイプを判定する `_getNodeTypeName()` ヘルパーを追加し、`visitClassNode`、`_extractClassMethodArg`、`targetCodeToBlocks` の判定を置き換えた。

また、`set_xxx` のみのクラスボディ（イベントブロックなし）で `_wrapWithClass` が末尾に不要な空行を出力する問題も修正した。

Fixes #158

## Implementation Steps

- [x] **Phase 1**: `_getNodeTypeName` ヘルパー追加と `visitClassNode` / `_extractClassMethodArg` の修正
- [x] **Phase 2**: `targetCodeToBlocks` 内の `constructor.name` 修正
- [x] **Phase Final**: Integration Tests（ラウンドトリップテスト + `_wrapWithClass` 空行修正）

## Test Plan

- [x] 既存テストすべてパス（73スイート、614テスト）
- [x] `set_name` のみの class ボディが正常変換される新テスト追加
- [x] `set_x`/`set_y` のみの class ボディが正常変換される新テスト追加
- [x] 全 `set_xxx` のみの class ボディが正常変換される新テスト追加
- [x] `set_xxx` のみの class ボディのラウンドトリップテスト追加（3件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
