### PR TITLE
feat: self.direction += N / -= N とブロックの相互変換対応

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/motion.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/motion.js
@@ -11,11 +11,19 @@ export default function (Generator) {
 
     Generator.motion_turnright = function (block) {
         const degrees = Generator.valueToCode(block, 'DEGREES', Generator.ORDER_NONE) || 0;
+        const comment = Generator.getCommentText(block);
+        if (comment && comment.includes('@ruby:operator:+=')) {
+            return `self.direction += ${degrees}\n`;
+        }
         return `turn_right(${degrees})\n`;
     };
 
     Generator.motion_turnleft = function (block) {
         const degrees = Generator.valueToCode(block, 'DEGREES', Generator.ORDER_NONE) || 0;
+        const comment = Generator.getCommentText(block);
+        if (comment && comment.includes('@ruby:operator:-=')) {
+            return `self.direction -= ${degrees}\n`;
+        }
         return `turn_left(${degrees})\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/motion.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/motion.js
@@ -169,6 +169,21 @@ const MotionConverter = {
                         converter._addNumberInput(block, `D${_.toUpper(xy)}`, 'math_number', rh, 10);
                     }
                     break;
+                case 'motion_direction':
+                    // All Motion blocks are sprite-only
+                    if (converter._isStage()) {
+                        throw new RubyToBlocksConverterError(lh.node, 'Stage selected: no motion blocks');
+                    }
+                    if (operator === '+') {
+                        block = converter._changeBlock(lh, 'motion_turnright', 'statement');
+                        converter._addNumberInput(block, 'DEGREES', 'math_number', rh, 15);
+                        block.comment = converter._createComment('@ruby:operator:+=', block.id);
+                    } else {
+                        block = converter._changeBlock(lh, 'motion_turnleft', 'statement');
+                        converter._addNumberInput(block, 'DEGREES', 'math_number', rh, 15);
+                        block.comment = converter._createComment('@ruby:operator:-=', block.id);
+                    }
+                    break;
                 }
             }
             return block;

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/motion.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/motion.test.js
@@ -58,4 +58,42 @@ describe('RubyGenerator/Motion', () => {
             expect(RubyGenerator.motion_changeyby(makeBlock('b1'))).toEqual('self.y += 0\n');
         });
     });
+
+    describe('motion_turnright', () => {
+        test('without comment emits turn_right(N)', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('15');
+            expect(RubyGenerator.motion_turnright(makeBlock('b1'))).toEqual('turn_right(15)\n');
+        });
+
+        test('with @ruby:operator:+= comment emits self.direction += N', () => {
+            RubyGenerator.cache_.comments['b1'] = {text: '@ruby:operator:+='};
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('10');
+            expect(RubyGenerator.motion_turnright(makeBlock('b1'))).toEqual('self.direction += 10\n');
+        });
+
+        test('with @ruby:operator:+= comment emits self.direction += expr', () => {
+            RubyGenerator.cache_.comments['b1'] = {text: '@ruby:operator:+='};
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('x');
+            expect(RubyGenerator.motion_turnright(makeBlock('b1'))).toEqual('self.direction += x\n');
+        });
+    });
+
+    describe('motion_turnleft', () => {
+        test('without comment emits turn_left(N)', () => {
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('15');
+            expect(RubyGenerator.motion_turnleft(makeBlock('b1'))).toEqual('turn_left(15)\n');
+        });
+
+        test('with @ruby:operator:-= comment emits self.direction -= N', () => {
+            RubyGenerator.cache_.comments['b1'] = {text: '@ruby:operator:-='};
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('10');
+            expect(RubyGenerator.motion_turnleft(makeBlock('b1'))).toEqual('self.direction -= 10\n');
+        });
+
+        test('with @ruby:operator:-= comment emits self.direction -= expr', () => {
+            RubyGenerator.cache_.comments['b1'] = {text: '@ruby:operator:-='};
+            RubyGenerator.valueToCode = jest.fn().mockReturnValue('x');
+            expect(RubyGenerator.motion_turnleft(makeBlock('b1'))).toEqual('self.direction -= x\n');
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/motion.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/motion.test.js
@@ -23,6 +23,8 @@ describe('Ruby Roundtrip: Motion category blocks', () => {
             move(10)
             turn_right(15)
             turn_left(15)
+            self.direction += 15
+            self.direction -= 15
             go_to("_random_")
             go_to("_mouse_")
             go_to("Abby")

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion3.test.js
@@ -267,6 +267,94 @@ describe('RubyToBlocksConverter/Motion', () => {
         await convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
 
+    test('self.direction += N maps to motion_turnright with @ruby:operator:+= comment', async () => {
+        let code;
+        let expected;
+
+        code = 'self.direction += 10';
+        expected = [
+            {
+                opcode: 'motion_turnright',
+                inputs: [
+                    {
+                        name: 'DEGREES',
+                        block: expectedInfo.makeNumber(10)
+                    }
+                ],
+                comment: {text: '@ruby:operator:+=', minimized: true}
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'self.direction += x';
+        expected = [
+            {
+                opcode: 'motion_turnright',
+                inputs: [
+                    {
+                        name: 'DEGREES',
+                        block: (await rubyToExpected(converter, target, 'x'))[0],
+                        shadow: expectedInfo.makeNumber(15)
+                    }
+                ],
+                comment: {text: '@ruby:operator:+=', minimized: true}
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        { for (const s of [
+            'self.direction += "10"',
+            'self.direction += :symbol',
+            'self.direction += abc'
+        ]) {
+            await convertAndExpectRubyBlockError(converter, target, s);
+        } }
+    });
+
+    test('self.direction -= N maps to motion_turnleft with @ruby:operator:-= comment', async () => {
+        let code;
+        let expected;
+
+        code = 'self.direction -= 10';
+        expected = [
+            {
+                opcode: 'motion_turnleft',
+                inputs: [
+                    {
+                        name: 'DEGREES',
+                        block: expectedInfo.makeNumber(10)
+                    }
+                ],
+                comment: {text: '@ruby:operator:-=', minimized: true}
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'self.direction -= x';
+        expected = [
+            {
+                opcode: 'motion_turnleft',
+                inputs: [
+                    {
+                        name: 'DEGREES',
+                        block: (await rubyToExpected(converter, target, 'x'))[0],
+                        shadow: expectedInfo.makeNumber(15)
+                    }
+                ],
+                comment: {text: '@ruby:operator:-=', minimized: true}
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        { for (const s of [
+            'self.direction -= "10"',
+            'self.direction -= :symbol',
+            'self.direction -= abc'
+        ]) {
+            await convertAndExpectRubyBlockError(converter, target, s);
+        } }
+    });
+
     describe('Stage validation', () => {
         let stageTarget;
 
@@ -296,6 +384,8 @@ describe('RubyToBlocksConverter/Motion', () => {
                 'self.y += 5',
                 'self.x -= 5',
                 'self.y -= 5',
+                'self.direction += 5',
+                'self.direction -= 5',
                 'x',
                 'y',
                 'direction'


### PR DESCRIPTION
## Summary

`self.direction += N` / `self.direction -= N` の Ruby コードとブロックの相互変換を実現する。

Closes #219

## Implementation Steps

- [x] Phase 1: Generator の変更（`@ruby:operator:+=/-=` コメントによる分岐）
- [x] Phase 2: Converter の変更（`self.direction +=/-=` → `motion_turnright/left` + コメント付与）
- [x] Phase Final: Round-trip テスト追加

## Test plan

- Generator unit tests: コメントあり/なし両パターン追加済み
- Converter unit tests: `self.direction +=/-=` → ブロック変換、コメント付与検証追加済み
- Round-trip tests: `self.direction += 15` / `-= 15` 追加済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)