### PR TITLE
feat: 従来の記法（self.when/print/puts/p）の補完スニペットを追加

### DIFF
--- a/packages/scratch-gui/src/containers/ruby-tab/control-snippets.json
+++ b/packages/scratch-gui/src/containers/ruby-tab/control-snippets.json
@@ -102,5 +102,13 @@
         "labelJa": "クローンを削除する",
         "filterText": "kuroonwo sakujosuru クローンを削除する delete_this_clone",
         "sortText": "05_kuroonwo_sakujo"
+    },
+    "when_start_as_a_clone_compat": {
+        "snippet": "when(:start_as_a_clone) do\n\t${1}\nend",
+        "description": "クローンされたとき（when:記法）",
+        "type": "event",
+        "labelJa": "クローンされたとき（when:記法）",
+        "filterText": "kuroon sareta クローンされたとき when start_as_a_clone self.when",
+        "sortText": "05z_kuroon_compat"
     }
 }

--- a/packages/scratch-gui/src/containers/ruby-tab/events-snippets.json
+++ b/packages/scratch-gui/src/containers/ruby-tab/events-snippets.json
@@ -62,5 +62,53 @@
         "labelJa": "メッセージを送って待つ",
         "filterText": "messeejiwo okutte matsu メッセージを送って待つ broadcast_and_wait",
         "sortText": "04_messeejiwo_okutte"
+    },
+    "when_flag_clicked_compat": {
+        "snippet": "when(:flag_clicked) do\n\t${1}\nend",
+        "description": "旗が押されたとき（when:記法）",
+        "type": "event",
+        "labelJa": "旗が押されたとき（when:記法）",
+        "filterText": "hataga osareta 旗が押されたとき when flag_clicked self.when",
+        "sortText": "04z_hataga_compat"
+    },
+    "when_clicked_compat": {
+        "snippet": "when(:clicked) do\n\t${1}\nend",
+        "description": "このスプライトが押されたとき（when:記法）",
+        "type": "event",
+        "labelJa": "スプライトが押されたとき（when:記法）",
+        "filterText": "supuraitoga osareta スプライトが押されたとき when clicked self.when",
+        "sortText": "04z_supuraitoga_compat"
+    },
+    "when_key_pressed_compat": {
+        "snippet": "when(:key_pressed, \"${1:space}\") do\n\t${2}\nend",
+        "description": "[スペース▼] キーが押されたとき（when:記法）",
+        "type": "event",
+        "labelJa": "キーが押されたとき（when:記法）",
+        "filterText": "kiiga osareta キーが押されたとき when key_pressed self.when スペース",
+        "sortText": "04z_kiiga_compat"
+    },
+    "when_backdrop_switches_compat": {
+        "snippet": "when(:backdrop_switches, \"${1:背景1}\") do\n\t${2}\nend",
+        "description": "背景が [背景1▼] になったとき（when:記法）",
+        "type": "event",
+        "labelJa": "背景が変わったとき（when:記法）",
+        "filterText": "haikeiga kawatta 背景が変わったとき when backdrop_switches self.when",
+        "sortText": "04z_haikeiga_compat"
+    },
+    "when_receive_compat": {
+        "snippet": "when(:receive, \"${1:メッセージ1}\") do\n\t${2}\nend",
+        "description": "[メッセージ1▼] を受け取ったとき（when:記法）",
+        "type": "event",
+        "labelJa": "受け取ったとき（when:記法）",
+        "filterText": "uketotta 受け取ったとき when receive self.when メッセージ",
+        "sortText": "04z_uketotta_compat"
+    },
+    "when_greater_than_compat": {
+        "snippet": "when(:greater_than, \"${1:loudness}\", ${2:10}) do\n\t${3}\nend",
+        "description": "[音量▼] > (10) のとき（when:記法）",
+        "type": "event",
+        "labelJa": "より大きいとき（when:記法）",
+        "filterText": "yori ookii 大きいとき when greater_than self.when 音量",
+        "sortText": "04z_yori_ookii_compat"
     }
 }

--- a/packages/scratch-gui/src/containers/ruby-tab/looks-snippets.json
+++ b/packages/scratch-gui/src/containers/ruby-tab/looks-snippets.json
@@ -166,5 +166,29 @@
         "labelJa": "大きさ",
         "filterText": "ookisa 大きさ size",
         "sortText": "02_ookisa"
+    },
+    "print": {
+        "snippet": "print(\"${1:こんにちは!}\")",
+        "description": "(こんにちは!) と言う（print）",
+        "type": "function",
+        "labelJa": "print（言う）",
+        "filterText": "print iu 言う こんにちは hyoujisuru 表示する",
+        "sortText": "02z_print"
+    },
+    "puts": {
+        "snippet": "puts(\"${1:こんにちは!}\")",
+        "description": "(こんにちは!) と言う（puts）",
+        "type": "function",
+        "labelJa": "puts（言う）",
+        "filterText": "puts iu 言う こんにちは hyoujisuru 表示する",
+        "sortText": "02z_puts"
+    },
+    "p_output": {
+        "snippet": "p(\"${1:こんにちは!}\")",
+        "description": "(こんにちは!) と言う（p）",
+        "type": "function",
+        "labelJa": "p（言う）",
+        "filterText": "p_output iu 言う こんにちは hyoujisuru 表示する",
+        "sortText": "02z_p_output"
     }
 }

--- a/packages/scratch-gui/test/unit/containers/ruby-tab/snippets-completer.test.js
+++ b/packages/scratch-gui/test/unit/containers/ruby-tab/snippets-completer.test.js
@@ -301,6 +301,131 @@ describe('SnippetsCompleter', () => {
         });
     });
 
+    describe('legacy notation snippets (self.when / print / puts / p)', () => {
+        describe('self.when(:xxx) event snippets at top level', () => {
+            const topLevelWord = 'when';
+            const topLevelModel = () => createModel(topLevelWord, topLevelWord, 1, 1 + topLevelWord.length);
+            const topLevelPos = {lineNumber: 1, column: 1 + topLevelWord.length};
+
+            test('should include when(:flag_clicked) compat snippet at top level', () => {
+                const result = completer.provideCompletionItems(topLevelModel(), topLevelPos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.includes('when(:flag_clicked)')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should include when(:clicked) compat snippet at top level', () => {
+                const result = completer.provideCompletionItems(topLevelModel(), topLevelPos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.includes('when(:clicked)')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should include when(:key_pressed) compat snippet at top level', () => {
+                const result = completer.provideCompletionItems(topLevelModel(), topLevelPos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.includes('when(:key_pressed,')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should include when(:backdrop_switches) compat snippet at top level', () => {
+                const result = completer.provideCompletionItems(topLevelModel(), topLevelPos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.includes('when(:backdrop_switches,')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should include when(:receive) compat snippet at top level', () => {
+                const result = completer.provideCompletionItems(topLevelModel(), topLevelPos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.includes('when(:receive,')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should include when(:greater_than) compat snippet at top level', () => {
+                const result = completer.provideCompletionItems(topLevelModel(), topLevelPos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.includes('when(:greater_than,')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should include when(:start_as_a_clone) compat snippet at top level', () => {
+                const result = completer.provideCompletionItems(topLevelModel(), topLevelPos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.includes('when(:start_as_a_clone)')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should not show compat event snippets inside a block', () => {
+                const fullText = `${INSIDE_BLOCK_TEXT}when`;
+                const col = INSIDE_BLOCK_COL_BASE + 4;
+                const model = createModel('when', fullText, INSIDE_BLOCK_LINE, col);
+                const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.includes('when(:flag_clicked)')
+                );
+                expect(snippet).toBeUndefined();
+            });
+        });
+
+        describe('print/puts/p output snippets inside block', () => {
+            test('should include print snippet when typing "pri" inside a block', () => {
+                const fullText = `${INSIDE_BLOCK_TEXT}pri`;
+                const col = INSIDE_BLOCK_COL_BASE + 3;
+                const model = createModel('pri', fullText, INSIDE_BLOCK_LINE, col);
+                const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.startsWith('print(')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should include puts snippet when typing "put" inside a block', () => {
+                const fullText = `${INSIDE_BLOCK_TEXT}put`;
+                const col = INSIDE_BLOCK_COL_BASE + 3;
+                const model = createModel('put', fullText, INSIDE_BLOCK_LINE, col);
+                const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.startsWith('puts(')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should include p snippet when typing "p_o" inside a block', () => {
+                const fullText = `${INSIDE_BLOCK_TEXT}p_o`;
+                const col = INSIDE_BLOCK_COL_BASE + 3;
+                const model = createModel('p_o', fullText, INSIDE_BLOCK_LINE, col);
+                const pos = {lineNumber: INSIDE_BLOCK_LINE, column: col};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.startsWith('p(')
+                );
+                expect(snippet).toBeDefined();
+            });
+
+            test('should not show print snippet at top level', () => {
+                const fullText = 'pri';
+                const model = createModel('pri', fullText, 1, 4);
+                const pos = {lineNumber: 1, column: 4};
+                const result = completer.provideCompletionItems(model, pos, context, token, monaco);
+                const snippet = result.suggestions.find(s =>
+                    s.insertText && s.insertText.startsWith('print(')
+                );
+                expect(snippet).toBeUndefined();
+            });
+        });
+    });
+
     describe('context-aware completion', () => {
         describe('type filtering', () => {
             test('should allow def snippet at top level', () => {


### PR DESCRIPTION
## Summary

「きらきらRuby本」で学習するユーザーが従来の記法（`self.when(...)` スタイル）を入力した際に補完候補が表示されるよう、スニペットJSONファイルに10件のエントリを追加しました。

- `self.when(:xxx)` 形式の7種類イベントスニペット（backward compat）
- `print` / `puts` / `p` の3種類出力メソッドスニペット

## Changes Made

- `events-snippets.json`: `when_flag_clicked_compat`, `when_clicked_compat`, `when_key_pressed_compat`, `when_backdrop_switches_compat`, `when_receive_compat`, `when_greater_than_compat` を追加
- `control-snippets.json`: `when_start_as_a_clone_compat` を追加
- `looks-snippets.json`: `print`, `puts`, `p_output` を追加
- `snippets-completer.test.js`: 上記10件のスニペットに対するユニットテストを追加（TDD: RED → GREEN）

## Technical Notes

ユーザーが `self.when` と入力した場合、Monaco の word 境界は `.` で区切られるため `when` が word として認識される。スニペット挿入時は `when` 部分のみ置換されるため、`when(:flag_clicked) do...end` を insertText として設定することで `self.when(:flag_clicked) do...end` が正しく補完される。

コンテキストフィルタリングとの整合性：
- `when_*_compat` は `type: "event"` → トップレベルのみ表示
- `print/puts/p_output` は `type: "function"` → ブロック内のみ表示

## Test Coverage

- 新規10件のユニットテストを追加（全39テストスイート通過）
- TDD アプローチ（RED → GREEN）で実装

## Related Issues

Closes #209
