### PR TITLE
fix: allow keyboard events from Blockly workspace SVG elements

### DIFF
--- a/packages/scratch-gui/src/lib/vm-listener-hoc.jsx
+++ b/packages/scratch-gui/src/lib/vm-listener-hoc.jsx
@@ -88,7 +88,21 @@ const vmListenerHOC = function (WrappedComponent) {
         }
         handleKeyDown (e) {
             // Don't capture keys intended for Blockly inputs.
-            if (e.target !== document && e.target !== document.body) return;
+            if (e.target !== document && e.target !== document.body) {
+                // === Smalruby: Start of scratch-blocks v2 keyboard focus fix ===
+                // scratch-blocks v2 adds tabindex="0" to workspace SVG <g> elements,
+                // causing keyboard events to target those elements instead of document.body.
+                // Allow keyboard events from Blockly workspace SVG elements, but still
+                // filter out events from text input fields (INPUT, TEXTAREA, contentEditable).
+                const isBlocklyWorkspaceElement = e.target &&
+                    e.target.closest &&
+                    e.target.closest('.injectionDiv') &&
+                    e.target.tagName !== 'INPUT' &&
+                    e.target.tagName !== 'TEXTAREA' &&
+                    !e.target.isContentEditable;
+                if (!isBlocklyWorkspaceElement) return;
+                // === Smalruby: End of scratch-blocks v2 keyboard focus fix ===
+            }
 
             const key = (!e.key || e.key === 'Dead') ? e.keyCode : e.key;
             this.props.vm.postIOData('keyboard', {

--- a/packages/scratch-gui/test/unit/util/vm-listener-hoc.test.jsx
+++ b/packages/scratch-gui/test/unit/util/vm-listener-hoc.test.jsx
@@ -184,4 +184,134 @@ describe('VMListenerHOC', () => {
         eventTriggers.keyup({key: 'Dead', keyCode: 10, target: document});
         expect(vm.postIOData).toHaveBeenLastCalledWith('keyboard', {key: 10, isDown: false});
     });
+
+    test('keypresses from Blockly workspace SVG elements go to the vm', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+
+        const eventTriggers = {};
+        document.addEventListener = jest.fn((event, cb) => {
+            eventTriggers[event] = cb;
+        });
+
+        vm.postIOData = jest.fn();
+
+        store = mockStore({
+            scratchGui: {
+                mode: {},
+                modals: {},
+                vm: vm
+            }
+        });
+        render(
+            <WrappedComponent
+                attachKeyboardEvents
+                store={store}
+                vm={vm}
+            />
+        );
+
+        // Create a mock SVG <g> element inside .injectionDiv (scratch-blocks v2 workspace)
+        const injectionDiv = document.createElement('div');
+        injectionDiv.className = 'injectionDiv';
+        const svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        svgElement.setAttribute('tabindex', '0');
+        injectionDiv.appendChild(svgElement);
+        document.body.appendChild(injectionDiv);
+
+        // Keydown from a Blockly workspace SVG element should be sent to the VM
+        eventTriggers.keydown({key: ' ', keyCode: 32, target: svgElement, preventDefault: jest.fn()});
+        expect(vm.postIOData).toHaveBeenLastCalledWith('keyboard', {key: ' ', isDown: true});
+
+        // Keydown from a Blockly workspace SVG element with arrow keys should also work
+        eventTriggers.keydown({key: 'ArrowRight', keyCode: 39, target: svgElement, preventDefault: jest.fn()});
+        expect(vm.postIOData).toHaveBeenLastCalledWith('keyboard', {key: 'ArrowRight', isDown: true});
+
+        // Cleanup
+        document.body.removeChild(injectionDiv);
+    });
+
+    test('keypresses from INPUT elements inside Blockly workspace are still filtered', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+
+        const eventTriggers = {};
+        document.addEventListener = jest.fn((event, cb) => {
+            eventTriggers[event] = cb;
+        });
+
+        vm.postIOData = jest.fn();
+
+        store = mockStore({
+            scratchGui: {
+                mode: {},
+                modals: {},
+                vm: vm
+            }
+        });
+        render(
+            <WrappedComponent
+                attachKeyboardEvents
+                store={store}
+                vm={vm}
+            />
+        );
+
+        // Create a mock INPUT element inside .injectionDiv (Blockly text field)
+        const injectionDiv = document.createElement('div');
+        injectionDiv.className = 'injectionDiv';
+        const inputElement = document.createElement('input');
+        injectionDiv.appendChild(inputElement);
+        document.body.appendChild(injectionDiv);
+
+        // Keydown from an INPUT inside Blockly should NOT be sent to the VM
+        vm.postIOData.mockClear();
+        eventTriggers.keydown({key: 'A', target: inputElement});
+        expect(vm.postIOData).not.toHaveBeenCalled();
+
+        // Cleanup
+        document.body.removeChild(injectionDiv);
+    });
+
+    test('keypresses from TEXTAREA elements inside Blockly workspace are still filtered', () => {
+        const Component = () => (<div />);
+        const WrappedComponent = vmListenerHOC(Component);
+
+        const eventTriggers = {};
+        document.addEventListener = jest.fn((event, cb) => {
+            eventTriggers[event] = cb;
+        });
+
+        vm.postIOData = jest.fn();
+
+        store = mockStore({
+            scratchGui: {
+                mode: {},
+                modals: {},
+                vm: vm
+            }
+        });
+        render(
+            <WrappedComponent
+                attachKeyboardEvents
+                store={store}
+                vm={vm}
+            />
+        );
+
+        // Create a mock TEXTAREA element inside .injectionDiv
+        const injectionDiv = document.createElement('div');
+        injectionDiv.className = 'injectionDiv';
+        const textareaElement = document.createElement('textarea');
+        injectionDiv.appendChild(textareaElement);
+        document.body.appendChild(injectionDiv);
+
+        // Keydown from a TEXTAREA inside Blockly should NOT be sent to the VM
+        vm.postIOData.mockClear();
+        eventTriggers.keydown({key: 'B', target: textareaElement});
+        expect(vm.postIOData).not.toHaveBeenCalled();
+
+        // Cleanup
+        document.body.removeChild(injectionDiv);
+    });
 });


### PR DESCRIPTION
## Summary

scratch-blocks v2.0.x のアクセシビリティ改善により、Blockly ワークスペース内の SVG `<g>` 要素に `tabindex="0"` が追加された。これにより、ワークスペースをクリックするとキーイベントの `e.target` が `document.body` ではなく `<g>` SVG 要素になり、`vm-listener-hoc.jsx` の `handleKeyDown` フィルタで除外されてしまっていた。

- `handleKeyDown` のフィルタ条件を修正：`.injectionDiv` 内の非入力要素からのキーイベントを許可
- テキスト入力要素（INPUT, TEXTAREA, contentEditable）からのイベントは引き続きフィルタ
- unit test 3件追加（SVG要素からの送信、INPUT/TEXTAREAのフィルタ確認）

## Test plan

- [ ] unit test: `keypresses from Blockly workspace SVG elements go to the vm`
- [ ] unit test: `keypresses from INPUT elements inside Blockly workspace are still filtered`
- [ ] unit test: `keypresses from TEXTAREA elements inside Blockly workspace are still filtered`
- [ ] ブラウザ確認: Code tab のワークスペースでスペースキーを押して「スペースキーが押されたとき」ブロックが動作する
- [ ] ブラウザ確認: Blockly のテキスト入力フィールドでの入力がブロック実行をトリガーしない

Fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)
