### PR TITLE
fix: clear previous errors when execute button is pressed in Ruby tab

### DIFF
--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -611,6 +611,9 @@ class RubyTab extends React.Component {
             return;
         }
 
+        // Clear any previous errors before starting a new execution
+        this.clearErrors();
+
         // Find the actual line to execute (skip empty lines)
         const rubyCode = this.props.rubyCode.code;
         const lines = rubyCode.split('\n');

--- a/packages/scratch-gui/test/helpers/ruby-helper.js
+++ b/packages/scratch-gui/test/helpers/ruby-helper.js
@@ -12,6 +12,7 @@ class RubyHelper {
             'getErrors',
             'getErrorOnLine',
             'waitForErrorOnLine',
+            'waitForNoErrors',
             'dismissAlertsIfPresent',
             'expectInterconvertBetweenCodeAndRuby'
         ]);
@@ -60,6 +61,13 @@ class RubyHelper {
         return this.driver.wait(async () => {
             const error = await this.getErrorOnLine(line);
             return !!error;
+        }, 5000);
+    }
+
+    async waitForNoErrors () {
+        return this.driver.wait(async () => {
+            const errors = await this.getErrors();
+            return errors.length === 0;
         }, 5000);
     }
 

--- a/packages/scratch-gui/test/integration/ruby-tab.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab.test.js
@@ -27,7 +27,8 @@ const rubyHelper = new RubyHelper(seleniumHelper);
 const {
     fillInRubyProgram,
     currentRubyProgram,
-    waitForErrorOnLine
+    waitForErrorOnLine,
+    waitForNoErrors
 } = rubyHelper;
 
 const uri = path.resolve(__dirname, '../../build/index.html');
@@ -121,6 +122,21 @@ describe('convert Code from Ruby', () => {
                     'span[text()="Could not convert Ruby to Code. Please fix Ruby!"]'
             );
             await waitForErrorOnLine(1);
+        });
+
+        test('errors cleared when executing fixed code with Go button', async () => {
+            // First, trigger errors by clicking Go with invalid code
+            await clickXpath('//img[@title="Go"]');
+            await waitForErrorOnLine(1);
+
+            // Fix the code
+            await fillInRubyProgram('move(10)');
+
+            // Execute the fixed code
+            await clickXpath('//img[@title="Go"]');
+
+            // Verify that errors are cleared
+            await waitForNoErrors();
         });
 
         test('recover with "Generate Ruby from Code" menu', async () => {


### PR DESCRIPTION
## Summary

- Rubyタブで実行ボタンを押したとき、前回のエラー表示（Monacoエディタのマーカーとナビゲーションウィジェット）をクリアするようにした
- `handleExecuteLine` の停止処理の後、変換処理の前に `clearErrors()` を呼び出す

## Implementation Steps

- [x] `handleExecuteLine` に `clearErrors()` 呼び出しを追加
- [x] 統合テストを追加

## Test Plan

- [x] lint pass
- [x] unit tests pass
- [x] integration tests: エラーコード実行 → 修正 → 再実行でエラーがクリアされることを確認

Fixes #162
