### PR TITLE
feat: support Japanese local variable names in Ruby ↔ blocks conversion

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -84,7 +84,7 @@ export default function (Generator) {
         if (compoundMatch && hasValueInput) {
             const op = compoundMatch[1];
             // Extract original variable name from @ruby:lvar comment if present
-            const lvarMatch = comment.match(/@ruby:lvar:(\w+):\d+/);
+            const lvarMatch = comment.match(/@ruby:lvar:([^:,\s]+):\d+/);
             const variable = lvarMatch ?
                 lvarMatch[1] :
                 Generator.variableName(Generator.getFieldId(block, 'VARIABLE'));

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variable-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/variable-utils.js
@@ -10,8 +10,9 @@ const VariableUtils = {
     // Helper function to convert argument names to snake_case lowercase
     _toSnakeCaseLowercase (name) {
         return name
-            // Replace any sequence of non-alphanumeric characters except underscores with underscore
-            .replace(/[^a-zA-Z0-9_]+/g, '_')
+            // Replace ASCII non-alphanumeric characters (except underscores) with underscore.
+            // Unicode characters (Japanese kana/kanji, etc.) are preserved as-is.
+            .replace(/[^a-zA-Z0-9_\u0100-\uFFFF]+/g, '_')
             // Convert camelCase to snake_case: insert underscore before uppercase letters
             .replace(/([a-z])([A-Z])/g, '$1_$2')
             // Convert to lowercase

--- a/packages/scratch-gui/test/unit/lib/ruby-generator-procedure-arguments.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator-procedure-arguments.test.js
@@ -18,4 +18,11 @@ describe('Ruby Generator Procedure Arguments', () => {
         expect(converter._toSnakeCaseLowercase('simple_arg')).toBe('simple_arg');
         expect(converter._toSnakeCaseLowercase('_private_var_')).toBe('_private_var_');
     });
+
+    test('toSnakeCaseLowercase preserves Japanese characters', async () => {
+        expect(converter._toSnakeCaseLowercase('価格')).toBe('価格');
+        expect(converter._toSnakeCaseLowercase('売値')).toBe('売値');
+        expect(converter._toSnakeCaseLowercase('ねこ')).toBe('ねこ');
+        expect(converter._toSnakeCaseLowercase('スコア')).toBe('スコア');
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -206,6 +206,23 @@ end
         await expectRoundTrip('1.0 / ((1.0 / 3435.0) * Math.log(20.0) + 1.0 / 298.0) - 273.0');
     });
 
+    test('Japanese local variable names round-trip correctly', async () => {
+        await expectRoundTrip('価格 = 100');
+        await expectRoundTrip('価格 = 100\n売値 = 価格 * 0.7\nputs 売値',
+            '価格 = 100\n売値 = 価格 * 0.7\nputs(売値)');
+        await expectRoundTrip('ねこ = "にゃー"\nputs ねこ',
+            'ねこ = "にゃー"\nputs(ねこ)');
+        await expectRoundTrip('スコア = 0\nスコア = スコア + 10');
+    });
+
+    test('Japanese local variable compound assignment round-trips correctly', async () => {
+        await expectRoundTrip('価格 = 100\n価格 += 10');
+        await expectRoundTrip('価格 = 100\n価格 -= 10');
+        await expectRoundTrip('価格 = 2\n価格 *= 3');
+        await expectRoundTrip('価格 = 100\n価格 /= 2');
+        await expectRoundTrip('価格 = 7\n価格 %= 3');
+    });
+
     describe('class syntax round trip', () => {
         const expectClassRoundTrip = async (code, expectedRuby = null, spriteOptions = {}) => {
             const result = await converter.targetCodeToBlocks(null, code);


### PR DESCRIPTION
## Summary

- Ruby の日本語ローカル変数名（ひらがな・カタカナ・漢字）の Ruby ↔ ブロック相互変換を修正
- `価格 = 100 / 売値 = 価格 * 0.7 / puts 売値` が正しくラウンドトリップできるようになる

## 根本原因と修正

**1. `_toSnakeCaseLowercase` が日本語文字を `_` に変換していた**

```js
// Before: 価格 → _ (全日本語文字が _ になり変数名が衝突)
.replace(/[^a-zA-Z0-9_]+/g, '_')

// After: Unicode 文字 (U+0100-FFFF) を保持
.replace(/[^a-zA-Z0-9_\u0100-\uFFFF]+/g, '_')
```

**2. `data.js` の lvar コメント正規表現が `\w+` (ASCII のみ) だった**

```js
// Before: 価格 を捕捉できず compound assignment が壊れる
comment.match(/@ruby:lvar:(\w+):\d+/)

// After: 日本語も含む任意の文字列を捕捉
comment.match(/@ruby:lvar:([^:,\s]+):\d+/)
```

## Test plan

- [x] `_toSnakeCaseLowercase('価格')` が `'価格'` を返す（unit test）
- [x] `価格 = 100` のラウンドトリップ
- [x] `価格 = 100\n売値 = 価格 * 0.7\nputs 売値` のラウンドトリップ
- [x] `価格 += 10`, `-=`, `*=`, `/=`, `%=` の compound assignment ラウンドトリップ
- [x] 既存テスト 206 件すべて PASS

## Related Issues

Closes #224
