### PR TITLE
fix: resolve sprite addition issue on smalruby3-editor GitHub Pages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -224,6 +224,21 @@ jobs:
           full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
           cname: smalruby.app
           external_repository: smalruby/smalruby.app
+      - name: Rebuild for smalruby3-editor GitHub Pages
+        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        env:
+          PUBLIC_PATH: /smalruby3-editor/
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          MESH_GRAPHQL_ENDPOINT: ${{ secrets.MESH_GRAPHQL_ENDPOINT }}
+          MESH_API_KEY: ${{ secrets.MESH_API_KEY }}
+          MESH_AWS_REGION: ${{ secrets.MESH_AWS_REGION }}
+          MESH_DATA_UPDATE_INTERVAL_MS: ${{ vars.MESH_DATA_UPDATE_INTERVAL_MS }}
+          MESH_EVENT_BATCH_INTERVAL_MS: ${{ vars.MESH_EVENT_BATCH_INTERVAL_MS }}
+          MESH_PERIODIC_DATA_SYNC_INTERVAL_MS: ${{ vars.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS }}
+          GTM_ID: ''
+          GTM_ENV_AUTH: ''
+        run: cd packages/scratch-gui && npm exec node ./scripts/postbuild.mjs
       - name: Prepare deployment files
         if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         run: touch packages/scratch-gui/build/.nojekyll

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -303,3 +303,25 @@ jobs:
           full_commit_message: "Build for ${{ steps.branch.outputs.BRANCH_NAME }} (${{ github.sha }}) ${{ github.event.head_commit.message }}"
           destination_dir: ${{ steps.branch.outputs.BRANCH_NAME }}
           keep_files: true
+      - name: Comment preview URL on PR (once only)
+        if: |
+          github.event_name == 'pull_request' &&
+          (!(
+            github.ref == 'refs/heads/develop' ||
+            github.ref == 'refs/heads/master' ||
+            github.ref == 'refs/heads/main' ||
+            startsWith(github.ref, 'refs/heads/hotfix/') ||
+            startsWith(github.ref, 'refs/heads/dependabot/') ||
+            startsWith(github.ref, 'refs/heads/renovate/')
+          ))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREVIEW_URL: https://smalruby.jp/smalruby3-editor/${{ steps.branch.outputs.BRANCH_NAME }}/
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          ALREADY_COMMENTED=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} --json comments \
+            --jq "[.comments[].body | contains(\"$PREVIEW_URL\")] | any")
+          if [ "$ALREADY_COMMENTED" != "true" ]; then
+            gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} \
+              --body "🚀 Preview deployed: $PREVIEW_URL"
+          fi

--- a/packages/scratch-gui/webpack.config.js
+++ b/packages/scratch-gui/webpack.config.js
@@ -212,7 +212,8 @@ const buildConfig = baseConfig.clone()
             // Having `publicPath: '/'` (the default) means the `gui.js` file in `build/index.html`
             // would be looked for at the root of the filesystem, which is incorrect.
             // Hence, we're resetting the public path to be relative.
-            publicPath: ''
+            // PUBLIC_PATH can be set for GitHub Pages subdirectory deployments (e.g. /smalruby3-editor/).
+            publicPath: process.env.PUBLIC_PATH || ''
         }
     })
     .addPlugin(new HtmlWebpackPlugin({


### PR DESCRIPTION
## Summary

- `packages/scratch-gui/webpack.config.js` の `buildConfig` で `publicPath` が `PUBLIC_PATH` 環境変数を参照するよう修正
- CI/CD に develop ブランチデプロイ前の `postbuild.mjs` 実行ステップを追加（`PUBLIC_PATH=/smalruby3-editor/`）
- CI/CD にブランチデプロイ後の PR プレビュー URL コメント機能を追加（1 PR につき 1 回のみ）

## Background

`https://smalruby.jp/smalruby3-editor` でスプライトを追加できない問題が発生していた。

原因は `webpack.config.js` の `buildConfig` の `publicPath` が `''`（空文字）に固定されているため、GitHub Pages のサブディレクトリ `/smalruby3-editor/` にデプロイされると `fetch-worker` などのワーカーチャンクのパスが相対パスで解決できなくなること。

同様の問題は以前 `smalruby/smalruby3-gui` でも発生しており、`PUBLIC_PATH` 環境変数対応と `postbuild.mjs` スクリプトによる後処理で解決した（smalruby/smalruby3-gui commits 3456358..1a51c3a）。今回はその同じ修正を `smalruby3-editor` に適用する。

## Changes

- `packages/scratch-gui/webpack.config.js`: `publicPath: ''` → `publicPath: process.env.PUBLIC_PATH || ''`
- `.github/workflows/ci-cd.yml`: develop ブランチデプロイ前に `PUBLIC_PATH=/smalruby3-editor/` で `postbuild.mjs` を実行するステップを追加
- `.github/workflows/ci-cd.yml`: ブランチの GitHub Pages デプロイ後、PR に `https://smalruby.jp/smalruby3-editor/<branch>/` のプレビュー URL を 1 回だけコメントするステップを追加

## Test Plan

- [ ] CI でブランチデプロイが完了し、PR にプレビュー URL コメントが 1 回投稿されることを確認
- [ ] プレビュー URL でスプライト追加が正常に動作することをブラウザで確認
- [ ] develop へのマージ後、`https://smalruby.jp/smalruby3-editor` でスプライト追加が正常に動作することをブラウザで確認

## Related

Closes #179
