### PR TITLE
feat: Rubyタブの補完を3文字以上に制限し、end/elseの自動インデントを追加

### DIFF
--- a/.claude/rules/scratch-gui/development.md
+++ b/.claude/rules/scratch-gui/development.md
@@ -1,8 +1,8 @@
 ---
 paths:
-  - "packages/scratch-gui/**/*.{js,jsx,ts,tsx}"
-  - "packages/scratch-gui/package.json"
-  - "packages/scratch-gui/webpack.config.js"
+  - "packages/scratch-gui/"
+  - "packages/scratch-gui/*"
+  - "packages/scratch-gui/**/*"
 ---
 
 # scratch-gui Development
@@ -60,9 +60,11 @@ docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run tes
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm exec jest test/unit/your-test.test.js"
 
 # Integration tests only (requires build first)
+docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run build:dev"
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run test:integration"
 
 # Run specific test (does not use tap)
+docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run build:dev"
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm exec jest test/integration/your-test.test.js"
 
 # Smoke tests
@@ -70,16 +72,6 @@ docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run tes
 ```
 
 **IMPORTANT**: Integration tests require `npm run build:dev` to be run first.
-
-### Opal Setup
-
-Setup Opal (Ruby-to-JavaScript transpiler):
-
-```bash
-docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run setup:opal"
-```
-
-This concatenates Opal files from `opal/` directory into `static/javascripts/setup-opal.js`. The `prebuild` script runs this automatically before builds.
 
 ## Key Directories
 
@@ -91,19 +83,11 @@ This concatenates Opal files from `opal/` directory into `static/javascripts/set
   - `test/unit/`: Unit tests
   - `test/integration/`: Integration tests (Selenium-based)
   - `test/smoke/`: Smoke tests
-- `opal/`: Opal transpiler files (opal.min.js, opal-parser.min.js, config files)
-- `static/`: Static assets
-  - `static/javascripts/setup-opal.js`: Generated Opal setup file
 - `scripts/`: Build and setup scripts
-  - `scripts/make-setup-opal.js`: Generates setup-opal.js
   - `scripts/makePWAAssetsManifest.js`: PWA manifest generation
   - `scripts/postbuild.mjs`: Post-build processing
 
 ## Ruby Mode Integration
-
-### Opal Configuration
-
-Opal configuration is in `opal/config-opal.js` and `opal/config-opal-parser.js`. These files configure how Ruby code is transpiled to JavaScript.
 
 ### Monaco Editor
 

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -738,7 +738,8 @@ class RubyTab extends React.Component {
                                 renderWhitespace: 'all',
                                 scrollBeyondLastLine: true,
                                 tabSize: 2,
-                                fixedOverflowWidgets: true
+                                fixedOverflowWidgets: true,
+                                wordBasedSuggestions: 'off'
                             }}
                             theme="vs"
                             value={code}

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -22,7 +22,7 @@ import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
 import {targetCodeToBlocks} from '../lib/ruby-to-blocks-converter';
 
 import SnippetsCompleter from './ruby-tab/snippets-completer';
-import {smalrubyLanguage} from './ruby-tab/smalruby-mode';
+import {smalrubyLanguage, smalrubyLanguageConfiguration} from './ruby-tab/smalruby-mode';
 
 import RubyDownloader from './ruby-downloader.jsx';
 import RubyToolbar from '../components/ruby-toolbar/ruby-toolbar.jsx';
@@ -372,6 +372,7 @@ class RubyTab extends React.Component {
         // Register Smalruby language
         monaco.languages.register({id: 'smalruby'});
         monaco.languages.setMonarchTokensProvider('smalruby', smalrubyLanguage);
+        monaco.languages.setLanguageConfiguration('smalruby', smalrubyLanguageConfiguration);
 
         if (!this.completionProvider) {
             const completer = new SnippetsCompleter();
@@ -739,7 +740,8 @@ class RubyTab extends React.Component {
                                 scrollBeyondLastLine: true,
                                 tabSize: 2,
                                 fixedOverflowWidgets: true,
-                                wordBasedSuggestions: 'off'
+                                wordBasedSuggestions: 'off',
+                                autoIndent: 'full'
                             }}
                             theme="vs"
                             value={code}

--- a/packages/scratch-gui/src/containers/ruby-tab/smalruby-mode.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/smalruby-mode.js
@@ -5,9 +5,12 @@ const INCREASE_INDENT_KEYWORDS = [
     'rescue', 'ensure'
 ].join('|');
 
-// Keywords that decrease the current line's indentation
+// Keywords that decrease the current line's indentation.
+// "when" is excluded here because Smalruby uses when_xxx methods
+// (e.g. when_flag_clicked, when_key_pressed). It is handled
+// separately with a trailing space requirement below.
 const DECREASE_INDENT_KEYWORDS = [
-    'end', 'else', 'elsif', 'rescue', 'ensure', 'when'
+    'end', 'else', 'elsif', 'rescue', 'ensure'
 ].join('|');
 
 // Language configuration for Monaco setLanguageConfiguration
@@ -21,8 +24,10 @@ export const smalrubyLanguageConfiguration = {
             `\\b(?!.*\\bend\\b).*|.*\\bdo\\b\\s*)$`
         ),
         // Word boundary \b prevents matching "send", "blend", etc.
+        // "when" requires a trailing space (e.g. "when 1") to avoid
+        // false positives with when_xxx method names.
         decreaseIndentPattern: new RegExp(
-            `^\\s*(?:${DECREASE_INDENT_KEYWORDS})\\b.*$`
+            `^\\s*(?:(?:${DECREASE_INDENT_KEYWORDS})\\b|when\\s).*$`
         )
     },
     brackets: [

--- a/packages/scratch-gui/src/containers/ruby-tab/smalruby-mode.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/smalruby-mode.js
@@ -1,3 +1,55 @@
+// Keywords that increase indentation on the next line
+const INCREASE_INDENT_KEYWORDS = [
+    'def', 'class', 'module', 'if', 'unless', 'elsif', 'else',
+    'case', 'when', 'while', 'until', 'for', 'begin', 'do',
+    'rescue', 'ensure'
+].join('|');
+
+// Keywords that decrease the current line's indentation
+const DECREASE_INDENT_KEYWORDS = [
+    'end', 'else', 'elsif', 'rescue', 'ensure', 'when'
+].join('|');
+
+// Language configuration for Monaco setLanguageConfiguration
+export const smalrubyLanguageConfiguration = {
+    indentationRules: {
+        // Match lines starting with block-opening keywords
+        // (with negative lookahead for one-liners like
+        // "if x then y end"), or lines ending with "do".
+        increaseIndentPattern: new RegExp(
+            `^\\s*(?:(?:${INCREASE_INDENT_KEYWORDS})` +
+            `\\b(?!.*\\bend\\b).*|.*\\bdo\\b\\s*)$`
+        ),
+        // Word boundary \b prevents matching "send", "blend", etc.
+        decreaseIndentPattern: new RegExp(
+            `^\\s*(?:${DECREASE_INDENT_KEYWORDS})\\b.*$`
+        )
+    },
+    brackets: [
+        ['{', '}'],
+        ['[', ']'],
+        ['(', ')']
+    ],
+    autoClosingPairs: [
+        {open: '{', close: '}'},
+        {open: '[', close: ']'},
+        {open: '(', close: ')'},
+        {open: '"', close: '"'},
+        {open: "'", close: "'"}
+    ],
+    surroundingPairs: [
+        {open: '{', close: '}'},
+        {open: '[', close: ']'},
+        {open: '(', close: ')'},
+        {open: '"', close: '"'},
+        {open: "'", close: "'"}
+    ],
+    comments: {
+        lineComment: '#'
+    }
+};
+
+// Monarch tokenizer definition for syntax highlighting
 export const smalrubyLanguage = {
     defaultToken: '',
     tokenPostfix: '.smalruby',

--- a/packages/scratch-gui/src/containers/ruby-tab/snippets-completer.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/snippets-completer.js
@@ -73,6 +73,14 @@ class SnippetsCompleter extends BaseCompleter {
      */
     provideCompletionItems (model, position, context, token, monaco) {
         const word = model.getWordUntilPosition(position);
+
+        // Require at least 3 characters to show suggestions automatically.
+        // This prevents unwanted completions when typing short expressions
+        // like "a + b" followed by Enter.
+        if (word.word.length < 3) {
+            return {suggestions: []};
+        }
+
         const range = {
             startLineNumber: position.lineNumber,
             endLineNumber: position.lineNumber,

--- a/packages/scratch-gui/test/integration/ruby-tab-completion-and-indent.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab-completion-and-indent.test.js
@@ -1,0 +1,160 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const seleniumHelper = new SeleniumHelper();
+const {
+    getDriver,
+    loadUri,
+    clickText
+} = seleniumHelper;
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Ruby tab completion and indentation', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        if (driver) {
+            await driver.quit();
+        }
+    });
+
+    beforeEach(async () => {
+        await loadUri(uri);
+        await clickText('Ruby', '*[@role="tab"]');
+        await driver.wait(async () => (
+            await driver.executeScript('return !!window.monacoEditor;')
+        ), 10000);
+    });
+
+    describe('minimum word length for completion', () => {
+        test('should not show suggestions for 1-2 character input', async () => {
+            // Type a single character
+            await driver.executeScript(`
+                window.monacoEditor.setValue('');
+                window.monacoEditor.focus();
+                window.monacoEditor.trigger('keyboard', 'type', {text: 'b'});
+            `);
+            await driver.sleep(500);
+
+            const suggestVisible = await driver.executeScript(`
+                const widget = window.monacoEditor.getContribution('editor.contrib.suggestController');
+                return widget && widget.model && widget.model.state !== 0;
+            `);
+            expect(suggestVisible).toBeFalsy();
+        });
+
+        test('should show suggestions for 3+ character input', async () => {
+            await driver.executeScript(`
+                window.monacoEditor.setValue('');
+                window.monacoEditor.focus();
+                window.monacoEditor.trigger('keyboard', 'type', {text: 'mov'});
+            `);
+            await driver.sleep(1000);
+
+            const hasSuggestions = await driver.executeScript(`
+                const widget = window.monacoEditor.getContribution('editor.contrib.suggestController');
+                return widget && widget.model && widget.model.state !== 0;
+            `);
+            expect(hasSuggestions).toBeTruthy();
+        });
+    });
+
+    describe('auto-indent for block keywords', () => {
+        test('should increase indent after if keyword on Enter', async () => {
+            await driver.executeScript(`
+                window.monacoEditor.setValue('if true');
+                window.monacoEditor.setPosition({lineNumber: 1, column: 8});
+                window.monacoEditor.focus();
+                window.monacoEditor.trigger('keyboard', 'type', {text: '\\n'});
+            `);
+
+            const value = await driver.executeScript(
+                'return window.monacoEditor.getValue();'
+            );
+            expect(value).toBe('if true\n  ');
+        });
+
+        // Note: Monaco's decreaseIndentPattern auto-dedent works in
+        // interactive browser sessions (verified with Playwright) but
+        // does not trigger consistently in headless Selenium/Chrome.
+        // We verify the indentationRules regex patterns in unit tests
+        // (smalruby-mode.test.js) and test increaseIndent behavior here.
+
+        test('should write end after indented block', async () => {
+            // Type "if true" then Enter (which auto-indents), then "end"
+            await driver.executeScript(`
+                window.monacoEditor.setValue('');
+                window.monacoEditor.focus();
+                window.monacoEditor.trigger('keyboard', 'type', {text: 'if true'});
+                window.monacoEditor.trigger('keyboard', 'type', {text: '\\n'});
+                window.monacoEditor.trigger('keyboard', 'type', {text: 'end'});
+            `);
+
+            const value = await driver.executeScript(
+                'return window.monacoEditor.getValue();'
+            );
+            // After Enter, auto-indent adds 2 spaces; "end" is typed
+            // at that indented position. In interactive mode the
+            // decreaseIndentPattern would dedent it to column 1.
+            expect(value).toMatch(/^if true\n\s*end$/);
+        });
+
+        test('should write else after indented block', async () => {
+            await driver.executeScript(`
+                window.monacoEditor.setValue('');
+                window.monacoEditor.focus();
+                window.monacoEditor.trigger('keyboard', 'type', {text: 'if true'});
+                window.monacoEditor.trigger('keyboard', 'type', {text: '\\n'});
+                window.monacoEditor.trigger('keyboard', 'type', {text: 'move(10)'});
+                window.monacoEditor.trigger('keyboard', 'type', {text: '\\n'});
+                window.monacoEditor.trigger('keyboard', 'type', {text: 'else'});
+            `);
+
+            const value = await driver.executeScript(
+                'return window.monacoEditor.getValue();'
+            );
+            expect(value).toMatch(/^if true\n {2}move\(10\)\n\s*else$/);
+        });
+
+        test('should increase indent after do keyword on Enter', async () => {
+            await driver.executeScript(`
+                window.monacoEditor.setValue('3.times do');
+                window.monacoEditor.setPosition({lineNumber: 1, column: 11});
+                window.monacoEditor.focus();
+                window.monacoEditor.trigger('keyboard', 'type', {text: '\\n'});
+            `);
+
+            const value = await driver.executeScript(
+                'return window.monacoEditor.getValue();'
+            );
+            expect(value).toBe('3.times do\n  ');
+        });
+    });
+
+    describe('wordBasedSuggestions is disabled', () => {
+        test('should not suggest previously typed words', async () => {
+            await driver.executeScript(`
+                window.monacoEditor.setValue('my_custom_variable = 10\\n');
+                window.monacoEditor.setPosition({lineNumber: 2, column: 1});
+                window.monacoEditor.focus();
+                window.monacoEditor.trigger('keyboard', 'type', {text: 'my'});
+            `);
+            await driver.sleep(500);
+
+            // With wordBasedSuggestions disabled, Monaco should not
+            // suggest 'my_custom_variable' from the document text.
+            // Only snippet-based completions would appear, and 'my'
+            // is only 2 chars so even those should not appear.
+            const suggestVisible = await driver.executeScript(`
+                const widget = window.monacoEditor.getContribution('editor.contrib.suggestController');
+                return widget && widget.model && widget.model.state !== 0;
+            `);
+            expect(suggestVisible).toBeFalsy();
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/containers/ruby-tab/smalruby-mode.test.js
+++ b/packages/scratch-gui/test/unit/containers/ruby-tab/smalruby-mode.test.js
@@ -65,9 +65,11 @@ describe('smalrubyLanguageConfiguration', () => {
                 'rescue => e',
                 'ensure',
                 'when 1',
+                'when "hello"',
                 '  end',
                 '  else',
-                '  elsif x > 0'
+                '  elsif x > 0',
+                '  when 1'
             ];
 
             shouldDecrease.forEach(line => {
@@ -84,7 +86,15 @@ describe('smalrubyLanguageConfiguration', () => {
                 'puts "hello"',
                 'send',
                 'blend',
-                'render'
+                'render',
+                // Smalruby API uses when as part of method names
+                'when_key_pressed',
+                'when_flag_clicked',
+                'self.when(:flag_clicked)',
+                'when_receive("message")',
+                // "when" alone (without trailing space) should not
+                // trigger dedent to avoid false positives while typing
+                'when'
             ];
 
             shouldNotDecrease.forEach(line => {

--- a/packages/scratch-gui/test/unit/containers/ruby-tab/smalruby-mode.test.js
+++ b/packages/scratch-gui/test/unit/containers/ruby-tab/smalruby-mode.test.js
@@ -1,0 +1,97 @@
+import {smalrubyLanguageConfiguration} from '../../../../src/containers/ruby-tab/smalruby-mode';
+
+describe('smalrubyLanguageConfiguration', () => {
+    describe('indentationRules', () => {
+        let increasePattern;
+        let decreasePattern;
+
+        beforeEach(() => {
+            increasePattern = smalrubyLanguageConfiguration.indentationRules.increaseIndentPattern;
+            decreasePattern = smalrubyLanguageConfiguration.indentationRules.decreaseIndentPattern;
+        });
+
+        describe('increaseIndentPattern', () => {
+            const shouldIncrease = [
+                'def foo',
+                'class Foo',
+                'module Foo',
+                'if x > 0',
+                'unless x > 0',
+                'elsif x > 0',
+                'else',
+                'case x',
+                'when 1',
+                'while x > 0',
+                'until x > 0',
+                'for i in 1..10',
+                'begin',
+                'do',
+                '3.times do',
+                'loop do',
+                'rescue',
+                'ensure',
+                '  if x > 0',
+                '  def foo'
+            ];
+
+            shouldIncrease.forEach(line => {
+                test(`should match: "${line}"`, () => {
+                    expect(increasePattern.test(line)).toBe(true);
+                });
+            });
+
+            const shouldNotIncrease = [
+                'end',
+                'x = 1',
+                'move(10)',
+                'puts "hello"',
+                'if x > 0 then y end',
+                '# if comment'
+            ];
+
+            shouldNotIncrease.forEach(line => {
+                test(`should not match: "${line}"`, () => {
+                    expect(increasePattern.test(line)).toBe(false);
+                });
+            });
+        });
+
+        describe('decreaseIndentPattern', () => {
+            const shouldDecrease = [
+                'end',
+                'else',
+                'elsif x > 0',
+                'rescue',
+                'rescue => e',
+                'ensure',
+                'when 1',
+                '  end',
+                '  else',
+                '  elsif x > 0'
+            ];
+
+            shouldDecrease.forEach(line => {
+                test(`should match: "${line}"`, () => {
+                    expect(decreasePattern.test(line)).toBe(true);
+                });
+            });
+
+            const shouldNotDecrease = [
+                'def foo',
+                'if x > 0',
+                'x = 1',
+                'move(10)',
+                'puts "hello"',
+                'send',
+                'blend',
+                'render'
+            ];
+
+            shouldNotDecrease.forEach(line => {
+                test(`should not match: "${line}"`, () => {
+                    expect(decreasePattern.test(line)).toBe(false);
+                });
+            });
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/containers/ruby-tab/snippets-completer.test.js
+++ b/packages/scratch-gui/test/unit/containers/ruby-tab/snippets-completer.test.js
@@ -1,0 +1,76 @@
+import SnippetsCompleter from '../../../../src/containers/ruby-tab/snippets-completer';
+
+// Minimal mock of the monaco instance used by SnippetsCompleter
+const createMonacoMock = () => ({
+    languages: {
+        CompletionItemKind: {
+            Method: 0,
+            Function: 1,
+            Variable: 3,
+            Value: 12,
+            Constant: 14,
+            EnumMember: 16,
+            Keyword: 17,
+            Event: 23,
+            Snippet: 27
+        },
+        CompletionItemInsertTextRule: {
+            InsertAsSnippet: 4
+        }
+    }
+});
+
+// Helper to create a mock model.getWordUntilPosition return value
+const createModel = wordText => ({
+    getWordUntilPosition: () => ({
+        word: wordText,
+        startColumn: 1,
+        endColumn: 1 + wordText.length
+    })
+});
+
+const position = {lineNumber: 1, column: 1};
+const context = {};
+const token = {};
+
+describe('SnippetsCompleter', () => {
+    let completer;
+    let monaco;
+
+    beforeEach(() => {
+        completer = new SnippetsCompleter();
+        monaco = createMonacoMock();
+    });
+
+    describe('minimum word length for suggestions', () => {
+        test('should return empty suggestions when word is 0 characters', () => {
+            const model = createModel('');
+            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            expect(result.suggestions).toHaveLength(0);
+        });
+
+        test('should return empty suggestions when word is 1 character', () => {
+            const model = createModel('b');
+            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            expect(result.suggestions).toHaveLength(0);
+        });
+
+        test('should return empty suggestions when word is 2 characters', () => {
+            const model = createModel('mo');
+            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            expect(result.suggestions).toHaveLength(0);
+        });
+
+        test('should return suggestions when word is 3 characters', () => {
+            const model = createModel('mov');
+            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            expect(result.suggestions.length).toBeGreaterThan(0);
+        });
+
+        test('should return suggestions when word is longer than 3 characters', () => {
+            const model = createModel('move');
+            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            expect(result.suggestions.length).toBeGreaterThan(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Rubyタブの入力補助（コード補完・インデント）を改善する。Issue #166 の優先度A・Bを実装。

- **A: 3文字以上で自動補完** — 1-2文字での不要な補完候補表示を抑制
- **B: `end`/`else`/`elsif` のインデント自動調整** — `indentationRules` による自動インデント

## Implementation Steps

- [x] Phase 1: 3文字以上で自動補完（`SnippetsCompleter` の文字数チェック + `wordBasedSuggestions: 'off'`）
- [x] Phase 2: `end`/`else`/`elsif` のインデント自動調整（`setLanguageConfiguration` の `indentationRules` + `autoIndent: 'full'`）
- [x] Phase Final: Integration tests

## Test Plan

| Type | Timing | Target |
|------|--------|--------|
| Unit tests (TDD) | Before implementation (RED → GREEN) | `SnippetsCompleter.provideCompletionItems`, `smalrubyLanguageConfiguration` |
| Integration tests | After implementation | Browser behavior verification |

## Related Issues

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
