### PR TITLE
feat: add context-aware completion filtering in Ruby tab

### DIFF
--- a/packages/scratch-gui/src/containers/ruby-tab/snippets-completer.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/snippets-completer.js
@@ -25,6 +25,21 @@ import GdxForSnippets from './gdx_for-snippets.json';
 // Regex to detect Japanese characters (hiragana, katakana, kanji)
 const JAPANESE_CHAR_PATTERN = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/;
 
+// Regex to detect expression-expected keywords at end of line before cursor
+const EXPRESSION_KEYWORD_PATTERN = /\b(if|unless|until|while|elsif)\s+$/;
+
+// Context types for completion filtering
+const CONTEXT_TOP_LEVEL = 'top_level';
+const CONTEXT_INSIDE_BLOCK = 'inside_block';
+const CONTEXT_EXPRESSION_EXPECTED = 'expression_expected';
+
+// Allowed snippet types per context
+const CONTEXT_ALLOWED_TYPES = {
+    [CONTEXT_TOP_LEVEL]: new Set(['event', 'enum_member']),
+    [CONTEXT_INSIDE_BLOCK]: new Set(['function', 'method', 'snippet', 'variable', 'value', 'constant', 'enum_member']),
+    [CONTEXT_EXPRESSION_EXPECTED]: new Set(['variable', 'value', 'constant', 'method', 'enum_member'])
+};
+
 class SnippetsCompleter extends BaseCompleter {
     #coreCompletions = [];
     #extensionCompletions = [];
@@ -111,11 +126,94 @@ class SnippetsCompleter extends BaseCompleter {
             this.#extensionCompletions.filter(item => this.#isExtensionActive(item.extensionId))
         );
 
-        const suggestions = activeCompletions.map(item => this.toCompletionItem(item, range, monaco));
+        const detectedContext = this.#detectContext(model, position);
+        const filteredCompletions = this.#filterByContext(activeCompletions, detectedContext);
+
+        const suggestions = filteredCompletions.map(item => this.toCompletionItem(item, range, monaco));
 
         return {
             suggestions: suggestions
         };
+    }
+
+    /**
+     * Detect the code context at the cursor position.
+     * @param {object} model - Monaco text model.
+     * @param {object} position - Current cursor position.
+     * @returns {string} One of 'top_level', 'inside_block', or 'expression_expected'.
+     */
+    #detectContext (model, position) {
+        const textBeforeCursor = model.getValueInRange({
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column
+        });
+
+        // Count nesting level by tracking do/def vs end keywords
+        let nestingLevel = 0;
+        const lines = textBeforeCursor.split('\n');
+        for (const line of lines) {
+            // Strip comments
+            const codePart = line.replace(/#.*$/, '');
+            const opens = (codePart.match(/\bdo\b/g) || []).length +
+                          (codePart.match(/\bdef\s/g) || []).length;
+            const closes = (codePart.match(/\bend\b/g) || []).length;
+            nestingLevel += opens - closes;
+        }
+
+        if (nestingLevel <= 0) {
+            return CONTEXT_TOP_LEVEL;
+        }
+
+        // Check current line for expression-expected patterns
+        const textUntilPosition = model.getValueInRange({
+            startLineNumber: position.lineNumber,
+            startColumn: 1,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column
+        });
+
+        // Remove the current word being typed to check the preceding context
+        const wordBeforeCursor = textUntilPosition.replace(/\S+$/, '');
+        if (EXPRESSION_KEYWORD_PATTERN.test(wordBeforeCursor)) {
+            return CONTEXT_EXPRESSION_EXPECTED;
+        }
+
+        return CONTEXT_INSIDE_BLOCK;
+    }
+
+    /**
+     * Filter completions based on the detected context.
+     * @param {Array} completions - Array of snippet items.
+     * @param {string} detectedContext - The detected context type.
+     * @returns {Array} Filtered completions.
+     */
+    #filterByContext (completions, detectedContext) {
+        const allowedTypes = CONTEXT_ALLOWED_TYPES[detectedContext];
+        if (!allowedTypes) {
+            return completions;
+        }
+
+        return completions.filter(item => {
+            const type = item.type || 'snippet';
+
+            // Special handling for 'snippet' type based on context
+            if (type === 'snippet') {
+                if (detectedContext === CONTEXT_TOP_LEVEL) {
+                    // At top level, only 'def' snippet is allowed
+                    return item.caption === 'def';
+                }
+                if (detectedContext === CONTEXT_INSIDE_BLOCK) {
+                    // Inside block, all snippets except 'def' are allowed
+                    return item.caption !== 'def';
+                }
+                // For expression_expected, snippets are not allowed
+                return false;
+            }
+
+            return allowedTypes.has(type);
+        });
     }
 
     #isExtensionActive (extensionId) {

--- a/packages/scratch-gui/test/integration/ruby-tab-completion-and-indent.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab-completion-and-indent.test.js
@@ -49,8 +49,10 @@ describe('Ruby tab completion and indentation', () => {
         });
 
         test('should show suggestions for 3+ character input', async () => {
+            // Place cursor inside a block so that function-type snippets are available
             await driver.executeScript(`
-                window.monacoEditor.setValue('');
+                window.monacoEditor.setValue('when_flag_clicked do\\n  \\nend');
+                window.monacoEditor.setPosition({lineNumber: 2, column: 3});
                 window.monacoEditor.focus();
                 window.monacoEditor.trigger('keyboard', 'type', {text: 'mov'});
             `);

--- a/packages/scratch-gui/test/unit/containers/ruby-tab/snippets-completer.test.js
+++ b/packages/scratch-gui/test/unit/containers/ruby-tab/snippets-completer.test.js
@@ -20,13 +20,34 @@ const createMonacoMock = () => ({
     }
 });
 
-// Helper to create a mock model.getWordUntilPosition return value
-const createModel = wordText => ({
+// Helper to create a mock model with getWordUntilPosition and getValueInRange.
+// fullText: the entire document text (defaults to empty = top-level context).
+// cursorLine/cursorCol: cursor position within fullText (1-based).
+const createModel = (wordText, fullText = '', cursorLine = 1, cursorCol = 1 + wordText.length) => ({
     getWordUntilPosition: () => ({
         word: wordText,
-        startColumn: 1,
-        endColumn: 1 + wordText.length
-    })
+        startColumn: cursorCol - wordText.length,
+        endColumn: cursorCol
+    }),
+    getValueInRange: ({startLineNumber, startColumn, endLineNumber, endColumn}) => {
+        if (!fullText) return '';
+        const lines = fullText.split('\n');
+        if (startLineNumber === endLineNumber) {
+            const line = lines[startLineNumber - 1] || '';
+            return line.substring(startColumn - 1, endColumn - 1);
+        }
+        const result = [];
+        for (let i = startLineNumber; i <= endLineNumber; i++) {
+            let line = lines[i - 1] || '';
+            if (i === startLineNumber) {
+                line = line.substring(startColumn - 1);
+            } else if (i === endLineNumber) {
+                line = line.substring(0, endColumn - 1);
+            }
+            result.push(line);
+        }
+        return result.join('\n');
+    }
 });
 
 // Helper to create a mock VM with extensionManager
@@ -40,6 +61,11 @@ const position = {lineNumber: 1, column: 1};
 const context = {};
 const token = {};
 
+// Common text placing cursor inside a block (line 2, after indentation)
+const INSIDE_BLOCK_TEXT = 'when_flag_clicked do\n  ';
+const INSIDE_BLOCK_LINE = 2;
+const INSIDE_BLOCK_COL_BASE = 3; // after "  " (2 spaces + 1 for 1-based)
+
 describe('SnippetsCompleter', () => {
     let completer;
     let monaco;
@@ -51,54 +77,76 @@ describe('SnippetsCompleter', () => {
 
     describe('minimum word length for suggestions', () => {
         test('should return empty suggestions when word is 0 characters', () => {
-            const model = createModel('');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const model = createModel('', INSIDE_BLOCK_TEXT, INSIDE_BLOCK_LINE, INSIDE_BLOCK_COL_BASE);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: INSIDE_BLOCK_COL_BASE};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             expect(result.suggestions).toHaveLength(0);
         });
 
         test('should return empty suggestions when word is 1 character', () => {
-            const model = createModel('b');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}b`;
+            const col = INSIDE_BLOCK_COL_BASE + 1;
+            const model = createModel('b', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             expect(result.suggestions).toHaveLength(0);
         });
 
         test('should return empty suggestions when word is 2 characters', () => {
-            const model = createModel('mo');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}mo`;
+            const col = INSIDE_BLOCK_COL_BASE + 2;
+            const model = createModel('mo', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             expect(result.suggestions).toHaveLength(0);
         });
 
         test('should return suggestions when word is 3 characters', () => {
-            const model = createModel('mov');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}mov`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('mov', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             expect(result.suggestions.length).toBeGreaterThan(0);
         });
 
         test('should return suggestions when word is longer than 3 characters', () => {
-            const model = createModel('move');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}move`;
+            const col = INSIDE_BLOCK_COL_BASE + 4;
+            const model = createModel('move', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             expect(result.suggestions.length).toBeGreaterThan(0);
         });
     });
 
     describe('Japanese minimum word length', () => {
         test('should return suggestions for a single Japanese character', () => {
-            const model = createModel('動');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}動`;
+            const col = INSIDE_BLOCK_COL_BASE + 1;
+            const model = createModel('動', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             expect(result.suggestions.length).toBeGreaterThan(0);
         });
 
         test('should return suggestions for two Japanese characters', () => {
-            const model = createModel('もし');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}もし`;
+            const col = INSIDE_BLOCK_COL_BASE + 2;
+            const model = createModel('もし', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             expect(result.suggestions.length).toBeGreaterThan(0);
         });
     });
 
     describe('structured label', () => {
         test('should use structured label with labelJa, detail, and description', () => {
-            const model = createModel('mov');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}mov`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('mov', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             const moveSuggestion = result.suggestions.find(s =>
                 typeof s.label === 'object' && s.label.label === '動かす'
             );
@@ -110,8 +158,11 @@ describe('SnippetsCompleter', () => {
 
     describe('filterText', () => {
         test('should include filterText with romaji, Japanese, and caption', () => {
-            const model = createModel('mov');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}mov`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('mov', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             const moveSuggestion = result.suggestions.find(s =>
                 s.filterText && s.filterText.includes('ugokasu')
             );
@@ -123,8 +174,11 @@ describe('SnippetsCompleter', () => {
 
     describe('sortText', () => {
         test('should include sortText with category prefix for motion snippets', () => {
-            const model = createModel('mov');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}mov`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('mov', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             const moveSuggestion = result.suggestions.find(s =>
                 s.filterText && s.filterText.includes('move')
             );
@@ -133,8 +187,11 @@ describe('SnippetsCompleter', () => {
         });
 
         test('should include sortText with category prefix for looks snippets', () => {
-            const model = createModel('sho');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}sho`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('sho', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             const showSuggestion = result.suggestions.find(s =>
                 s.sortText && s.sortText.startsWith('02_')
             );
@@ -142,8 +199,11 @@ describe('SnippetsCompleter', () => {
         });
 
         test('should auto-generate sortText for snippets without explicit sortText', () => {
-            const model = createModel('mov');
-            const result = completer.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}mov`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('mov', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = completer.provideCompletionItems(model, pos, context, token, monaco);
             // All suggestions should have sortText (either from JSON or auto-generated)
             result.suggestions.forEach(s => {
                 expect(s.sortText).toBeDefined();
@@ -155,8 +215,11 @@ describe('SnippetsCompleter', () => {
         test('should exclude extension snippets when no extensions are loaded', () => {
             const vm = createVmMock([]);
             const extCompleter = new SnippetsCompleter(vm);
-            const model = createModel('pla');
-            const result = extCompleter.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}pla`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('pla', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = extCompleter.provideCompletionItems(model, pos, context, token, monaco);
             // Music snippet "play_drum" should not appear
             const musicSuggestion = result.suggestions.find(s =>
                 s.sortText && s.sortText.startsWith('10_')
@@ -167,8 +230,11 @@ describe('SnippetsCompleter', () => {
         test('should include extension snippets when the extension is loaded', () => {
             const vm = createVmMock(['music']);
             const extCompleter = new SnippetsCompleter(vm);
-            const model = createModel('pla');
-            const result = extCompleter.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}pla`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('pla', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = extCompleter.provideCompletionItems(model, pos, context, token, monaco);
             // Music snippet should appear
             const musicSuggestion = result.suggestions.find(s =>
                 s.sortText && s.sortText.startsWith('10_')
@@ -179,8 +245,11 @@ describe('SnippetsCompleter', () => {
         test('should always include core snippets regardless of loaded extensions', () => {
             const vm = createVmMock([]);
             const extCompleter = new SnippetsCompleter(vm);
-            const model = createModel('mov');
-            const result = extCompleter.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}mov`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('mov', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = extCompleter.provideCompletionItems(model, pos, context, token, monaco);
             // Core motion snippet should still appear
             const moveSuggestion = result.suggestions.find(s =>
                 s.filterText && s.filterText.includes('move')
@@ -190,8 +259,11 @@ describe('SnippetsCompleter', () => {
 
         test('should show all snippets when vm is not provided (backward compatibility)', () => {
             const noVmCompleter = new SnippetsCompleter();
-            const model = createModel('pla');
-            const result = noVmCompleter.provideCompletionItems(model, position, context, token, monaco);
+            const fullText = `${INSIDE_BLOCK_TEXT}pla`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('pla', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+            const result = noVmCompleter.provideCompletionItems(model, pos, context, token, monaco);
             // Extension snippets should still appear without VM
             const musicSuggestion = result.suggestions.find(s =>
                 s.sortText && s.sortText.startsWith('10_')
@@ -207,10 +279,13 @@ describe('SnippetsCompleter', () => {
                 }
             };
             const extCompleter = new SnippetsCompleter(vm);
-            const model = createModel('pla');
+            const fullText = `${INSIDE_BLOCK_TEXT}pla`;
+            const col = INSIDE_BLOCK_COL_BASE + 3;
+            const model = createModel('pla', fullText, INSIDE_BLOCK_LINE, col);
+            const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
 
             // Initially no music extension
-            let result = extCompleter.provideCompletionItems(model, position, context, token, monaco);
+            let result = extCompleter.provideCompletionItems(model, pos, context, token, monaco);
             let musicSuggestion = result.suggestions.find(s =>
                 s.sortText && s.sortText.startsWith('10_')
             );
@@ -218,11 +293,293 @@ describe('SnippetsCompleter', () => {
 
             // Load music extension
             loadedExtensions.push('music');
-            result = extCompleter.provideCompletionItems(model, position, context, token, monaco);
+            result = extCompleter.provideCompletionItems(model, pos, context, token, monaco);
             musicSuggestion = result.suggestions.find(s =>
                 s.sortText && s.sortText.startsWith('10_')
             );
             expect(musicSuggestion).toBeDefined();
+        });
+    });
+
+    describe('context-aware completion', () => {
+        describe('context detection', () => {
+            test('should detect top_level in an empty document', () => {
+                const fullText = 'whe';
+                const model = createModel('whe', fullText, 1, 4);
+                const pos = {lineNumber: 1, column: 4};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                // At top level, event snippets should appear
+                const eventSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('04_')
+                );
+                expect(eventSuggestion).toBeDefined();
+                // function snippets (e.g., move from motion) should NOT appear at top level
+                const functionSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('ugokasu')
+                );
+                expect(functionSuggestion).toBeUndefined();
+            });
+
+            test('should detect inside_block inside when_flag_clicked do...end', () => {
+                const fullText = 'when_flag_clicked do\n  mov';
+                const model = createModel('mov', fullText, 2, 6);
+                const pos = {lineNumber: 2, column: 6};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                // Inside block, function snippets should appear
+                const moveSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('ugokasu')
+                );
+                expect(moveSuggestion).toBeDefined();
+                // event snippets should NOT appear inside block
+                const eventSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('04_hataga')
+                );
+                expect(eventSuggestion).toBeUndefined();
+            });
+
+            test('should detect inside_block inside def...end', () => {
+                const fullText = 'def self.my_method(n)\n  mov';
+                const model = createModel('mov', fullText, 2, 6);
+                const pos = {lineNumber: 2, column: 6};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const moveSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('move')
+                );
+                expect(moveSuggestion).toBeDefined();
+            });
+
+            test('should return to top_level after end closes a block', () => {
+                const fullText = 'when_flag_clicked do\n  move(10)\nend\nwhe';
+                const model = createModel('whe', fullText, 4, 4);
+                const pos = {lineNumber: 4, column: 4};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                // Back at top level: events should appear
+                const eventSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('04_')
+                );
+                expect(eventSuggestion).toBeDefined();
+                // function snippets (e.g., move from motion) should NOT appear
+                const functionSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('ugokasu')
+                );
+                expect(functionSuggestion).toBeUndefined();
+            });
+
+            test('should detect inside_block in nested blocks (if inside event)', () => {
+                const fullText = 'when_flag_clicked do\n  if true\n    mov';
+                const model = createModel('mov', fullText, 3, 8);
+                const pos = {lineNumber: 3, column: 8};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const moveSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('move')
+                );
+                expect(moveSuggestion).toBeDefined();
+            });
+
+            test('should stay inside_block after nested end (if closed, event still open)', () => {
+                const fullText = 'when_flag_clicked do\n  if true\n    move(10)\n  end\n  mov';
+                const model = createModel('mov', fullText, 5, 6);
+                const pos = {lineNumber: 5, column: 6};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const moveSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('move')
+                );
+                expect(moveSuggestion).toBeDefined();
+            });
+
+            test('should ignore do/end in comment lines', () => {
+                const fullText = '# do\nwhe';
+                const model = createModel('whe', fullText, 2, 4);
+                const pos = {lineNumber: 2, column: 4};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                // Comment do should not affect nesting, so we are at top level
+                const eventSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('04_')
+                );
+                expect(eventSuggestion).toBeDefined();
+            });
+
+            test('should detect expression_expected after if keyword', () => {
+                const fullText = 'when_flag_clicked do\n  if tou';
+                const model = createModel('tou', fullText, 2, 9);
+                const pos = {lineNumber: 2, column: 9};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                // method type (e.g., touching?) should appear in expression context
+                const touchingSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('touching')
+                );
+                expect(touchingSuggestion).toBeDefined();
+                // function type (e.g., move) should NOT appear in expression context
+                const moveSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('ugokasu')
+                );
+                expect(moveSuggestion).toBeUndefined();
+            });
+
+            test('should detect expression_expected after until keyword', () => {
+                const fullText = 'when_flag_clicked do\n  until tou';
+                const model = createModel('tou', fullText, 2, 12);
+                const pos = {lineNumber: 2, column: 12};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const touchingSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('touching')
+                );
+                expect(touchingSuggestion).toBeDefined();
+            });
+
+            test('should detect expression_expected after elsif keyword', () => {
+                const fullText = 'when_flag_clicked do\n  if false\n    move(10)\n  elsif tou';
+                const model = createModel('tou', fullText, 4, 12);
+                const pos = {lineNumber: 4, column: 12};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const touchingSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('touching')
+                );
+                expect(touchingSuggestion).toBeDefined();
+            });
+
+            test('should detect expression_expected after unless keyword', () => {
+                const fullText = 'when_flag_clicked do\n  unless tou';
+                const model = createModel('tou', fullText, 2, 13);
+                const pos = {lineNumber: 2, column: 13};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const touchingSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('touching')
+                );
+                expect(touchingSuggestion).toBeDefined();
+            });
+
+            test('should detect expression_expected after while keyword', () => {
+                const fullText = 'when_flag_clicked do\n  while tou';
+                const model = createModel('tou', fullText, 2, 12);
+                const pos = {lineNumber: 2, column: 12};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const touchingSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('touching')
+                );
+                expect(touchingSuggestion).toBeDefined();
+            });
+        });
+
+        describe('type filtering', () => {
+            test('should allow def snippet at top level', () => {
+                const fullText = 'def';
+                const model = createModel('def', fullText, 1, 4);
+                const pos = {lineNumber: 1, column: 4};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const defSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('09_')
+                );
+                expect(defSuggestion).toBeDefined();
+            });
+
+            test('should not allow def snippet inside block', () => {
+                const fullText = 'when_flag_clicked do\n  def';
+                const model = createModel('def', fullText, 2, 6);
+                const pos = {lineNumber: 2, column: 6};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const defSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('09_')
+                );
+                expect(defSuggestion).toBeUndefined();
+            });
+
+            test('should allow control structure snippets (if, loop) inside block', () => {
+                const fullText = 'when_flag_clicked do\n  loo';
+                const model = createModel('loo', fullText, 2, 6);
+                const pos = {lineNumber: 2, column: 6};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const loopSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('loop')
+                );
+                expect(loopSuggestion).toBeDefined();
+            });
+
+            test('should not allow control structure snippets at top level', () => {
+                const fullText = 'loo';
+                const model = createModel('loo', fullText, 1, 4);
+                const pos = {lineNumber: 1, column: 4};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const loopSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('zutto') && s.filterText.includes('loop')
+                );
+                expect(loopSuggestion).toBeUndefined();
+            });
+
+            test('should always allow enum_member at top level', () => {
+                const fullText = 'ran';
+                const model = createModel('ran', fullText, 1, 4);
+                const pos = {lineNumber: 1, column: 4};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const enumSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('01z_')
+                );
+                expect(enumSuggestion).toBeDefined();
+            });
+
+            test('should always allow enum_member inside block', () => {
+                const fullText = 'when_flag_clicked do\n  ran';
+                const model = createModel('ran', fullText, 2, 6);
+                const pos = {lineNumber: 2, column: 6};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const enumSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('01z_')
+                );
+                expect(enumSuggestion).toBeDefined();
+            });
+
+            test('should not allow snippet types in expression_expected context', () => {
+                const fullText = 'when_flag_clicked do\n  if loo';
+                const model = createModel('loo', fullText, 2, 9);
+                const pos = {lineNumber: 2, column: 9};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                // loop (snippet type) should not appear after "if "
+                const loopSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('zutto') && s.filterText.includes('loop')
+                );
+                expect(loopSuggestion).toBeUndefined();
+            });
+
+            test('should allow variable type in expression_expected context', () => {
+                const fullText = 'when_flag_clicked do\n  if ran';
+                const model = createModel('ran', fullText, 2, 9);
+                const pos = {lineNumber: 2, column: 9};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                // rand (variable type) should appear after "if "
+                const randSuggestion = result.suggestions.find(s =>
+                    s.filterText && s.filterText.includes('ransuu') && s.filterText.includes('rand')
+                );
+                expect(randSuggestion).toBeDefined();
+            });
+
+            test('should allow constant type in expression_expected context', () => {
+                const fullText = 'when_flag_clicked do\n  if gen';
+                const model = createModel('gen', fullText, 2, 9);
+                const pos = {lineNumber: 2, column: 9};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                // Time.now.year (constant type) should appear
+                const constantSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('06_genzaino')
+                );
+                expect(constantSuggestion).toBeDefined();
+            });
+        });
+
+        describe('integration with extension filtering', () => {
+            test('should apply both context and extension filtering', () => {
+                const vm = createVmMock([]);
+                const extCompleter = new SnippetsCompleter(vm);
+                const fullText = `${INSIDE_BLOCK_TEXT}pla`;
+                const col = INSIDE_BLOCK_COL_BASE + 3;
+                const model = createModel('pla', fullText, INSIDE_BLOCK_LINE, col);
+                const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+                const result = extCompleter.provideCompletionItems(model, pos, context, token, monaco);
+                // Music extension not loaded, so music snippets should not appear
+                const musicSuggestion = result.suggestions.find(s =>
+                    s.sortText && s.sortText.startsWith('10_')
+                );
+                expect(musicSuggestion).toBeUndefined();
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary
- カーソル位置のコンテキスト（トップレベル/ブロック内/式が期待される箇所）に応じて補完候補をフィルタリング
- `do`/`def` vs `end` のカウントでネストレベルを算出し、コメント行は除外
- `if`/`unless`/`until`/`while`/`elsif` の直後では値を返す型のみ表示

## Changes Made
- `snippets-completer.js`: `#detectContext()` と `#filterByContext()` メソッドを追加
- `snippets-completer.test.js`: コンテキスト検出・フィルタリング・統合テスト 22件追加（既存テストも inside_block コンテキストに適応）

## Context Filtering Rules

| コンテキスト | 条件 | 表示する type |
|---|---|---|
| `top_level` | ブロック外 | `event`, `enum_member`, `def` snippet |
| `inside_block` | `do...end` / `def...end` 内 | `function`, `method`, `snippet`(非def), `variable`, `value`, `constant`, `enum_member` |
| `expression_expected` | `if`/`unless`/`until`/`while`/`elsif` 直後 | `variable`, `value`, `constant`, `method`, `enum_member` |

## Test Coverage
- 全39テスト合格（既存17 + 新規22）
- 全165テストスイート合格（1134テスト、リグレッションなし）
- Lint合格
- Playwright MCP でブラウザ動作確認済み

## Related Issues
Resolves #166 課題4 段階1
