### PR TITLE
feat: Gemini生成コードの無効なリソース名を有効なものに置き換える

### DIFF
--- a/packages/scratch-gui/src/containers/gemini-modal-hoc.jsx
+++ b/packages/scratch-gui/src/containers/gemini-modal-hoc.jsx
@@ -8,6 +8,76 @@ import VM from '@smalruby/scratch-vm';
 import GeminiAPI, {RateLimitError} from '../lib/gemini-api';
 import GeminiModal from '../components/gemini-modal/gemini-modal.jsx';
 
+/**
+ * Replace invalid resource references in Gemini-generated Ruby code with valid ones.
+ * - Sounds: replace with first valid sound; comment out if no sounds exist
+ * - Costumes: replace with first valid costume; skip if no costumes exist
+ * - Backdrops: replace with first valid backdrop; skip if no backdrops exist
+ * @param {string} code - Ruby source code to sanitize
+ * @param {string[]} validSounds - List of valid sound names on the current sprite
+ * @param {string[]} validCostumes - List of valid costume names on the current sprite
+ * @param {string[]} validBackdrops - List of valid backdrop names on the stage
+ * @returns {string} Sanitized code
+ */
+export const sanitizeResourceReferences = (code, validSounds, validCostumes, validBackdrops) => {
+    let result = code;
+
+    // --- Sounds ---
+    result = result.replace(
+        /^( *)(play(?:_until_done)?)\(("[^"]*"|'[^']*')\)/gm,
+        (match, indent, fn, nameWithQuotes) => {
+            const name = nameWithQuotes.slice(1, -1);
+            if (validSounds.includes(name)) return match;
+            if (validSounds.length === 0) {
+                return `${indent}# ${fn}(${nameWithQuotes}) # この音は存在しないのでコメントアウトしました`;
+            }
+            return `${indent}${fn}("${validSounds[0]}")`;
+        }
+    );
+
+    // --- Costumes ---
+    if (validCostumes.length > 0) {
+        result = result.replace(
+            /^( *)switch_costume\(("[^"]*"|'[^']*')\)/gm,
+            (match, indent, nameWithQuotes) => {
+                const name = nameWithQuotes.slice(1, -1);
+                if (validCostumes.includes(name)) return match;
+                return `${indent}switch_costume("${validCostumes[0]}")`;
+            }
+        );
+        result = result.replace(
+            /^( *)(?:self\.)?costume\s*=\s*("[^"]*"|'[^']*')/gm,
+            (match, indent, nameWithQuotes) => {
+                const name = nameWithQuotes.slice(1, -1);
+                if (validCostumes.includes(name)) return match;
+                return `${indent}self.costume = "${validCostumes[0]}"`;
+            }
+        );
+    }
+
+    // --- Backdrops ---
+    if (validBackdrops.length > 0) {
+        result = result.replace(
+            /^( *)(switch_backdrop(?:_(?:and_wait|to_and_wait))?)\(("[^"]*"|'[^']*')\)/gm,
+            (match, indent, fn, nameWithQuotes) => {
+                const name = nameWithQuotes.slice(1, -1);
+                if (validBackdrops.includes(name)) return match;
+                return `${indent}${fn}("${validBackdrops[0]}")`;
+            }
+        );
+        result = result.replace(
+            /^( *)(?:self\.)?backdrop\s*=\s*("[^"]*"|'[^']*')/gm,
+            (match, indent, nameWithQuotes) => {
+                const name = nameWithQuotes.slice(1, -1);
+                if (validBackdrops.includes(name)) return match;
+                return `${indent}self.backdrop = "${validBackdrops[0]}"`;
+            }
+        );
+    }
+
+    return result;
+};
+
 const TIMEOUT_SECONDS = 120;
 
 const messages = defineMessages({
@@ -306,36 +376,19 @@ const GeminiModalHOC = function (WrappedComponent) {
             const {latestCodes} = this.state;
             let code = latestCodes[index];
             if (code && this._applyGeminiCode) {
-                code = this._sanitizeSoundNames(code);
+                const target = this.props.editingTarget;
+                const validSounds = target && target.sprite && target.sprite.sounds ?
+                    target.sprite.sounds.map(s => s.name) : [];
+                const validCostumes = target && target.sprite && target.sprite.costumes ?
+                    target.sprite.costumes.map(c => c.name) : [];
+                const stage = this.props.vm && this.props.vm.runtime &&
+                    this.props.vm.runtime.targets &&
+                    this.props.vm.runtime.targets.find(t => t.isStage);
+                const validBackdrops = stage && stage.sprite && stage.sprite.costumes ?
+                    stage.sprite.costumes.map(c => c.name) : [];
+                code = sanitizeResourceReferences(code, validSounds, validCostumes, validBackdrops);
                 this._applyGeminiCode(code);
             }
-        }
-
-        /**
-         * Comment out play()/play_until_done() calls with sound names
-         * that don't exist on the current sprite.
-         * @param {string} code - Ruby source code to sanitize
-         * @returns {string} Sanitized code with invalid play() calls commented out
-         */
-        _sanitizeSoundNames (code) {
-            const target = this.props.editingTarget;
-            if (!target || !target.sprite || !target.sprite.sounds) {
-                return code;
-            }
-            const validSounds = new Set(
-                target.sprite.sounds.map(s => s.name)
-            );
-            // Match play("...") or play_until_done("...") lines
-            return code.replace(
-                /^( *)(play(?:_until_done)?)\(("[^"]*")\)/gm,
-                (match, indent, fn, nameWithQuotes) => {
-                    const name = nameWithQuotes.slice(1, -1);
-                    if (validSounds.has(name)) {
-                        return match; // keep as-is
-                    }
-                    return `${indent}# ${fn}(${nameWithQuotes}) # この音は存在しないのでコメントアウトしました`;
-                }
-            );
         }
 
         handleClearHistory () {

--- a/packages/scratch-gui/src/containers/gemini-modal-hoc.jsx
+++ b/packages/scratch-gui/src/containers/gemini-modal-hoc.jsx
@@ -301,7 +301,7 @@ const GeminiModalHOC = function (WrappedComponent) {
                 // Collect state context
                 const stateContext = collectStateContext(
                     this.props.vm,
-                    this.props.editingTarget
+                    this.props.vm && this.props.vm.editingTarget
                 );
 
                 // Call Gemini API
@@ -376,7 +376,7 @@ const GeminiModalHOC = function (WrappedComponent) {
             const {latestCodes} = this.state;
             let code = latestCodes[index];
             if (code && this._applyGeminiCode) {
-                const target = this.props.editingTarget;
+                const target = this.props.vm && this.props.vm.editingTarget;
                 const validSounds = target && target.sprite && target.sprite.sounds ?
                     target.sprite.sounds.map(s => s.name) : [];
                 const validCostumes = target && target.sprite && target.sprite.costumes ?
@@ -448,12 +448,7 @@ const GeminiModalHOC = function (WrappedComponent) {
 
     GeminiModalComponent.propTypes = {
         intl: intlShape.isRequired,
-        vm: PropTypes.instanceOf(VM).isRequired,
-        editingTarget: PropTypes.object
-    };
-
-    GeminiModalComponent.defaultProps = {
-        editingTarget: null
+        vm: PropTypes.instanceOf(VM).isRequired
     };
 
     return injectIntl(GeminiModalComponent);

--- a/packages/scratch-gui/test/unit/containers/gemini-modal-hoc-sanitize.test.js
+++ b/packages/scratch-gui/test/unit/containers/gemini-modal-hoc-sanitize.test.js
@@ -1,0 +1,162 @@
+import {sanitizeResourceReferences} from '../../../src/containers/gemini-modal-hoc';
+
+describe('sanitizeResourceReferences', () => {
+    // --- Sound ---
+    describe('sounds', () => {
+        test('replaces invalid sound name in play() with first valid sound', () => {
+            const code = 'play("ポップ")';
+            const result = sanitizeResourceReferences(code, ['ネコ', 'イヌ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('play("ネコ")');
+        });
+
+        test('replaces invalid sound name in play_until_done() with first valid sound', () => {
+            const code = 'play_until_done("ポップ")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('play_until_done("ネコ")');
+        });
+
+        test('comments out play() when sound list is empty', () => {
+            const code = 'play("ポップ")';
+            const result = sanitizeResourceReferences(code, [], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('# play("ポップ") # この音は存在しないのでコメントアウトしました');
+        });
+
+        test('comments out play_until_done() when sound list is empty', () => {
+            const code = 'play_until_done("ポップ")';
+            const result = sanitizeResourceReferences(code, [], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('# play_until_done("ポップ") # この音は存在しないのでコメントアウトしました');
+        });
+
+        test('keeps valid play() unchanged', () => {
+            const code = 'play("ネコ")';
+            const result = sanitizeResourceReferences(code, ['ネコ', 'イヌ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('play("ネコ")');
+        });
+
+        test('handles indented play() lines', () => {
+            const code = '  play("ポップ")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('  play("ネコ")');
+        });
+
+        test('handles multiple lines with mixed valid/invalid sounds', () => {
+            const code = [
+                'play("ネコ")',
+                'play("ポップ")',
+                'play_until_done("ドン")'
+            ].join('\n');
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe([
+                'play("ネコ")',
+                'play("ネコ")',
+                'play_until_done("ネコ")'
+            ].join('\n'));
+        });
+    });
+
+    // --- Costume ---
+    describe('costumes', () => {
+        test('replaces invalid costume name in switch_costume() with first valid costume', () => {
+            const code = 'switch_costume("存在しないコスチューム")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1', 'コスチューム2'], ['背景1']);
+            expect(result).toBe('switch_costume("コスチューム1")');
+        });
+
+        test('replaces invalid costume name in self.costume = with first valid costume', () => {
+            const code = 'self.costume = "存在しないコスチューム"';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('self.costume = "コスチューム1"');
+        });
+
+        test('keeps valid switch_costume() unchanged', () => {
+            const code = 'switch_costume("コスチューム1")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1', 'コスチューム2'], ['背景1']);
+            expect(result).toBe('switch_costume("コスチューム1")');
+        });
+
+        test('handles indented switch_costume() lines', () => {
+            const code = '  switch_costume("存在しない")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('  switch_costume("コスチューム1")');
+        });
+
+        test('skips costume replacement when costume list is empty', () => {
+            const code = 'switch_costume("存在しないコスチューム")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], [], ['背景1']);
+            expect(result).toBe('switch_costume("存在しないコスチューム")');
+        });
+    });
+
+    // --- Backdrop ---
+    describe('backdrops', () => {
+        test('replaces invalid backdrop name in switch_backdrop() with first valid backdrop', () => {
+            const code = 'switch_backdrop("存在しない背景")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1', '背景2']);
+            expect(result).toBe('switch_backdrop("背景1")');
+        });
+
+        test('replaces invalid backdrop name in switch_backdrop_and_wait()', () => {
+            const code = 'switch_backdrop_and_wait("存在しない背景")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('switch_backdrop_and_wait("背景1")');
+        });
+
+        test('replaces invalid backdrop name in switch_backdrop_to_and_wait()', () => {
+            const code = 'switch_backdrop_to_and_wait("存在しない背景")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('switch_backdrop_to_and_wait("背景1")');
+        });
+
+        test('replaces invalid backdrop name in self.backdrop =', () => {
+            const code = 'self.backdrop = "存在しない背景"';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('self.backdrop = "背景1"');
+        });
+
+        test('keeps valid switch_backdrop() unchanged', () => {
+            const code = 'switch_backdrop("背景1")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1', '背景2']);
+            expect(result).toBe('switch_backdrop("背景1")');
+        });
+
+        test('handles indented switch_backdrop() lines', () => {
+            const code = '  switch_backdrop("存在しない背景")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('  switch_backdrop("背景1")');
+        });
+
+        test('skips backdrop replacement when backdrop list is empty', () => {
+            const code = 'switch_backdrop("存在しない背景")';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], []);
+            expect(result).toBe('switch_backdrop("存在しない背景")');
+        });
+    });
+
+    // --- Edge cases ---
+    describe('edge cases', () => {
+        test('handles empty code string', () => {
+            const result = sanitizeResourceReferences('', ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('');
+        });
+
+        test('handles code with no resource references', () => {
+            const code = 'move(10)\nwait(1)';
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe('move(10)\nwait(1)');
+        });
+
+        test('handles multiple resource types in one code block', () => {
+            const code = [
+                'play("ポップ")',
+                'switch_costume("存在しないコスチューム")',
+                'switch_backdrop("存在しない背景")'
+            ].join('\n');
+            const result = sanitizeResourceReferences(code, ['ネコ'], ['コスチューム1'], ['背景1']);
+            expect(result).toBe([
+                'play("ネコ")',
+                'switch_costume("コスチューム1")',
+                'switch_backdrop("背景1")'
+            ].join('\n'));
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Gemini（スモウルビー先生）が生成した Ruby コードに含まれる、存在しないリソース名を**実際に存在する最初のリソース名に置き換える**処理を追加
- 既存の `_sanitizeSoundNames`（コメントアウト方式）を廃止し、`sanitizeResourceReferences` 純粋関数に置き換え

## Changes Made

- `packages/scratch-gui/src/containers/gemini-modal-hoc.jsx`
  - `export const sanitizeResourceReferences(code, validSounds, validCostumes, validBackdrops)` を追加（純粋関数・テスト可能）
  - **音声**: `play("xxx")` / `play_until_done("xxx")` → 最初の有効な音声名に置き換え（音声なしならコメントアウト）
  - **コスチューム**: `switch_costume("xxx")` / `self.costume = "xxx"` → 最初の有効なコスチューム名に置き換え
  - **背景**: `switch_backdrop*("xxx")` / `self.backdrop = "xxx"` → 最初の有効な背景名に置き換え
  - **バグ修正**: `this.props.editingTarget`（常に undefined）を `this.props.vm.editingTarget` に修正。`collectStateContext` も同様に修正
  - `handleApplyCode` を更新して新関数を使用

## Test Coverage

- `test/unit/containers/gemini-modal-hoc-sanitize.test.js`（新規）: 22 tests、音声・コスチューム・背景の全パターンをカバー
- Playwright ブラウザ確認: 全パターン動作確認済み

## Implementation Steps

- [x] Phase 1: テスト追加（RED）
- [x] Phase 2: 実装（GREEN）
- [x] Phase Final: Playwright 動作確認

Closes #234