### PR TITLE
test: 変数を while/until/if/unless の条件式に使うラウンドトリップ統合テストを追加する

### DIFF
--- a/packages/scratch-gui/test/integration/ruby-tab.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab.test.js
@@ -68,6 +68,44 @@ end`;
         await rubyHelper.expectInterconvertBetweenCodeAndRuby(code);
     });
 
+    test('variable as while condition round-trip: Ruby -> Blocks -> Ruby', async () => {
+        await loadUri(uri);
+        const code = `@game_on = true
+while @game_on
+  move(10)
+  @game_on = false
+end`;
+        await rubyHelper.expectInterconvertBetweenCodeAndRuby(code);
+    });
+
+    test('variable as until condition round-trip: Ruby -> Blocks -> Ruby', async () => {
+        await loadUri(uri);
+        const code = `@done = false
+until @done
+  move(10)
+  @done = true
+end`;
+        await rubyHelper.expectInterconvertBetweenCodeAndRuby(code);
+    });
+
+    test('variable as if condition round-trip: Ruby -> Blocks -> Ruby', async () => {
+        await loadUri(uri);
+        const code = `@flag = true
+if @flag
+  move(10)
+end`;
+        await rubyHelper.expectInterconvertBetweenCodeAndRuby(code);
+    });
+
+    test('variable as unless condition round-trip: Ruby -> Blocks -> Ruby', async () => {
+        await loadUri(uri);
+        const code = `@flag = false
+unless @flag
+  move(10)
+end`;
+        await rubyHelper.expectInterconvertBetweenCodeAndRuby(code);
+    });
+
     describe('syntax error', () => {
         beforeEach(async () => {
             await loadUri(uri);


### PR DESCRIPTION
## Summary

PR #232 の Phase Final として、変数を `while`/`until`/`if`/`unless` の条件式に使う機能のラウンドトリップ統合テストを追加します。

## Changes Made

- `packages/scratch-gui/test/integration/ruby-tab.test.js` に4件の統合テストを追加:
  - `variable as while condition round-trip` — `@game_on` を while 条件に使う往復変換
  - `variable as until condition round-trip` — `@done` を until 条件に使う往復変換
  - `variable as if condition round-trip` — `@flag` を if 条件に使う往復変換
  - `variable as unless condition round-trip` — `@flag` を unless 条件に使う往復変換

## Test Coverage

- ローカルで全12テスト pass 確認済み（既存8件 + 新規4件）

## Related Issues

Closes the Phase Final checkbox of #231
