### PR TITLE
fix: increase next button lock timeout from 3 to 5 seconds

### DIFF
--- a/packages/scratch-gui/src/containers/cards.jsx
+++ b/packages/scratch-gui/src/containers/cards.jsx
@@ -49,7 +49,7 @@ import {PLATFORM} from '../lib/platform.js';
 const ANIMATION_DELAY_MS = 3000;
 const INSERT_CODE_ANIMATION_DELAY_MS = 300; // Shorter delay so users notice the button quickly
 // === Smalruby: Start of next-button lock ===
-const NEXT_LOCK_TIMEOUT_MS = 3000; // Unlock next button after 3 seconds even if action button not clicked
+const NEXT_LOCK_TIMEOUT_MS = 5000; // Unlock next button after 5 seconds even if action button not clicked
 // === Smalruby: End of next-button lock ===
 // === Smalruby: End of tutorial glow animation ===
 

--- a/packages/scratch-gui/test/unit/containers/cards.test.jsx
+++ b/packages/scratch-gui/test/unit/containers/cards.test.jsx
@@ -192,12 +192,12 @@ describe('Cards container - next button lock', () => {
         expect(actions.some(a => a.type === 'scratch-gui/cards/NEXT_STEP')).toBe(false);
     });
 
-    test('unlocks onNextStep after 3 seconds', () => {
+    test('unlocks onNextStep after 5 seconds', () => {
         const {store} = renderCards();
 
         // Advance past lock timeout
         act(() => {
-            jest.advanceTimersByTime(3100);
+            jest.advanceTimersByTime(5100);
         });
 
         act(() => {


### PR DESCRIPTION
## Summary
- チュートリアルの「次へ」ボタンのロック時間を3秒から5秒に延長
- ステップ内容を読む前にロックが解除されてしまう問題を改善

## Changes Made
- `NEXT_LOCK_TIMEOUT_MS` を 3000 → 5000 に変更 (`cards.jsx`)
- テストのタイムアウト値とテスト名を更新 (`cards.test.jsx`)

## Test Coverage
- `cards.test.jsx` の next-button lock テスト全10件パス
- lint パス（既存 warning のみ）
