### PR TITLE
feat: support -=, *=, /=, %= compound assignment operators in Ruby mode

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -40,8 +40,8 @@ export default function (Generator) {
         const comment = Generator.getCommentText(block);
         const hasValueInput = block.inputs && block.inputs.VALUE && block.inputs.VALUE.block;
 
-        // Check for local variable metadata
-        if (comment && comment.startsWith('@ruby:lvar:')) {
+        // Check for local variable metadata (skip if compound assignment syntax is also present)
+        if (comment && comment.startsWith('@ruby:lvar:') && !comment.includes('@ruby:syntax:')) {
             const parts = comment.split(':');
             if (parts.length === 4) {
                 const originalName = parts[2];
@@ -78,14 +78,21 @@ export default function (Generator) {
             // Not the last block, output normal variable assignment
         }
 
-        // Check for compound assignment syntax comments (@ruby:syntax:-=, *=, /=, %=)
-        const compoundMatch = comment ? comment.match(/^@ruby:syntax:([+\-*/%])=$/) : null;
+        // Check for compound assignment syntax comments (@ruby:syntax:+=, -=, *=, /=, %=)
+        // Supports both standalone (@ruby:syntax:+=) and combined with lvar (@ruby:lvar:name:idx,@ruby:syntax:+=)
+        const compoundMatch = comment ? comment.match(/@ruby:syntax:([+\-*/%])=/) : null;
         if (compoundMatch && hasValueInput) {
-            const variable = Generator.variableName(Generator.getFieldId(block, 'VARIABLE'));
             const op = compoundMatch[1];
+            // Extract original variable name from @ruby:lvar comment if present
+            const lvarMatch = comment.match(/@ruby:lvar:(\w+):\d+/);
+            const variable = lvarMatch ?
+                lvarMatch[1] :
+                Generator.variableName(Generator.getFieldId(block, 'VARIABLE'));
             const operatorBlock = Generator.getBlock(block.inputs.VALUE.block);
             if (operatorBlock) {
-                const rh = Generator.valueToCode(operatorBlock, 'NUM2', Generator.ORDER_NONE) || '0';
+                // For operator_join (string +=), use STRING2 input; for numeric operators, use NUM2
+                const rhInput = operatorBlock.opcode === 'operator_join' ? 'STRING2' : 'NUM2';
+                const rh = Generator.valueToCode(operatorBlock, rhInput, Generator.ORDER_NONE) || '0';
                 return `${variable} ${op}= ${Generator.nosToCode(rh)}\n`;
             }
         }

--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -78,6 +78,18 @@ export default function (Generator) {
             // Not the last block, output normal variable assignment
         }
 
+        // Check for compound assignment syntax comments (@ruby:syntax:-=, *=, /=, %=)
+        const compoundMatch = comment ? comment.match(/^@ruby:syntax:([+\-*/%])=$/) : null;
+        if (compoundMatch && hasValueInput) {
+            const variable = Generator.variableName(Generator.getFieldId(block, 'VARIABLE'));
+            const op = compoundMatch[1];
+            const operatorBlock = Generator.getBlock(block.inputs.VALUE.block);
+            if (operatorBlock) {
+                const rh = Generator.valueToCode(operatorBlock, 'NUM2', Generator.ORDER_NONE) || '0';
+                return `${variable} ${op}= ${Generator.nosToCode(rh)}\n`;
+            }
+        }
+
         const variable = Generator.variableName(Generator.getFieldId(block, 'VARIABLE'));
 
         // Check if this is a return value marker block (return variable with no VALUE input)

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
@@ -199,11 +199,24 @@ const VariablesConverter = {
             return block;
         });
 
+        // Operator to opcode mapping for compound assignments
+        const COMPOUND_OPERATOR_MAP = {
+            '-': 'operator_subtract',
+            '*': 'operator_multiply',
+            '/': 'operator_divide',
+            '%': 'operator_mod'
+        };
+
         // Register onXxx handlers
         converter.registerOnOpAsgn((lh, operator, rh) => {
             let block;
-            if (operator === '+' && converter._isString(lh) && converter._isNumberOrBlock(rh)) {
-                const variable = converter._lookupOrCreateVariable(lh);
+            if (!converter._isString(lh) || !converter._isNumberOrBlock(rh)) {
+                return block;
+            }
+
+            const variable = converter._lookupOrCreateVariable(lh);
+
+            if (operator === '+') {
                 if (variable.scope === 'global' || variable.scope === 'instance') {
                     block = converter._createBlock('data_changevariableby', 'statement', {
                         fields: {
@@ -250,6 +263,43 @@ const VariablesConverter = {
 
                     converter._addInput(block, 'VALUE', addBlock);
                 }
+            } else if (COMPOUND_OPERATOR_MAP.hasOwnProperty(operator)) {
+                const opcode = COMPOUND_OPERATOR_MAP[operator];
+
+                block = converter._createBlock('data_setvariableto', 'statement', {
+                    fields: {
+                        VARIABLE: {
+                            name: 'VARIABLE',
+                            id: variable.id,
+                            value: variable.name,
+                            variableType: variable.type
+                        }
+                    }
+                });
+
+                block.comment = converter._createComment(`@ruby:syntax:${operator}=`, block.id);
+
+                const variableBlock = converter._createBlock('data_variable', 'value_variable', {
+                    fields: {
+                        VARIABLE: {
+                            name: 'VARIABLE',
+                            id: variable.id,
+                            value: variable.name,
+                            variableType: variable.type
+                        }
+                    }
+                });
+
+                if (variable.scope === 'local') {
+                    const lvarComment = `@ruby:lvar:${variable.originalName}:${variable.scopeIndex}`;
+                    variableBlock.comment = converter._createComment(lvarComment, variableBlock.id);
+                }
+
+                const operatorBlock = converter._createBlock(opcode, 'value');
+                converter._addInput(operatorBlock, 'NUM1', variableBlock);
+                converter._addNumberInput(operatorBlock, 'NUM2', 'math_number', rh, 1);
+
+                converter._addInput(block, 'VALUE', operatorBlock);
             }
             return block;
         });

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
@@ -210,14 +210,64 @@ const VariablesConverter = {
         // Register onXxx handlers
         converter.registerOnOpAsgn((lh, operator, rh) => {
             let block;
-            if (!converter._isString(lh) || !converter._isNumberOrBlock(rh)) {
+            if (!converter._isString(lh)) {
+                return block;
+            }
+            if (!converter._isNumberOrBlock(rh) && !converter._isStringOrBlock(rh)) {
                 return block;
             }
 
             const variable = converter._lookupOrCreateVariable(lh);
 
             if (operator === '+') {
-                if (variable.scope === 'global' || variable.scope === 'instance') {
+                // Check if this is a string-typed variable: use operator_join
+                if (variable.dataType === 'string') {
+                    block = converter._createBlock('data_setvariableto', 'statement', {
+                        fields: {
+                            VARIABLE: {
+                                name: 'VARIABLE',
+                                id: variable.id,
+                                value: variable.name,
+                                variableType: variable.type
+                            }
+                        }
+                    });
+
+                    const syntaxComment = `@ruby:syntax:+=`;
+                    if (variable.scope === 'local') {
+                        const lvarComment = `@ruby:lvar:${variable.originalName}:${variable.scopeIndex}`;
+                        block.comment = converter._createComment(
+                            `${lvarComment},${syntaxComment}`, block.id
+                        );
+                    } else {
+                        block.comment = converter._createComment(syntaxComment, block.id);
+                    }
+
+                    const variableBlock = converter._createBlock('data_variable', 'value_variable', {
+                        fields: {
+                            VARIABLE: {
+                                name: 'VARIABLE',
+                                id: variable.id,
+                                value: variable.name,
+                                variableType: variable.type
+                            }
+                        }
+                    });
+                    if (variable.scope === 'local') {
+                        const lvarComment = `@ruby:lvar:${variable.originalName}:${variable.scopeIndex}`;
+                        variableBlock.comment = converter._createComment(lvarComment, variableBlock.id);
+                    }
+
+                    const joinBlock = converter._createBlock('operator_join', 'value');
+                    converter._addTextInput(joinBlock, 'STRING1', variableBlock, 'apple');
+                    converter._addTextInput(
+                        joinBlock, 'STRING2', converter._isNumber(rh) ? rh.toString() : rh, 'banana'
+                    );
+
+                    converter._addInput(block, 'VALUE', joinBlock);
+                } else if (variable.scope === 'global' || variable.scope === 'instance') {
+                    if (!converter._isNumberOrBlock(rh)) return block;
+
                     block = converter._createBlock('data_changevariableby', 'statement', {
                         fields: {
                             VARIABLE: {
@@ -230,7 +280,9 @@ const VariablesConverter = {
                     });
                     converter._addNumberInput(block, 'VALUE', 'math_number', rh, 1);
                 } else {
-                    // Assignment for local variables
+                    // Numeric += for local variables
+                    if (!converter._isNumberOrBlock(rh)) return block;
+
                     block = converter._createBlock('data_setvariableto', 'statement', {
                         fields: {
                             VARIABLE: {
@@ -242,8 +294,10 @@ const VariablesConverter = {
                         }
                     });
 
-                    const commentText = `@ruby:lvar:${variable.originalName}:${variable.scopeIndex}`;
-                    block.comment = converter._createComment(commentText, block.id);
+                    const lvarComment = `@ruby:lvar:${variable.originalName}:${variable.scopeIndex}`;
+                    block.comment = converter._createComment(
+                        `${lvarComment},@ruby:syntax:+=`, block.id
+                    );
 
                     const variableBlock = converter._createBlock('data_variable', 'value_variable', {
                         fields: {
@@ -255,7 +309,7 @@ const VariablesConverter = {
                             }
                         }
                     });
-                    variableBlock.comment = converter._createComment(commentText, variableBlock.id);
+                    variableBlock.comment = converter._createComment(lvarComment, variableBlock.id);
 
                     const addBlock = converter._createBlock('operator_add', 'value');
                     converter._addInput(addBlock, 'NUM1', variableBlock);
@@ -264,6 +318,8 @@ const VariablesConverter = {
                     converter._addInput(block, 'VALUE', addBlock);
                 }
             } else if (Object.prototype.hasOwnProperty.call(COMPOUND_OPERATOR_MAP, operator)) {
+                if (!converter._isNumberOrBlock(rh)) return block;
+
                 const opcode = COMPOUND_OPERATOR_MAP[operator];
 
                 block = converter._createBlock('data_setvariableto', 'statement', {
@@ -277,7 +333,15 @@ const VariablesConverter = {
                     }
                 });
 
-                block.comment = converter._createComment(`@ruby:syntax:${operator}=`, block.id);
+                const syntaxComment = `@ruby:syntax:${operator}=`;
+                if (variable.scope === 'local') {
+                    const lvarComment = `@ruby:lvar:${variable.originalName}:${variable.scopeIndex}`;
+                    block.comment = converter._createComment(
+                        `${lvarComment},${syntaxComment}`, block.id
+                    );
+                } else {
+                    block.comment = converter._createComment(syntaxComment, block.id);
+                }
 
                 const variableBlock = converter._createBlock('data_variable', 'value_variable', {
                     fields: {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variables.js
@@ -263,7 +263,7 @@ const VariablesConverter = {
 
                     converter._addInput(block, 'VALUE', addBlock);
                 }
-            } else if (COMPOUND_OPERATOR_MAP.hasOwnProperty(operator)) {
+            } else if (Object.prototype.hasOwnProperty.call(COMPOUND_OPERATOR_MAP, operator)) {
                 const opcode = COMPOUND_OPERATOR_MAP[operator];
 
                 block = converter._createBlock('data_setvariableto', 'statement', {

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/data.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/data.test.js
@@ -13,6 +13,60 @@ describe('RubyGenerator/Data', () => {
         DataBlocks(RubyGenerator);
     });
 
+    describe('data_setvariableto', () => {
+        const makeCompoundAssignmentTest = (operator, opcode, rhValue) => {
+            const operatorBlock = {
+                id: 'operator-block-id',
+                opcode: opcode,
+                inputs: {
+                    NUM2: {block: 'num2-block-id'}
+                }
+            };
+            const block = {
+                id: 'block-id',
+                opcode: 'data_setvariableto',
+                fields: {
+                    VARIABLE: {
+                        id: 'var-id',
+                        value: 'a'
+                    }
+                },
+                inputs: {
+                    VALUE: {
+                        block: 'operator-block-id'
+                    }
+                }
+            };
+            RubyGenerator.cache_.comments['block-id'] = {text: `@ruby:syntax:${operator}=`};
+            RubyGenerator.variableName = jest.fn().mockReturnValue('@a');
+            RubyGenerator.getFieldId = jest.fn().mockReturnValue('var-id');
+            RubyGenerator.getBlock = jest.fn().mockReturnValue(operatorBlock);
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue(String(rhValue));
+            RubyGenerator.nosToCode = jest.fn(v => v);
+            return block;
+        };
+
+        test('compound assignment -= generates variable -= value', () => {
+            const block = makeCompoundAssignmentTest('-', 'operator_subtract', 1);
+            expect(RubyGenerator.data_setvariableto(block)).toEqual('@a -= 1\n');
+        });
+
+        test('compound assignment *= generates variable *= value', () => {
+            const block = makeCompoundAssignmentTest('*', 'operator_multiply', 2);
+            expect(RubyGenerator.data_setvariableto(block)).toEqual('@a *= 2\n');
+        });
+
+        test('compound assignment /= generates variable /= value', () => {
+            const block = makeCompoundAssignmentTest('/', 'operator_divide', 2);
+            expect(RubyGenerator.data_setvariableto(block)).toEqual('@a /= 2\n');
+        });
+
+        test('compound assignment %= generates variable %= value', () => {
+            const block = makeCompoundAssignmentTest('%', 'operator_mod', 3);
+            expect(RubyGenerator.data_setvariableto(block)).toEqual('@a %= 3\n');
+        });
+    });
+
     describe('data_lengthoflist', () => {
         test('normal', () => {
             const block = {

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/variables.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/variables.test.js
@@ -24,6 +24,14 @@ describe('Ruby Roundtrip: Variables category blocks', () => {
             @sprite_only_variable = 0
             $my_variable += 1
             @sprite_only_variable += 1
+            $my_variable -= 1
+            @sprite_only_variable -= 1
+            $my_variable *= 2
+            @sprite_only_variable *= 2
+            $my_variable /= 3
+            @sprite_only_variable /= 3
+            $my_variable %= 4
+            @sprite_only_variable %= 4
             show_variable("$my_variable")
             show_variable("@sprite_only_variable")
             hide_variable("$my_variable")

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -98,6 +98,13 @@ describe('Ruby Round Trip', () => {
         await expectRoundTrip('a = 1.to_s\na + "!"', 'a = 1.to_s\n\na + "!"');
     });
 
+    test('compound assignment operators (-=, *=, /=, %=)', async () => {
+        await expectRoundTrip('@a = 10\n@a -= 1');
+        await expectRoundTrip('@a = 10\n@a *= 2');
+        await expectRoundTrip('@a = 10\n@a /= 3');
+        await expectRoundTrip('@a = 10\n@a %= 4');
+    });
+
     test('return statement in method', async () => {
         await expectRoundTrip(`
 def self.add(a, b)

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -105,6 +105,18 @@ describe('Ruby Round Trip', () => {
         await expectRoundTrip('@a = 10\n@a %= 4');
     });
 
+    test('string variable += uses operator_join', async () => {
+        await expectRoundTrip('@a = "hello"\n@a += "!"');
+    });
+
+    test('local variable compound assignment operators', async () => {
+        await expectRoundTrip('a = 1\na += 2');
+        await expectRoundTrip('a = 1\na -= 3');
+        await expectRoundTrip('a = 1\na *= 4');
+        await expectRoundTrip('a = 1\na /= 5');
+        await expectRoundTrip('a = 1\na %= 6');
+    });
+
     test('return statement in method', async () => {
         await expectRoundTrip(`
 def self.add(a, b)

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-global1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-global1.test.js
@@ -115,6 +115,178 @@ describe('RubyToBlocksConverter/Variables', () => {
             await convertAndExpectToEqualBlocks(converter, target, code, expected);
         });
 
+        test('compound assignment -= (data_setvariableto + operator_subtract)', async () => {
+            const code = `${varName} -= 1`;
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: varName
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: {
+                                opcode: 'operator_subtract',
+                                inputs: [
+                                    {
+                                        name: 'NUM1',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: varName
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        name: 'NUM2',
+                                        block: expectedInfo.makeNumber(1)
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    comment: {text: '@ruby:syntax:-=', minimized: true}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('compound assignment *= (data_setvariableto + operator_multiply)', async () => {
+            const code = `${varName} *= 2`;
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: varName
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: {
+                                opcode: 'operator_multiply',
+                                inputs: [
+                                    {
+                                        name: 'NUM1',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: varName
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        name: 'NUM2',
+                                        block: expectedInfo.makeNumber(2)
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    comment: {text: '@ruby:syntax:*=', minimized: true}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('compound assignment /= (data_setvariableto + operator_divide)', async () => {
+            const code = `${varName} /= 2`;
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: varName
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: {
+                                opcode: 'operator_divide',
+                                inputs: [
+                                    {
+                                        name: 'NUM1',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: varName
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        name: 'NUM2',
+                                        block: expectedInfo.makeNumber(2)
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    comment: {text: '@ruby:syntax:/=', minimized: true}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('compound assignment %= (data_setvariableto + operator_mod)', async () => {
+            const code = `${varName} %= 3`;
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: varName
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: {
+                                opcode: 'operator_mod',
+                                inputs: [
+                                    {
+                                        name: 'NUM1',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: varName
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        name: 'NUM2',
+                                        block: expectedInfo.makeNumber(3)
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    comment: {text: '@ruby:syntax:%=', minimized: true}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
         test('data_showvariable', async () => {
             const code = `show_variable("${varName}")`;
             const expected = [

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-instance1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-instance1.test.js
@@ -115,6 +115,178 @@ describe('RubyToBlocksConverter/Variables', () => {
             await convertAndExpectToEqualBlocks(converter, target, code, expected);
         });
 
+        test('compound assignment -= (data_setvariableto + operator_subtract)', async () => {
+            const code = `${varName} -= 1`;
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: varName
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: {
+                                opcode: 'operator_subtract',
+                                inputs: [
+                                    {
+                                        name: 'NUM1',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: varName
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        name: 'NUM2',
+                                        block: expectedInfo.makeNumber(1)
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    comment: {text: '@ruby:syntax:-=', minimized: true}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('compound assignment *= (data_setvariableto + operator_multiply)', async () => {
+            const code = `${varName} *= 2`;
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: varName
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: {
+                                opcode: 'operator_multiply',
+                                inputs: [
+                                    {
+                                        name: 'NUM1',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: varName
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        name: 'NUM2',
+                                        block: expectedInfo.makeNumber(2)
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    comment: {text: '@ruby:syntax:*=', minimized: true}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('compound assignment /= (data_setvariableto + operator_divide)', async () => {
+            const code = `${varName} /= 2`;
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: varName
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: {
+                                opcode: 'operator_divide',
+                                inputs: [
+                                    {
+                                        name: 'NUM1',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: varName
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        name: 'NUM2',
+                                        block: expectedInfo.makeNumber(2)
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    comment: {text: '@ruby:syntax:/=', minimized: true}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('compound assignment %= (data_setvariableto + operator_mod)', async () => {
+            const code = `${varName} %= 3`;
+            const expected = [
+                {
+                    opcode: 'data_setvariableto',
+                    fields: [
+                        {
+                            name: 'VARIABLE',
+                            variable: varName
+                        }
+                    ],
+                    inputs: [
+                        {
+                            name: 'VALUE',
+                            block: {
+                                opcode: 'operator_mod',
+                                inputs: [
+                                    {
+                                        name: 'NUM1',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: varName
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        name: 'NUM2',
+                                        block: expectedInfo.makeNumber(3)
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    comment: {text: '@ruby:syntax:%=', minimized: true}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
         test('data_showvariable', async () => {
             const code = `show_variable("${varName}")`;
             const expected = [


### PR DESCRIPTION
## Summary

- Add support for `-=`, `*=`, `/=`, `%=` compound assignment operators in Ruby mode
- Ruby-to-Blocks: generate `data_setvariableto` + operator block combinations with `@ruby:syntax:{op}=` comments
- Blocks-to-Ruby: detect `@ruby:syntax:{op}=` comments and generate compound assignment form (e.g., `@a -= 1`)
- Full round-trip fidelity: Ruby → Blocks → Ruby preserves compound assignment syntax
- **String variable `+=`**: uses `operator_join` instead of `data_changevariableby` when the variable has string data type
- **Local variable compound assignments**: all operators (`+=`, `-=`, `*=`, `/=`, `%=`) round-trip correctly using combined `@ruby:lvar:` + `@ruby:syntax:` comments

## Implementation Details

| Ruby | Blocks | Comment |
|------|--------|---------|
| `@a += 1` (numeric) | `data_changevariableby` | Unchanged (existing) |
| `@a += "!"` (string) | `data_setvariableto` + `operator_join` | `@ruby:syntax:+=` |
| `@a -= 1` | `data_setvariableto` + `operator_subtract` | `@ruby:syntax:-=` |
| `@a *= 2` | `data_setvariableto` + `operator_multiply` | `@ruby:syntax:*=` |
| `@a /= 2` | `data_setvariableto` + `operator_divide` | `@ruby:syntax:/=` |
| `@a %= 3` | `data_setvariableto` + `operator_mod` | `@ruby:syntax:%=` |
| `a += 2` (local) | `data_setvariableto` + `operator_add` | `@ruby:lvar:a:0,@ruby:syntax:+=` |
| `a -= 3` (local) | `data_setvariableto` + `operator_subtract` | `@ruby:lvar:a:0,@ruby:syntax:-=` |

## Implementation Steps

- [x] **Phase 1**: Ruby → Blocks: global/instance variable `-=`, `*=`, `/=`, `%=` support
- [x] **Phase 2**: Blocks → Ruby: `@ruby:syntax:{op}=` comment handling in generator
- [x] **Phase 3**: Round-trip tests for all compound assignment operators
- [x] **Phase 4**: Playwright MCP manual verification
- [x] **Phase 5**: String `+=` uses `operator_join` for string-typed variables
- [x] **Phase 6**: Local variable compound assignments round-trip correctly

## Test Plan

- Unit tests for Ruby-to-Blocks conversion (global + instance variables × 4 operators)
- Unit tests for Ruby generator compound assignment output
- Round-trip tests (Ruby → Blocks → Ruby) for instance, global, and local variables
- Round-trip tests for string variable `+=`
- Full unit test suite passes (1352 tests)
- Manual browser verification: all operators round-trip correctly

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
