### PR TITLE
fix: prevent compat when-snippets from matching 'sel' by removing self from filterText

### DIFF
--- a/packages/scratch-gui/src/containers/ruby-tab/control-snippets.json
+++ b/packages/scratch-gui/src/containers/ruby-tab/control-snippets.json
@@ -108,7 +108,7 @@
         "description": "クローンされたとき（when:記法）",
         "type": "event",
         "labelJa": "クローンされたとき（when:記法）",
-        "filterText": "kuroon sareta クローンされたとき when start_as_a_clone self.when",
+        "filterText": "kuroon sareta クローンされたとき when start_as_a_clone",
         "sortText": "05z_kuroon_compat"
     }
 }

--- a/packages/scratch-gui/src/containers/ruby-tab/events-snippets.json
+++ b/packages/scratch-gui/src/containers/ruby-tab/events-snippets.json
@@ -68,7 +68,7 @@
         "description": "旗が押されたとき（when:記法）",
         "type": "event",
         "labelJa": "旗が押されたとき（when:記法）",
-        "filterText": "hataga osareta 旗が押されたとき when flag_clicked self.when",
+        "filterText": "hataga osareta 旗が押されたとき when flag_clicked",
         "sortText": "04z_hataga_compat"
     },
     "when_clicked_compat": {
@@ -76,7 +76,7 @@
         "description": "このスプライトが押されたとき（when:記法）",
         "type": "event",
         "labelJa": "スプライトが押されたとき（when:記法）",
-        "filterText": "supuraitoga osareta スプライトが押されたとき when clicked self.when",
+        "filterText": "supuraitoga osareta スプライトが押されたとき when clicked",
         "sortText": "04z_supuraitoga_compat"
     },
     "when_key_pressed_compat": {
@@ -84,7 +84,7 @@
         "description": "[スペース▼] キーが押されたとき（when:記法）",
         "type": "event",
         "labelJa": "キーが押されたとき（when:記法）",
-        "filterText": "kiiga osareta キーが押されたとき when key_pressed self.when スペース",
+        "filterText": "kiiga osareta キーが押されたとき when key_pressed スペース",
         "sortText": "04z_kiiga_compat"
     },
     "when_backdrop_switches_compat": {
@@ -92,7 +92,7 @@
         "description": "背景が [背景1▼] になったとき（when:記法）",
         "type": "event",
         "labelJa": "背景が変わったとき（when:記法）",
-        "filterText": "haikeiga kawatta 背景が変わったとき when backdrop_switches self.when",
+        "filterText": "haikeiga kawatta 背景が変わったとき when backdrop_switches",
         "sortText": "04z_haikeiga_compat"
     },
     "when_receive_compat": {
@@ -100,7 +100,7 @@
         "description": "[メッセージ1▼] を受け取ったとき（when:記法）",
         "type": "event",
         "labelJa": "受け取ったとき（when:記法）",
-        "filterText": "uketotta 受け取ったとき when receive self.when メッセージ",
+        "filterText": "uketotta 受け取ったとき when receive メッセージ",
         "sortText": "04z_uketotta_compat"
     },
     "when_greater_than_compat": {
@@ -108,7 +108,7 @@
         "description": "[音量▼] > (10) のとき（when:記法）",
         "type": "event",
         "labelJa": "より大きいとき（when:記法）",
-        "filterText": "yori ookii 大きいとき when greater_than self.when 音量",
+        "filterText": "yori ookii 大きいとき when greater_than 音量",
         "sortText": "04z_yori_ookii_compat"
     }
 }

--- a/packages/scratch-gui/test/unit/containers/ruby-tab/snippets-completer.test.js
+++ b/packages/scratch-gui/test/unit/containers/ruby-tab/snippets-completer.test.js
@@ -374,6 +374,21 @@ describe('SnippetsCompleter', () => {
                 );
                 expect(snippet).toBeUndefined();
             });
+
+            test('compat when snippets filterText should not contain "self" to prevent matching when typing "sel"', () => {
+                // When user types "sel", Monaco word is "sel".
+                // If filterText contains "self.when", Monaco fuzzy-matches "sel" and shows these snippets.
+                // When selected, it replaces "sel" with "when(:xxx)..." — missing the "self." prefix.
+                // Fix: remove "self.when" from filterText so "sel" does not trigger compat snippets.
+                const result = completer.provideCompletionItems(topLevelModel(), topLevelPos, context, token, monaco);
+                const compatSnippets = result.suggestions.filter(s =>
+                    s.insertText && s.insertText.includes('when(:')
+                );
+                expect(compatSnippets.length).toBeGreaterThan(0);
+                compatSnippets.forEach(snippet => {
+                    expect(snippet.filterText).not.toContain('self');
+                });
+            });
         });
 
         describe('print/puts/p output snippets inside block', () => {


### PR DESCRIPTION
## Summary

- `self.when` を入力して補完候補を選択すると `when(:flag_clicked) do...end` になり `self.` が失われる問題を修正
- 原因: compat snippets の `filterText` に `self.when` が含まれており、Monaco が `sel` を fuzzy match して誤った候補を表示していた
- 修正: 7 件すべての compat when-snippet から `self.when` を `filterText` より削除

## 動作原理

Monaco はカーソル位置の「word」を `.` で分割するため、`self.when` の場合の word は `when`。
compat snippet の `insertText` は `when(:flag_clicked) do...end` であり、`when` を置換すると `self.when(:flag_clicked) do...end` になる（正しい動作）。

`sel` → word `sel` → `filterText` に `self.when` がなければ fuzzy match しない → 候補に表示されない（修正後の正しい動作）。

## Changes

- `events-snippets.json`: 6 件の `_compat` エントリの `filterText` から `self.when` を削除
- `control-snippets.json`: `when_start_as_a_clone_compat` の `filterText` から `self.when` を削除
- `snippets-completer.test.js`: compat snippets の `filterText` が `self` を含まないことを確認するテストを追加（TDD: RED → GREEN 確認済み）

## Test plan

- [x] 追加した単体テスト (40/40 pass)
- [x] 全ユニットテスト (1306/1306 pass)
- [x] lint pass
- [ ] Playwright MCP で `self.when` 補完 → ブロック変換の DoD 確認（CI 完了後）

## Related Issues

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
