### PR TITLE
ci: remove unnecessary build step from lint job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,8 +67,6 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-      - name: Build dependency packages
-        run: npm run build:dev --workspace=packages/scratch-svg-renderer --workspace=packages/scratch-render --workspace=packages/scratch-vm
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
## Summary

lint ジョブから不要な依存パッケージのビルドステップを削除し、CI の実行時間を短縮する。

## Changes Made

- `lint` ジョブの `Build dependency packages` ステップを削除
- lint は静的解析のためビルド成果物は不要
