### PR TITLE
feat: 変数を while/until/if の条件式に使えるようにする (@ruby:variable: round-trip)

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -63,14 +63,16 @@ export default function (Generator) {
 
     const getUnlessInfo = function (block) {
         const comment = Generator.getCommentText(block);
-        if (comment === '@ruby:syntax:unless') {
-            return {hasElse: false};
-        }
-        if (comment === '@ruby:syntax:unless_else') {
+        if (!comment) return null;
+        // Check more specific patterns first to avoid substring conflicts
+        if (comment.includes('@ruby:syntax:unless_else')) {
             return {hasElse: true};
         }
-        if (comment === '@ruby:syntax:unless_modifier') {
+        if (comment.includes('@ruby:syntax:unless_modifier')) {
             return {isModifier: true};
+        }
+        if (comment.includes('@ruby:syntax:unless')) {
+            return {hasElse: false};
         }
         return null;
     };
@@ -90,10 +92,17 @@ export default function (Generator) {
 
     const getModifierInfo = function (block) {
         const comment = Generator.getCommentText(block);
-        if (comment === '@ruby:syntax:if_modifier') {
+        if (comment && comment.includes('@ruby:syntax:if_modifier')) {
             return 'if';
         }
         return null;
+    };
+
+    const getVariableHint = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (!comment) return null;
+        const match = comment.match(/@ruby:variable:([^,]+)/);
+        return match ? match[1] : null;
     };
 
     Generator.control_if = function (block) {
@@ -103,6 +112,21 @@ export default function (Generator) {
             if (content) {
                 return `case ${caseInfo.subject}\n${content}end\n`;
             }
+        }
+        const comment = Generator.getCommentText(block);
+        const varName = getVariableHint(block);
+        if (varName) {
+            const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
+            if (comment.includes('@ruby:syntax:unless_modifier')) {
+                return `${branch.trim()} unless ${varName}\n`;
+            }
+            if (comment.includes('@ruby:syntax:unless')) {
+                return `unless ${varName}\n${branch}end\n`;
+            }
+            if (comment.includes('@ruby:syntax:if_modifier')) {
+                return `${branch.trim()} if ${varName}\n`;
+            }
+            return `if ${varName}\n${branch}end\n`;
         }
         const unlessInfo = getUnlessInfo(block);
         if (unlessInfo) {
@@ -169,6 +193,17 @@ export default function (Generator) {
                 return `case ${caseInfo.subject}\n${content}end\n`;
             }
         }
+        const varName = getVariableHint(block);
+        if (varName) {
+            const comment = Generator.getCommentText(block);
+            const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
+            const branch2 = Generator.statementToCode(block, 'SUBSTACK2') || '';
+            if (comment.includes('@ruby:syntax:unless_else') ||
+                comment.includes('@ruby:syntax:unless')) {
+                return `unless ${varName}\n${branch}else\n${branch2}end\n`;
+            }
+            return `if ${varName}\n${branch}else\n${branch2}end\n`;
+        }
         const unlessInfo = getUnlessInfo(block);
         if (unlessInfo && unlessInfo.hasElse) {
             const operator = getUnlessCondition(block);
@@ -200,6 +235,14 @@ export default function (Generator) {
 
     Generator.control_repeat_until = function (block) {
         const comment = Generator.getCommentText(block);
+        const varName = getVariableHint(block);
+        if (varName) {
+            const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
+            if (comment.includes('@ruby:syntax:while')) {
+                return `while ${varName}\n${branch}end\n`;
+            }
+            return `until ${varName}\n${branch}end\n`;
+        }
         if (comment === '@ruby:syntax:while') {
             const operator = getWhileCondition(block);
             const branch = Generator.statementToCode(block, 'SUBSTACK') || '';

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/control-flow.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/control-flow.js
@@ -9,7 +9,10 @@ const ControlFlowHandlers = {
         const saved = this._saveContext();
 
         const preBlocks = [];
+        this._context.variableHint = null;
         let cond = this._processCondition(node.predicate);
+        const variableHint = this._context.variableHint;
+        this._context.variableHint = null;
         const split = this._splitPreBlocksAndValue(cond);
         cond = split.value;
         preBlocks.push(...split.preBlocks);
@@ -34,7 +37,9 @@ const ControlFlowHandlers = {
             }
         }
 
+        let hasElsif = false;
         if (node.subsequent && node.subsequent.constructor.name === 'IfNode') {
+            hasElsif = true;
             const elseBlock = _.isArray(elseStatement) ? elseStatement[0] : elseStatement;
             if (this.isBlock(block) && this.isBlock(elseBlock)) {
                 let n;
@@ -69,7 +74,8 @@ const ControlFlowHandlers = {
 
         // Detect if modifier form: endKeywordLoc is null for modifier syntax
         if (node.endKeywordLoc === null && this._isBlock(block)) {
-            const commentText = '@ruby:syntax:if_modifier';
+            let commentText = '@ruby:syntax:if_modifier';
+            if (variableHint) commentText += `,@ruby:variable:${variableHint}`;
             if (block.comment) {
                 const comment = this._context.comments[block.comment];
                 if (comment) {
@@ -78,6 +84,16 @@ const ControlFlowHandlers = {
                 }
             } else {
                 const commentId = this._createComment(commentText, block.id, 0, 0, true);
+                block.comment = commentId;
+            }
+        } else if (variableHint && !hasElsif && this._isBlock(block)) {
+            // Attach @ruby:variable: comment for round-trip (non-modifier, non-elsif forms)
+            const varCommentText = `@ruby:variable:${variableHint}`;
+            if (block.comment) {
+                const existingComment = this._context.comments[block.comment];
+                if (existingComment) existingComment.text += `,${varCommentText}`;
+            } else {
+                const commentId = this._createComment(varCommentText, block.id, 0, 0, true);
                 block.comment = commentId;
             }
         }
@@ -193,7 +209,10 @@ const ControlFlowHandlers = {
         const saved = this._saveContext();
 
         const preBlocks = [];
+        this._context.variableHint = null;
         let cond = this._processCondition(node.predicate);
+        const variableHint = this._context.variableHint;
+        this._context.variableHint = null;
         const split = this._splitPreBlocksAndValue(cond);
         cond = split.value;
         preBlocks.push(...split.preBlocks);
@@ -205,6 +224,17 @@ const ControlFlowHandlers = {
             this._restoreContext(saved);
 
             block = this._createRubyStatementBlock(this._getSource(node), node);
+        }
+
+        if (variableHint && this._isBlock(block)) {
+            const varCommentText = `@ruby:variable:${variableHint}`;
+            if (block.comment) {
+                const existingComment = this._context.comments[block.comment];
+                if (existingComment) existingComment.text += `,${varCommentText}`;
+            } else {
+                const commentId = this._createComment(varCommentText, block.id, 0, 0, true);
+                block.comment = commentId;
+            }
         }
 
         if (preBlocks.length > 0 && block) {
@@ -220,7 +250,10 @@ const ControlFlowHandlers = {
         const saved = this._saveContext();
 
         const preBlocks = [];
+        this._context.variableHint = null;
         let cond = this._processCondition(node.predicate);
+        const variableHint = this._context.variableHint;
+        this._context.variableHint = null;
         const split = this._splitPreBlocksAndValue(cond);
         cond = split.value;
         preBlocks.push(...split.preBlocks);
@@ -259,6 +292,7 @@ const ControlFlowHandlers = {
             } else {
                 commentText = '@ruby:syntax:unless';
             }
+            if (variableHint) commentText += `,@ruby:variable:${variableHint}`;
             if (block.comment) {
                 const comment = this._context.comments[block.comment];
                 if (comment) {
@@ -288,7 +322,10 @@ const ControlFlowHandlers = {
         const saved = this._saveContext();
 
         const preBlocks = [];
+        this._context.variableHint = null;
         let cond = this._processCondition(node.predicate);
+        const variableHint = this._context.variableHint;
+        this._context.variableHint = null;
         const split = this._splitPreBlocksAndValue(cond);
         cond = split.value;
         preBlocks.push(...split.preBlocks);
@@ -308,7 +345,11 @@ const ControlFlowHandlers = {
             block = this._createRubyStatementBlock(this._getSource(node), node);
         } else if (this._isBlock(block)) {
             // Attach @ruby:syntax:while comment for round-trip fidelity
-            const commentId = this._createComment('@ruby:syntax:while', block.id, 0, 0, true);
+            let commentText = '@ruby:syntax:while';
+            if (variableHint) {
+                commentText += `,@ruby:variable:${variableHint}`;
+            }
+            const commentId = this._createComment(commentText, block.id, 0, 0, true);
             block.comment = commentId;
         }
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/core.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/core.js
@@ -94,10 +94,15 @@ const CoreHandlers = {
         }
         cond = split.value;
         if (!this._isFalseOrBooleanBlock(cond)) {
-            throw new RubyToBlocksConverterError(
-                node,
-                `condition is not boolean: ${this._getSource(node)}`
-            );
+            if (this._isBlock(cond) && cond.opcode === 'data_variable') {
+                this._context.variableHint = this._getRubyVariableName(cond);
+                cond = this._wrapVariableAsBooleanCondition(cond);
+            } else {
+                throw new RubyToBlocksConverterError(
+                    node,
+                    `condition is not boolean: ${this._getSource(node)}`
+                );
+            }
         }
         return cond;
     },

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/context-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/context-utils.js
@@ -26,6 +26,7 @@ const ContextUtils = {
             literalCallIndices: {},
             elsifCounter: 0,
             caseCounter: 0,
+            variableHint: null,
             isValue: false,
             inMyBlockDefinition: false,
             scopeStack: [],

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
@@ -232,13 +232,14 @@ const NodeUtils = {
 
     _wrapVariableAsBooleanCondition (varBlock) {
         // Creates !(varBlock == (0 < 0)) as a boolean block.
+        // Uses the same pattern as visitFalseNode: operator_lt with OPERAND1/OPERAND2 text inputs.
         // (0 < 0) is false; !(varBlock == false) is truthy when varBlock is truthy.
         const previousNode = this._context.currentNode;
         this._context.currentNode = null;
 
         const ltBlock = this._createBlock('operator_lt', 'value_boolean');
-        this._addNumberInput(ltBlock, 'NUM1', 'math_number', 0, 0);
-        this._addNumberInput(ltBlock, 'NUM2', 'math_number', 0, 0);
+        this._addTextInput(ltBlock, 'OPERAND1', '0', '0');
+        this._addTextInput(ltBlock, 'OPERAND2', '0', '0');
 
         const eqBlock = this._createBlock('operator_equals', 'value_boolean');
         this._addInput(eqBlock, 'OPERAND1', varBlock);

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
@@ -220,6 +220,37 @@ const NodeUtils = {
         return /_variable$/.test(this._getBlockType(block));
     },
 
+    _getRubyVariableName (varBlock) {
+        const varName = varBlock.fields.VARIABLE.value;
+        const variable = this._context.variables[varName] ||
+            this._context.localVariables[varName];
+        if (!variable) return varName;
+        if (variable.scope === 'instance') return `@${variable.name}`;
+        if (variable.scope === 'global') return `$${variable.name}`;
+        return variable.originalName || variable.name;
+    },
+
+    _wrapVariableAsBooleanCondition (varBlock) {
+        // Creates !(varBlock == (0 < 0)) as a boolean block.
+        // (0 < 0) is false; !(varBlock == false) is truthy when varBlock is truthy.
+        const previousNode = this._context.currentNode;
+        this._context.currentNode = null;
+
+        const ltBlock = this._createBlock('operator_lt', 'value_boolean');
+        this._addNumberInput(ltBlock, 'NUM1', 'math_number', 0, 0);
+        this._addNumberInput(ltBlock, 'NUM2', 'math_number', 0, 0);
+
+        const eqBlock = this._createBlock('operator_equals', 'value_boolean');
+        this._addInput(eqBlock, 'OPERAND1', varBlock);
+        this._addInput(eqBlock, 'OPERAND2', ltBlock);
+
+        const notBlock = this._createBlock('operator_not', 'value_boolean');
+        this._addInput(notBlock, 'OPERAND', eqBlock);
+
+        this._context.currentNode = previousNode;
+        return notBlock;
+    },
+
     isVariableBlock (block) {
         return this.isVariableBlockType(block) && block.opcode === 'data_variable';
     },

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -235,6 +235,42 @@ end
         );
     });
 
+    describe('variable as condition (@ruby:variable: round-trip)', () => {
+        test('while with instance variable', async () => {
+            await expectRoundTrip('while @game_on\n  move(10)\nend');
+        });
+
+        test('until with instance variable', async () => {
+            await expectRoundTrip('until @done\n  move(10)\nend');
+        });
+
+        test('if with instance variable', async () => {
+            await expectRoundTrip('if @flag\n  move(10)\nend');
+        });
+
+        test('if with instance variable and else', async () => {
+            await expectRoundTrip('if @flag\n  move(10)\nelse\n  turn_right(180)\nend');
+        });
+
+        test('unless with instance variable', async () => {
+            await expectRoundTrip('unless @flag\n  move(10)\nend');
+        });
+
+        test('if_modifier with instance variable', async () => {
+            await expectRoundTrip('move(10) if @flag');
+        });
+
+        test('global variable as while condition', async () => {
+            await expectRoundTrip('while $running\n  move(10)\nend');
+        });
+
+        test('complex program with while and boolean variable', async () => {
+            await expectRoundTrip(
+                'when_flag_clicked do\n  @game_on = true\n  while @game_on\n    go_to("_random_")\n    @game_on = false\n  end\nend'
+            );
+        });
+    });
+
     describe('class syntax round trip', () => {
         const expectClassRoundTrip = async (code, expectedRuby = null, spriteOptions = {}) => {
             const result = await converter.targetCodeToBlocks(null, code);


### PR DESCRIPTION
## Summary

`while @game_on` のように変数を while/until/if の条件式に使う Ruby コードが、
これまで「condition is not boolean」エラーで命令ブロックに変換できなかった問題を修正。

変数が条件式に指定された場合に `!(var == (0 < 0))` のブール式ブロックに自動変換し、
`@ruby:variable:varName` コメントを付与することで Ruby↔ブロック の round-trip を実現。

## Changes Made

- **`_processCondition`** (core.js): `data_variable` ブロックを検出したら `_wrapVariableAsBooleanCondition` でラップし `variableHint` をコンテキストにセット
- **`node-utils.js`**: `_wrapVariableAsBooleanCondition` と `_getRubyVariableName` ユーティリティを追加
- **`context-utils.js`**: コンテキストに `variableHint: null` フィールドを追加
- **`ast-handlers/control-flow.js`**: `visitWhileNode`, `visitUntilNode`, `visitIfNode`, `visitUnlessNode` で `variableHint` を読み取りコメントに付与
- **`ruby-generator/control.js`**: `getVariableHint` 関数を追加。`control_repeat_until`, `control_if`, `control_if_else` で `@ruby:variable:` コメントを検出して元の変数名を出力
  - また `getUnlessInfo`, `getModifierInfo` を `includes` ベースに変更（コメントが複数情報を含む場合に対応）

## Supported Syntax

```ruby
while @flag        # instance variable
until @done
if @flag
unless @flag
if @flag...else...end
move(10) if @flag  # modifier form
while $running     # global variable
while local_var    # local variable
```

## Test Coverage

- `test/unit/lib/ruby-to-blocks-converter/round-trip.test.js` に 8 テストを追加
- 全 702 ユニットテスト通過

## Implementation Steps

- [x] **Phase 1+2**: ユーティリティ追加 + `_processCondition` 修正 + visit メソッド修正
- [x] **Phase 3**: ジェネレータ修正（`@ruby:variable:` コメント処理）
- [ ] **Phase Final**: 統合テスト追加

Closes #231
