### PR TITLE
chore: simplify tutorial tags to ruby and mesh only, translate to Japanese

### DIFF
--- a/packages/scratch-gui/src/lib/libraries/decks/index.jsx
+++ b/packages/scratch-gui/src/lib/libraries/decks/index.jsx
@@ -88,7 +88,7 @@ end`,
                 id="gui.howtos.chat-1-basic-1.name"
             />
         ),
-        tags: ['ruby', 'mesh'],
+        tags: ['mesh'],
         category: CATEGORIES.chatApp,
         img: libraryChat1Basic1,
         allowedBlocks: {
@@ -215,7 +215,7 @@ end`,
                 id="gui.howtos.chat-2-sprites-1.name"
             />
         ),
-        tags: ['ruby', 'mesh'],
+        tags: ['mesh'],
         category: CATEGORIES.chatApp,
         img: libraryChat2Sprites1,
         allowedBlocks: {
@@ -345,7 +345,7 @@ end`,
                 id="gui.howtos.chat-3-mesh-1.name"
             />
         ),
-        tags: ['ruby', 'mesh'],
+        tags: ['mesh'],
         category: CATEGORIES.chatApp,
         img: libraryChat3Mesh1,
         allowedBlocks: {

--- a/packages/scratch-gui/src/lib/libraries/tutorial-tags.js
+++ b/packages/scratch-gui/src/lib/libraries/tutorial-tags.js
@@ -6,12 +6,6 @@ export const CATEGORIES = {
 };
 
 export default [
-    {tag: 'animation', intlLabel: messages.animation},
-    {tag: 'art', intlLabel: messages.art},
-    {tag: 'music', intlLabel: messages.music},
-    {tag: 'games', intlLabel: messages.games},
-    {tag: 'stories', intlLabel: messages.stories},
     {tag: 'ruby', intlLabel: messages.ruby},
-    {tag: 'mesh', intlLabel: messages.mesh},
-    {tag: 'はじめて', intlLabel: messages.firstTime}
+    {tag: 'mesh', intlLabel: messages.mesh}
 ];

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -376,7 +376,7 @@ export default {
     'gui.howtos.chat-3-mesh-1.step8.title': 'だいじなこと：ほかのひとの「そうしんメッセージ」は「センサーのあたい」でとりだせるよ',
     'gui.howtos.chat-3-mesh-1.external.kairyudo.name': 'かいりゅうどう やってみよう！プログラミング「チャットアプリをせいさくしよう」',
     // Mesh tag
-    'gui.libraryTags.mesh': 'Mesh',
+    'gui.libraryTags.mesh': 'メッシュ',
     'gui.cards.insert-ruby': 'ルビーをにゅうりょくする',
     'gui.cards.insert-blocks': 'コードをにゅうりょくする',
     'gui.libraryTags.ruby': 'ルビー',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -380,7 +380,7 @@ export default {
     'gui.howtos.chat-3-mesh-1.step8.title': '大事なこと：他の人の「送信メッセージ」は「センサーの値」で取り出せるよ',
     'gui.howtos.chat-3-mesh-1.external.kairyudo.name': '開隆堂 やってみよう！プログラミング「チャットアプリを制作しよう」',
     // Mesh tag
-    'gui.libraryTags.mesh': 'Mesh',
+    'gui.libraryTags.mesh': 'メッシュ',
     'gui.cards.all-tutorials': 'チュートリアル',
     'gui.cards.shrink': '縮小',
     'gui.cards.expand': '展開',


### PR DESCRIPTION
## Summary

チュートリアルのタグを整理する。

- upstream のタグ (animation, art, music, games, stories, はじめて) を削除。対応するチュートリアルが存在しないため、タグだけが表示されていた
- `ruby` と `mesh` タグのみ残す
- `mesh` の日本語訳を `'Mesh'` → `'メッシュ'` に修正（`ruby` はすでに `'ルビー'` に翻訳済み）

## Changes

- `tutorial-tags.js`: `ruby` と `mesh` のみに絞る
- `ja.js` / `ja-Hira.js`: `gui.libraryTags.mesh` を `'メッシュ'` に変更
