### PR TITLE
fix: upstream merge bugs - palette toggle, zoom alignment, screenshot error

### DIFF
--- a/packages/scratch-gui/src/components/blocks-screenshot-button/blocks-screenshot-button.css
+++ b/packages/scratch-gui/src/components/blocks-screenshot-button/blocks-screenshot-button.css
@@ -1,12 +1,12 @@
 @import "../../css/z-index.css";
 
 /* Position above the Scratch Blocks zoom controls.
-   bottom = scrollbar(10) + MARGIN_BOTTOM(12) + HEIGHT(124) + MARGIN_BETWEEN(8) = 154px
-   right  = MARGIN_SIDE(12) + scrollbar(10) = 22px */
+   bottom = scrollbar(11) + MARGIN_BOTTOM(12) + HEIGHT(124) + gap(8) + offset(7) = 162px
+   right  = MARGIN_SIDE(12) + scrollbar(11) + offset(7) = 30px */
 .screenshotButton {
     position: absolute;
-    bottom: 154px;
-    right: 22px;
+    bottom: 162px;
+    right: 30px;
     width: 36px;
     height: 36px;
     padding: 0;

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -242,6 +242,11 @@ class Blocks extends React.Component {
 
         if (this.props.paletteVisible !== prevProps.paletteVisible) {
             this._applyPaletteVisibility(this.props.paletteVisible);
+            // Re-render after DOM visibility changes so the toggle position
+            // is computed with correct toolbox/flyout widths.
+            if (this.props.paletteVisible) {
+                requestAnimationFrame(() => this.forceUpdate());
+            }
         }
 
         if (this.props.isVisible === prevProps.isVisible) {
@@ -917,8 +922,14 @@ class Blocks extends React.Component {
         } = this.props;
 
         // Calculate toggle button position based on toolbox width (toolbox + flyout combined)
+        // In Scratch Blocks v2, getWidth() returns only the category menu width;
+        // the flyout width must be added separately.
         const toolbox = this.workspace ? this.workspace.getToolbox() : null;
-        const toggleButtonLeft = paletteVisible && toolbox ? toolbox.getWidth() : 0;
+        const flyout = toolbox ? toolbox.getFlyout() : null;
+        const toolboxTotalWidth = toolbox ?
+            toolbox.getWidth() + (flyout ? flyout.getWidth() : 0) :
+            0;
+        const toggleButtonLeft = paletteVisible ? toolboxTotalWidth : 0;
 
         return (
             <React.Fragment>

--- a/packages/scratch-gui/src/containers/ruby-tab/ruby-tab.css
+++ b/packages/scratch-gui/src/containers/ruby-tab/ruby-tab.css
@@ -24,8 +24,8 @@
 
 .downloadWrapper {
     position: absolute;
-    bottom: 22px;
-    right: 70px; /* 22px (zoom margin) + 36px (zoom width) + 12px (gap) */
+    bottom: 30px;
+    right: 78px; /* 30px (zoom margin) + 36px (zoom width) + 12px (gap) */
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -33,8 +33,8 @@
 
 .zoomControlsWrapper {
     position: absolute;
-    bottom: 22px;
-    right: 22px; /* 12px (MARGIN_SIDE) + 10px (scrollbar thickness) */
+    bottom: 30px;
+    right: 30px; /* Match Blockly zoom controls position */
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/packages/scratch-gui/src/lib/blocks-screenshot.js
+++ b/packages/scratch-gui/src/lib/blocks-screenshot.js
@@ -100,6 +100,10 @@ const buildExportSVG = function (workspace, bbox, scale, width, height, padding 
     // Clone block canvas and re-position so bbox top-left -> (padding, padding).
     // bbox.x and bbox.y are workspace coordinates of the top-left of all blocks.
     const canvasClone = blockCanvas.cloneNode(true);
+    // Scratch Blocks v2 uses CSS style.transform (e.g. "translate(311px, 0px) scale(0.675)")
+    // instead of an SVG transform attribute. Clear the CSS transform so it doesn't
+    // override the SVG transform attribute we set below for export positioning.
+    canvasClone.style.transform = '';
     const tx = ((-bbox.x) * scale) + padding;
     const ty = ((-bbox.y) * scale) + padding;
     canvasClone.setAttribute('transform', `translate(${tx}, ${ty}) scale(${scale})`);

--- a/packages/scratch-gui/src/lib/blocks-screenshot.js
+++ b/packages/scratch-gui/src/lib/blocks-screenshot.js
@@ -15,8 +15,13 @@ const EXPORT_PADDING = 16;
 const getBlocksBoundingBox = function (workspace) {
     const bbox = workspace.getBlocksBoundingBox();
     if (!bbox) return null;
-    if (bbox.width === 0 && bbox.height === 0) return null;
-    return bbox;
+    // Scratch Blocks v2 returns {top, bottom, left, right}; convert to {x, y, width, height}
+    const x = 'x' in bbox ? bbox.x : bbox.left;
+    const y = 'y' in bbox ? bbox.y : bbox.top;
+    const width = 'width' in bbox ? bbox.width : (bbox.right - bbox.left);
+    const height = 'height' in bbox ? bbox.height : (bbox.bottom - bbox.top);
+    if (width === 0 && height === 0) return null;
+    return {x, y, width, height};
 };
 
 /**

--- a/packages/scratch-gui/test/unit/lib/blocks-screenshot.test.js
+++ b/packages/scratch-gui/test/unit/lib/blocks-screenshot.test.js
@@ -48,6 +48,31 @@ describe('getBlocksBoundingBox', () => {
         const workspace = makeMockWorkspace({boundingBox: bbox});
         expect(getBlocksBoundingBox(workspace)).toEqual(bbox);
     });
+
+    test('converts {top, bottom, left, right} format to {x, y, width, height}', () => {
+        const workspace = makeMockWorkspace({
+            boundingBox: {top: 10, bottom: 110, left: 20, right: 220}
+        });
+        expect(getBlocksBoundingBox(workspace)).toEqual({
+            x: 20, y: 10, width: 200, height: 100
+        });
+    });
+
+    test('returns null for zero-area {top, bottom, left, right} format', () => {
+        const workspace = makeMockWorkspace({
+            boundingBox: {top: 0, bottom: 0, left: 0, right: 0}
+        });
+        expect(getBlocksBoundingBox(workspace)).toBeNull();
+    });
+
+    test('handles {top, bottom, left, right} with negative coordinates', () => {
+        const workspace = makeMockWorkspace({
+            boundingBox: {top: -50, bottom: 50, left: -30, right: 70}
+        });
+        expect(getBlocksBoundingBox(workspace)).toEqual({
+            x: -30, y: -50, width: 100, height: 100
+        });
+    });
 });
 
 // ---- calculateCanvasDimensions ----
@@ -165,6 +190,18 @@ describe('downloadBlocksAsImage', () => {
         expect(capturedCanvas.height).toBe(100 + EXPORT_PADDING * 2);
 
         document.createElement.mockRestore();
+    });
+
+    test('downloads PNG with {top, bottom, left, right} bbox format', async () => {
+        const workspace = makeMockWorkspace({
+            boundingBox: {top: 10, bottom: 110, left: 20, right: 220},
+            scale: 1
+        });
+        await downloadBlocksAsImage(workspace, 'proj', 'Sprite1');
+        expect(downloadBlob).toHaveBeenCalledWith(
+            'proj_Sprite1.png',
+            expect.any(Blob)
+        );
     });
 
     test('canvas dimensions respect scale', async () => {


### PR DESCRIPTION
## Summary

upstream Scratch Blocks v2 マージで発生した3つのバグを修正:

- **パレットトグル位置**: v2 では `toolbox.getWidth()` がカテゴリメニュー幅のみ返すため、flyout 幅を加算して正しい位置を計算。また、表示切替後の DOM 測定タイミング問題を `requestAnimationFrame + forceUpdate` で修正
- **スクリーンショットボタン・ズームアイコン位置**: Blockly zoom controls の新しい配置に合わせて CSS を更新（right: 22→30px 等）
- **スクリーンショット機能エラー**: v2 の `getBlocksBoundingBox()` が `{top,bottom,left,right}` 形式を返すため変換処理を追加。また v2 では `svgBlockCanvas_` が CSS `style.transform` を使用するため、クローン時にクリアして SVG transform 属性が正しく適用されるよう修正

## Implementation Steps

- [x] Phase 1: Fix blocks-screenshot.js bounding box format (TDD)
- [x] Phase 2: Fix palette toggle position calculation
- [x] Phase 3: Align screenshot button and ruby tab zoom with Blockly controls
- [x] Phase 3.5: Fix blank screenshot (CSS transform override in v2)
- [ ] Phase Final: Integration tests

## Test Plan

| Type | Timing | Target |
|------|--------|--------|
| Unit tests (TDD) | Phase 1 | blocks-screenshot.js (19 tests) |
| Playwright verification | Phase 2-3.5 | UI positioning, toggle behavior, screenshot download |
| Integration tests | Phase Final | regression detection |

## Related Issues

Fixes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
