### PR TITLE
feat: unless / if修飾子の round-trip 保持（コメントアノテーション方式）

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -69,16 +69,29 @@ export default function (Generator) {
         if (comment === '@ruby:syntax:unless_else') {
             return {hasElse: true};
         }
+        if (comment === '@ruby:syntax:unless_modifier') {
+            return {isModifier: true};
+        }
         return null;
+    };
+
+    // Extract condition from inside operator_not wrapper.
+    // unless blocks store condition as operator_not(original_cond),
+    // so we need to unwrap it to get the original condition for "unless" keyword output.
+    const getUnlessCondition = function (block) {
+        const condBlockId = block.inputs.CONDITION ? block.inputs.CONDITION.block : null;
+        const condBlock = condBlockId ? Generator.getBlock(condBlockId) : null;
+        if (condBlock && condBlock.opcode === 'operator_not') {
+            return Generator.valueToCode(condBlock, 'OPERAND', Generator.ORDER_NONE) || false;
+        }
+        // Fallback: use the full condition as-is
+        return Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
     };
 
     const getModifierInfo = function (block) {
         const comment = Generator.getCommentText(block);
         if (comment === '@ruby:syntax:if_modifier') {
             return 'if';
-        }
-        if (comment === '@ruby:syntax:unless_modifier') {
-            return 'unless';
         }
         return null;
     };
@@ -90,6 +103,15 @@ export default function (Generator) {
             if (content) {
                 return `case ${caseInfo.subject}\n${content}end\n`;
             }
+        }
+        const unlessInfo = getUnlessInfo(block);
+        if (unlessInfo) {
+            const operator = getUnlessCondition(block);
+            const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
+            if (unlessInfo.isModifier) {
+                return `${branch.trim()} unless ${operator}\n`;
+            }
+            return `unless ${operator}\n${branch}end\n`;
         }
         const modifierKeyword = getModifierInfo(block);
         if (modifierKeyword) {
@@ -147,25 +169,13 @@ export default function (Generator) {
                 return `case ${caseInfo.subject}\n${content}end\n`;
             }
         }
-        const modifierKeyword = getModifierInfo(block);
-        if (modifierKeyword) {
-            const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
-            // For unless modifier, body is in SUBSTACK2 (swapped by visitUnlessNode)
-            const body = modifierKeyword === 'unless' ?
-                Generator.statementToCode(block, 'SUBSTACK2') || '' :
-                Generator.statementToCode(block, 'SUBSTACK') || '';
-            return `${body.trim()} ${modifierKeyword} ${operator}\n`;
-        }
         const unlessInfo = getUnlessInfo(block);
-        if (unlessInfo) {
-            const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
-            // Swap branches back: SUBSTACK2 was the original unless-then, SUBSTACK was unless-else
-            const unlessThen = Generator.statementToCode(block, 'SUBSTACK2') || '';
-            const unlessElse = Generator.statementToCode(block, 'SUBSTACK') || '';
-            if (unlessInfo.hasElse) {
-                return `unless ${operator}\n${unlessThen}else\n${unlessElse}end\n`;
-            }
-            return `unless ${operator}\n${unlessThen}end\n`;
+        if (unlessInfo && unlessInfo.hasElse) {
+            const operator = getUnlessCondition(block);
+            // Branches are in natural order: SUBSTACK = unless-then, SUBSTACK2 = unless-else
+            const unlessThen = Generator.statementToCode(block, 'SUBSTACK') || '';
+            const unlessElse = Generator.statementToCode(block, 'SUBSTACK2') || '';
+            return `unless ${operator}\n${unlessThen}else\n${unlessElse}end\n`;
         }
         const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
         const branch = Generator.statementToCode(block, 'SUBSTACK') || '';

--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -61,6 +61,17 @@ export default function (Generator) {
         return result;
     };
 
+    const getUnlessInfo = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment === '@ruby:syntax:unless') {
+            return {hasElse: false};
+        }
+        if (comment === '@ruby:syntax:unless_else') {
+            return {hasElse: true};
+        }
+        return null;
+    };
+
     Generator.control_if = function (block) {
         const caseInfo = getCaseInfo(block);
         if (caseInfo) {
@@ -118,6 +129,17 @@ export default function (Generator) {
             if (content) {
                 return `case ${caseInfo.subject}\n${content}end\n`;
             }
+        }
+        const unlessInfo = getUnlessInfo(block);
+        if (unlessInfo) {
+            const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
+            // Swap branches back: SUBSTACK2 was the original unless-then, SUBSTACK was unless-else
+            const unlessThen = Generator.statementToCode(block, 'SUBSTACK2') || '';
+            const unlessElse = Generator.statementToCode(block, 'SUBSTACK') || '';
+            if (unlessInfo.hasElse) {
+                return `unless ${operator}\n${unlessThen}else\n${unlessElse}end\n`;
+            }
+            return `unless ${operator}\n${unlessThen}end\n`;
         }
         const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
         const branch = Generator.statementToCode(block, 'SUBSTACK') || '';

--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -72,6 +72,17 @@ export default function (Generator) {
         return null;
     };
 
+    const getModifierInfo = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment === '@ruby:syntax:if_modifier') {
+            return 'if';
+        }
+        if (comment === '@ruby:syntax:unless_modifier') {
+            return 'unless';
+        }
+        return null;
+    };
+
     Generator.control_if = function (block) {
         const caseInfo = getCaseInfo(block);
         if (caseInfo) {
@@ -79,6 +90,12 @@ export default function (Generator) {
             if (content) {
                 return `case ${caseInfo.subject}\n${content}end\n`;
             }
+        }
+        const modifierKeyword = getModifierInfo(block);
+        if (modifierKeyword) {
+            const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
+            const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
+            return `${branch.trim()} ${modifierKeyword} ${operator}\n`;
         }
         const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
         const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
@@ -129,6 +146,15 @@ export default function (Generator) {
             if (content) {
                 return `case ${caseInfo.subject}\n${content}end\n`;
             }
+        }
+        const modifierKeyword = getModifierInfo(block);
+        if (modifierKeyword) {
+            const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
+            // For unless modifier, body is in SUBSTACK2 (swapped by visitUnlessNode)
+            const body = modifierKeyword === 'unless' ?
+                Generator.statementToCode(block, 'SUBSTACK2') || '' :
+                Generator.statementToCode(block, 'SUBSTACK') || '';
+            return `${body.trim()} ${modifierKeyword} ${operator}\n`;
         }
         const unlessInfo = getUnlessInfo(block);
         if (unlessInfo) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/control-flow.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/control-flow.js
@@ -67,6 +67,21 @@ const ControlFlowHandlers = {
             }
         }
 
+        // Detect if modifier form: endKeywordLoc is null for modifier syntax
+        if (node.endKeywordLoc === null && this._isBlock(block)) {
+            const commentText = '@ruby:syntax:if_modifier';
+            if (block.comment) {
+                const comment = this._context.comments[block.comment];
+                if (comment) {
+                    comment.text = commentText;
+                    comment.minimized = true;
+                }
+            } else {
+                const commentId = this._createComment(commentText, block.id, 0, 0, true);
+                block.comment = commentId;
+            }
+        }
+
         if (preBlocks.length > 0 && block) {
             if (_.isArray(block)) {
                 return [...preBlocks, ...block];
@@ -233,10 +248,17 @@ const ControlFlowHandlers = {
             }
         }
 
-        // Attach @ruby:syntax:unless comment to preserve round-trip fidelity
-        // Use @ruby:syntax:unless_else when an else clause is present
+        // Attach @ruby:syntax:unless* comment to preserve round-trip fidelity
         if (this._isBlock(block)) {
-            const commentText = hasElseClause ? '@ruby:syntax:unless_else' : '@ruby:syntax:unless';
+            const isModifier = node.endKeywordLoc === null;
+            let commentText;
+            if (isModifier) {
+                commentText = '@ruby:syntax:unless_modifier';
+            } else if (hasElseClause) {
+                commentText = '@ruby:syntax:unless_else';
+            } else {
+                commentText = '@ruby:syntax:unless';
+            }
             if (block.comment) {
                 const comment = this._context.comments[block.comment];
                 if (comment) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/control-flow.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/control-flow.js
@@ -225,23 +225,23 @@ const ControlFlowHandlers = {
         cond = split.value;
         preBlocks.push(...split.preBlocks);
 
-        // unless cond; thenBody; else; elseBody; end
-        // is equivalent to: if cond; elseBody; else; thenBody; end
-        // (branches are swapped relative to if)
+        // Negate condition: unless cond => if !(cond)
+        const notBlock = this._createBlock('operator_not', 'value_boolean');
+        if (this._isFalseOrBooleanBlock(cond)) {
+            this._addInput(notBlock, 'OPERAND', cond);
+        }
+
         const unlessThen = this._processStatement(node.statements);
         const unlessElse = node.elseClause ? this._processStatement(node.elseClause) : null;
         const hasElseClause = !!node.elseClause;
 
-        // Swap: unless-then becomes if-else, unless-else becomes if-then
-        const ifThen = unlessElse;
-        const ifElse = unlessThen;
-
-        let block = this._callConvertersHandler('onIf', cond, ifThen, ifElse);
+        // Pass branches in natural order (no swap): unless-then → statement, unless-else → elseStatement
+        let block = this._callConvertersHandler('onIf', notBlock, unlessThen, unlessElse);
         if (!block) {
             this._restoreContext(saved);
             block = this._createRubyStatementBlock(this._getSource(node), node);
         } else if (hasElseClause && this._isBlock(block)) {
-            // Ensure control_if_else and SUBSTACK2 exist even when ifElse is null
+            // Ensure control_if_else and SUBSTACK2 exist even when unlessElse is null
             block.opcode = 'control_if_else';
             if (!block.inputs.SUBSTACK2) {
                 block.inputs.SUBSTACK2 = {name: 'SUBSTACK2', block: null, shadow: null};

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/control-flow.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/control-flow.js
@@ -233,6 +233,22 @@ const ControlFlowHandlers = {
             }
         }
 
+        // Attach @ruby:syntax:unless comment to preserve round-trip fidelity
+        // Use @ruby:syntax:unless_else when an else clause is present
+        if (this._isBlock(block)) {
+            const commentText = hasElseClause ? '@ruby:syntax:unless_else' : '@ruby:syntax:unless';
+            if (block.comment) {
+                const comment = this._context.comments[block.comment];
+                if (comment) {
+                    comment.text = commentText;
+                    comment.minimized = true;
+                }
+            } else {
+                const commentId = this._createComment(commentText, block.id, 0, 0, true);
+                block.comment = commentId;
+            }
+        }
+
         if (preBlocks.length > 0 && block) {
             if (_.isArray(block)) {
                 return [...preBlocks, ...block];

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/control.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/control.test.js
@@ -143,20 +143,20 @@ describe('Ruby Roundtrip: Control category blocks', () => {
             if touching?("_edge_")
               turn_right(180)
             end
-            if touching?("_edge_")
-              move(10)
-            else
+            unless touching?("_edge_")
               turn_right(180)
-            end
-            if touching?("_edge_")
+            else
               move(10)
-            else
             end
-            if touching?("_edge_")
+            unless touching?("_edge_")
             else
+              move(10)
+            end
+            unless touching?("_edge_")
               turn_right(180)
+            else
             end
-            if touching?("_edge_")
+            unless touching?("_edge_")
             else
             end
             wait until touching?("_edge_")

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control4.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control4.test.js
@@ -13,11 +13,10 @@ describe('RubyToBlocksConverter/Control/unless', () => {
         target = null;
     });
 
-    describe('unless (branches swapped relative to if)', () => {
-        test('unless cond; A; end => control_if_else(cond, branch1=empty, branch2=A)', async () => {
+    describe('unless (negated condition, natural branch order)', () => {
+        test('unless cond; A; end => control_if(not(cond), branch=A)', async () => {
             // unless cond; A; end
-            // => if cond; (empty); else; A; end
-            // branch[0]=null (empty then), branch[1]=A (unless-then becomes if-else)
+            // => if !(cond); A; end
             const code = `
                 unless touching?("_edge_")
                   move(10)
@@ -27,86 +26,108 @@ describe('RubyToBlocksConverter/Control/unless', () => {
             const moveBlock = (await rubyToExpected(converter, target, 'move(10)'))[0];
             const expected = [
                 {
+                    opcode: 'control_if',
+                    inputs: [
+                        {
+                            name: 'CONDITION',
+                            block: {
+                                opcode: 'operator_not',
+                                inputs: [
+                                    {
+                                        name: 'OPERAND',
+                                        block: condBlock
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    branches: [
+                        moveBlock
+                    ]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('unless cond; A; else; B; end => control_if_else(not(cond), branch1=A, branch2=B)', async () => {
+            // unless cond; A; else; B; end
+            // => if !(cond); A; else; B; end
+            const code = `
+                unless touching?("_edge_")
+                  move(10)
+                else
+                  turn_right(90)
+                end
+            `;
+            const condBlock = (await rubyToExpected(converter, target, 'touching?("_edge_")'))[0];
+            const moveBlock = (await rubyToExpected(converter, target, 'move(10)'))[0];
+            const turnBlock = (await rubyToExpected(converter, target, 'turn_right(90)'))[0];
+            const expected = [
+                {
                     opcode: 'control_if_else',
                     inputs: [
                         {
                             name: 'CONDITION',
-                            block: condBlock
+                            block: {
+                                opcode: 'operator_not',
+                                inputs: [
+                                    {
+                                        name: 'OPERAND',
+                                        block: condBlock
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    branches: [
+                        moveBlock,
+                        turnBlock
+                    ]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('unless cond; else; B; end => control_if_else(not(cond), branch1=empty, branch2=B)', async () => {
+            // unless cond; (empty); else; B; end
+            // => if !(cond); (empty); else; B; end
+            const code = `
+                unless touching?("_edge_")
+                else
+                  turn_right(90)
+                end
+            `;
+            const condBlock = (await rubyToExpected(converter, target, 'touching?("_edge_")'))[0];
+            const turnBlock = (await rubyToExpected(converter, target, 'turn_right(90)'))[0];
+            const expected = [
+                {
+                    opcode: 'control_if_else',
+                    inputs: [
+                        {
+                            name: 'CONDITION',
+                            block: {
+                                opcode: 'operator_not',
+                                inputs: [
+                                    {
+                                        name: 'OPERAND',
+                                        block: condBlock
+                                    }
+                                ]
+                            }
                         }
                     ],
                     branches: [
                         null,
-                        moveBlock
+                        turnBlock
                     ]
                 }
             ];
             await convertAndExpectToEqualBlocks(converter, target, code, expected);
         });
 
-        test('unless cond; A; else; B; end => control_if_else(cond, branch1=B, branch2=A)', async () => {
-            // unless cond; A; else; B; end
-            // => if cond; B; else; A; end
-            const code = `
-                unless touching?("_edge_")
-                  move(10)
-                else
-                  turn_right(90)
-                end
-            `;
-            const condBlock = (await rubyToExpected(converter, target, 'touching?("_edge_")'))[0];
-            const moveBlock = (await rubyToExpected(converter, target, 'move(10)'))[0];
-            const turnBlock = (await rubyToExpected(converter, target, 'turn_right(90)'))[0];
-            const expected = [
-                {
-                    opcode: 'control_if_else',
-                    inputs: [
-                        {
-                            name: 'CONDITION',
-                            block: condBlock
-                        }
-                    ],
-                    branches: [
-                        turnBlock,
-                        moveBlock
-                    ]
-                }
-            ];
-            await convertAndExpectToEqualBlocks(converter, target, code, expected);
-        });
-
-        test('unless cond; else; B; end => control_if_else(cond, branch1=B, branch2=empty)', async () => {
-            // unless cond; (empty); else; B; end
-            // => if cond; B; else; (empty); end
-            // branch[0]=B, branch[1]=null (empty else)
-            const code = `
-                unless touching?("_edge_")
-                else
-                  turn_right(90)
-                end
-            `;
-            const condBlock = (await rubyToExpected(converter, target, 'touching?("_edge_")'))[0];
-            const turnBlock = (await rubyToExpected(converter, target, 'turn_right(90)'))[0];
-            const expected = [
-                {
-                    opcode: 'control_if_else',
-                    inputs: [
-                        {
-                            name: 'CONDITION',
-                            block: condBlock
-                        }
-                    ],
-                    branches: [
-                        turnBlock,
-                        null
-                    ]
-                }
-            ];
-            await convertAndExpectToEqualBlocks(converter, target, code, expected);
-        });
-
-        test('unless cond; else; end => control_if_else(cond, both branches empty)', async () => {
+        test('unless cond; else; end => control_if_else(not(cond), both branches empty)', async () => {
             // unless cond; (empty); else; (empty); end
-            // => if cond; (empty); else; (empty); end
+            // => if !(cond); (empty); else; (empty); end
             const code = `
                 unless touching?("_edge_")
                 else
@@ -119,7 +140,15 @@ describe('RubyToBlocksConverter/Control/unless', () => {
                     inputs: [
                         {
                             name: 'CONDITION',
-                            block: condBlock
+                            block: {
+                                opcode: 'operator_not',
+                                inputs: [
+                                    {
+                                        name: 'OPERAND',
+                                        block: condBlock
+                                    }
+                                ]
+                            }
                         }
                     ],
                     branches: [

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/core-prism.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/core-prism.test.js
@@ -85,7 +85,7 @@ describe('RubyToBlocksConverter Core (Prism)', () => {
             const converter = await targetCodeToBlocks(vm, target, code);
             expect(converter.result).toBeTruthy();
             const blocks = Object.values(converter.blocks);
-            const ifBlock = blocks.find(b => b.opcode === 'control_if_else');
+            const ifBlock = blocks.find(b => b.opcode === 'control_if');
             expect(ifBlock).toBeDefined();
             expect(getCommentText(converter, ifBlock)).toBe('@ruby:syntax:unless');
         });
@@ -115,7 +115,7 @@ describe('RubyToBlocksConverter Core (Prism)', () => {
             const converter = await targetCodeToBlocks(vm, target, code);
             expect(converter.result).toBeTruthy();
             const blocks = Object.values(converter.blocks);
-            const ifBlock = blocks.find(b => b.opcode === 'control_if_else');
+            const ifBlock = blocks.find(b => b.opcode === 'control_if');
             expect(ifBlock).toBeDefined();
             expect(getCommentText(converter, ifBlock)).toBe('@ruby:syntax:unless_modifier');
         });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/core-prism.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/core-prism.test.js
@@ -72,4 +72,52 @@ describe('RubyToBlocksConverter Core (Prism)', () => {
         const stepsBlock = converter.blocks[moveBlock.inputs.STEPS.block];
         expect(stepsBlock.fields.NUM.value).toBe('3435.0');
     });
+
+    describe('unless and modifier comment annotations', () => {
+        const getCommentText = (converter, block) => {
+            if (!block.comment) return null;
+            const comment = converter._context.comments[block.comment];
+            return comment ? comment.text : null;
+        };
+
+        test('unless...end attaches @ruby:syntax:unless comment', async () => {
+            const code = 'unless touching?("_edge_")\n  move(10)\nend';
+            const converter = await targetCodeToBlocks(vm, target, code);
+            expect(converter.result).toBeTruthy();
+            const blocks = Object.values(converter.blocks);
+            const ifBlock = blocks.find(b => b.opcode === 'control_if_else');
+            expect(ifBlock).toBeDefined();
+            expect(getCommentText(converter, ifBlock)).toBe('@ruby:syntax:unless');
+        });
+
+        test('unless...else...end attaches @ruby:syntax:unless_else comment', async () => {
+            const code = 'unless touching?("_edge_")\n  move(10)\nelse\n  turn_right(180)\nend';
+            const converter = await targetCodeToBlocks(vm, target, code);
+            expect(converter.result).toBeTruthy();
+            const blocks = Object.values(converter.blocks);
+            const ifBlock = blocks.find(b => b.opcode === 'control_if_else');
+            expect(ifBlock).toBeDefined();
+            expect(getCommentText(converter, ifBlock)).toBe('@ruby:syntax:unless_else');
+        });
+
+        test('if modifier attaches @ruby:syntax:if_modifier comment', async () => {
+            const code = 'move(10) if true';
+            const converter = await targetCodeToBlocks(vm, target, code);
+            expect(converter.result).toBeTruthy();
+            const blocks = Object.values(converter.blocks);
+            const ifBlock = blocks.find(b => b.opcode === 'control_if');
+            expect(ifBlock).toBeDefined();
+            expect(getCommentText(converter, ifBlock)).toBe('@ruby:syntax:if_modifier');
+        });
+
+        test('unless modifier attaches @ruby:syntax:unless_modifier comment', async () => {
+            const code = 'move(10) unless true';
+            const converter = await targetCodeToBlocks(vm, target, code);
+            expect(converter.result).toBeTruthy();
+            const blocks = Object.values(converter.blocks);
+            const ifBlock = blocks.find(b => b.opcode === 'control_if_else');
+            expect(ifBlock).toBeDefined();
+            expect(getCommentText(converter, ifBlock)).toBe('@ruby:syntax:unless_modifier');
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -121,6 +121,27 @@ end
 `.trim());
     });
 
+    test('unless...end round-trip', async () => {
+        await expectRoundTrip(
+            'unless touching?("_edge_")\n  move(10)\nend'
+        );
+    });
+
+    test('unless...else...end round-trip', async () => {
+        await expectRoundTrip(
+            'unless touching?("_edge_")\n  move(10)\nelse\n  turn_right(180)\nend'
+        );
+        await expectRoundTrip(
+            'unless touching?("_edge_")\n  move(10)\nelse\nend'
+        );
+        await expectRoundTrip(
+            'unless touching?("_edge_")\nelse\n  move(10)\nend'
+        );
+        await expectRoundTrip(
+            'unless touching?("_edge_")\nelse\nend'
+        );
+    });
+
     test('float literals with integer appearance (x.0) are preserved', async () => {
         await expectRoundTrip('1.0 + 1.0');
         await expectRoundTrip('move(1.0)');

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -142,6 +142,16 @@ end
         );
     });
 
+    test('if modifier round-trip', async () => {
+        await expectRoundTrip('move(10) if true');
+        await expectRoundTrip('move(10) if touching?("_edge_")');
+    });
+
+    test('unless modifier round-trip', async () => {
+        await expectRoundTrip('move(10) unless true');
+        await expectRoundTrip('move(10) unless touching?("_edge_")');
+    });
+
     test('float literals with integer appearance (x.0) are preserved', async () => {
         await expectRoundTrip('1.0 + 1.0');
         await expectRoundTrip('move(1.0)');


### PR DESCRIPTION
## Summary

`unless` 構文と `if`/`unless` 修飾子構文の Ruby ↔ Block round-trip 保持を実装する。

Fixes #164

## Implementation Steps

- [x] **Phase 1+2**: unless...end / unless...else...end の round-trip 対応
- [x] **Phase 3**: if 修飾子の round-trip 対応
- [x] **Phase 4**: unless 修飾子の round-trip 対応
- [x] **Phase 5**: Playwright MCP での手動動作確認
- [x] **Phase Final**: Integration Tests

## Changes Made

- `visitUnlessNode` に `@ruby:syntax:unless` / `@ruby:syntax:unless_else` / `@ruby:syntax:unless_modifier` コメント付与ロジック追加
- `visitIfNode` に `@ruby:syntax:if_modifier` コメント付与ロジック追加
- `control_if` / `control_if_else` generator に unless / modifier 出力ロジック追加
- 既存テストの期待値更新 + 新規 round-trip テスト追加
- `core-prism.test.js` にコメントアノテーション検証テスト追加

## Test Coverage

- `round-trip.test.js`: unless...end, unless...else...end (4パターン), if modifier (2パターン), unless modifier (2パターン)
- `control.test.js`: 既存テストの期待値を unless 出力に更新
- `core-prism.test.js`: コメントアノテーション検証テスト (4パターン)
- 全163テストスイート・1044テスト pass
