### PR TITLE
perf: scratch-vm integration test の高速化（shard 分割）

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,6 +86,9 @@ jobs:
 
   integration-test-vm:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
     env:
       NODE_OPTIONS: --max-old-space-size=4000
     steps:
@@ -113,12 +116,27 @@ jobs:
           MESH_DATA_UPDATE_INTERVAL_MS: 100
           MESH_EVENT_BATCH_INTERVAL_MS: 100
           MESH_PERIODIC_DATA_SYNC_INTERVAL_MS: 1000
-        run: npm run test:integration --workspace=packages/scratch-vm
+        working-directory: packages/scratch-vm
+        run: |
+          # Collect all integration test files and sort for deterministic sharding
+          files=$(find test/integration -name '*.js' -o -name '*.test.js' | sort)
+          total=$(echo "$files" | wc -l)
+          half=$(( (total + 1) / 2 ))
+
+          if [ "${{ matrix.shard }}" = "1" ]; then
+            selected=$(echo "$files" | head -n "$half")
+          else
+            selected=$(echo "$files" | tail -n +"$((half + 1))")
+          fi
+
+          echo "Shard ${{ matrix.shard }}/$total files: running $(echo "$selected" | wc -l) files"
+          echo "$selected"
+          echo "$selected" | xargs npx tap
       - name: Store Test Results
         if: always() # Even if tests fail
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
-          name: test-output-integration-vm
+          name: test-output-integration-vm-shard-${{ matrix.shard }}
           path: packages/scratch-vm/test-results/*
 
   integration-test-gui:


### PR DESCRIPTION
## Summary

scratch-vm の integration test CI ジョブを 2 shard に分割して壁時計時間を半減させる。

- 変更前: 209.5s（70 ファイル、1 ジョブ）
- 目標: ~105s

tap には jest の `--shard` 相当がないため、`find | sort | head/tail` でファイルリストを半分に分割して各 shard に配分する。

## Test Plan

- CI で 2 shard がそれぞれ pass すること
- 壁時計時間が ~105s 程度に短縮されること
