### PR TITLE
fix: skip integration tests on develop/master/main branch pushes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -120,6 +120,12 @@ jobs:
 
   integration-test-vm:
     runs-on: ubuntu-latest
+    if: |
+      (!(
+        github.ref == 'refs/heads/develop' ||
+        github.ref == 'refs/heads/master' ||
+        github.ref == 'refs/heads/main'
+      ))
     strategy:
       matrix:
         shard: [1, 2]
@@ -175,6 +181,12 @@ jobs:
 
   integration-test-gui:
     runs-on: ubuntu-latest
+    if: |
+      (!(
+        github.ref == 'refs/heads/develop' ||
+        github.ref == 'refs/heads/master' ||
+        github.ref == 'refs/heads/main'
+      ))
     strategy:
       matrix:
         shard: [1, 2]


### PR DESCRIPTION
## Summary
- `integration-test-vm` と `integration-test-gui` ジョブに、develop/master/main ブランチへの push 時にスキップする `if` 条件を追加
- `lint`, `unit-test-vm`, `unit-test-gui` には既にこの条件があったが、integration test ジョブには欠落していた

## Changes Made
- `.github/workflows/ci-cd.yml`: `integration-test-vm` と `integration-test-gui` に branch exclusion 条件を追加

## Related Issues
Fixes the issue where integration tests ran unnecessarily on merge to develop (e.g., [run #22823601497](https://github.com/smalruby/smalruby3-editor/actions/runs/22823601497))
