### PR TITLE
fix: change Gemini OAuth scope from retriever to peruserquota

### DIFF
--- a/packages/scratch-gui/src/lib/google-drive-api.js
+++ b/packages/scratch-gui/src/lib/google-drive-api.js
@@ -13,11 +13,13 @@ import {loadAllGoogleScripts} from './google-script-loader';
 // Using 'drive.file' scope to allow:
 // - Reading files selected by the user via Picker
 // - Uploading new files to Google Drive
-// Adding 'generative-language.retriever' scope to allow:
+// Adding 'generative-language.peruserquota' scope to allow:
 // - Calling Gemini API (generateContent) for AI-assisted code generation
+// Note: peruserquota is a non-sensitive scope sufficient for generateContent;
+//       the broader 'retriever' scope is not needed as we do not use corpus operations.
 const SCOPES = [
     'https://www.googleapis.com/auth/drive.file',
-    'https://www.googleapis.com/auth/generative-language.retriever'
+    'https://www.googleapis.com/auth/generative-language.peruserquota'
 ].join(' ');
 
 // Discovery docs for Google Drive API


### PR DESCRIPTION
## Summary

Google OAuth スコープを `generative-language.retriever`（機密性の高いスコープ）から `generative-language.peruserquota`（非機密スコープ）へ変更します。

## 変更理由

現在のコードが呼び出す Gemini API は `generateContent` のみであり、Corpus / Document / Chunk を操作する Semantic Retriever API は一切使用していません。`generative-language.retriever` スコープは過剰な権限であるため、`generateContent` の呼び出しに必要十分な `generative-language.peruserquota` へ変更します。

これにより：
- OAuth 同意画面での要求権限が最小化される
- Google OAuth アプリ審査において機密スコープが不要になり、検証が簡略化される

## 変更内容

- `packages/scratch-gui/src/lib/google-drive-api.js` — SCOPES の `generative-language.retriever` を `generative-language.peruserquota` に変更

## スコープ比較

| スコープ | 変更前 | 変更後 |
|---|---|---|
| `drive.file` | ✅ | ✅ |
| `generative-language.retriever` | ✅（機密） | ❌ 削除 |
| `generative-language.peruserquota` | ❌ | ✅（非機密） |

## Playwright 検証

- Google ドライブから読み込む → OAuth ポップアップのスコープに `drive.file` + `generative-language.peruserquota` が含まれることを確認
- スモウルビー先生 (Gemini) → メッセージ送信時に同スコープで認証リクエストが発行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
