### PR TITLE
fix: temporarily disable Smalruby Teacher (Gemini AI) until OAuth scope is approved

### DIFF
--- a/packages/scratch-gui/src/components/gemini-modal/gemini-modal.jsx
+++ b/packages/scratch-gui/src/components/gemini-modal/gemini-modal.jsx
@@ -396,7 +396,7 @@ const GeminiModal = ({
                                 value={inputValue}
                                 onChange={onInputChange}
                                 onKeyDown={onInputKeyDown}
-                                disabled={isLoading}
+                                disabled
                                 rows={2}
                             />
                             {isLoading ? (

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -437,6 +437,7 @@ const RubyToolbar = props => {
                     onClick={handleOpenAI}
                     aria-label={intl.formatMessage(messages.aiAssistant)}
                     title={intl.formatMessage(messages.aiAssistant)}
+                    disabled
                 >
                     <img
                         src={iconAI}

--- a/packages/scratch-gui/src/lib/google-drive-api.js
+++ b/packages/scratch-gui/src/lib/google-drive-api.js
@@ -13,13 +13,11 @@ import {loadAllGoogleScripts} from './google-script-loader';
 // Using 'drive.file' scope to allow:
 // - Reading files selected by the user via Picker
 // - Uploading new files to Google Drive
-// Adding 'generative-language.peruserquota' scope to allow:
-// - Calling Gemini API (generateContent) for AI-assisted code generation
-// Note: peruserquota is a non-sensitive scope sufficient for generateContent;
-//       the broader 'retriever' scope is not needed as we do not use corpus operations.
+// Note: 'generative-language' scope for Gemini AI (スモウルビー先生) is temporarily
+//       excluded until the OAuth consent screen is approved by Google.
+//       To re-enable, add: 'https://www.googleapis.com/auth/generative-language.peruserquota'
 const SCOPES = [
-    'https://www.googleapis.com/auth/drive.file',
-    'https://www.googleapis.com/auth/generative-language.peruserquota'
+    'https://www.googleapis.com/auth/drive.file'
 ].join(' ');
 
 // Discovery docs for Google Drive API

--- a/packages/scratch-gui/test/unit/lib/google-drive-api.test.js
+++ b/packages/scratch-gui/test/unit/lib/google-drive-api.test.js
@@ -115,7 +115,7 @@ describe('GoogleDriveAPI', () => {
             });
         });
 
-        test('should include generative-language scope for Gemini', () => {
+        test('should NOT include generative-language scope (temporarily disabled until OAuth consent is approved)', () => {
             const mockTokenClient = {
                 callback: null,
                 requestAccessToken: jest.fn()
@@ -123,12 +123,9 @@ describe('GoogleDriveAPI', () => {
             mockGoogle.accounts.oauth2.initTokenClient.mockReturnValue(mockTokenClient);
 
             return GoogleDriveAPI.initialize().then(() => {
-                expect(mockGoogle.accounts.oauth2.initTokenClient).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        scope: expect.stringContaining(
-                            'https://www.googleapis.com/auth/generative-language'
-                        )
-                    })
+                const callArg = mockGoogle.accounts.oauth2.initTokenClient.mock.calls[0][0];
+                expect(callArg.scope).not.toContain(
+                    'https://www.googleapis.com/auth/generative-language'
                 );
             });
         });


### PR DESCRIPTION
## Summary

Google OAuth consent screen で `generative-language` スコープの承認が取得できないため、スモウルビー先生（Gemini AI アシスタント）機能を一時的に無効化する。

- OAuthの設定が整い次第、元に戻せるようコードはそのまま保持する

## Changes Made

- [x] `fix: remove generative-language scope from OAuth until consent screen is approved`
- [x] `fix: disable AI assistant button in ruby toolbar`
- [x] `fix: disable prompt input field in gemini modal`

## Test Coverage

- Unit tests: `google-drive-api.test.js` — `generative-language` スコープが含まれないことを確認するテストに更新

## Related Issues

Closes #204
