### PR TITLE
fix: change Gemini OAuth scope from peruserquota to generative-language

### DIFF
--- a/packages/scratch-gui/src/lib/gemini-api.js
+++ b/packages/scratch-gui/src/lib/gemini-api.js
@@ -4,9 +4,10 @@
  *
  * Communicates with Google Gemini API using the OAuth 2.0 access token
  * from GoogleDriveAPI (shared authentication).
+ * Each user's own Google account quota is used for Gemini API calls.
  *
  * API: POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent
- * Auth: Bearer token from Google Identity Services
+ * Auth: Bearer token from Google Identity Services (generative-language scope)
  */
 
 import googleDriveAPI from './google-drive-api';

--- a/packages/scratch-gui/src/lib/google-drive-api.js
+++ b/packages/scratch-gui/src/lib/google-drive-api.js
@@ -13,13 +13,12 @@ import {loadAllGoogleScripts} from './google-script-loader';
 // Using 'drive.file' scope to allow:
 // - Reading files selected by the user via Picker
 // - Uploading new files to Google Drive
-// Adding 'generative-language.peruserquota' scope to allow:
+// Using 'generative-language' scope to allow:
 // - Calling Gemini API (generateContent) for AI-assisted code generation
-// Note: peruserquota is a non-sensitive scope sufficient for generateContent;
-//       the broader 'retriever' scope is not needed as we do not use corpus operations.
+// Each user's own Google account quota is used for Gemini API calls.
 const SCOPES = [
     'https://www.googleapis.com/auth/drive.file',
-    'https://www.googleapis.com/auth/generative-language.peruserquota'
+    'https://www.googleapis.com/auth/generative-language'
 ].join(' ');
 
 // Discovery docs for Google Drive API


### PR DESCRIPTION
## Summary

スモウルビー先生（Gemini AI）が `kouji.takao@smalruby.jp` 以外のユーザーで 403 エラーになる問題を修正します。

## 問題

```
Gemini API error 403: Request had insufficient authentication scopes.
ACCESS_TOKEN_SCOPE_INSUFFICIENT
method: google.ai.generativelanguage.v1beta.GenerativeService.GenerateContent
```

**原因**: OAuth スコープに `https://www.googleapis.com/auth/generative-language.peruserquota` を使用していたが、このスコープは非公式・廃止予定であり、`GenerateContent` に必要なスコープとして認識されない。

## 変更内容

`google-drive-api.js` の OAuth スコープを変更:

| 変更前 | 変更後 |
|---|---|
| `generative-language.peruserquota` | `generative-language` |

`generative-language` は Generative Language API の公式スコープです。各ユーザーは自分の Google アカウントで認証するため、Gemini API のクォータと使用制限はユーザーごとに独立して適用されます。

## 動作確認

- ローカルユニットテスト 26 件 pass
- `gemini-api.js` の OAuth Bearer token 方式は変更なし

## Related

- PR #200: fix: change Gemini OAuth scope from retriever to peruserquota（前回の修正）
- Google OAuth best practices: https://developers.google.com/identity/protocols/oauth2/resources/best-practices
