### PR TITLE
feat: タブバーにプライバシーポリシーリンクを追加（Google OAuth ブランディング確認対応）

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -78,9 +78,14 @@
     height: $stage-menu-height;
 }
 
-.privacy-link {
+.legal-links {
     margin-left: auto;
-    padding: 0 1rem 0.25rem;
+    display: flex;
+    align-items: flex-end;
+}
+
+.privacy-link {
+    padding: 0 0.5rem 0.25rem;
     font-size: 0.65rem;
     color: $text-primary-transparent;
     text-decoration: none;
@@ -93,8 +98,15 @@
     text-decoration: underline;
 }
 
+.link-separator {
+    padding: 0 0 0.25rem;
+    font-size: 0.65rem;
+    color: $text-primary-transparent;
+    align-self: flex-end;
+}
+
 .feedback-link {
-    padding: 0 3.75rem 0.25rem;
+    padding: 0 3.75rem 0.25rem 0.5rem;
     font-size: 0.65rem;
     color: $text-primary-transparent;
     text-decoration: none;

--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -78,8 +78,22 @@
     height: $stage-menu-height;
 }
 
-.feedback-link {
+.privacy-link {
     margin-left: auto;
+    padding: 0 1rem 0.25rem;
+    font-size: 0.65rem;
+    color: $text-primary-transparent;
+    text-decoration: none;
+    white-space: nowrap;
+    align-self: flex-end;
+}
+
+.privacy-link:hover {
+    color: $text-primary;
+    text-decoration: underline;
+}
+
+.feedback-link {
     padding: 0 3.75rem 0.25rem;
     font-size: 0.65rem;
     color: $text-primary-transparent;

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -542,6 +542,18 @@ const GUIComponent = props => {
                                         </Tab>
                                     </TabList>
                                     <a
+                                        className={styles.privacyLink}
+                                        href="/privacy-policy.html"
+                                        rel="noopener noreferrer"
+                                        target="_blank"
+                                    >
+                                        <FormattedMessage
+                                            defaultMessage="Privacy Policy"
+                                            description="Link to privacy policy"
+                                            id="gui.smalruby3.gui.privacyPolicy"
+                                        />
+                                    </a>
+                                    <a
                                         className={styles.feedbackLink}
                                         href="https://docs.google.com/forms/d/e/1FAIpQLSemSOgv8TlJXF6vmFzVm5yUdcNZVMEKBcBcsKHnbW0RFmU3sg/viewform?usp=dialog"
                                         rel="noopener noreferrer"

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -541,31 +541,34 @@ const GUIComponent = props => {
                                             />
                                         </Tab>
                                     </TabList>
-                                    <a
-                                        className={styles.privacyLink}
-                                        href="/privacy-policy.html"
-                                        rel="noopener noreferrer"
-                                        target="_blank"
-                                    >
-                                        <FormattedMessage
-                                            defaultMessage="Privacy Policy"
-                                            description="Link to privacy policy"
-                                            id="gui.smalruby3.gui.privacyPolicy"
-                                        />
-                                    </a>
-                                    <a
-                                        className={styles.feedbackLink}
-                                        href="https://docs.google.com/forms/d/e/1FAIpQLSemSOgv8TlJXF6vmFzVm5yUdcNZVMEKBcBcsKHnbW0RFmU3sg/viewform?usp=dialog"
-                                        rel="noopener noreferrer"
-                                        target="_blank"
-                                        onClick={handleFeedbackClick}
-                                    >
-                                        <FormattedMessage
-                                            defaultMessage="Send feedback"
-                                            description="Link to send feedback"
-                                            id="gui.smalruby3.gui.feedback"
-                                        />
-                                    </a>
+                                    <div className={styles.legalLinks}>
+                                        <a
+                                            className={styles.privacyLink}
+                                            href="/privacy-policy.html"
+                                            rel="noopener noreferrer"
+                                            target="_blank"
+                                        >
+                                            <FormattedMessage
+                                                defaultMessage="Privacy Policy"
+                                                description="Link to privacy policy"
+                                                id="gui.smalruby3.gui.privacyPolicy"
+                                            />
+                                        </a>
+                                        <span className={styles.linkSeparator}>{'|'}</span>
+                                        <a
+                                            className={styles.feedbackLink}
+                                            href="https://docs.google.com/forms/d/e/1FAIpQLSemSOgv8TlJXF6vmFzVm5yUdcNZVMEKBcBcsKHnbW0RFmU3sg/viewform?usp=dialog"
+                                            rel="noopener noreferrer"
+                                            target="_blank"
+                                            onClick={handleFeedbackClick}
+                                        >
+                                            <FormattedMessage
+                                                defaultMessage="Send feedback"
+                                                description="Link to send feedback"
+                                                id="gui.smalruby3.gui.feedback"
+                                            />
+                                        </a>
+                                    </div>
                                 </Box>
                                 <TabPanel
                                     className={tabClassNames.tabPanel}

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -99,6 +99,7 @@ export default {
     'gui.menuBar.koshienEntryForm': 'Entry Form',
     'gui.menuBar.koshienCannotChangeRubyVersion': 'The Ruby version cannot be changed when the Koshien extension is loaded.',
 
+    'gui.smalruby3.gui.privacyPolicy': 'Privacy Policy',
     'gui.smalruby3.gui.feedback': 'Send feedback',
     'gui.smalruby3.feedbackConfirm': 'You are about to open an external site to send feedback to help us improve Smalruby. Is it okay?',
 

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -158,6 +158,7 @@ export default {
     'gui.menuBar.blockDisplay': 'ブロックひょうじ...',
     'gui.menuBar.learn': 'まなぶ',
 
+    'gui.smalruby3.gui.privacyPolicy': 'プライバシーポリシー',
     'gui.smalruby3.gui.feedback': 'フィードバックをそうしん',
     'gui.smalruby3.feedbackConfirm': 'スモウルビーをよりよくするためのフィードバック（ごいけん）をそうしんするがいぶサイトをひらきます。よろしいですか？',
 

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -158,6 +158,7 @@ export default {
     'gui.menuBar.blockDisplay': 'ブロック表示...',
     'gui.menuBar.tutorials': 'チュートリアル',
 
+    'gui.smalruby3.gui.privacyPolicy': 'プライバシーポリシー',
     'gui.smalruby3.gui.feedback': 'フィードバックを送信',
     'gui.smalruby3.feedbackConfirm': 'スモウルビーをよりよくするためのフィードバック（ご意見）を送信する外部サイトを開きます。よろしいですか？',
 


### PR DESCRIPTION
## Summary

Google OAuth ブランディング確認の要件「ホームページの URL にプライバシーポリシーへのリンクが含まれていません」を解消するため、タブバーの右側に「プライバシーポリシー」リンクを追加します。

## Changes Made

- `packages/scratch-gui/src/components/gui/gui.jsx`
  - タブバーの「フィードバックを送信」リンクの左隣に「プライバシーポリシー」リンクを追加
  - リンク先: `/privacy-policy.html`（#198 でデプロイ済み）
- `packages/scratch-gui/src/components/gui/gui.css`
  - `privacy-link` クラスを新規追加（`margin-left: auto` で右寄せ）
  - `feedback-link` から `margin-left: auto` を削除（`privacy-link` に移動）
- `packages/scratch-gui/src/locales/ja.js` — `gui.smalruby3.gui.privacyPolicy: 'プライバシーポリシー'` を追加
- `packages/scratch-gui/src/locales/ja-Hira.js` — 同上
- `packages/scratch-gui/src/locales/en.js` — `gui.smalruby3.gui.privacyPolicy: 'Privacy Policy'` を追加

## Test Plan

- [x] Playwright MCP でタブバーに「プライバシーポリシー」リンクが表示されることを確認
- [x] リンクが `/privacy-policy.html` に正しくリンクされていることを確認
- [x] 「フィードバックを送信」リンクの左隣に表示されることを確認

## Related Issues

関連: #197
