### PR TITLE
feat: ブロックパレット開閉トグルボタンを追加 (#188)

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -76,9 +76,10 @@ response format. Update client code to handle the new structure."
    ```
 
 4. **Create PR using `gh` CLI**:
-   ```bash
-   # Create temporary file for PR body
-   cat > /tmp/pr-body.md <<'EOF'
+
+   Use the **Write tool** to write the PR body to `/tmp/pr-body.md`:
+
+   ```markdown
    ## Summary
    Brief description of changes.
 
@@ -92,9 +93,11 @@ response format. Update client code to handle the new structure."
 
    ## Related Issues
    Fixes #123
-   EOF
+   ```
 
-   # Create PR
+   Then run:
+
+   ```bash
    gh pr create \
      --repo smalruby/smalruby3-editor \
      --base develop \
@@ -102,7 +105,6 @@ response format. Update client code to handle the new structure."
      --title "feat: descriptive title" \
      --body-file /tmp/pr-body.md
 
-   # Clean up
    rm /tmp/pr-body.md
    ```
 
@@ -134,9 +136,11 @@ gh issue list --repo smalruby/smalruby3-editor
 
 # View specific issue
 gh issue view 123 --repo smalruby/smalruby3-editor
+```
 
-# Create issue (use temporary file)
-cat > /tmp/issue-body.md <<'EOF'
+Use the **Write tool** to write the issue body to `/tmp/issue-body.md`:
+
+```markdown
 ## Description
 Issue description here.
 
@@ -149,8 +153,11 @@ What should happen.
 
 ## Actual Behavior
 What actually happens.
-EOF
+```
 
+Then run:
+
+```bash
 gh issue create \
   --repo smalruby/smalruby3-editor \
   --title "bug: descriptive title" \
@@ -172,10 +179,16 @@ gh issue create --body "Description with \`code\` and \"quotes\""
 ```
 
 ✅ **Do this instead**:
-```bash
-cat > /tmp/body.md <<'EOF'
+
+Use the **Write tool** to write the content to `/tmp/body.md`:
+
+```markdown
 Description with `code` and "quotes"
-EOF
+```
+
+Then run:
+
+```bash
 gh issue create --body-file /tmp/body.md
 rm /tmp/body.md
 ```

--- a/packages/scratch-gui/src/components/blocks/blocks.css
+++ b/packages/scratch-gui/src/components/blocks/blocks.css
@@ -4,6 +4,7 @@
 
 .blocks {
     height: 100%;
+    position: relative;
 }
 
 .drag-over:after {

--- a/packages/scratch-gui/src/components/palette-toggle/palette-toggle.css
+++ b/packages/scratch-gui/src/components/palette-toggle/palette-toggle.css
@@ -1,0 +1,35 @@
+@import "../../css/z-index.css";
+
+.palette-toggle-button {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: $z-index-extension-button;
+    width: 16px;
+    height: 48px;
+    padding: 0;
+    background-color: white;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-left: none;
+    border-radius: 0 4px 4px 0;
+    cursor: pointer;
+    font-size: 8px;
+    color: rgb(87, 94, 117);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
+    transition: opacity 0.15s ease;
+}
+
+.palette-toggle-button:hover {
+    opacity: 0.85;
+    background-color: #f8f8f8;
+}
+
+.palette-toggle-button-hidden {
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 0 4px 4px 0;
+    border-left: none;
+    left: 0;
+}

--- a/packages/scratch-gui/src/components/palette-toggle/palette-toggle.jsx
+++ b/packages/scratch-gui/src/components/palette-toggle/palette-toggle.jsx
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classNames from 'classnames';
+import styles from './palette-toggle.css';
+
+const PaletteToggle = ({paletteVisible, onClick, style}) => (
+    <button
+        className={classNames(
+            styles.paletteToggleButton,
+            {[styles.paletteToggleButtonHidden]: !paletteVisible}
+        )}
+        style={style}
+        title={paletteVisible ? 'ブロックパレットを隠す' : 'ブロックパレットを表示する'}
+        onClick={onClick}
+    >
+        {paletteVisible ? '◀' : '▶'}
+    </button>
+);
+
+PaletteToggle.propTypes = {
+    onClick: PropTypes.func.isRequired,
+    paletteVisible: PropTypes.bool.isRequired,
+    style: PropTypes.object
+};
+
+export default PaletteToggle;

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -40,6 +40,8 @@ import {
     SOUNDS_TAB_INDEX,
     RUBY_TAB_INDEX
 } from '../reducers/editor-tab';
+import {togglePalette} from '../reducers/palette-visibility';
+import PaletteToggle from '../components/palette-toggle/palette-toggle.jsx';
 
 const addFunctionListener = (object, property, callback) => {
     const oldFn = object[property];
@@ -73,6 +75,7 @@ class Blocks extends React.Component {
             'handlePromptCallback',
             'handlePromptClose',
             'handleCustomProceduresClose',
+            'handleTogglePalette',
             'onScriptGlowOn',
             'onScriptGlowOff',
             'onBlockGlowOn',
@@ -171,7 +174,8 @@ class Blocks extends React.Component {
             this.props.locale !== nextProps.locale ||
             this.props.anyModalVisible !== nextProps.anyModalVisible ||
             this.props.stageSize !== nextProps.stageSize ||
-            this.props.selectedBlocks !== nextProps.selectedBlocks
+            this.props.selectedBlocks !== nextProps.selectedBlocks ||
+            this.props.paletteVisible !== nextProps.paletteVisible
         );
     }
     componentDidUpdate (prevProps) {
@@ -193,6 +197,10 @@ class Blocks extends React.Component {
         // Do not check against prevProps.toolboxXML because that may not have been rendered.
         if (this.props.isVisible && this.props.toolboxXML !== this._renderedToolboxXML) {
             this.requestToolboxUpdate();
+        }
+
+        if (this.props.paletteVisible !== prevProps.paletteVisible) {
+            this._applyPaletteVisibility(this.props.paletteVisible);
         }
 
         if (this.props.isVisible === prevProps.isVisible) {
@@ -236,6 +244,29 @@ class Blocks extends React.Component {
 
         // Clear the flyout blocks so that they can be recreated on mount.
         this.props.vm.clearFlyoutBlocks();
+    }
+    handleTogglePalette () {
+        this.props.onTogglePalette();
+    }
+    _applyPaletteVisibility (visible) {
+        if (!this.workspace) return;
+        const flyout = this.workspace.getFlyout();
+        const toolbox = this.workspace.getToolbox();
+        if (!flyout || !toolbox) return;
+        const extensionButton = document.querySelector('[class*="extension-button_extension-button-container"]');
+        if (visible) {
+            toolbox.HtmlDiv.style.display = '';
+            if (extensionButton) extensionButton.style.display = '';
+            const selectedItem = toolbox.getSelectedItem();
+            if (selectedItem) {
+                toolbox.setSelectedItem(selectedItem);
+            }
+        } else {
+            flyout.hide();
+            toolbox.HtmlDiv.style.display = 'none';
+            if (extensionButton) extensionButton.style.display = 'none';
+        }
+        this.ScratchBlocks.svgResize(this.workspace);
     }
     requestToolboxUpdate () {
         clearTimeout(this.toolboxUpdateTimeout);
@@ -751,8 +782,14 @@ class Blocks extends React.Component {
             updateMetrics: _updateMetricsProp,
             useCatBlocks: _useCatBlocks,
             workspaceMetrics: _workspaceMetrics,
+            paletteVisible,
+            onTogglePalette: _onTogglePalette,
             ...props
         } = this.props;
+
+        // Calculate toggle button position based on toolbox width (toolbox + flyout combined)
+        const toolbox = this.workspace ? this.workspace.getToolbox() : null;
+        const toggleButtonLeft = paletteVisible && toolbox ? toolbox.getWidth() : 0;
 
         return (
             <React.Fragment>
@@ -761,6 +798,13 @@ class Blocks extends React.Component {
                     onDrop={this.handleDrop}
                     {...props}
                 />
+                {toolbox ? (
+                    <PaletteToggle
+                        paletteVisible={paletteVisible}
+                        style={{left: `${toggleButtonLeft}px`}}
+                        onClick={this.handleTogglePalette}
+                    />
+                ) : null}
                 {this.state.prompt ? (
                     <Prompt
                         defaultValue={this.state.prompt.defaultValue}
@@ -835,7 +879,9 @@ Blocks.propTypes = {
     activeTabIndex: PropTypes.number,
     workspaceMetrics: PropTypes.shape({
         targets: PropTypes.objectOf(PropTypes.object)
-    })
+    }),
+    paletteVisible: PropTypes.bool,
+    onTogglePalette: PropTypes.func
 };
 
 Blocks.defaultOptions = {
@@ -874,7 +920,8 @@ const mapStateToProps = state => ({
     activeTabIndex: state.scratchGui.editorTab.activeTabIndex,
     customProceduresVisible: state.scratchGui.customProcedures.active,
     workspaceMetrics: state.scratchGui.workspaceMetrics,
-    useCatBlocks: isTimeTravel2020(state) || state.scratchGui.settings.theme === CAT_BLOCKS_THEME
+    useCatBlocks: isTimeTravel2020(state) || state.scratchGui.settings.theme === CAT_BLOCKS_THEME,
+    paletteVisible: state.scratchGui.paletteVisibility.paletteVisible
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -902,6 +949,9 @@ const mapDispatchToProps = dispatch => ({
     },
     updateMetrics: metrics => {
         dispatch(updateMetrics(metrics));
+    },
+    onTogglePalette: () => {
+        dispatch(togglePalette());
     }
 });
 

--- a/packages/scratch-gui/src/reducers/palette-visibility.js
+++ b/packages/scratch-gui/src/reducers/palette-visibility.js
@@ -1,0 +1,33 @@
+const SHOW_PALETTE = 'scratch-gui/palette-visibility/SHOW_PALETTE';
+const HIDE_PALETTE = 'scratch-gui/palette-visibility/HIDE_PALETTE';
+const TOGGLE_PALETTE = 'scratch-gui/palette-visibility/TOGGLE_PALETTE';
+
+const initialState = {
+    paletteVisible: true
+};
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+    switch (action.type) {
+    case SHOW_PALETTE:
+        return Object.assign({}, state, {paletteVisible: true});
+    case HIDE_PALETTE:
+        return Object.assign({}, state, {paletteVisible: false});
+    case TOGGLE_PALETTE:
+        return Object.assign({}, state, {paletteVisible: !state.paletteVisible});
+    default:
+        return state;
+    }
+};
+
+const showPalette = () => ({type: SHOW_PALETTE});
+const hidePalette = () => ({type: HIDE_PALETTE});
+const togglePalette = () => ({type: TOGGLE_PALETTE});
+
+export {
+    reducer as default,
+    initialState,
+    showPalette,
+    hidePalette,
+    togglePalette
+};

--- a/packages/scratch-gui/src/reducers/smalruby-registry.ts
+++ b/packages/scratch-gui/src/reducers/smalruby-registry.ts
@@ -19,6 +19,7 @@ import koshienFileReducer, {koshienFileInitialState} from './koshien-file';
 import rubyCodeReducer, {rubyCodeInitialState} from './ruby-code';
 import cardsReducer, {cardsInitialState} from './cards';
 import tutorialOnboardingReducer, {tutorialOnboardingInitialState} from './tutorial-onboarding';
+import paletteVisibilityReducer, {initialState as paletteVisibilityInitialState} from './palette-visibility';
 
 /**
  * All Smalruby reducers
@@ -30,7 +31,8 @@ export const smalrubyReducers = {
     koshienFile: koshienFileReducer,
     rubyCode: rubyCodeReducer,
     cards: cardsReducer,
-    tutorialOnboarding: tutorialOnboardingReducer
+    tutorialOnboarding: tutorialOnboardingReducer,
+    paletteVisibility: paletteVisibilityReducer
 };
 
 /**
@@ -43,5 +45,6 @@ export const smalrubyInitialState = {
     koshienFile: koshienFileInitialState,
     rubyCode: rubyCodeInitialState,
     cards: cardsInitialState,
-    tutorialOnboarding: tutorialOnboardingInitialState
+    tutorialOnboarding: tutorialOnboardingInitialState,
+    paletteVisibility: paletteVisibilityInitialState
 };

--- a/packages/scratch-gui/test/integration/palette-toggle.test.js
+++ b/packages/scratch-gui/test/integration/palette-toggle.test.js
@@ -1,0 +1,92 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickText,
+    clickXpath,
+    findByXpath,
+    getDriver,
+    getLogs,
+    loadUri
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('Palette toggle', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('◀ button is visible when palette is open', async () => {
+        await loadUri(uri);
+        await clickText('Code');
+        // The hide-palette button (◀) should be visible by default
+        await findByXpath('//button[@title="ブロックパレットを隠す"]');
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('clicking ◀ hides the palette and shows ▶', async () => {
+        await loadUri(uri);
+        await clickText('Code');
+        // Click the hide button
+        await clickXpath('//button[@title="ブロックパレットを隠す"]');
+        // The show-palette button (▶) should now be visible
+        await findByXpath('//button[@title="ブロックパレットを表示する"]');
+        // The toolbox should be hidden
+        const toolboxVisible = await driver.executeScript(
+            'const el = document.querySelector(".blocklyToolboxDiv"); return el ? el.style.display !== "none" : true;'
+        );
+        expect(toolboxVisible).toBe(false);
+        // The extension button should be hidden
+        const extensionButtonVisible = await driver.executeScript(
+            'const el = document.querySelector(\'[class*="extension-button_extension-button-container"]\'); return el ? el.style.display !== "none" : false;'
+        );
+        expect(extensionButtonVisible).toBe(false);
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('clicking ▶ shows the palette again', async () => {
+        await loadUri(uri);
+        await clickText('Code');
+        // First hide the palette
+        await clickXpath('//button[@title="ブロックパレットを隠す"]');
+        await findByXpath('//button[@title="ブロックパレットを表示する"]');
+        // Now show it again
+        await clickXpath('//button[@title="ブロックパレットを表示する"]');
+        // The hide-palette button should be visible again
+        await findByXpath('//button[@title="ブロックパレットを隠す"]');
+        // The toolbox should be visible again
+        const toolboxVisible = await driver.executeScript(
+            'const el = document.querySelector(".blocklyToolboxDiv"); return el ? el.style.display !== "none" : true;'
+        );
+        expect(toolboxVisible).toBe(true);
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('palette toggle works after switching sprite', async () => {
+        await loadUri(uri);
+        await clickText('Code');
+        // Hide palette
+        await clickXpath('//button[@title="ブロックパレットを隠す"]');
+        await findByXpath('//button[@title="ブロックパレットを表示する"]');
+        // Switch to backdrop tab and back
+        await clickText('Backdrops');
+        await clickText('Code');
+        // Show palette button should still be visible (state preserved)
+        await findByXpath('//button[@title="ブロックパレットを表示する"]');
+        // Show the palette again
+        await clickXpath('//button[@title="ブロックパレットを表示する"]');
+        await findByXpath('//button[@title="ブロックパレットを隠す"]');
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+});

--- a/packages/scratch-gui/test/unit/components/palette-toggle.test.jsx
+++ b/packages/scratch-gui/test/unit/components/palette-toggle.test.jsx
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PaletteToggle from '../../../src/components/palette-toggle/palette-toggle.jsx';
+
+describe('PaletteToggle', () => {
+    test('renders ◀ when paletteVisible is true', () => {
+        const {container} = render(<PaletteToggle paletteVisible onClick={() => {}} />);
+        expect(container.querySelector('button').textContent).toBe('◀');
+    });
+
+    test('renders ▶ when paletteVisible is false', () => {
+        const {container} = render(<PaletteToggle paletteVisible={false} onClick={() => {}} />);
+        expect(container.querySelector('button').textContent).toBe('▶');
+    });
+
+    test('calls onClick when button is clicked', () => {
+        const handleClick = jest.fn();
+        const {container} = render(<PaletteToggle paletteVisible onClick={handleClick} />);
+        fireEvent.click(container.querySelector('button'));
+        expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('has correct title when paletteVisible is true', () => {
+        const {container} = render(<PaletteToggle paletteVisible onClick={() => {}} />);
+        expect(container.querySelector('button').title).toBe('ブロックパレットを隠す');
+    });
+
+    test('has correct title when paletteVisible is false', () => {
+        const {container} = render(<PaletteToggle paletteVisible={false} onClick={() => {}} />);
+        expect(container.querySelector('button').title).toBe('ブロックパレットを表示する');
+    });
+});

--- a/packages/scratch-gui/test/unit/reducers/palette-visibility-reducer.test.js
+++ b/packages/scratch-gui/test/unit/reducers/palette-visibility-reducer.test.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+import paletteVisibilityReducer, {
+    initialState,
+    showPalette,
+    hidePalette,
+    togglePalette
+} from '../../../src/reducers/palette-visibility';
+
+test('initialState', () => {
+    let defaultState;
+    expect(paletteVisibilityReducer(defaultState, {type: 'anything'})).toBeDefined();
+});
+
+test('initial state has paletteVisible true', () => {
+    let defaultState;
+    expect(paletteVisibilityReducer(defaultState, {type: 'anything'}).paletteVisible).toBe(true);
+});
+
+test('showPalette sets paletteVisible to true', () => {
+    const state = {paletteVisible: false};
+    const newState = paletteVisibilityReducer(state, showPalette());
+    expect(newState.paletteVisible).toBe(true);
+});
+
+test('hidePalette sets paletteVisible to false', () => {
+    const state = {paletteVisible: true};
+    const newState = paletteVisibilityReducer(state, hidePalette());
+    expect(newState.paletteVisible).toBe(false);
+});
+
+test('togglePalette toggles paletteVisible from true to false', () => {
+    const state = {paletteVisible: true};
+    const newState = paletteVisibilityReducer(state, togglePalette());
+    expect(newState.paletteVisible).toBe(false);
+});
+
+test('togglePalette toggles paletteVisible from false to true', () => {
+    const state = {paletteVisible: false};
+    const newState = paletteVisibilityReducer(state, togglePalette());
+    expect(newState.paletteVisible).toBe(true);
+});
+
+test('unknown action returns same state', () => {
+    const state = {paletteVisible: true};
+    expect(paletteVisibilityReducer(state, {type: 'unknown'})).toEqual(state);
+});
+
+test('initialState export is defined', () => {
+    expect(initialState).toBeDefined();
+    expect(initialState.paletteVisible).toBe(true);
+});


### PR DESCRIPTION
## Summary

- ブロックパレット（Flyout）とカテゴリ（Toolbox）を開閉できるトグルボタンを追加する (#188)

## Implementation Steps

- [x] Phase 1: palette-visibility Redux reducer を追加（TDD）
- [x] Phase 2: PaletteToggle UI コンポーネントを追加（TDD）
- [x] Phase 3: blocks.jsx に統合（flyout/toolbox制御）
- [x] Phase Final: 統合テストを追加（Playwright検証含む）

## Test Plan

- Unit tests（TDD）: reducer と PaletteToggle コンポーネント
- Integration tests（実装後）: 開閉動作、Playwright による DoD 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
