### PR TITLE
fix: restore palette visibility state when switching back to code tab

### DIFF
--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -260,6 +260,7 @@ class Blocks extends React.Component {
         if (visible) {
             toolbox.HtmlDiv.style.display = '';
             if (extensionButton) extensionButton.style.display = '';
+            if (flyout.svgGroup_) flyout.svgGroup_.style.display = '';
             const selectedItem = toolbox.getSelectedItem();
             if (selectedItem) {
                 toolbox.setSelectedItem(selectedItem);
@@ -268,6 +269,10 @@ class Blocks extends React.Component {
             flyout.hide();
             toolbox.HtmlDiv.style.display = 'none';
             if (extensionButton) extensionButton.style.display = 'none';
+            // flyout.hide() only sets isVisible_=false, but workspace.setVisible(true)
+            // restores containerVisible_=true which makes updateDisplay_ show the flyout again.
+            // Directly hide the SVG group to ensure it stays hidden regardless of containerVisible_.
+            if (flyout.svgGroup_) flyout.svgGroup_.style.display = 'none';
         }
         this.ScratchBlocks.svgResize(this.workspace);
     }
@@ -321,6 +326,11 @@ class Blocks extends React.Component {
         const queue = this.toolboxUpdateQueue;
         this.toolboxUpdateQueue = [];
         queue.forEach(fn => fn());
+
+        // Re-apply palette visibility since updateToolbox/setFlyoutScrollPos may re-show the flyout
+        if (!this.props.paletteVisible) {
+            this._applyPaletteVisibility(false);
+        }
     }
 
     withToolboxUpdates (fn) {

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -225,6 +225,9 @@ class Blocks extends React.Component {
 
             window.dispatchEvent(new Event('resize'));
 
+            // Restore palette visibility state when switching back to the code tab
+            this._applyPaletteVisibility(this.props.paletteVisible);
+
             if (this._pendingScrollCenter) {
                 this._pendingScrollCenter = false;
                 if (this.workspace.options && this.workspace.options.zoomOptions) {


### PR DESCRIPTION
## Summary

- ブロックパレットを閉じた状態でルビータブ等に切り替え、コードタブに戻ると、パレットが開いて表示されてしまう不具合を修正

## Root Cause

`componentDidUpdate` で `isVisible` が `false` → `true` になった（コードタブに戻った）タイミングで、`_applyPaletteVisibility` が呼ばれていなかった。

Redux の `paletteVisible` 状態は正しく `false` のまま保持されていたが、DOM（toolbox の `display`、拡張機能ボタンの `display`）が再適用されないため、コードタブに戻ると toolbox がデフォルトの表示状態に戻っていた。

## Fix

`componentDidUpdate` の `isVisible` が `true` になるブロック内で `_applyPaletteVisibility(this.props.paletteVisible)` を呼び出し、タブ切り替え後も Redux の状態と DOM を同期させる。

## Test

- 既存の統合テスト (`palette-toggle.test.js`) がすべて PASS することを確認
- Playwright MCP で手動動作確認:
  - パレットを閉じる → ルビータブへ → コードタブへ戻る → パレットは閉じたまま（▶ボタンが左端に表示）
  - ▶ボタンをクリック → パレットが正しく開く

## Related

Fixes regression introduced in #189 (feat: add palette toggle)
