### PR TITLE
fix: add OAuth state parameter for CSRF protection in Google Drive auth

### DIFF
--- a/packages/scratch-gui/src/lib/google-drive-api.js
+++ b/packages/scratch-gui/src/lib/google-drive-api.js
@@ -55,6 +55,16 @@ class GoogleDriveAPI {
     }
 
     /**
+     * Generate a cryptographically random state string for CSRF protection
+     * @returns {string} Random 32-character hex string
+     */
+    _generateState () {
+        const array = new Uint8Array(16);
+        window.crypto.getRandomValues(array);
+        return Array.from(array, b => b.toString(16).padStart(2, '0')).join('');
+    }
+
+    /**
      * Initialize Google API and Identity Services
      * @returns {Promise<void>} Promise that resolves when initialization is complete
      */
@@ -110,23 +120,32 @@ class GoogleDriveAPI {
      */
     requestAccessToken () {
         return new Promise((resolve, reject) => {
-            this.tokenClient.callback = response => {
-                if (response.error) {
-                    reject(new Error(`Authentication failed: ${response.error}`));
-                    return;
-                }
-                this.accessToken = response.access_token;
-                resolve(response.access_token);
-            };
-
             // Check if user already has a valid, non-expired token
             if (this.accessToken && this._isTokenValid()) {
                 resolve(this.accessToken);
                 return;
             }
 
-            // Request new token (prompt: '' = silent re-auth if session still valid)
-            this.tokenClient.requestAccessToken({prompt: ''});
+            // Generate a random state value for CSRF protection
+            const expectedState = this._generateState();
+
+            this.tokenClient.callback = response => {
+                if (response.error) {
+                    reject(new Error(`Authentication failed: ${response.error}`));
+                    return;
+                }
+                // Validate state to guard against CSRF attacks
+                if (response.state !== expectedState) {
+                    reject(new Error('OAuth state mismatch: potential CSRF attack detected'));
+                    return;
+                }
+                this.accessToken = response.access_token;
+                resolve(response.access_token);
+            };
+
+            // Request new token with state for CSRF protection
+            // (prompt: '' = silent re-auth if session still valid)
+            this.tokenClient.requestAccessToken({prompt: '', state: expectedState});
         });
     }
 

--- a/packages/scratch-gui/test/unit/lib/google-drive-api.test.js
+++ b/packages/scratch-gui/test/unit/lib/google-drive-api.test.js
@@ -147,8 +147,8 @@ describe('GoogleDriveAPI', () => {
         });
 
         test('should resolve with access token when new token is received', () => {
-            mockTokenClient.requestAccessToken.mockImplementation(() => {
-                mockTokenClient.callback({access_token: 'new-token-123'});
+            mockTokenClient.requestAccessToken.mockImplementation(config => {
+                mockTokenClient.callback({access_token: 'new-token-123', state: config && config.state});
             });
             mockGapi.client.getToken.mockReturnValue(null);
 
@@ -176,8 +176,8 @@ describe('GoogleDriveAPI', () => {
             mockGapi.client.getToken.mockReturnValue(expiredToken);
 
             // Should request new token
-            mockTokenClient.requestAccessToken.mockImplementation(() => {
-                mockTokenClient.callback({access_token: 'fresh-token'});
+            mockTokenClient.requestAccessToken.mockImplementation(config => {
+                mockTokenClient.callback({access_token: 'fresh-token', state: config && config.state});
             });
 
             return GoogleDriveAPI.requestAccessToken().then(token => {
@@ -208,8 +208,8 @@ describe('GoogleDriveAPI', () => {
             };
             mockGapi.client.getToken.mockReturnValue(tokenWithoutExpiry);
 
-            mockTokenClient.requestAccessToken.mockImplementation(() => {
-                mockTokenClient.callback({access_token: 'refreshed-token'});
+            mockTokenClient.requestAccessToken.mockImplementation(config => {
+                mockTokenClient.callback({access_token: 'refreshed-token', state: config && config.state});
             });
 
             return GoogleDriveAPI.requestAccessToken().then(token => {
@@ -226,8 +226,8 @@ describe('GoogleDriveAPI', () => {
             };
             mockGapi.client.getToken.mockReturnValue(expiredToken);
 
-            mockTokenClient.requestAccessToken.mockImplementation(() => {
-                mockTokenClient.callback({access_token: 'updated-token'});
+            mockTokenClient.requestAccessToken.mockImplementation(config => {
+                mockTokenClient.callback({access_token: 'updated-token', state: config && config.state});
             });
 
             return GoogleDriveAPI.requestAccessToken().then(() => {


### PR DESCRIPTION
## Summary

Google の OAuth 同意画面で「state パラメータを使用していない」という CSRF 脆弱性の警告が表示されていたため、対策を実施しました。

## Changes Made

- `_generateState()` メソッドを追加: `window.crypto.getRandomValues` を使って暗号学的に安全な 32 文字の hex 文字列を生成
- `requestAccessToken()` を更新:
  - リクエスト毎に新しい state 値を生成
  - `tokenClient.requestAccessToken({state: expectedState})` で state を渡す
  - コールバックで `response.state !== expectedState` を検証し、不一致なら CSRF 攻撃として reject
  - 有効なトークンがある場合のアーリーリターンをコールバック設定の前に移動（ロジックの整理）

## Security Context

Google Identity Services の Token flow（ポップアップ方式）は Authorization Code flow（リダイレクト方式）ほど CSRF リスクは高くありませんが、state パラメータの実装により：

- 自分が開始したリクエストへのレスポンスであることを確認可能
- 第三者による偽レスポンスの注入を防止

## Test Coverage

Playwright MCP でブラウザ上の動作を確認:
- `_generateState()` が 32 文字 hex 文字列を生成 ✅
- 呼び出し毎に異なる値を生成（ランダム性） ✅
- state がリクエストに渡され、バリデーションが実装されている ✅

## Related

Google OAuth best practices: https://developers.google.com/identity/protocols/oauth2/resources/best-practices#handle-user-tokens-securely
