### PR TITLE
docs: update CLAUDE.md and dev rules for @ruby/prism

### DIFF
--- a/.claude/rules/scratch-gui/development.md
+++ b/.claude/rules/scratch-gui/development.md
@@ -53,17 +53,17 @@ docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm test"
 # Lint only
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run test:lint"
 
-# Unit tests only
+# Unit tests only (uses jest)
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run test:unit"
 
-# Run specific unit test (does not use tap)
+# Run specific unit test file
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm exec jest test/unit/your-test.test.js"
 
 # Integration tests only (requires build first)
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run build:dev"
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run test:integration"
 
-# Run specific test (does not use tap)
+# Run specific integration test file
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run build:dev"
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm exec jest test/integration/your-test.test.js"
 
@@ -76,26 +76,94 @@ docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run tes
 ## Key Directories
 
 - `src/`: React components and application code
-  - `containers/ruby-tab/`: Ruby code editor integration
-  - `lib/ruby-to-blocks-converter/`: Ruby-to-blocks conversion logic
-  - `lib/ruby-generator/`: Blocks-to-Ruby code generation
+  - `containers/ruby-tab/`: Ruby code editor integration (Monaco Editor + tab switching)
+  - `lib/ruby-to-blocks-converter/`: Ruby AST → Scratch blocks conversion logic
+  - `lib/ruby-generator/`: Scratch blocks → Ruby code generation
+  - `lib/prism-parser.js`: `@ruby/prism` WebAssembly loader (browser + Node.js)
+  - `lib/ruby-parser.js`: High-level Ruby parsing interface
 - `test/`: Test files
-  - `test/unit/`: Unit tests
-  - `test/integration/`: Integration tests (Selenium-based)
+  - `test/unit/`: Unit tests (jest)
+  - `test/integration/`: Integration tests (jest + Selenium)
   - `test/smoke/`: Smoke tests
-- `scripts/`: Build and setup scripts
-  - `scripts/makePWAAssetsManifest.js`: PWA manifest generation
-  - `scripts/postbuild.mjs`: Post-build processing
 
 ## Ruby Mode Integration
+
+### Parser: @ruby/prism
+
+Ruby code is parsed using [@ruby/prism](https://github.com/ruby/prism), a WebAssembly-based Ruby parser. The WASM module runs both in the browser and in Node.js (for tests).
+
+- **Entry point**: `src/lib/prism-parser.js` — loads the WASM module and caches the prism instance
+- **High-level API**: `src/lib/ruby-parser.js` — wraps prism-parser for use by converters
+
+### Ruby ↔ Blocks Conversion
+
+| Direction | Directory | Description |
+|-----------|-----------|-------------|
+| Ruby → Blocks | `src/lib/ruby-to-blocks-converter/` | Walks prism AST, creates Scratch block data |
+| Blocks → Ruby | `src/lib/ruby-generator/` | Generates Ruby source from block tree |
+
+**Key files in `ruby-to-blocks-converter/`:**
+- `index.js` — entry point, orchestrates conversion
+- `ast-handlers/` — handlers for each prism AST node type
+- `converter-registry.js` — registry mapping block opcodes to converters
+- `register-converters.js` — registers all converter modules
+- `target-applier.js` — applies converted blocks to a Scratch target (VM)
+- `scope-manager.js` — variable/scope tracking during conversion
 
 ### Monaco Editor
 
 Ruby code editing uses Monaco Editor (`@monaco-editor/react`). The Ruby editor is integrated in `src/containers/ruby-tab/`.
 
-### Ruby-to-Blocks Conversion
+## Testing Philosophy for Ruby ↔ Blocks Conversion
 
-The `src/lib/ruby-to-blocks-converter/` directory contains logic for converting Ruby code back to Scratch blocks.
+### General Policy
+
+- **Unit tests are preferred** for all Ruby ↔ Blocks conversion logic
+- A VM mock is available, so most conversion behavior can be tested without a real browser
+- Extend the VM mock (add methods/state) as needed to cover new cases
+- Integration tests are reserved for behavior that genuinely requires a browser environment
+
+### When to Use Unit Tests (`test/unit/`)
+
+Use unit tests for:
+- Ruby → Blocks conversion (`ruby-to-blocks-converter/`)
+- Blocks → Ruby generation (`ruby-generator/`)
+- Round-trip correctness (Ruby → Blocks → Ruby)
+- Individual converter modules (motion, looks, sound, control, etc.)
+- Parser behavior (`prism-parser.js`, `ruby-parser.js`)
+- Snippet completion logic (`snippets-completer.js`)
+
+**Key unit test directories:**
+- `test/unit/lib/ruby-to-blocks-converter/` — converter unit tests
+- `test/unit/lib/ruby-generator/` — generator unit tests
+
+### When to Use Integration Tests (`test/integration/`)
+
+Use integration tests **only** for behavior that cannot be tested in unit tests:
+- Tab switching timing (Ruby tab ↔ Blocks tab)
+- Monaco Editor lifecycle (mount, unmount, editor readiness)
+- UI interactions that depend on browser rendering or actual DOM timing
+- End-to-end flows requiring a real build (e.g., `ruby-tab.test.js`)
+
+**Key integration test files:**
+- `test/integration/ruby-tab.test.js` — tab switching, editor lifecycle
+- `test/integration/ruby-tab-completion-and-indent.test.js` — Monaco completion/indent behavior
+- `test/integration/ruby-tab/` — additional Ruby tab integration scenarios
+
+### Test Structure Example
+
+```javascript
+// Unit test: ruby-to-blocks-converter
+import {createRubyToBlocksConverter} from '../../../src/lib/ruby-to-blocks-converter';
+
+describe('motion converter', () => {
+    test('should convert move(10) to motion_movesteps block', async () => {
+        const converter = createRubyToBlocksConverter(mockVM);
+        const blocks = await converter.convertRuby('move(10)');
+        expect(blocks).toMatchBlock({ opcode: 'motion_movesteps' });
+    });
+});
+```
 
 ## Google Drive Integration
 
@@ -159,3 +227,5 @@ The GUI is built as a PWA. Assets and manifest are generated by:
 - Hot module replacement (HMR) is enabled in development mode
 - The app uses scratch-blocks (Blockly fork) for visual block programming
 - CSS modules are used for styling (except raw.css files and driver.js)
+- Unit tests use jest with jsdom environment (configured in `package.json`)
+- The `@ruby/prism` WASM module requires special jest transform configuration (see `package.json`)

--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,6 @@ built-monorepo
 
 # Claude Code local settings
 .claude/settings.local.json
+.*-mcp/
 
 /notes

--- a/.serena/memories/completion_system_analysis.md
+++ b/.serena/memories/completion_system_analysis.md
@@ -1,0 +1,230 @@
+# Smalruby Completion System Analysis
+
+## Overview
+The Smalruby completion system is a Monaco Editor-based snippet completion provider for the Ruby mode in the Smalruby 3 Editor. It provides context-aware code completion for Ruby blocks, methods, and language features with heavy Japanese language support.
+
+## 1. Current Architecture
+
+### Main Components
+1. **SnippetsCompleter** (`snippets-completer.js`) - Main completion provider
+2. **BaseCompleter** (`base-completer.js`) - Base class for converting snippets to Monaco CompletionItems
+3. **Snippet JSON Files** (23 files) - Data sources for completions
+4. **RubyTab** (`ruby-tab.jsx`) - Integration point in React component
+5. **SmalrubyMode** (`smalruby-mode.js`) - Language configuration
+
+## 2. SnippetsCompleter.js (Full Content)
+
+### Key Features:
+- Manages both core and extension snippets
+- Filters completions based on loaded extensions
+- Handles Japanese character detection for minimum word length
+- Provides completion items to Monaco Editor
+
+### Core Logic:
+- **Minimum word length**: 3 characters for ASCII, 1 character for Japanese
+- **Japanese pattern**: `/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/` (hiragana, katakana, kanji)
+- **Core snippets**: 9 categories (motion, looks, sound, events, control, sensing, operators, variables, procedures)
+- **Extension snippets**: 11 categories (music, pen, video sensing, text-to-speech, translate, microbit, smalrubotS1, microbitMore, koshien, makeymakey, gdxfor)
+- **Category sorting**: 01-09 for core, 10-21 for extensions
+
+### Extension Filtering:
+- Extensions are filtered dynamically via `vm.extensionManager.isExtensionLoaded(extensionId)`
+- Categories with extensionId are only shown if extension is loaded
+- Backward compatible: shows all if VM is not provided
+
+### provideCompletionItems() Method:
+```javascript
+// Checks minimum word length
+// Uses getWordUntilPosition() from Monaco model
+// Combines core + active extension snippets
+// Converts to CompletionItems and returns
+```
+
+## 3. BaseCompleter.js (Full Content)
+
+### toCompletionItem() Method:
+Converts snippet object to Monaco CompletionItem with:
+- **label**: Uses structured label if `labelJa` exists: `{label, detail, description}`
+- **kind**: Maps type to CompletionItemKind (Method, Function, Variable, Value, Constant, EnumMember, Keyword, Event, Snippet)
+- **documentation**: Markdown formatted with description and code snippet
+- **insertText**: The code snippet to insert
+- **insertTextRules**: Marked as snippet for tab stops handling
+- **range**: Where the completion will be inserted
+- **detail**: "Smalruby Snippet" if no Japanese label
+- **filterText**: Optional, used for matching
+- **sortText**: Optional, used for sorting
+
+### Type Mapping:
+- `method` → Method
+- `function` → Function
+- `variable` → Variable
+- `value` → Value
+- `constant` → Constant
+- `enum_member` → EnumMember
+- `keyword` → Keyword
+- `event` → Event
+- `snippet` or default → Snippet
+
+## 4. Snippet JSON Structure
+
+### Structure of Each Snippet:
+```json
+{
+    "key_name": {
+        "snippet": "code(${1:default})",
+        "description": "Japanese description of what it does",
+        "type": "function|snippet|variable|value|constant|enum_member|keyword|event",
+        "labelJa": "Japanese label shown in dropdown",
+        "filterText": "romaji japanese kanji aliases additional_search_terms",
+        "sortText": "XX_romanization"
+    }
+}
+```
+
+### Key Fields:
+- **snippet**: Monaco snippet syntax with `${N:default}` for tab stops
+- **description**: Full Japanese explanation (shown in docs)
+- **type**: Determines icon and kind in completion menu
+- **labelJa**: Japanese display name (becomes structured label)
+- **filterText**: Space-separated romaji, Japanese, and aliases for matching
+- **sortText**: Category prefix (01-21) + romanization for consistent ordering
+
+### Example (motion-snippets.json):
+```json
+"move": {
+    "snippet": "move(${1:10})",
+    "description": "(10) 歩動かす",
+    "type": "function",
+    "labelJa": "動かす",
+    "filterText": "ugokasu 動かす move 歩動かす",
+    "sortText": "01_ugokasu"
+}
+```
+
+## 5. Snippet Files Inventory (23 files)
+
+### Core Snippets (9):
+- **01**: motion-snippets.json (25 items) - move, turn, go_to, direction, x/y positioning
+- **02**: looks-snippets.json - say, think, costume, backdrop, effects, size
+- **03**: sound-snippets.json - play sound, effects, volume
+- **04**: events-snippets.json - when_flag_clicked, when_key_pressed, when_clicked, broadcast
+- **05**: control-snippets.json - sleep, times, loop, if, wait, stop, clone
+- **06**: sensing-snippets.json - touching, distance, ask_and_wait, mouse, timer
+- **07**: operators-snippets.json (30+ items) - rand, and, or, not, strings, math functions
+- **08**: variables-snippets.json - variables, lists, operations
+- **09**: procedure-snippets.json - define, call procedures
+
+### Extension Snippets (11):
+- **10**: music-snippets.json (extensionId: 'music')
+- **11**: pen-snippets.json (extensionId: 'pen')
+- **12**: video-sensing-snippets.json (extensionId: 'videoSensing')
+- **13**: text-to-speech-snippets.json (extensionId: 'text2speech')
+- **14**: translate-snippets.json (extensionId: 'translate')
+- **15**: microbit-snippets.json (extensionId: 'microbit')
+- **17**: smalrubot-s1-snippets.json (extensionId: 'smalrubotS1')
+- **18**: microbit-more-snippets.json (extensionId: 'microbitMore')
+- **19**: koshien-snippets.json (extensionId: 'koshien')
+- **20**: makey-snippets.json (extensionId: 'makeymakey')
+- **21**: gdx_for-snippets.json (extensionId: 'gdxfor')
+
+## 6. RubyTab.jsx Integration
+
+### Registration Point (lines 377-384):
+```javascript
+if (!this.completionProvider) {
+    const completer = new SnippetsCompleter(this.props.vm);
+    this.completionProvider = monaco.languages.registerCompletionItemProvider('smalruby', {
+        provideCompletionItems: (model, position, context, token) => (
+            completer.provideCompletionItems(model, position, context, token, monaco)
+        )
+    });
+}
+```
+
+### Completion Registration:
+- Registered in `handleEditorDidMount()` lifecycle method
+- Uses 'smalruby' language ID
+- Passes VM instance to completer for extension filtering
+- Provider is disposed in `componentWillUnmount()`
+
+## 7. SmalrubyMode.js Configuration
+
+### Language Configuration:
+- **wordPattern**: Includes Japanese characters (hiragana, katakana, kanji)
+- **indentationRules**: Handles Ruby block indentation
+- **autoClosingPairs**: Parentheses, brackets, quotes
+- **comments**: Line comments with `#`
+
+### Word Pattern:
+```javascript
+wordPattern: new RegExp(`(-?\\d*\\.\\d\\w*)|([a-zA-Z_${JA}][\\w${JA}]*)`)
+```
+This allows Japanese characters in word boundaries, enabling completion triggering on Japanese input.
+
+## 8. Current Filtering/Context Capabilities
+
+### Implemented:
+1. **Minimum word length**: 3 ASCII or 1 Japanese character
+2. **Extension filtering**: Based on loaded extensions via VM
+3. **Category sorting**: Via sortText (01-21 prefixes)
+4. **Type-based icons**: Via CompletionItemKind mapping
+
+### NOT Yet Implemented (Opportunity for 課題4):
+1. **Context awareness**: No analysis of preceding code/line context
+2. **Block type filtering**: All snippets shown regardless of what's valid at cursor
+3. **Scope analysis**: No variable/scope detection
+4. **Line position analysis**: No detection of statement vs expression context
+5. **Block nesting rules**: No Ruby syntax rules applied
+6. **Parent block detection**: No detection of what block we're in (event, loop, if, etc.)
+7. **Parameter context**: No showing only relevant enum values based on function context
+
+## 9. Key Data in Snippets
+
+### Context Information Available:
+- **type field**: Distinguishes methods, functions, variables, events, constants
+- **description field**: Describes what each snippet does
+- **filterText field**: Contains contextual keywords
+
+### Example Patterns:
+- Event snippets (when_*) have type: 'event'
+- Loop snippets (times, loop) have type: 'snippet'
+- Parameter values have type: 'enum_member'
+- Variables/expressions have type: 'variable' or 'value'
+
+## 10. Opportunities for Context-Aware Completion (課題4)
+
+### Analysis of Line Context:
+Could analyze preceding code to understand:
+1. Are we in an event block? (show only event-appropriate snippets)
+2. Are we in a loop? (show loop-exit snippets)
+3. Are we in an if condition? (show boolean/comparison snippets)
+4. What's the expected type? (expression vs statement)
+
+### Block Nesting Analysis:
+- Detect if cursor is inside do...end block
+- Detect if cursor is inside loop (times, loop, until, while)
+- Show only exit-capable snippets in loops
+
+### Parameter Context:
+- Detect if we're inside a function parameter
+- Show only enum values relevant to that parameter
+- Example: If in `go_to(...)`, only show movement target enums
+
+### Scope Analysis:
+- Track defined variables and show only available ones
+- Show method parameters in completion
+- Filter based on what's defined in current target
+
+## 11. Current Test Coverage
+
+### Test File: snippets-completer.test.js
+Tests cover:
+- Minimum word length (3 ASCII, 1 Japanese)
+- Structured labels with labelJa
+- filterText matching
+- sortText categorization
+- Extension filtering (dynamic loading)
+- Core snippets always shown
+- Backward compatibility (no VM)
+
+### Gap: No tests for context-aware filtering yet

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,10 +1,11 @@
 # Smalruby 3 Editor Monorepo
 
-Smalruby 3 is a Ruby-based visual programming environment forked from Scratch 3.0. It allows users to write Ruby code which is transpiled to JavaScript using Opal and executed within the Scratch VM.
+Smalruby 3 is a Ruby-based visual programming environment forked from Scratch 3.0. Users write Ruby code in a Monaco Editor; the code is parsed by @ruby/prism (WASM) and converted to/from Scratch blocks within the browser.
 
 ## Tech Stack
-- **Frontend**: React, Redux, Ace Editor (for Ruby code editing)
-- **Runtime**: Node.js/JavaScript (Scratch VM), Opal (Ruby-to-JS transpiler)
+- **Frontend**: React, Redux, Monaco Editor (for Ruby code editing)
+- **Parser**: @ruby/prism (WebAssembly-based Ruby parser — runs in browser and Node.js)
+- **Runtime**: Node.js/JavaScript (Scratch VM)
 - **Rendering**: WebGL (scratch-render), SVG (scratch-svg-renderer)
 - **Environment**: Docker-based development environment
 - **Monorepo Management**: npm workspaces

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -11,8 +11,18 @@ Smalruby 3 is a Ruby-based visual programming environment forked from Scratch 3.
 - **Monorepo Management**: npm workspaces
 
 ## Codebase Structure
-- `packages/scratch-gui`: The React web interface.
-- `packages/scratch-vm`: The execution engine.
+- `packages/scratch-gui`: React web interface. Key subdirectories:
+  - `src/lib/ruby-to-blocks-converter/`: Ruby AST (prism) → Scratch blocks
+  - `src/lib/ruby-generator/`: Scratch blocks → Ruby source
+  - `src/containers/ruby-tab/`: Monaco Editor integration and tab switching
+  - `src/lib/prism-parser.js`: @ruby/prism WASM loader (browser + Node.js)
+- `packages/scratch-vm`: Scratch VM — executes projects, manages block runtime.
 - `packages/scratch-render`: WebGL rendering engine.
 - `packages/scratch-svg-renderer`: SVG rendering engine.
-- `packages/task-herder`: Task management/tracking utility.
+- `packages/task-herder`: Async task queue with throttling.
+
+## Key Rules Files
+- `.claude/rules/scratch-gui/development.md`: Testing philosophy, Ruby mode architecture, commands
+- `.claude/rules/scratch-vm/development.md`: VM-specific commands and patterns
+- `.claude/rules/code-style.md`: ESLint, naming conventions, React/Redux patterns
+- `.claude/rules/git-workflow.md`: Branching, Conventional Commits, PR workflow

--- a/.serena/memories/suggest_commands.md
+++ b/.serena/memories/suggest_commands.md
@@ -5,46 +5,52 @@
 ## Monorepo Root Commands
 ```bash
 # Install dependencies
-docker compose run --rm app bash -c "npm install"
+docker compose run --rm app npm install
 
-# Build all packages
-docker compose run --rm app bash -c "npm run build"
+# Build all packages (production)
+docker compose run --rm app npm run build
 
-# Build in development mode
-docker compose run --rm app bash -c "npm run build:dev"
+# Build in development mode (faster, with source maps)
+docker compose run --rm app npm run build:dev
 
-# Run all tests (unit and integration)
-docker compose run --rm app bash -c "npm test"
+# Run all tests (lint + unit + integration)
+docker compose run --rm app npm test
 
 # Run unit tests only
-docker compose run --rm app bash -c "npm run test:unit"
+docker compose run --rm app npm run test:unit
 
 # Run integration tests only
-docker compose run --rm app bash -c "npm run test:integration"
+docker compose run --rm app npm run test:integration
 
 # Run lint for all packages
-docker compose run --rm app bash -c "npm run lint"
+docker compose run --rm app npm run lint
 ```
 
 ## Package-Specific Commands
-You can run commands for specific packages by changing to their directory.
 
-### Scratch VM
+### Scratch VM (unit tests use tap)
 ```bash
-# Run VM tests
+# Run all VM tests
 docker compose run --rm app bash -c "cd /app/packages/scratch-vm && npm test"
 
-# Run specific tap tests
-docker compose run --rm app bash -c "cd /app/packages/scratch-vm && npm run tap:unit"
+# Run a specific unit test file
+docker compose run --rm app bash -c "cd /app/packages/scratch-vm && npm exec tap test/unit/specific-file.js"
 ```
 
-### Scratch GUI
+### Scratch GUI (unit and integration tests use jest)
 ```bash
 # Run GUI unit tests
 docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run test:unit"
 
+# Run a specific unit test file
+docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm exec jest test/unit/path/to/test.test.js"
+
 # Run GUI integration tests (requires build:dev first)
-docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run build:dev && npm run test:integration"
+docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run build:dev"
+docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run test:integration"
+
+# Run a specific integration test file
+docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm exec jest test/integration/specific.test.js"
 ```
 
 ## System Utilities (Darwin)

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -2,22 +2,32 @@
 
 Before considering a task complete and preparing a Pull Request:
 
-1. **Verify Functionality**: Ensure the changes work as expected and add new tests if applicable.
+1. **Verify Functionality**: Ensure changes work as expected and add new tests if applicable.
 2. **Run Lint Checks**:
    ```bash
-   docker compose run --rm app bash -c "npm run lint"
+   docker compose run --rm app npm run lint
    ```
 3. **Run Unit Tests**:
    ```bash
-   docker compose run --rm app bash -c "npm run test:unit"
+   docker compose run --rm app npm run test:unit
    ```
-4. **Run Integration Tests** (if applicable):
+4. **Run Integration Tests** (if applicable — requires build:dev first):
    ```bash
-   docker compose run --rm app bash -c "npm run test:integration"
+   docker compose run --rm app bash -c "cd /app/packages/scratch-gui && npm run build:dev"
+   docker compose run --rm app npm run test:integration
    ```
 5. **Build Check**: Ensure the project builds successfully.
    ```bash
-   docker compose run --rm app bash -c "npm run build"
+   docker compose run --rm app npm run build
    ```
 6. **Git Status**: Check for untracked files and ensure all changes are staged.
-7. **Commit**: Use Conventional Commits.
+7. **Commit**: Use Conventional Commits format.
+
+## Ruby ↔ Blocks Testing Guidance
+
+- **Prefer unit tests** for all `ruby-to-blocks-converter/` and `ruby-generator/` logic.
+- The VM mock is available; extend it (add methods/state) to cover new cases rather than resorting to integration tests.
+- Use **integration tests** only for browser-specific behavior:
+  - Tab switching timing (Ruby tab ↔ Blocks tab)
+  - Monaco Editor lifecycle (mount, unmount, readiness)
+  - UI interactions dependent on actual DOM/browser rendering

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This is the **Smalruby 3 Editor** monorepo - a Ruby-based visual programming env
 This project uses npm workspaces with the following packages:
 
 - **`packages/scratch-gui`**: React-based web interface with Ruby mode, custom extensions, and Google Drive integration
-- **`packages/scratch-vm`**: Virtual machine that executes projects, with Opal integration for Ruby execution
+- **`packages/scratch-vm`**: Virtual machine that executes projects and manages blocks
 - **`packages/scratch-render`**: WebGL-based rendering engine for sprites and backdrops
 - **`packages/scratch-svg-renderer`**: SVG processing for vector images
 - **`packages/task-herder`**: Asynchronous task queue with throttling and concurrency control
@@ -98,14 +98,14 @@ docker compose run --rm app npm run test:integration
 
 **IMPORTANT**: `test:unit` and `test:integration` commands do NOT accept file arguments. To run individual test files, use `npm exec` (or `npx`):
 
-For unit tests (uses tap):
+For unit tests:
 
 ```bash
-# scratch-vm unit tests
+# scratch-vm unit tests (uses tap)
 docker compose run --rm app bash -c "cd packages/scratch-vm && npm exec tap test/unit/specific-file.js"
 
-# scratch-gui unit tests
-docker compose run --rm app bash -c "cd packages/scratch-gui && npm exec tap test/unit/specific-file.test.js"
+# scratch-gui unit tests (uses jest)
+docker compose run --rm app bash -c "cd packages/scratch-gui && npm exec jest test/unit/specific-file.test.js"
 ```
 
 For integration tests (uses jest):
@@ -130,11 +130,14 @@ docker compose run --rm app npm run clean
 
 ## Smalruby-Specific Features
 
-### Ruby Mode with Opal
+### Ruby Mode with @ruby/prism
 
-Smalruby integrates [Opal](https://opalrb.com/) to transpile Ruby code into JavaScript that runs within the Scratch VM. The `scratch-vm` package handles Ruby execution, while `scratch-gui` provides the Ruby code editor (Monaco Editor) and UI.
+Smalruby provides a Ruby code editor (Monaco Editor) in `scratch-gui`. Ruby code is parsed using [@ruby/prism](https://github.com/ruby/prism) (a WebAssembly-based Ruby parser) and converted to/from Scratch blocks within the browser.
 
-**Opal Setup**: The `packages/scratch-gui` package runs `npm run setup:opal` automatically before builds to generate `static/javascripts/setup-opal.js` from Opal sources.
+- **Parser**: `@ruby/prism` — parses Ruby source into an AST (WebAssembly, runs in browser and Node.js)
+- **Ruby → Blocks**: `src/lib/ruby-to-blocks-converter/` — converts prism AST nodes into Scratch blocks
+- **Blocks → Ruby**: `src/lib/ruby-generator/` — generates Ruby source from Scratch block data
+- **Integration**: `src/containers/ruby-tab/` — Monaco Editor integration and tab switching logic
 
 ### Google Drive Integration
 
@@ -157,7 +160,7 @@ Custom Smalruby extensions are located in `packages/scratch-vm/src/extensions/`:
 
 Each package has its own development workflow. See package-specific rules in `.claude/rules/`:
 
-- `.claude/rules/scratch-gui/` - GUI development, Opal integration, testing
+- `.claude/rules/scratch-gui/` - GUI development, Ruby mode, testing
 - `.claude/rules/scratch-vm/` - VM development, extensions, playground
 - `.claude/rules/scratch-render/` - Rendering engine development
 - `.claude/rules/scratch-svg-renderer/` - SVG processing


### PR DESCRIPTION
## Summary

- Opal に関する記述を削除し、現在の実装である `@ruby/prism` (WebAssembly) に更新
- `scratch-gui` の unit テストランナーを `tap` → `jest` に修正
- `.claude/rules/scratch-gui/development.md` を大幅拡充
- serena MCP メモリ（`project_overview`, `suggest_commands`, `task_completion`）を現状に同期

## Changes Made

### CLAUDE.md
- `scratch-vm` の説明から "Opal integration" を削除
- `Smalruby-Specific Features` の "Ruby Mode with Opal" を "Ruby Mode with @ruby/prism" に全面更新（パーサー・変換ディレクトリ・統合ポイントを記述）
- scratch-gui unit test の注記を `tap` → `jest` に修正

### `.claude/rules/scratch-gui/development.md`
- `@ruby/prism` パーサーセクションを追加（`prism-parser.js`、`ruby-parser.js` の役割）
- Ruby ↔ Blocks 変換アーキテクチャの表と主要ファイル一覧を追加
- **テスト方針セクション** (Testing Philosophy) を新設：
  - `ruby-to-blocks-converter/` / `ruby-generator/` は unit test を基本とする
  - VM mock を活用してできる限り unit でカバーする
  - integration test はタブ切り替えタイミング・Monaco Editor ライフサイクルなどブラウザ依存の挙動に限定する

### `.serena/memories/`
- `project_overview`: scratch-gui の主要サブディレクトリ詳細、`.claude/rules/` 参照を追加
- `suggest_commands`: コマンドスタイル統一、tap vs jest の明示、個別ファイル実行例追加
- `task_completion`: Ruby ↔ Blocks テスト指針セクションを追加

### `.serena/memories/completion_system_analysis.md` (new)
- スニペット補完システムの分析メモを追加

### `.gitignore`
- `.*-mcp/` を追加

## Related Issues

N/A（ドキュメント・メモのメンテナンス）
