### PR TITLE
fix: use play icon for start-tutorial button

### DIFF
--- a/packages/scratch-gui/src/components/cards/cards.jsx
+++ b/packages/scratch-gui/src/components/cards/cards.jsx
@@ -15,6 +15,9 @@ import leftArrow from './icon--prev.svg';
 import helpIcon from '../../lib/assets/icon--tutorials.svg';
 import closeIcon from './icon--close.svg';
 import codeIcon from './icon--code.svg';
+// === Smalruby: Start of start-tutorial button ===
+import startIcon from './icon--start.svg';
+// === Smalruby: End of start-tutorial button ===
 
 import {translateVideo} from '../../lib/libraries/decks/translate-video.js';
 import {translateImage} from '../../lib/libraries/decks/translate-image.js';
@@ -176,7 +179,7 @@ const ImageStep = ({
             >
                 <img
                     className={styles.codeIcon}
-                    src={codeIcon}
+                    src={startIcon}
                 />
                 <FormattedMessage
                     defaultMessage="Start Tutorial"

--- a/packages/scratch-gui/src/components/cards/icon--start.svg
+++ b/packages/scratch-gui/src/components/cards/icon--start.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <polygon fill="currentColor" points="3,1 14,8 3,15"/>
+</svg>


### PR DESCRIPTION
## Summary
「チュートリアルをはじめる」ボタンのアイコンを `</>` (コードアイコン) から ▶ (再生アイコン) に変更。「スタート」の意味を直感的に伝えるため。

## Changes Made
- `icon--start.svg` を新規作成（16x16 の再生ボタン、`currentColor` 使用）
- `cards.jsx` で start-tutorial ボタンに `startIcon` を使用するよう変更

## Test Coverage
- 既存の unit tests / integration tests が全て pass

## Related Issues
Follow-up to #260
