### PR TITLE
fix: support -= operator for Ruby ↔ blocks bidirectional conversion (motion/looks/sound)

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/looks.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/looks.js
@@ -81,6 +81,10 @@ export default function (Generator) {
 
     Generator.looks_changesizeby = function (block) {
         const change = Generator.valueToCode(block, 'CHANGE', Generator.ORDER_NONE) || '0';
+        const changeNum = parseFloat(change);
+        if (!isNaN(changeNum) && changeNum < 0) {
+            return `self.size -= ${-changeNum}\n`;
+        }
         return `self.size += ${change}\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-generator/motion.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/motion.js
@@ -67,6 +67,10 @@ export default function (Generator) {
 
     Generator.motion_changexby = function (block) {
         const dx = Generator.valueToCode(block, 'DX', Generator.ORDER_NONE) || 0;
+        const dxNum = parseFloat(dx);
+        if (!isNaN(dxNum) && dxNum < 0) {
+            return `self.x -= ${-dxNum}\n`;
+        }
         return `self.x += ${dx}\n`;
     };
 
@@ -77,6 +81,10 @@ export default function (Generator) {
 
     Generator.motion_changeyby = function (block) {
         const dy = Generator.valueToCode(block, 'DY', Generator.ORDER_NONE) || 0;
+        const dyNum = parseFloat(dy);
+        if (!isNaN(dyNum) && dyNum < 0) {
+            return `self.y -= ${-dyNum}\n`;
+        }
         return `self.y += ${dy}\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-generator/sound.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/sound.js
@@ -41,6 +41,10 @@ export default function (Generator){
 
     Generator.sound_changevolumeby = function (block) {
         const volume = Generator.valueToCode(block, 'VOLUME', Generator.ORDER_NONE) || '0';
+        const volumeNum = parseFloat(volume);
+        if (!isNaN(volumeNum) && volumeNum < 0) {
+            return `self.volume -= ${-volumeNum}\n`;
+        }
         return `self.volume += ${volume}\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/looks.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/looks.js
@@ -442,11 +442,24 @@ const LooksConverter = {
         // Register onXxx handlers
         converter.registerOnOpAsgn((lh, operator, rh) => {
             let block;
-            if (converter._isBlock(lh) && operator === '+' && converter._isNumberOrBlock(rh)) {
+            if (converter._isBlock(lh) && (operator === '+' || operator === '-') && converter._isNumberOrBlock(rh)) {
                 if (lh.opcode === 'looks_size') {
                     // Looks blocks are common to sprite and stage
                     block = converter._changeBlock(lh, 'looks_changesizeby', 'statement');
-                    converter._addNumberInput(block, 'CHANGE', 'math_number', rh, 10);
+                    if (operator === '-') {
+                        let negatedRh;
+                        if (converter._isNumber(rh)) {
+                            negatedRh = -Number(rh.toString());
+                        } else {
+                            const subtractBlock = converter._createBlock('operator_subtract', 'value');
+                            converter._addNumberInput(subtractBlock, 'NUM1', 'math_number', 0, '');
+                            converter._addNumberInput(subtractBlock, 'NUM2', 'math_number', rh, '');
+                            negatedRh = subtractBlock;
+                        }
+                        converter._addNumberInput(block, 'CHANGE', 'math_number', negatedRh, 10);
+                    } else {
+                        converter._addNumberInput(block, 'CHANGE', 'math_number', rh, 10);
+                    }
                 }
             }
             return block;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/motion.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/motion.js
@@ -143,7 +143,7 @@ const MotionConverter = {
         // Register onXxx handlers
         converter.registerOnOpAsgn((lh, operator, rh) => {
             let block;
-            if (converter._isBlock(lh) && operator === '+' && converter._isNumberOrBlock(rh)) {
+            if (converter._isBlock(lh) && (operator === '+' || operator === '-') && converter._isNumberOrBlock(rh)) {
                 let xy;
                 switch (lh.opcode) {
                 case 'motion_xposition':
@@ -152,13 +152,22 @@ const MotionConverter = {
                     if (converter._isStage()) {
                         throw new RubyToBlocksConverterError(lh.node, 'Stage selected: no motion blocks');
                     }
-                    if (lh.opcode === 'motion_xposition') {
-                        xy = 'x';
-                    } else {
-                        xy = 'y';
-                    }
+                    xy = lh.opcode === 'motion_xposition' ? 'x' : 'y';
                     block = converter._changeBlock(lh, `motion_change${xy}by`, 'statement');
-                    converter._addNumberInput(block, `D${_.toUpper(xy)}`, 'math_number', rh, 10);
+                    if (operator === '-') {
+                        let negatedRh;
+                        if (converter._isNumber(rh)) {
+                            negatedRh = -Number(rh.toString());
+                        } else {
+                            const subtractBlock = converter._createBlock('operator_subtract', 'value');
+                            converter._addNumberInput(subtractBlock, 'NUM1', 'math_number', 0, '');
+                            converter._addNumberInput(subtractBlock, 'NUM2', 'math_number', rh, '');
+                            negatedRh = subtractBlock;
+                        }
+                        converter._addNumberInput(block, `D${_.toUpper(xy)}`, 'math_number', negatedRh, 10);
+                    } else {
+                        converter._addNumberInput(block, `D${_.toUpper(xy)}`, 'math_number', rh, 10);
+                    }
                     break;
                 }
             }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/sound.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/sound.js
@@ -122,10 +122,23 @@ const SoundConverter = {
         // Register onXxx handlers
         converter.registerOnOpAsgn((lh, operator, rh) => {
             let block;
-            if (converter._isBlock(lh) && operator === '+' && converter._isNumberOrBlock(rh)) {
+            if (converter._isBlock(lh) && (operator === '+' || operator === '-') && converter._isNumberOrBlock(rh)) {
                 if (lh.opcode === 'sound_volume') {
                     block = converter._changeBlock(lh, 'sound_changevolumeby', 'statement');
-                    converter._addNumberInput(block, 'VOLUME', 'math_number', rh, -10);
+                    if (operator === '-') {
+                        let negatedRh;
+                        if (converter._isNumber(rh)) {
+                            negatedRh = -Number(rh.toString());
+                        } else {
+                            const subtractBlock = converter._createBlock('operator_subtract', 'value');
+                            converter._addNumberInput(subtractBlock, 'NUM1', 'math_number', 0, '');
+                            converter._addNumberInput(subtractBlock, 'NUM2', 'math_number', rh, '');
+                            negatedRh = subtractBlock;
+                        }
+                        converter._addNumberInput(block, 'VOLUME', 'math_number', negatedRh, -10);
+                    } else {
+                        converter._addNumberInput(block, 'VOLUME', 'math_number', rh, -10);
+                    }
                 }
             }
             return block;

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/looks.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/looks.test.js
@@ -155,6 +155,26 @@ describe('RubyGenerator/Looks', () => {
         });
     });
 
+    describe('looks_changesizeby', () => {
+        test('positive CHANGE emits self.size += N', () => {
+            const block = {id: 'b1', opcode: 'looks_changesizeby', inputs: {CHANGE: {}}};
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('10');
+            expect(RubyGenerator.looks_changesizeby(block)).toEqual('self.size += 10\n');
+        });
+
+        test('negative CHANGE emits self.size -= N (absolute value)', () => {
+            const block = {id: 'b1', opcode: 'looks_changesizeby', inputs: {CHANGE: {}}};
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('-10');
+            expect(RubyGenerator.looks_changesizeby(block)).toEqual('self.size -= 10\n');
+        });
+
+        test('zero CHANGE emits self.size += 0', () => {
+            const block = {id: 'b1', opcode: 'looks_changesizeby', inputs: {CHANGE: {}}};
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('0');
+            expect(RubyGenerator.looks_changesizeby(block)).toEqual('self.size += 0\n');
+        });
+    });
+
     describe('scrub_ (meta-comment filtering)', () => {
         test('should filter out @ruby: comments', () => {
             const block = {

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/motion.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/motion.test.js
@@ -1,0 +1,61 @@
+import RubyGenerator from '../../../../src/lib/ruby-generator';
+import MotionBlocks from '../../../../src/lib/ruby-generator/motion';
+
+describe('RubyGenerator/Motion', () => {
+    beforeEach(() => {
+        RubyGenerator.cache_ = {
+            comments: {},
+            targetCommentTexts: []
+        };
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.functionNames_ = {};
+        RubyGenerator.currentTarget = null;
+        MotionBlocks(RubyGenerator);
+    });
+
+    const makeBlock = id => ({id, opcode: 'dummy', inputs: {}, fields: {}});
+
+    describe('motion_changexby', () => {
+        test('positive DX emits self.x += N', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('10');
+            expect(RubyGenerator.motion_changexby(makeBlock('b1'))).toEqual('self.x += 10\n');
+        });
+
+        test('negative DX emits self.x -= N (absolute value)', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('-10');
+            expect(RubyGenerator.motion_changexby(makeBlock('b1'))).toEqual('self.x -= 10\n');
+        });
+
+        test('negative float DX emits self.x -= N', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('-3.5');
+            expect(RubyGenerator.motion_changexby(makeBlock('b1'))).toEqual('self.x -= 3.5\n');
+        });
+
+        test('zero DX emits self.x += 0', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('0');
+            expect(RubyGenerator.motion_changexby(makeBlock('b1'))).toEqual('self.x += 0\n');
+        });
+
+        test('block expression DX emits self.x += expr', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('y');
+            expect(RubyGenerator.motion_changexby(makeBlock('b1'))).toEqual('self.x += y\n');
+        });
+    });
+
+    describe('motion_changeyby', () => {
+        test('positive DY emits self.y += N', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('10');
+            expect(RubyGenerator.motion_changeyby(makeBlock('b1'))).toEqual('self.y += 10\n');
+        });
+
+        test('negative DY emits self.y -= N (absolute value)', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('-10');
+            expect(RubyGenerator.motion_changeyby(makeBlock('b1'))).toEqual('self.y -= 10\n');
+        });
+
+        test('zero DY emits self.y += 0', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('0');
+            expect(RubyGenerator.motion_changeyby(makeBlock('b1'))).toEqual('self.y += 0\n');
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/sound.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/sound.test.js
@@ -1,0 +1,39 @@
+import RubyGenerator from '../../../../src/lib/ruby-generator';
+import SoundBlocks from '../../../../src/lib/ruby-generator/sound';
+
+describe('RubyGenerator/Sound', () => {
+    beforeEach(() => {
+        RubyGenerator.cache_ = {
+            comments: {},
+            targetCommentTexts: []
+        };
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.functionNames_ = {};
+        RubyGenerator.currentTarget = null;
+        SoundBlocks(RubyGenerator);
+    });
+
+    const makeBlock = id => ({id, opcode: 'dummy', inputs: {}, fields: {}});
+
+    describe('sound_changevolumeby', () => {
+        test('positive VOLUME emits self.volume += N', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('10');
+            expect(RubyGenerator.sound_changevolumeby(makeBlock('b1'))).toEqual('self.volume += 10\n');
+        });
+
+        test('negative VOLUME emits self.volume -= N (absolute value)', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('-10');
+            expect(RubyGenerator.sound_changevolumeby(makeBlock('b1'))).toEqual('self.volume -= 10\n');
+        });
+
+        test('zero VOLUME emits self.volume += 0', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('0');
+            expect(RubyGenerator.sound_changevolumeby(makeBlock('b1'))).toEqual('self.volume += 0\n');
+        });
+
+        test('block expression VOLUME emits self.volume += expr', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('x');
+            expect(RubyGenerator.sound_changevolumeby(makeBlock('b1'))).toEqual('self.volume += x\n');
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/sound.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/sound.test.js
@@ -27,7 +27,7 @@ describe('Ruby Roundtrip: Sound category blocks', () => {
             change_sound_effect_by("PAN", 10)
             set_sound_effect("PITCH", 100)
             clear_sound_effects
-            self.volume += -10
+            self.volume -= 10
             self.volume = 100
 
             volume

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks2.test.js
@@ -248,6 +248,37 @@ describe('RubyToBlocksConverter/Looks', () => {
             await convertAndExpectToEqualBlocks(converter, target, code, expected);
         });
 
+        test('minus assign', async () => {
+            code = 'self.size -= 10';
+            expected = [
+                {
+                    opcode: 'looks_changesizeby',
+                    inputs: [
+                        {
+                            name: 'CHANGE',
+                            block: expectedInfo.makeNumber(-10)
+                        }
+                    ]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+            code = 'self.size -= x';
+            expected = [
+                {
+                    opcode: 'looks_changesizeby',
+                    inputs: [
+                        {
+                            name: 'CHANGE',
+                            block: (await rubyToExpected(converter, target, '0 - x'))[0],
+                            shadow: expectedInfo.makeNumber(10)
+                        }
+                    ]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
         test('invalid', async () => {
             { for (const c of [
                 'self.size += "10"',

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion3.test.js
@@ -49,6 +49,35 @@ describe('RubyToBlocksConverter/Motion', () => {
         ];
         await convertAndExpectToEqualBlocks(converter, target, code, expected);
 
+        code = 'self.x -= 10';
+        expected = [
+            {
+                opcode: 'motion_changexby',
+                inputs: [
+                    {
+                        name: 'DX',
+                        block: expectedInfo.makeNumber(-10)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'self.x -= y';
+        expected = [
+            {
+                opcode: 'motion_changexby',
+                inputs: [
+                    {
+                        name: 'DX',
+                        block: (await rubyToExpected(converter, target, '0 - y'))[0],
+                        shadow: expectedInfo.makeNumber(10)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
         { for (const s of [
             'self.x += "10"',
             'self.x += :symbol',
@@ -126,6 +155,35 @@ describe('RubyToBlocksConverter/Motion', () => {
                     {
                         name: 'DY',
                         block: (await rubyToExpected(converter, target, 'x'))[0],
+                        shadow: expectedInfo.makeNumber(10)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'self.y -= 10';
+        expected = [
+            {
+                opcode: 'motion_changeyby',
+                inputs: [
+                    {
+                        name: 'DY',
+                        block: expectedInfo.makeNumber(-10)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'self.y -= x';
+        expected = [
+            {
+                opcode: 'motion_changeyby',
+                inputs: [
+                    {
+                        name: 'DY',
+                        block: (await rubyToExpected(converter, target, '0 - x'))[0],
                         shadow: expectedInfo.makeNumber(10)
                     }
                 ]
@@ -236,6 +294,8 @@ describe('RubyToBlocksConverter/Motion', () => {
                 'self.y = 10',
                 'self.x += 5',
                 'self.y += 5',
+                'self.x -= 5',
+                'self.y -= 5',
                 'x',
                 'y',
                 'direction'

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -177,6 +177,23 @@ end
         await expectRoundTrip('move(10) unless touching?("_edge_")');
     });
 
+    test('-= operator on motion x/y round-trips correctly', async () => {
+        await expectRoundTrip('self.x -= 10');
+        await expectRoundTrip('self.y -= 10');
+        await expectRoundTrip('self.x -= 3.5');
+        await expectRoundTrip('self.y -= 3.5');
+    });
+
+    test('-= operator on looks size round-trips correctly', async () => {
+        await expectRoundTrip('self.size -= 10');
+        await expectRoundTrip('self.size -= 5.5');
+    });
+
+    test('-= operator on sound volume round-trips correctly', async () => {
+        await expectRoundTrip('self.volume -= 10');
+        await expectRoundTrip('self.volume -= 2.5');
+    });
+
     test('float literals with integer appearance (x.0) are preserved', async () => {
         await expectRoundTrip('1.0 + 1.0');
         await expectRoundTrip('move(1.0)');

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sound/sound1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sound/sound1.test.js
@@ -242,6 +242,37 @@ describe('RubyToBlocksConverter/Sound', () => {
             await convertAndExpectToEqualBlocks(converter, target, code, expected);
         });
 
+        test('minus assign', async () => {
+            code = 'self.volume -= 10';
+            expected = [
+                {
+                    opcode: 'sound_changevolumeby',
+                    inputs: [
+                        {
+                            name: 'VOLUME',
+                            block: expectedInfo.makeNumber(-10)
+                        }
+                    ]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+            code = 'self.volume -= x';
+            expected = [
+                {
+                    opcode: 'sound_changevolumeby',
+                    inputs: [
+                        {
+                            name: 'VOLUME',
+                            block: (await rubyToExpected(converter, target, '0 - x'))[0],
+                            shadow: expectedInfo.makeNumber(-10)
+                        }
+                    ]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
         test('invalid', async () => {
             { for (const c of [
                 'self.volume += "10"',


### PR DESCRIPTION
## Summary

- `self.x -= 10` / `self.y -= 10` など `-=` 演算子を使った Ruby コードをブロックに変換できない問題を修正した
- motion（x/y）・looks（size）・sound（volume）の 3 カテゴリについてコンバーターとジェネレーター双方を修正し、相互変換を可能にした

Closes #208

## Implementation Steps

- [x] Phase 1: motion コンバーター `-=` 対応（`self.x -= 10` → `motion_changexby(DX=-10)`）
- [x] Phase 2: motion ジェネレーター 負値 `-=` 出力（`motion_changexby(DX=-10)` → `self.x -= 10`）
- [x] Phase 3: looks/sound コンバーター `-=` 対応
- [x] Phase 4: looks/sound ジェネレーター 負値 `-=` 出力
- [x] Phase Final: ラウンドトリップ統合テスト追加

## Test plan

- [x] unit tests pass (TDD: RED → GREEN)
- [x] lint passes
- [x] round-trip tests pass
- [x] full test suite passes (unit: 177 suites, 1292 passed)
