### PR TITLE
chore: add postMergeReverts to upstream merge history and skill workflow

### DIFF
--- a/.claude/skills/upstream-merge/SKILL.md
+++ b/.claude/skills/upstream-merge/SKILL.md
@@ -23,12 +23,55 @@ upstream scratch-editor の変更を Smalruby fork に取り込む半自動ワ�
 | `reference-api-migration.md` | ScratchBlocks API 変更一覧 |
 | `reference-test-patterns.md` | テスト修正の既知パターン集 |
 
+## `.upstream-merge-history.json` スキーマ
+
+```json
+{
+  "lastMerge": {
+    "date": "YYYY-MM-DD",
+    "upstreamCommit": "<upstream commit hash>",
+    "smalrubyCommit": "<smalruby commit hash before merge>",
+    "mergeCommit": "<merge commit hash>",
+    "notes": "description"
+  },
+  "postMergeReverts": [
+    {
+      "date": "YYYY-MM-DD",
+      "pr": "#NNN",
+      "reason": "why the revert was needed",
+      "scope": "short scope label",
+      "affectedAreas": [
+        {
+          "category": "human-readable category name",
+          "files": ["path/to/file1", "path/to/file2"],
+          "detail": "what was reverted and why"
+        }
+      ],
+      "nextMergeGuidance": "instructions for how to handle these files on the next upstream merge"
+    }
+  ],
+  "previousMerges": [
+    { "...(rotated from lastMerge)" }
+  ]
+}
+```
+
+### `postMergeReverts` の意味
+
+upstream merge 後に、取り込んだ変更の一部を revert した場合に記録する。
+
+- Git 上は `lastMerge.upstreamCommit` まで取り込み済みだが、**一部のファイルは revert されている**ことを示す
+- 次回の upstream merge 時、`affectedAreas` のファイルでコンフリクトが発生する可能性が高い
+- `nextMergeGuidance` に従ってコンフリクトを解決する
+- revert の原因が解消された場合（upstream 側で修正された等）、merge 完了後に該当エントリを削除する
+
 ## 進め方
 
 1. Phase 1 から順番に実行する
 2. 各フェーズの開始時に該当ファイルを読み込む
-3. コンフリクト解決やテスト修正で詰まったら、リファレンスファイルを読み込む
-4. 各フェーズが完了したら次のフェーズに進む
+3. **Phase 1 で `postMergeReverts` がある場合は、Phase 2 の前にユーザーと方針を確認する**
+4. コンフリクト解決やテスト修正で詰まったら、リファレンスファイルを読み込む
+5. 各フェーズが完了したら次のフェーズに進む
 
 ## 絶対に守るルール
 

--- a/.claude/skills/upstream-merge/phase1-prepare.md
+++ b/.claude/skills/upstream-merge/phase1-prepare.md
@@ -24,7 +24,30 @@ git remote add upstream https://github.com/scratchfoundation/scratch-editor.git
 `.upstream-merge-history.json` を読み込み、前回 merge の commit ID を取得する。
 ファイルが存在しない場合はエラー。
 
-### 1.3 Upstream差分確認
+### 1.3 Post-Merge Reverts 確認
+
+`postMergeReverts` 配列が存在する場合、**revert された変更がある**ことを意味する。
+
+ユーザーに以下を報告し、方針を確認する:
+
+```
+⚠️  前回の upstream merge 後に revert された変更があります:
+
+  - scope: <scope>
+  - reason: <reason>
+  - affected: <N> ファイル (<categories>)
+
+次回 merge ガイダンス:
+  <nextMergeGuidance>
+
+以下のどちらの方針で進めますか？
+  (A) upstream の変更を受け入れて revert を解消する（upstream 側で問題が修正済みの場合）
+  (B) 引き続き revert を維持する（upstream 側で問題が未解決の場合）
+```
+
+選択された方針を Phase 2 で使用する。
+
+### 1.4 Upstream差分確認
 
 **重要**: `git fetch upstream` は絶対に使わない（gh-pages を含む全ブランチを取得してしまう）。
 
@@ -35,8 +58,13 @@ git log <lastMerge.upstreamCommit>..upstream/develop --oneline --format="%h %s"
 
 - 新しい commit 数を表示
 - 最新10件の commit message を表示
+- `postMergeReverts` がある場合、upstream の diff に revert 対象のファイル変更が含まれるか確認:
+  ```bash
+  git diff --name-only <lastMerge.upstreamCommit>..upstream/develop
+  ```
+  `affectedAreas` のファイルと重複があれば報告する
 
-### 1.4 ユーザー確認
+### 1.5 ユーザー確認
 
 - "X commits を merge します。続行しますか？"
 - Yes / No / View all commits の選択肢

--- a/.claude/skills/upstream-merge/phase2-conflicts.md
+++ b/.claude/skills/upstream-merge/phase2-conflicts.md
@@ -2,6 +2,38 @@
 
 コンフリクトを検出し、既知パターンに従って解決する。
 
+## Post-Merge Reverts の処理
+
+`.upstream-merge-history.json` に `postMergeReverts` がある場合、Phase 1 で確認した方針に従う。
+
+### 方針A: upstream を受け入れて revert を解消する場合
+
+`affectedAreas` に記載されたファイルのコンフリクトは **upstream (theirs) を受け入れ**、Smalruby マーカーブロックのみ再適用する。
+
+```bash
+# 特定ファイルを upstream 版で解決する場合
+git checkout --theirs <file>
+git add <file>
+```
+
+ただし Smalruby マーカーを含むファイル（`blocks.jsx` 等）は手動でマーカー部分だけ再挿入する。
+
+`affectedAreas` の `category: "Smalruby-specific additions"` に記載されたファイルは **ours を保持**する。
+
+### 方針B: revert を維持する場合
+
+`affectedAreas` に記載されたファイルのコンフリクトは **ours を保持**する。
+
+```bash
+# 特定ファイルを現在の Smalruby 版で解決する場合
+git checkout --ours <file>
+git add <file>
+```
+
+upstream が追加した新しいファイルや、revert 対象外のファイルは通常通り受け入れる。
+
+---
+
 ## Known Conflicts 一覧
 
 以下のファイルは upstream merge 時にほぼ毎回コンフリクトが発生する。

--- a/.claude/skills/upstream-merge/phase4-finalize.md
+++ b/.claude/skills/upstream-merge/phase4-finalize.md
@@ -13,10 +13,18 @@
     "mergeCommit": "<Phase 3 で作成した merge commit hash>",
     "notes": "X commits merged from upstream develop"
   },
+  "postMergeReverts": [],
   "previousMerges": [
     { "(前回の lastMerge をここに移動)" }
   ]
 }
+```
+
+### `postMergeReverts` の処理
+
+- **方針A（upstream を受け入れた）**: revert が解消されたので `postMergeReverts` を空配列 `[]` にする
+- **方針B（revert を維持した）**: `postMergeReverts` はそのまま残す（次回 merge でも参照される）
+- 一部だけ解消された場合: 解消されたエントリのみ削除し、残りは保持する
 ```
 
 ### Commit and Push

--- a/.upstream-merge-history.json
+++ b/.upstream-merge-history.json
@@ -6,6 +6,98 @@
     "mergeCommit": "6ac14806a",
     "notes": "146 upstream commits merged - scratch-blocks v2.0.0, release 13.0.0"
   },
+  "postMergeReverts": [
+    {
+      "date": "2026-03-10",
+      "pr": "#271",
+      "reason": "scratch-blocks v2.0.3 caused block argument dragging regression (custom block arguments could not be dragged); downgraded to v1.3.0",
+      "scope": "scratch-blocks v2 API changes",
+      "affectedAreas": [
+        {
+          "category": "scratch-blocks dependency",
+          "files": [
+            "packages/scratch-gui/package.json",
+            "packages/scratch-vm/package.json",
+            "package-lock.json"
+          ],
+          "detail": "scratch-blocks v2.0.3 → v1.3.0; scratch-vm release.config.js removed (semantic-release for npm removed)"
+        },
+        {
+          "category": "ScratchBlocks v2 API → v1 API revert (GUI)",
+          "files": [
+            "packages/scratch-gui/src/containers/blocks.jsx",
+            "packages/scratch-gui/src/containers/backpack.jsx",
+            "packages/scratch-gui/src/containers/custom-procedures.jsx",
+            "packages/scratch-gui/src/lib/blocks.js",
+            "packages/scratch-gui/src/lib/make-toolbox-xml.js",
+            "packages/scratch-gui/src/lib/define-dynamic-block.js",
+            "packages/scratch-gui/src/lib/generator.js",
+            "packages/scratch-gui/src/lib/vm-listener-hoc.jsx",
+            "packages/scratch-gui/src/lib/backpack/block-to-image.js",
+            "packages/scratch-gui/src/components/monitor/monitor.jsx",
+            "packages/scratch-gui/src/components/context-menu/context-menu.jsx",
+            "packages/scratch-gui/src/components/sprite-selector-item/sprite-selector-item.jsx",
+            "packages/scratch-gui/src/components/block-display-modal/block-display-modal.jsx"
+          ],
+          "detail": "Reverted ScratchBlocks.utils.xml.*, ScratchBlocks.dialog.setPrompt(), etc. back to v1 API. See reference-api-migration.md for mapping."
+        },
+        {
+          "category": "ScratchBlocks v2 API → v1 API revert (VM)",
+          "files": [
+            "packages/scratch-vm/src/engine/blocks.js",
+            "packages/scratch-vm/src/engine/adapter.js",
+            "packages/scratch-vm/src/engine/comment.js",
+            "packages/scratch-vm/src/engine/runtime.js",
+            "packages/scratch-vm/src/serialization/sb3.js"
+          ],
+          "detail": "Reverted block.type field access patterns and XML utility usage to v1 API"
+        },
+        {
+          "category": "Color mode / theme (blockHelpers)",
+          "files": [
+            "packages/scratch-gui/src/lib/settings/color-mode/blockHelpers.js",
+            "packages/scratch-gui/src/lib/settings/color-mode/dark/index.js",
+            "packages/scratch-gui/src/lib/settings/color-mode/default/index.js",
+            "packages/scratch-gui/src/lib/settings/color-mode/high-contrast/index.js"
+          ],
+          "detail": "Reverted Colours/zelos theme references to v1 colour registration API"
+        },
+        {
+          "category": "Tests reverted to v1 patterns",
+          "files": [
+            "packages/scratch-gui/test/helpers/selenium-helper.js",
+            "packages/scratch-gui/test/integration/block-display-modal.test.js",
+            "packages/scratch-gui/test/integration/block-palette.test.js",
+            "packages/scratch-gui/test/integration/blocks-standalone.test.js",
+            "packages/scratch-gui/test/integration/blocks.test.js",
+            "packages/scratch-gui/test/integration/localization.test.js",
+            "packages/scratch-gui/test/integration/menu-bar.test.js",
+            "packages/scratch-gui/test/integration/project-loading.test.js",
+            "packages/scratch-gui/test/integration/sprites.test.js",
+            "packages/scratch-gui/test/unit/util/color-modes.test.js",
+            "packages/scratch-gui/test/unit/util/define-dynamic-block.test.js",
+            "packages/scratch-vm/test/unit/engine_adapter.js",
+            "packages/scratch-vm/test/unit/extension_conversion.js",
+            "packages/scratch-vm/test/unit/project_changed_state_blocks.js",
+            "packages/scratch-vm/test/integration/stack-click.js",
+            "packages/scratch-vm/test/fixtures/events.json"
+          ],
+          "detail": "CSS selectors (.blocklyToolbox → .blocklyToolboxDiv), v1 API mocks, v1 DOM structure"
+        },
+        {
+          "category": "Smalruby-specific additions in downgrade PR",
+          "files": [
+            "packages/scratch-gui/src/lib/blocks-screenshot.js",
+            "packages/scratch-gui/src/lib/radix-ui-context-menu.js",
+            "packages/scratch-gui/src/containers/ruby-tab/ruby-tab.css",
+            "packages/scratch-gui/src/components/blocks-screenshot-button/blocks-screenshot-button.css"
+          ],
+          "detail": "Screenshot icon inlining fix, context-menu shim, CSS position adjustments — these are Smalruby-specific and should be preserved on next merge"
+        }
+      ],
+      "nextMergeGuidance": "When upstream stabilizes scratch-blocks v2 and the argument dragging issue is resolved: (1) Accept upstream v2 versions for files in 'ScratchBlocks v2 API' and 'Color mode' categories, (2) Re-apply Smalruby marker blocks only, (3) Accept upstream test changes, (4) Preserve 'Smalruby-specific additions' category files. If upstream is still on v2 with the bug unresolved, resolve conflicts by keeping v1 (ours) for API files."
+    }
+  ],
   "previousMerges": [
     {
       "date": "2026-02-14",


### PR DESCRIPTION
## Summary

PR #271 で scratch-blocks v2.0.3 → v1.3.0 にダウングレードした結果、`.upstream-merge-history.json` の `lastMerge` が示す「取り込み済み」状態と実際のコードに乖離が生じた。

次回の upstream merge でスムーズにコンフリクト解決できるよう、以下を対応:

- `.upstream-merge-history.json` に `postMergeReverts` フィールドを追加し、revert の範囲・理由・影響ファイル・次回マージ時のガイダンスを記録
- upstream-merge skill の全フェーズを `postMergeReverts` 対応に更新

## Changes

### `.upstream-merge-history.json`
- `postMergeReverts` 配列を追加（PR #271 の scratch-blocks ダウングレード情報）
- 影響ファイルを6カテゴリに分類（dependency, GUI API, VM API, color mode, tests, Smalruby-specific）
- `nextMergeGuidance` に方針A/B の判断基準を記載

### `.claude/skills/upstream-merge/SKILL.md`
- `postMergeReverts` の JSON スキーマをドキュメント化
- フィールドの意味と運用ルールを記載
- ワークフロー進め方に revert 確認ステップを追加

### `.claude/skills/upstream-merge/phase1-prepare.md`
- Step 1.3: `postMergeReverts` の存在チェックとユーザーへの方針確認フロー追加
- Step 1.4: upstream diff と `affectedAreas` の重複確認追加

### `.claude/skills/upstream-merge/phase2-conflicts.md`
- 方針A（upstream 受け入れ）と方針B（revert 維持）の具体的なコンフリクト解決手順を追加

### `.claude/skills/upstream-merge/phase4-finalize.md`
- merge history 更新時の `postMergeReverts` 処理ルール追加（方針に応じてクリアまたは維持）
