### PR TITLE
fix: force consent re-auth when Gemini API returns 403 scope error

### DIFF
--- a/packages/scratch-gui/src/lib/gemini-api.js
+++ b/packages/scratch-gui/src/lib/gemini-api.js
@@ -125,7 +125,10 @@ class GeminiAPI {
     }
 
     /**
-     * Perform fetch with automatic retry on 401 (token expired)
+     * Perform fetch with automatic retry on auth errors.
+     * - 401: token expired → request new token silently and retry
+     * - 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT: user has an old token without the
+     *   required peruserquota scope → force consent screen and retry
      * @param {string} url - API endpoint URL
      * @param {string} accessToken - OAuth access token
      * @param {object} body - Request body
@@ -150,6 +153,27 @@ class GeminiAPI {
             console.warn('[GeminiAPI] 401 received, requesting new access token...');
             const newToken = await googleDriveAPI.requestAccessToken();
             response = await doFetch(newToken);
+        } else if (!response.ok && response.status === 403) {
+            // Check if the token is missing the required scope (e.g. user has an old
+            // token obtained before peruserquota was added to the app's OAuth scopes)
+            const errorText = await response.text();
+            let isScopeError = false;
+            try {
+                const errorData = JSON.parse(errorText);
+                isScopeError = errorData?.error?.details?.some(
+                    d => d.reason === 'ACCESS_TOKEN_SCOPE_INSUFFICIENT'
+                );
+            } catch {
+                // Not JSON - not a scope error
+            }
+            if (isScopeError) {
+                // Show consent screen so the user grants the missing scope, then retry
+                console.warn('[GeminiAPI] Scope insufficient, requesting re-authorization...');
+                const newToken = await googleDriveAPI.requestAccessToken(true);
+                response = await doFetch(newToken);
+            } else {
+                throw new Error(`Gemini API error ${response.status}: ${errorText}`);
+            }
         }
 
         if (!response.ok) {

--- a/packages/scratch-gui/src/lib/google-drive-api.js
+++ b/packages/scratch-gui/src/lib/google-drive-api.js
@@ -116,12 +116,15 @@ class GoogleDriveAPI {
 
     /**
      * Request access token
+     * @param {boolean} forceConsent - When true, always show the consent screen to ensure
+     *   all required scopes are granted (e.g. after a scope is added to the app).
      * @returns {Promise<string>} Promise that resolves with access token
      */
-    requestAccessToken () {
+    requestAccessToken (forceConsent = false) {
         return new Promise((resolve, reject) => {
-            // Check if user already has a valid, non-expired token
-            if (this.accessToken && this._isTokenValid()) {
+            // Check if user already has a valid, non-expired token.
+            // Skip when forceConsent=true to ensure new scopes are granted.
+            if (!forceConsent && this.accessToken && this._isTokenValid()) {
                 resolve(this.accessToken);
                 return;
             }
@@ -143,9 +146,10 @@ class GoogleDriveAPI {
                 resolve(response.access_token);
             };
 
-            // Request new token with state for CSRF protection
-            // (prompt: '' = silent re-auth if session still valid)
-            this.tokenClient.requestAccessToken({prompt: '', state: expectedState});
+            // forceConsent=true: show consent screen to grant newly added scopes
+            // prompt='': silent re-auth if session still valid
+            const prompt = forceConsent ? 'consent' : '';
+            this.tokenClient.requestAccessToken({prompt, state: expectedState});
         });
     }
 

--- a/packages/scratch-gui/src/lib/google-drive-api.js
+++ b/packages/scratch-gui/src/lib/google-drive-api.js
@@ -13,13 +13,15 @@ import {loadAllGoogleScripts} from './google-script-loader';
 // Using 'drive.file' scope to allow:
 // - Reading files selected by the user via Picker
 // - Uploading new files to Google Drive
-// Adding 'generative-language.peruserquota' scope to allow:
+// Adding 'generative-language' scope to allow:
 // - Calling Gemini API (generateContent) for AI-assisted code generation
-// Note: peruserquota is a non-sensitive scope sufficient for generateContent;
-//       the broader 'retriever' scope is not needed as we do not use corpus operations.
+// Note: 'generative-language' is the correct scope for GenerateContent per the API docs.
+//       The 'peruserquota' sub-scope only tracks quota and does not grant API access.
+//       The 'retriever' sub-scope only covers corpus/semantic-retrieval operations.
+//       This scope is sensitive and requires Google OAuth app verification.
 const SCOPES = [
     'https://www.googleapis.com/auth/drive.file',
-    'https://www.googleapis.com/auth/generative-language.peruserquota'
+    'https://www.googleapis.com/auth/generative-language'
 ].join(' ');
 
 // Discovery docs for Google Drive API

--- a/packages/scratch-gui/test/unit/lib/gemini-api.test.js
+++ b/packages/scratch-gui/test/unit/lib/gemini-api.test.js
@@ -164,6 +164,48 @@ describe('GeminiAPI', () => {
             expect(mockGoogleDriveAPI.requestAccessToken).toHaveBeenCalled();
             expect(result).toContain('loop do');
         });
+
+        test('should force consent re-authorization when 403 is ACCESS_TOKEN_SCOPE_INSUFFICIENT', async () => {
+            const scopeErrorBody = JSON.stringify({
+                error: {
+                    code: 403,
+                    message: 'Request had insufficient authentication scopes.',
+                    status: 'PERMISSION_DENIED',
+                    details: [{
+                        '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                        reason: 'ACCESS_TOKEN_SCOPE_INSUFFICIENT'
+                    }]
+                }
+            });
+
+            global.fetch
+                .mockResolvedValueOnce({
+                    ok: false,
+                    status: 403,
+                    text: jest.fn().mockResolvedValue(scopeErrorBody)
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: jest.fn().mockResolvedValue(mockSuccessResponse)
+                });
+
+            mockGoogleDriveAPI.requestAccessToken.mockResolvedValue('consent-token');
+
+            const result = await geminiApi.sendMessage('test', {});
+            // forceConsent=true should be passed
+            expect(mockGoogleDriveAPI.requestAccessToken).toHaveBeenCalledWith(true);
+            expect(result).toContain('loop do');
+        });
+
+        test('should throw on 403 that is not a scope error', async () => {
+            global.fetch.mockResolvedValue({
+                ok: false,
+                status: 403,
+                text: jest.fn().mockResolvedValue('{"error":{"code":403,"message":"Forbidden"}}')
+            });
+
+            await expect(geminiApi.sendMessage('test', {})).rejects.toThrow('Gemini API error 403');
+        });
     });
 
     describe('extractCodeBlock', () => {

--- a/packages/scratch-gui/test/unit/lib/google-drive-api.test.js
+++ b/packages/scratch-gui/test/unit/lib/google-drive-api.test.js
@@ -125,9 +125,7 @@ describe('GoogleDriveAPI', () => {
             return GoogleDriveAPI.initialize().then(() => {
                 expect(mockGoogle.accounts.oauth2.initTokenClient).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        scope: expect.stringContaining(
-                            'https://www.googleapis.com/auth/generative-language'
-                        )
+                        scope: 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/generative-language'
                     })
                 );
             });

--- a/packages/scratch-gui/test/unit/lib/google-drive-api.test.js
+++ b/packages/scratch-gui/test/unit/lib/google-drive-api.test.js
@@ -200,6 +200,27 @@ describe('GoogleDriveAPI', () => {
             });
         });
 
+        test('should bypass cached token and show consent when forceConsent=true', () => {
+            GoogleDriveAPI.accessToken = 'valid-token';
+            const validToken = {
+                access_token: 'valid-token',
+                expires_at: (Date.now() + 3600000) / 1000 // 1 hour from now
+            };
+            mockGapi.client.getToken.mockReturnValue(validToken);
+
+            mockTokenClient.requestAccessToken.mockImplementation(config => {
+                expect(config.prompt).toBe('consent');
+                mockTokenClient.callback({access_token: 'new-scope-token', state: config && config.state});
+            });
+
+            return GoogleDriveAPI.requestAccessToken(true).then(token => {
+                expect(token).toBe('new-scope-token');
+                expect(mockTokenClient.requestAccessToken).toHaveBeenCalledWith(
+                    expect.objectContaining({prompt: 'consent'})
+                );
+            });
+        });
+
         test('should handle token without expires_at (treat as expired)', () => {
             GoogleDriveAPI.accessToken = 'token-no-expiry';
             const tokenWithoutExpiry = {


### PR DESCRIPTION
## Summary

スモウルビー先生（Gemini AI）が `kouji.takao@smalruby.jp` 以外のユーザーで 403 エラーになる問題を修正します。

## 問題の真因

```
Gemini API error 403: Request had insufficient authentication scopes.
ACCESS_TOKEN_SCOPE_INSUFFICIENT
```

**`peruserquota` はクォータ追跡のみのスコープで、`GenerateContent` の認証には使えない**ことが判明しました。

- `generative-language.peruserquota` — クォータ追跡のみ。`GenerateContent` API への認証スコープではない
- `generative-language.retriever` — Semantic Retrieval（コーパス操作）専用。`GenerateContent` には不要
- `generative-language` — **`GenerateContent` に必要な正しいスコープ**（Google 公式ドキュメントより）

開発者（`kouji.takao@smalruby.jp`）は以前の OAuth 設定で `generative-language` スコープのトークンを持っていたため動作していた。

## 変更内容

### `google-drive-api.js`

OAuth スコープを `peruserquota` から `generative-language` に変更:

```javascript
// Before
'https://www.googleapis.com/auth/generative-language.peruserquota'

// After
'https://www.googleapis.com/auth/generative-language'
```

また、`requestAccessToken()` に `forceConsent` パラメータを追加:
- `requestAccessToken(true)` で `prompt='consent'` のコンセント画面を強制表示
- これにより古いスコープのトークンを持つ既存ユーザーが再認証できる

### `gemini-api.js`

`_fetchWithRetry()` に 403 スコープエラー検出とリトライを追加:
- `ACCESS_TOKEN_SCOPE_INSUFFICIENT` を検出した場合、`requestAccessToken(true)` で再認証してリトライ
- 他の 403 エラーは従来どおりエラーとしてスロー

## 前提条件

`generative-language` スコープは**機密性の高いスコープ**のため、Google OAuth アプリ審査が必要です。
アプリ審査完了後にこの PR をマージしてください。

## ユーザー体験

- **既存ユーザー**: 初回の Gemini 使用時に一度だけコンセント画面が表示され、新しいスコープを承認後は正常動作
- **新規ユーザー**: 最初の Google ログイン時にスコープを承認するため影響なし

## Test Coverage

- `google-drive-api.test.js`: 正しいスコープ文字列でトークンクライアントが初期化されることを確認
- `google-drive-api.test.js`: `forceConsent=true` でコンセントプロンプトが使われることを確認
- `gemini-api.test.js`: 403 スコープエラー → 強制再認証 → リトライ成功のフローをテスト
- `gemini-api.test.js`: スコープ以外の 403 は従来どおりエラーになることをテスト
