### PR TITLE
feat: チュートリアル表示中はチュートリアルで使うブロックのみに制限する

### DIFF
--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -474,8 +474,23 @@ class Blocks extends React.Component {
                 this.props.colorMode
             );
 
-            // Check for only_blocks setting in Stage comments first (highest priority)
-            let onlyBlocks = this.extractOnlyBlocksFromStageComments();
+            let onlyBlocks;
+
+            // tutorialAllowedBlocks has highest priority (active tutorial overrides stage comments and URL params)
+            if (this.props.tutorialAllowedBlocks) {
+                const allowedBlockIds = [];
+                Object.values(this.props.tutorialAllowedBlocks).forEach(categoryBlocks => {
+                    allowedBlockIds.push(...categoryBlocks);
+                });
+                if (allowedBlockIds.length < TOTAL_DEFAULT_BLOCKS) {
+                    onlyBlocks = allowedBlockIds.join(',');
+                }
+            }
+
+            // Check for only_blocks setting in Stage comments (second priority)
+            if (!onlyBlocks) {
+                onlyBlocks = this.extractOnlyBlocksFromStageComments();
+            }
 
             // If no Stage comment setting, check URL parameter
             if (!onlyBlocks) {
@@ -483,17 +498,12 @@ class Blocks extends React.Component {
                 onlyBlocks = queryParams.only_blocks;
             }
 
-            // If no URL parameter, use GUI settings to generate only_blocks equivalent
-            // tutorialAllowedBlocks (from active tutorial deck) takes priority over selectedBlocks
-            const effectiveSelectedBlocks = this.props.tutorialAllowedBlocks || this.props.selectedBlocks;
-            if (!onlyBlocks && effectiveSelectedBlocks) {
-                // Convert selectedBlocks to onlyBlocks format (individual block IDs)
+            // If no URL parameter, use GUI selectedBlocks setting
+            if (!onlyBlocks && this.props.selectedBlocks) {
                 const selectedBlockIds = [];
-                Object.values(effectiveSelectedBlocks).forEach(categoryBlocks => {
+                Object.values(this.props.selectedBlocks).forEach(categoryBlocks => {
                     selectedBlockIds.push(...categoryBlocks);
                 });
-
-                // If not all blocks are selected, generate onlyBlocks string
                 if (selectedBlockIds.length < TOTAL_DEFAULT_BLOCKS) {
                     onlyBlocks = selectedBlockIds.join(',');
                 }

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -175,6 +175,7 @@ class Blocks extends React.Component {
             this.props.anyModalVisible !== nextProps.anyModalVisible ||
             this.props.stageSize !== nextProps.stageSize ||
             this.props.selectedBlocks !== nextProps.selectedBlocks ||
+            this.props.tutorialAllowedBlocks !== nextProps.tutorialAllowedBlocks ||
             this.props.paletteVisible !== nextProps.paletteVisible
         );
     }
@@ -184,8 +185,9 @@ class Blocks extends React.Component {
             this.ScratchBlocks.hideChaff();
         }
 
-        // If selectedBlocks changed, update toolbox
-        if (this.props.selectedBlocks !== prevProps.selectedBlocks) {
+        // If selectedBlocks or tutorialAllowedBlocks changed, update toolbox
+        if (this.props.selectedBlocks !== prevProps.selectedBlocks ||
+            this.props.tutorialAllowedBlocks !== prevProps.tutorialAllowedBlocks) {
             const toolboxXML = this.getToolboxXML();
             if (toolboxXML) {
                 this.props.updateToolboxState(toolboxXML);
@@ -482,10 +484,12 @@ class Blocks extends React.Component {
             }
 
             // If no URL parameter, use GUI settings to generate only_blocks equivalent
-            if (!onlyBlocks && this.props.selectedBlocks) {
+            // tutorialAllowedBlocks (from active tutorial deck) takes priority over selectedBlocks
+            const effectiveSelectedBlocks = this.props.tutorialAllowedBlocks || this.props.selectedBlocks;
+            if (!onlyBlocks && effectiveSelectedBlocks) {
                 // Convert selectedBlocks to onlyBlocks format (individual block IDs)
                 const selectedBlockIds = [];
-                Object.values(this.props.selectedBlocks).forEach(categoryBlocks => {
+                Object.values(effectiveSelectedBlocks).forEach(categoryBlocks => {
                     selectedBlockIds.push(...categoryBlocks);
                 });
 
@@ -854,6 +858,7 @@ class Blocks extends React.Component {
 
 Blocks.propTypes = {
     selectedBlocks: PropTypes.object,
+    tutorialAllowedBlocks: PropTypes.object,
     anyModalVisible: PropTypes.bool,
     canUseCloud: PropTypes.bool,
     customProceduresVisible: PropTypes.bool,
@@ -929,6 +934,7 @@ const mapStateToProps = state => ({
     locale: state.locales.locale,
     messages: state.locales.messages,
     selectedBlocks: state.scratchGui.blockDisplay.selectedBlocks,
+    tutorialAllowedBlocks: state.scratchGui.cards.tutorialAllowedBlocks,
     toolboxXML: state.scratchGui.toolbox.toolboxXML,
     activeTabIndex: state.scratchGui.editorTab.activeTabIndex,
     customProceduresVisible: state.scratchGui.customProcedures.active,

--- a/packages/scratch-gui/src/lib/libraries/decks/index.jsx
+++ b/packages/scratch-gui/src/lib/libraries/decks/index.jsx
@@ -91,6 +91,15 @@ end`,
         tags: ['ruby', 'mesh'],
         category: CATEGORIES.chatApp,
         img: libraryChat1Basic1,
+        allowedBlocks: {
+            motion: [],
+            looks: ['looks_sayforsecs', 'looks_say'],
+            sound: [],
+            event: ['event_whenflagclicked', 'event_whenbroadcastreceived', 'event_broadcast'],
+            control: [],
+            sensing: [],
+            operators: []
+        },
         steps: [
             {
                 title: (
@@ -209,6 +218,15 @@ end`,
         tags: ['ruby', 'mesh'],
         category: CATEGORIES.chatApp,
         img: libraryChat2Sprites1,
+        allowedBlocks: {
+            motion: [],
+            looks: ['looks_sayforsecs'],
+            sound: [],
+            event: ['event_whenthisspriteclicked', 'event_whenbroadcastreceived', 'event_broadcast'],
+            control: [],
+            sensing: [],
+            operators: []
+        },
         steps: [
             {
                 title: (
@@ -330,6 +348,15 @@ end`,
         tags: ['ruby', 'mesh'],
         category: CATEGORIES.chatApp,
         img: libraryChat3Mesh1,
+        allowedBlocks: {
+            motion: [],
+            looks: ['looks_sayforsecs'],
+            sound: [],
+            event: ['event_whenthisspriteclicked', 'event_whenbroadcastreceived', 'event_broadcast'],
+            control: [],
+            sensing: [],
+            operators: []
+        },
         steps: [
             {
                 title: (

--- a/packages/scratch-gui/src/reducers/cards.js
+++ b/packages/scratch-gui/src/reducers/cards.js
@@ -20,7 +20,8 @@ const initialState = {
     x: 0,
     y: 0,
     expanded: true,
-    dragging: false
+    dragging: false,
+    tutorialAllowedBlocks: null
 };
 
 const reducer = function (state, action) {
@@ -28,7 +29,8 @@ const reducer = function (state, action) {
     switch (action.type) {
     case CLOSE_CARDS:
         return Object.assign({}, state, {
-            visible: false
+            visible: false,
+            tutorialAllowedBlocks: null
         });
     case SHRINK_EXPAND_CARDS:
         return Object.assign({}, state, {
@@ -38,15 +40,18 @@ const reducer = function (state, action) {
         return Object.assign({}, state, {
             visible: true
         });
-    case ACTIVATE_DECK:
+    case ACTIVATE_DECK: {
+        const deck = state.content[action.activeDeckId];
         return Object.assign({}, state, {
             activeDeckId: action.activeDeckId,
             step: 0,
             x: 0,
             y: 0,
             expanded: true,
-            visible: true
+            visible: true,
+            tutorialAllowedBlocks: (deck && deck.allowedBlocks) ? deck.allowedBlocks : null
         });
+    }
     case NEXT_STEP:
         if (state.activeDeckId !== null) {
             analytics.event({

--- a/packages/scratch-gui/test/integration/tutorial-block-restriction.test.js
+++ b/packages/scratch-gui/test/integration/tutorial-block-restriction.test.js
@@ -1,0 +1,134 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickText,
+    findByXpath,
+    getDriver,
+    getLogs,
+    loadUri,
+    scope,
+    textExists
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+const uriWithTutorial = id => `${uri}?tutorial=${id}`;
+
+let driver;
+
+describe('Tutorial Block Restriction', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    describe('chat-1-basic-1 tutorial', () => {
+        test('restricts toolbox to allowed blocks (Looks and Events; no Motion or Sound)', async () => {
+            await loadUri(uriWithTutorial('chat1Basic1'));
+            await findByXpath('//div[contains(@class, "card_card_")]');
+            await driver.sleep(1000);
+
+            // Allowed categories: Looks, Events
+            expect(await textExists('Looks', scope.blocksTab)).toBe(true);
+            expect(await textExists('Events', scope.blocksTab)).toBe(true);
+
+            // Disallowed categories: Motion, Sound, Control, Sensing, Operators
+            expect(await textExists('Motion', scope.blocksTab)).toBe(false);
+            expect(await textExists('Sound', scope.blocksTab)).toBe(false);
+            expect(await textExists('Control', scope.blocksTab)).toBe(false);
+            expect(await textExists('Sensing', scope.blocksTab)).toBe(false);
+            expect(await textExists('Operators', scope.blocksTab)).toBe(false);
+
+            const logs = await getLogs();
+            expect(logs).toEqual([]);
+        });
+
+        test('restores all blocks after tutorial is closed', async () => {
+            await loadUri(uriWithTutorial('chat1Basic1'));
+            await findByXpath('//div[contains(@class, "card_card_")]');
+            await driver.sleep(1000);
+
+            // Verify restriction is active
+            expect(await textExists('Motion', scope.blocksTab)).toBe(false);
+
+            // Close the tutorial
+            await clickText('Close');
+            await driver.sleep(500);
+
+            // All categories should be restored
+            expect(await textExists('Motion', scope.blocksTab)).toBe(true);
+            expect(await textExists('Looks', scope.blocksTab)).toBe(true);
+            expect(await textExists('Sound', scope.blocksTab)).toBe(true);
+            expect(await textExists('Events', scope.blocksTab)).toBe(true);
+            expect(await textExists('Control', scope.blocksTab)).toBe(true);
+            expect(await textExists('Sensing', scope.blocksTab)).toBe(true);
+            expect(await textExists('Operators', scope.blocksTab)).toBe(true);
+
+            const logs = await getLogs();
+            expect(logs).toEqual([]);
+        });
+
+        test('overrides only_blocks restriction; restores it after close', async () => {
+            // Load with only_blocks=sound_ (only Sound) AND chat-1-basic-1 tutorial
+            const testUri = `${uri}?only_blocks=sound_&tutorial=chat1Basic1`;
+            await loadUri(testUri);
+            await findByXpath('//div[contains(@class, "card_card_")]');
+            await driver.sleep(1000);
+
+            // Tutorial restriction should override only_blocks:
+            // chat-1-basic-1 allows Looks and Events, not Sound
+            expect(await textExists('Looks', scope.blocksTab)).toBe(true);
+            expect(await textExists('Events', scope.blocksTab)).toBe(true);
+            expect(await textExists('Sound', scope.blocksTab)).toBe(false);
+            expect(await textExists('Motion', scope.blocksTab)).toBe(false);
+
+            // Close the tutorial
+            await clickText('Close');
+            await driver.sleep(500);
+
+            // only_blocks restriction (Sound only) should be restored
+            expect(await textExists('Sound', scope.blocksTab)).toBe(true);
+            expect(await textExists('Looks', scope.blocksTab)).toBe(false);
+            expect(await textExists('Events', scope.blocksTab)).toBe(false);
+            expect(await textExists('Motion', scope.blocksTab)).toBe(false);
+
+            const logs = await getLogs();
+            expect(logs).toEqual([]);
+        });
+    });
+
+    describe('chat-2-sprites-1 tutorial', () => {
+        test('restricts toolbox to allowed blocks (no Motion)', async () => {
+            await loadUri(uriWithTutorial('chat2Sprites1'));
+            await findByXpath('//div[contains(@class, "card_card_")]');
+            await driver.sleep(1000);
+
+            expect(await textExists('Looks', scope.blocksTab)).toBe(true);
+            expect(await textExists('Events', scope.blocksTab)).toBe(true);
+            expect(await textExists('Motion', scope.blocksTab)).toBe(false);
+            expect(await textExists('Sound', scope.blocksTab)).toBe(false);
+
+            const logs = await getLogs();
+            expect(logs).toEqual([]);
+        });
+    });
+
+    describe('chat-3-mesh-1 tutorial', () => {
+        test('restricts toolbox to allowed blocks (no Motion)', async () => {
+            await loadUri(uriWithTutorial('chat3Mesh1'));
+            await findByXpath('//div[contains(@class, "card_card_")]');
+            await driver.sleep(1000);
+
+            expect(await textExists('Looks', scope.blocksTab)).toBe(true);
+            expect(await textExists('Events', scope.blocksTab)).toBe(true);
+            expect(await textExists('Motion', scope.blocksTab)).toBe(false);
+            expect(await textExists('Sound', scope.blocksTab)).toBe(false);
+
+            const logs = await getLogs();
+            expect(logs).toEqual([]);
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/reducers/cards_reducer.test.js
+++ b/packages/scratch-gui/test/unit/reducers/cards_reducer.test.js
@@ -11,7 +11,8 @@ describe('cards reducer', () => {
             x: 0,
             y: 0,
             expanded: true,
-            dragging: false
+            dragging: false,
+            tutorialAllowedBlocks: null
         });
     });
 
@@ -46,5 +47,46 @@ describe('cards reducer', () => {
         expect(state.visible).toBe(true);
         state = reducer(state, closeCards());
         expect(state.visible).toBe(false);
+    });
+
+    describe('tutorialAllowedBlocks', () => {
+        test('should set tutorialAllowedBlocks when activating a deck with allowedBlocks', () => {
+            const state = reducer(undefined, activateDeck('chat-1-basic-1'));
+            expect(state.tutorialAllowedBlocks).not.toBeNull();
+            expect(state.tutorialAllowedBlocks.event).toContain('event_whenflagclicked');
+            expect(state.tutorialAllowedBlocks.event).toContain('event_whenbroadcastreceived');
+            expect(state.tutorialAllowedBlocks.event).toContain('event_broadcast');
+            expect(state.tutorialAllowedBlocks.looks).toContain('looks_sayforsecs');
+            expect(state.tutorialAllowedBlocks.looks).toContain('looks_say');
+            expect(state.tutorialAllowedBlocks.motion).toEqual([]);
+        });
+
+        test('should set tutorialAllowedBlocks when activating chat-2-sprites-1', () => {
+            const state = reducer(undefined, activateDeck('chat-2-sprites-1'));
+            expect(state.tutorialAllowedBlocks).not.toBeNull();
+            expect(state.tutorialAllowedBlocks.event).toContain('event_whenthisspriteclicked');
+            expect(state.tutorialAllowedBlocks.looks).toContain('looks_sayforsecs');
+            expect(state.tutorialAllowedBlocks.looks).not.toContain('looks_say');
+        });
+
+        test('should set tutorialAllowedBlocks when activating chat-3-mesh-1', () => {
+            const state = reducer(undefined, activateDeck('chat-3-mesh-1'));
+            expect(state.tutorialAllowedBlocks).not.toBeNull();
+            expect(state.tutorialAllowedBlocks.event).toContain('event_whenthisspriteclicked');
+        });
+
+        test('should clear tutorialAllowedBlocks when activating a deck without allowedBlocks', () => {
+            let state = reducer(undefined, activateDeck('chat-1-basic-1'));
+            expect(state.tutorialAllowedBlocks).not.toBeNull();
+            state = reducer(state, activateDeck('intro-getting-started'));
+            expect(state.tutorialAllowedBlocks).toBeNull();
+        });
+
+        test('should clear tutorialAllowedBlocks when closing cards', () => {
+            let state = reducer(undefined, activateDeck('chat-1-basic-1'));
+            expect(state.tutorialAllowedBlocks).not.toBeNull();
+            state = reducer(state, closeCards());
+            expect(state.tutorialAllowedBlocks).toBeNull();
+        });
     });
 });


### PR DESCRIPTION
## Summary

チュートリアル (Cards) 表示中はチュートリアルで使うブロックのみに制限する機能を追加する。

Closes #194

## Implementation Steps

- [x] Phase 1: `allowedBlocks` をデッキに追加 (`feat: add allowedBlocks config to chat-* tutorial decks`)
- [x] Phase 2: cards reducer に `tutorialAllowedBlocks` を追加 (TDD)
- [x] Phase 3: `blocks.jsx` でツールボックスに適用
- [x] Phase Final: Playwright確認 + 統合テスト

## Test plan

- [x] `cards_reducer` 単体テストでの状態管理確認 (Phase 2 TDD)
- [x] Playwright MCP によるブラウザ上の動作確認 (Phase Final)
- [x] 統合テスト追加 (Phase Final)
