### PR TITLE
feat: 型認識による operator_add / operator_join の使い分け (#181)

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
@@ -228,6 +228,67 @@ const NodeUtils = {
         return this.getBlockType(block) === 'value_variable' && block.opcode === 'data_listcontents';
     },
 
+    /**
+     * Infer the data type of a value (literal or block).
+     * Returns null if the type cannot be determined statically.
+     * @param {*} value - A literal value or block object
+     * @returns {'string'|'number'|'boolean'|null}
+     */
+    _inferDataType (value) {
+        if (this._isString(value)) return 'string';
+        if (this._isNumber(value)) return 'number';
+        if (this._isTrue(value) || this._isFalse(value)) return 'boolean';
+        if (this._isBlock(value)) return this._getBlockDataType(value);
+        return null;
+    },
+
+    /**
+     * Determine the data type ('string', 'number', 'boolean') of a block's return value.
+     * Returns null if the type cannot be determined statically.
+     * @param {object} block - The block object
+     * @returns {'string'|'number'|'boolean'|null}
+     */
+    _getBlockDataType (block) {
+        if (!this._isBlock(block)) return null;
+
+        const comment = block.comment ? this._context.comments[block.comment] : null;
+        const commentText = comment ? comment.text : '';
+
+        if (commentText === '@ruby:method:to_s') return 'string';
+        if (commentText === '@ruby:method:to_i') return 'number';
+
+        const STRING_OPCODES = [
+            'operator_join',
+            'operator_letter_of'
+        ];
+        const NUMBER_OPCODES = [
+            'operator_add',
+            'operator_subtract',
+            'operator_multiply',
+            'operator_divide',
+            'operator_mod',
+            'operator_round',
+            'operator_mathop',
+            'operator_random',
+            'operator_length'
+        ];
+        const BOOLEAN_OPCODES = [
+            'operator_and',
+            'operator_or',
+            'operator_not',
+            'operator_equals',
+            'operator_gt',
+            'operator_lt',
+            'operator_contains'
+        ];
+
+        if (STRING_OPCODES.includes(block.opcode)) return 'string';
+        if (NUMBER_OPCODES.includes(block.opcode)) return 'number';
+        if (BOOLEAN_OPCODES.includes(block.opcode)) return 'boolean';
+
+        return null;
+    },
+
     isRubyExpression (block) {
         return this._isRubyExpression(block);
     },

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
@@ -232,7 +232,7 @@ const NodeUtils = {
      * Infer the data type of a value (literal or block).
      * Returns null if the type cannot be determined statically.
      * @param {*} value - A literal value or block object
-     * @returns {'string'|'number'|'boolean'|null}
+     * @returns {'string'|'number'|'boolean'|null} The inferred data type, or null if unknown
      */
     _inferDataType (value) {
         if (this._isString(value)) return 'string';
@@ -246,7 +246,7 @@ const NodeUtils = {
      * Determine the data type ('string', 'number', 'boolean') of a block's return value.
      * Returns null if the type cannot be determined statically.
      * @param {object} block - The block object
-     * @returns {'string'|'number'|'boolean'|null}
+     * @returns {'string'|'number'|'boolean'|null} The data type of the block's return value, or null if unknown
      */
     _getBlockDataType (block) {
         if (!this._isBlock(block)) return null;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -8,6 +8,26 @@ const MathE = '::Math::E';
  */
 const OperatorsConverter = {
     register: function (converter) {
+        // String-typed variable + any: use operator_join (must be registered before the numeric + handler)
+        converter.registerOnSend('variable', '+', 1, params => {
+            const {receiver, args} = params;
+            const variable = converter.lookupVariableFromVariableBlock(receiver);
+            if (!variable || variable.dataType !== 'string') return null;
+
+            let rh = args[0];
+            if (_.isArray(rh)) {
+                if (rh.length !== 1) return null;
+                rh = rh[0];
+            }
+
+            if (!converter._isStringOrBlock(rh)) return null;
+
+            const block = converter._createBlock('operator_join', 'value');
+            converter._addTextInput(block, 'STRING1', receiver, 'apple');
+            converter._addTextInput(block, 'STRING2', converter._isNumber(rh) ? rh.toString() : rh, 'banana');
+            return block;
+        });
+
         converter.registerOnSend('self', 'rand', 1, params => {
             const {args} = params;
             if (!converter._isBlock(args[0]) || args[0].opcode !== 'ruby_range') return null;
@@ -80,6 +100,12 @@ const OperatorsConverter = {
                     rh = rh[0];
                 }
 
+                // Skip string-typed variables for + (handled by the dedicated string handler)
+                if (operator === '+' && converter.isVariableBlock(receiver)) {
+                    const variable = converter.lookupVariableFromVariableBlock(receiver);
+                    if (variable && variable.dataType === 'string') return null;
+                }
+
                 if (!converter._isNumberOrBlock(rh)) return null;
 
                 let opcode;
@@ -102,7 +128,7 @@ const OperatorsConverter = {
             });
         });
 
-        converter.registerOnSend(['variable', 'string', 'block'], '+', 1, params => {
+        converter.registerOnSend(['string', 'block'], '+', 1, params => {
             const {receiver, args} = params;
             let rh = args[0];
             if (_.isArray(rh)) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -20,6 +20,9 @@ const OperatorsConverter = {
                 rh = rh[0];
             }
 
+            // Boolean values are not valid operands for string concatenation
+            if (converter._isTrue(rh) || converter._isFalse(rh)) return null;
+
             if (!converter._isStringOrBlock(rh)) return null;
 
             const block = converter._createBlock('operator_join', 'value');
@@ -106,6 +109,9 @@ const OperatorsConverter = {
                     if (variable && variable.dataType === 'string') return null;
                 }
 
+                // Boolean values are not valid operands for numeric arithmetic
+                if (converter._isTrue(rh) || converter._isFalse(rh)) return null;
+
                 if (!converter._isNumberOrBlock(rh)) return null;
 
                 let opcode;
@@ -135,6 +141,9 @@ const OperatorsConverter = {
                 if (rh.length !== 1) return null;
                 rh = rh[0];
             }
+
+            // Boolean values are not valid operands for string concatenation
+            if (converter._isTrue(rh) || converter._isFalse(rh)) return null;
 
             if (!converter._isStringOrBlock(rh)) return null;
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variable-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variable-utils.js
@@ -73,7 +73,8 @@ const VariableUtils = {
                     scope: 'local', // Mark as local for internal tracking
                     scopeIndex: scopeIndex,
                     type: type,
-                    isArgument: isArgument
+                    isArgument: isArgument,
+                    dataType: null
                 };
                 this._context[storeName][transformedName] = variable;
             }
@@ -99,7 +100,8 @@ const VariableUtils = {
                 id: Blockly.utils.genUid(),
                 name: varName,
                 scope: scope,
-                type: type
+                type: type,
+                dataType: null
             };
             this._context[storeName][varName] = variable;
         }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
@@ -300,6 +300,7 @@ const VariablesConverter = {
                         }
                     });
                     converter._addTextInput(block, 'VALUE', converter._isNumber(rh) ? rh.toString() : rh, '0');
+                    variable.dataType = converter._inferDataType(rh);
                     return block;
                 }
             } else if (scope === 'local' && !variable.isArgument) {
@@ -319,6 +320,7 @@ const VariablesConverter = {
                     block.comment = converter._createComment(commentText, block.id);
 
                     converter._addTextInput(block, 'VALUE', converter._isNumber(rh) ? rh.toString() : rh, '0');
+                    variable.dataType = converter._inferDataType(rh);
                     return block;
                 }
             }

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/arithmetic-add-subtract.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/arithmetic-add-subtract.test.js
@@ -217,5 +217,31 @@ describe('RubyToBlocksConverter/Operators', () => {
             code = 'a = touching?("edge")\na + "!"';
             await convertAndExpectRubyBlockError(converter, target, code);
         });
+
+        test('string variable + boolean literal is ruby block error', async () => {
+            code = 'a = "Hello"\na + true';
+            await convertAndExpectRubyBlockError(converter, target, code);
+
+            converter = new RubyToBlocksConverter(null);
+            code = 'a = "Hello"\na + false';
+            await convertAndExpectRubyBlockError(converter, target, code);
+        });
+    });
+
+    describe('operator_add type safety', () => {
+        test('number variable + boolean literal is ruby block error', async () => {
+            code = 'a = 10\na + true';
+            await convertAndExpectRubyBlockError(converter, target, code);
+        });
+
+        test('number variable + false is ruby block error', async () => {
+            code = 'a = 10\na + false';
+            await convertAndExpectRubyBlockError(converter, target, code);
+        });
+
+        test('number variable + string literal is ruby block error', async () => {
+            code = 'a = 10\na + "Hello"';
+            await convertAndExpectRubyBlockError(converter, target, code);
+        });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/arithmetic-add-subtract.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/arithmetic-add-subtract.test.js
@@ -171,4 +171,51 @@ describe('RubyToBlocksConverter/Operators', () => {
             await convertAndExpectRubyBlockError(converter, target, s);
         } }
     });
+
+    describe('operator_join via string variable', () => {
+        test('string variable + string literal uses operator_join', async () => {
+            code = 'a = "He"\na + "llo"';
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            const scripts = Object.values(converter.blocks).filter(b => !b.parent);
+            const joinBlock = scripts.find(b => b.opcode === 'operator_join');
+            expect(joinBlock).toBeDefined();
+        });
+
+        test('two string variables use operator_join', async () => {
+            code = 'a = "He"\nb = "llo"\na + b';
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            const joinBlock = Object.values(converter.blocks).find(b => b.opcode === 'operator_join');
+            expect(joinBlock).toBeDefined();
+        });
+
+        test('to_s result variable + string literal uses operator_join', async () => {
+            code = 'a = 1.to_s\na + "!"';
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            const joinBlock = Object.values(converter.blocks).find(b => b.opcode === 'operator_join');
+            expect(joinBlock).toBeDefined();
+        });
+
+        test('number variable + number uses operator_add (unchanged)', async () => {
+            code = 'a = 1\na + 2';
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(0);
+            const addBlock = Object.values(converter.blocks).find(b => b.opcode === 'operator_add');
+            expect(addBlock).toBeDefined();
+            const joinBlock = Object.values(converter.blocks).find(b => b.opcode === 'operator_join');
+            expect(joinBlock).toBeUndefined();
+        });
+
+        test('string variable + number is ruby block error (type mismatch)', async () => {
+            code = 'a = "He"\na + 2';
+            await convertAndExpectRubyBlockError(converter, target, code);
+        });
+
+        test('unknown-type variable + string literal is ruby block error', async () => {
+            code = 'a = touching?("edge")\na + "!"';
+            await convertAndExpectRubyBlockError(converter, target, code);
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -92,6 +92,12 @@ describe('Ruby Round Trip', () => {
         await expectRoundTrip('if touching?("_edge_")\n  move(10)\nend');
     });
 
+    test('string variable concatenation uses operator_join (regression for #181)', async () => {
+        await expectRoundTrip('a = "He"\nb = "llo"\na + b', 'a = "He"\nb = "llo"\n\na + b');
+        await expectRoundTrip('a = "He"\na + "llo"', 'a = "He"\n\na + "llo"');
+        await expectRoundTrip('a = 1.to_s\na + "!"', 'a = 1.to_s\n\na + "!"');
+    });
+
     test('return statement in method', async () => {
         await expectRoundTrip(`
 def self.add(a, b)

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-data-type.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-data-type.test.js
@@ -1,0 +1,120 @@
+import RubyToBlocksConverter from '../../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectToEqualBlocks,
+    expectedInfo
+} from '../../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/Variables/dataType', () => {
+    let converter;
+    let target;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null);
+        target = null;
+    });
+
+    describe('global variable ($a)', () => {
+        test('string literal assignment records dataType string', async () => {
+            const code = '$a = "hello"';
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [{ name: 'VARIABLE', variable: '$a' }],
+                    inputs: [{ name: 'VALUE', block: expectedInfo.makeText('hello') }]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+            expect(converter.variables['a'].dataType).toBe('string');
+        });
+
+        test('number literal assignment records dataType number', async () => {
+            const code = '$a = 42';
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [{ name: 'VARIABLE', variable: '$a' }],
+                    inputs: [{ name: 'VALUE', block: expectedInfo.makeText('42') }]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+            expect(converter.variables['a'].dataType).toBe('number');
+        });
+
+        test('true literal assignment records dataType boolean', async () => {
+            const code = '$a = true';
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.variables['a'].dataType).toBe('boolean');
+        });
+
+        test('false literal assignment records dataType boolean', async () => {
+            const code = '$a = false';
+            await converter.targetCodeToBlocks(target, code);
+            expect(converter.variables['a'].dataType).toBe('boolean');
+        });
+    });
+
+    describe('local variable (a)', () => {
+        test('string literal assignment records dataType string', async () => {
+            const code = 'a = "He"';
+            await converter.targetCodeToBlocks(target, code);
+            const localVars = converter._context.localVariables;
+            const varEntry = Object.values(localVars).find(v => v.originalName === 'a');
+            expect(varEntry).toBeDefined();
+            expect(varEntry.dataType).toBe('string');
+        });
+
+        test('number literal assignment records dataType number', async () => {
+            const code = 'a = 1';
+            await converter.targetCodeToBlocks(target, code);
+            const localVars = converter._context.localVariables;
+            const varEntry = Object.values(localVars).find(v => v.originalName === 'a');
+            expect(varEntry).toBeDefined();
+            expect(varEntry.dataType).toBe('number');
+        });
+
+        test('true assignment records dataType boolean', async () => {
+            const code = 'a = true';
+            await converter.targetCodeToBlocks(target, code);
+            const localVars = converter._context.localVariables;
+            const varEntry = Object.values(localVars).find(v => v.originalName === 'a');
+            expect(varEntry).toBeDefined();
+            expect(varEntry.dataType).toBe('boolean');
+        });
+
+        test('operator_join result assignment records dataType string', async () => {
+            const code = 'a = "He" + "llo"';
+            await converter.targetCodeToBlocks(target, code);
+            const localVars = converter._context.localVariables;
+            const varEntry = Object.values(localVars).find(v => v.originalName === 'a');
+            expect(varEntry).toBeDefined();
+            expect(varEntry.dataType).toBe('string');
+        });
+
+        test('to_s result assignment records dataType string', async () => {
+            const code = 'a = 1.to_s';
+            await converter.targetCodeToBlocks(target, code);
+            const localVars = converter._context.localVariables;
+            const varEntry = Object.values(localVars).find(v => v.originalName === 'a');
+            expect(varEntry).toBeDefined();
+            expect(varEntry.dataType).toBe('string');
+        });
+
+        test('to_i result assignment records dataType number', async () => {
+            const code = 'a = "1".to_i';
+            await converter.targetCodeToBlocks(target, code);
+            const localVars = converter._context.localVariables;
+            const varEntry = Object.values(localVars).find(v => v.originalName === 'a');
+            expect(varEntry).toBeDefined();
+            expect(varEntry.dataType).toBe('number');
+        });
+
+        test('unknown block result assignment records dataType null', async () => {
+            const code = 'a = touching?("edge")';
+            await converter.targetCodeToBlocks(target, code);
+            const localVars = converter._context.localVariables;
+            const varEntry = Object.values(localVars).find(v => v.originalName === 'a');
+            expect(varEntry).toBeDefined();
+            expect(varEntry.dataType).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- 変数代入時に `dataType`（`'string'`/`'number'`/`'boolean'`/`null`）を記録するフィールドを追加
- `_inferDataType` / `_getBlockDataType` ヘルパーを `node-utils.js` に追加
- `+` 演算子変換で左辺変数の `dataType` を参照し、`operator_add` / `operator_join` を使い分け
- `+` 演算子のオペランドに boolean リテラル（`true`/`false`）が来た場合にエラーを返すよう修正

## Implementation Steps

- [x] Phase 1+2: 変数への dataType 記録 & `_getBlockDataType` ヘルパー追加
- [x] Phase 3: `+` 演算子変換ロジック変更
- [x] Phase Final: Integration Tests 追加
- [x] fix: boolean リテラルを `+` のオペランドとして受け付けないよう修正

Closes #181
