### PR TITLE
feat: Rubyタブに全角→半角の自動置換機能を追加

### DIFF
--- a/packages/scratch-gui/src/components/auto-correct-modal/auto-correct-modal.css
+++ b/packages/scratch-gui/src/components/auto-correct-modal/auto-correct-modal.css
@@ -59,6 +59,9 @@
 }
 
 .settingLabel {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     font-size: 0.875rem;
     color: hsla(0, 0%, 0%, 0.85);
     cursor: pointer;

--- a/packages/scratch-gui/src/components/auto-correct-modal/auto-correct-modal.css
+++ b/packages/scratch-gui/src/components/auto-correct-modal/auto-correct-modal.css
@@ -1,0 +1,66 @@
+@import "../../css/colors.css";
+@import "../../css/units.css";
+
+.modalContent {
+    width: 360px;
+}
+
+.header {
+    background-color: $ui-green-2;
+}
+
+.body {
+    background: $ui-white;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.settingItem {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.25rem;
+}
+
+.settingItem:not(:last-child) {
+    border-bottom: 1px solid hsla(0, 0%, 0%, 0.08);
+}
+
+.checkbox {
+    width: 1.125rem;
+    height: 1.125rem;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    border: 2px solid #ccc;
+    border-radius: 3px;
+    background-color: white;
+    position: relative;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+}
+
+.checkbox:checked {
+    background-color: $ui-green-2;
+    border-color: #0da571;
+}
+
+.checkbox:checked::after {
+    content: "\2713";
+    position: absolute;
+    top: -2px;
+    left: 1px;
+    color: white;
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.settingLabel {
+    font-size: 0.875rem;
+    color: hsla(0, 0%, 0%, 0.85);
+    cursor: pointer;
+    user-select: none;
+}

--- a/packages/scratch-gui/src/components/auto-correct-modal/auto-correct-modal.jsx
+++ b/packages/scratch-gui/src/components/auto-correct-modal/auto-correct-modal.jsx
@@ -1,0 +1,104 @@
+// === Smalruby: This file is Smalruby-specific (auto-correct settings modal) ===
+import PropTypes from 'prop-types';
+import React, {useCallback} from 'react';
+import {defineMessages, injectIntl} from 'react-intl';
+import intlShape from '../../lib/intlShape.js';
+
+import Box from '../box/box.jsx';
+import Modal from '../../containers/modal.jsx';
+
+import styles from './auto-correct-modal.css';
+
+const messages = defineMessages({
+    title: {
+        defaultMessage: 'Auto-Correct Settings',
+        description: 'Title for the auto-correct settings modal',
+        id: 'gui.autoCorrectModal.title'
+    },
+    fullwidthNumbers: {
+        defaultMessage: 'Fullwidth numbers → Halfwidth numbers',
+        description: 'Setting for fullwidth number conversion',
+        id: 'gui.autoCorrectModal.fullwidthNumbers'
+    },
+    fullwidthAlpha: {
+        defaultMessage: 'Fullwidth alphabet → Halfwidth alphabet',
+        description: 'Setting for fullwidth alphabet conversion',
+        id: 'gui.autoCorrectModal.fullwidthAlpha'
+    },
+    fullwidthSymbols: {
+        defaultMessage: 'Fullwidth symbols → Halfwidth symbols',
+        description: 'Setting for fullwidth symbol conversion',
+        id: 'gui.autoCorrectModal.fullwidthSymbols'
+    },
+    fullwidthSpace: {
+        defaultMessage: 'Fullwidth space → Halfwidth space',
+        description: 'Setting for fullwidth space conversion',
+        id: 'gui.autoCorrectModal.fullwidthSpace'
+    },
+    replaceInStrings: {
+        defaultMessage: 'Also replace inside strings',
+        description: 'Setting for replacing inside string literals',
+        id: 'gui.autoCorrectModal.replaceInStrings'
+    }
+});
+
+const SETTING_KEYS = [
+    'fullwidthNumbers',
+    'fullwidthAlpha',
+    'fullwidthSymbols',
+    'fullwidthSpace',
+    'replaceInStrings'
+];
+
+const AutoCorrectModal = ({intl, settings, onSettingChange, onRequestClose}) => {
+    const handleChange = useCallback(event => {
+        const key = event.target.getAttribute('data-setting');
+        const checked = event.target.checked;
+        onSettingChange(key, checked);
+    }, [onSettingChange]);
+
+    return (
+        <Modal
+            className={styles.modalContent}
+            contentLabel={intl.formatMessage(messages.title)}
+            headerClassName={styles.header}
+            id="autoCorrectModal"
+            onRequestClose={onRequestClose}
+        >
+            <Box className={styles.body}>
+                {SETTING_KEYS.map(key => (
+                    <div
+                        key={key}
+                        className={styles.settingItem}
+                    >
+                        <label className={styles.settingLabel}>
+                            <input
+                                type="checkbox"
+                                className={styles.checkbox}
+                                data-setting={key}
+                                checked={settings[key]}
+                                onChange={handleChange}
+                            />
+                            {intl.formatMessage(messages[key])}
+                        </label>
+                    </div>
+                ))}
+            </Box>
+        </Modal>
+    );
+};
+
+AutoCorrectModal.propTypes = {
+    intl: intlShape.isRequired,
+    settings: PropTypes.shape({
+        fullwidthNumbers: PropTypes.bool.isRequired,
+        fullwidthAlpha: PropTypes.bool.isRequired,
+        fullwidthSymbols: PropTypes.bool.isRequired,
+        fullwidthSpace: PropTypes.bool.isRequired,
+        replaceInStrings: PropTypes.bool.isRequired
+    }).isRequired,
+    onSettingChange: PropTypes.func.isRequired,
+    onRequestClose: PropTypes.func.isRequired
+};
+
+export default injectIntl(AutoCorrectModal);

--- a/packages/scratch-gui/src/components/ruby-toolbar/icon--auto-correct.svg
+++ b/packages/scratch-gui/src/components/ruby-toolbar/icon--auto-correct.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28" width="28" height="28">
+  <!-- Fullwidth A -->
+  <text x="1" y="20" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#e04040">Ａ</text>
+  <!-- Arrow -->
+  <path d="M13 14 L17 14" stroke="#555" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M15.5 11.5 L17.5 14 L15.5 16.5" stroke="#555" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <!-- Halfwidth A -->
+  <text x="18" y="20" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#4c97ff">A</text>
+</svg>

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
@@ -204,6 +204,7 @@
     width: 2rem;
     height: 2rem;
     padding: 2px;
+    margin-left: 2px;
     border: none;
     background-color: transparent;
     cursor: pointer;

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
@@ -276,3 +276,8 @@
 .moreMenuIcon {
     font-size: 1rem;
 }
+
+.moreMenuIconImg {
+    width: 20px;
+    height: 20px;
+}

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
@@ -227,3 +227,51 @@
     background: linear-gradient(to bottom, #e8f8ee, #c2eacc);
     box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.7), 0 0 10px 4px rgba(76, 175, 80, 0.35);
 }
+
+.moreMenuWrapper {
+    position: relative;
+}
+
+.moreIcon {
+    font-size: 1.25rem;
+    line-height: 1;
+    color: #575e75;
+    letter-spacing: 1px;
+}
+
+.moreMenu {
+    position: absolute;
+    top: calc(100% + calc($space / 2));
+    right: 0;
+    min-width: 200px;
+    background-color: white;
+    border: 1px solid hsla(0, 0%, 0%, 0.15);
+    border-radius: $form-radius;
+    box-shadow: 0 0 8px 1px hsla(0, 0%, 0%, 0.15);
+    z-index: 100;
+    padding: calc($space / 2) 0;
+}
+
+[dir="rtl"] .moreMenu {
+    right: auto;
+    left: 0;
+}
+
+.moreMenuItem {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: #575e75;
+    white-space: nowrap;
+}
+
+.moreMenuItem:hover {
+    background-color: hsla(0, 0%, 0%, 0.05);
+}
+
+.moreMenuIcon {
+    font-size: 1rem;
+}

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
@@ -199,3 +199,31 @@
     background: linear-gradient(to bottom, #e8f8ee, #c2eacc);
     box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.7), 0 0 10px 4px rgba(76, 175, 80, 0.35);
 }
+
+.autoCorrectButton {
+    width: 2rem;
+    height: 2rem;
+    padding: 2px;
+    border: none;
+    background-color: transparent;
+    cursor: pointer;
+    border-radius: $form-radius;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: box-shadow 0.2s, opacity 0.2s;
+}
+
+.autoCorrectButton img {
+    width: 28px;
+    height: 28px;
+}
+
+.autoCorrectButton:hover:not(:disabled) {
+    opacity: 0.85;
+}
+
+.autoCorrectButtonActive {
+    background: linear-gradient(to bottom, #e8f8ee, #c2eacc);
+    box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.7), 0 0 10px 4px rgba(76, 175, 80, 0.35);
+}

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -15,6 +15,7 @@ import iconForward from './icon--forward.svg';
 import iconDownload from './icon--download.svg';
 import iconAI from './icon--ai.svg';
 import iconFurigana from './icon--furigana.svg';
+import iconAutoCorrect from './icon--auto-correct.svg';
 
 const messages = defineMessages({
     executeLine: {
@@ -76,6 +77,16 @@ const messages = defineMessages({
         id: 'gui.rubyToolbar.furiganaOff',
         defaultMessage: 'Show furigana',
         description: 'Tooltip for furigana toggle button when OFF'
+    },
+    autoCorrectOn: {
+        id: 'gui.rubyToolbar.autoCorrectOn',
+        defaultMessage: 'Disable auto-correct',
+        description: 'Tooltip for auto-correct toggle button when ON'
+    },
+    autoCorrectOff: {
+        id: 'gui.rubyToolbar.autoCorrectOff',
+        defaultMessage: 'Enable auto-correct',
+        description: 'Tooltip for auto-correct toggle button when OFF'
     },
     stage: {
         id: 'gui.rubyToolbar.stage',
@@ -289,6 +300,15 @@ const RubyToolbar = props => {
         }
     }, [props]);
 
+    const handleToggleAutoCorrect = useCallback(() => {
+        if (props.onDismissBubble) {
+            props.onDismissBubble();
+        }
+        if (props.onToggleAutoCorrect) {
+            props.onToggleAutoCorrect();
+        }
+    }, [props]);
+
     const handleExecuteLine = useCallback(() => {
         if (!props.editorRef) {
             return;
@@ -400,7 +420,7 @@ const RubyToolbar = props => {
                 </button>
             </div>
 
-            {/* Furigana Toggle */}
+            {/* Furigana Toggle & Auto Correct Toggle */}
             <div className={`${styles.toolbarPart} ${styles.modDashedBorder}`}>
                 <button
                     className={`${styles.furiganaButton} ${props.furiganaEnabled ? styles.furiganaButtonActive : ''}`}
@@ -411,6 +431,24 @@ const RubyToolbar = props => {
                 >
                     <img
                         src={iconFurigana}
+                        alt=""
+                    />
+                </button>
+                <button
+                    className={`${styles.autoCorrectButton} ${
+                        props.autoCorrectEnabled ? styles.autoCorrectButtonActive : ''
+                    }`}
+                    onClick={handleToggleAutoCorrect}
+                    aria-label={intl.formatMessage(
+                        props.autoCorrectEnabled ? messages.autoCorrectOn : messages.autoCorrectOff
+                    )}
+                    aria-pressed={props.autoCorrectEnabled}
+                    title={intl.formatMessage(
+                        props.autoCorrectEnabled ? messages.autoCorrectOn : messages.autoCorrectOff
+                    )}
+                >
+                    <img
+                        src={iconAutoCorrect}
                         alt=""
                     />
                 </button>
@@ -512,7 +550,9 @@ RubyToolbar.propTypes = {
     canUndo: PropTypes.bool,
     canRedo: PropTypes.bool,
     furiganaEnabled: PropTypes.bool,
-    onToggleFurigana: PropTypes.func
+    onToggleFurigana: PropTypes.func,
+    autoCorrectEnabled: PropTypes.bool,
+    onToggleAutoCorrect: PropTypes.func
 };
 
 export default RubyToolbar;

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -98,6 +98,11 @@ const messages = defineMessages({
         defaultMessage: 'Auto-Correct Settings',
         description: 'Label for auto-correct settings menu item'
     },
+    saveRubyScript: {
+        id: 'gui.rubyToolbar.saveRubyScript',
+        defaultMessage: 'Save Ruby script',
+        description: 'Label for save Ruby script menu item'
+    },
     stage: {
         id: 'gui.rubyToolbar.stage',
         defaultMessage: 'Stage',
@@ -300,10 +305,10 @@ const RubyToolbar = props => {
     }, [handleSelectTarget]);
 
     const handleDownload = useCallback(() => {
+        setShowMoreMenu(false);
         if (props.onDismissBubble) {
             props.onDismissBubble();
         }
-        // Trigger download Ruby code
         if (props.onDownload) {
             props.onDownload();
         }
@@ -557,19 +562,8 @@ const RubyToolbar = props => {
                 </button>
             </div>
 
-            {/* Download & More Part */}
+            {/* More Menu Part */}
             <div className={styles.toolbarPart}>
-                <button
-                    className={styles.iconButton}
-                    onClick={handleDownload}
-                    aria-label={intl.formatMessage(messages.download)}
-                    title={intl.formatMessage(messages.download)}
-                >
-                    <img
-                        src={iconDownload}
-                        alt=""
-                    />
-                </button>
                 <div
                     className={styles.moreMenuWrapper}
                     ref={moreMenuRef}
@@ -586,11 +580,26 @@ const RubyToolbar = props => {
                         <div className={styles.moreMenu}>
                             <div
                                 className={styles.moreMenuItem}
+                                onClick={handleDownload}
+                            >
+                                <img
+                                    className={styles.moreMenuIconImg}
+                                    src={iconDownload}
+                                    alt=""
+                                />
+                                {intl.formatMessage(
+                                    messages.saveRubyScript
+                                )}
+                            </div>
+                            <div
+                                className={styles.moreMenuItem}
                                 onClick={handleOpenAutoCorrectSettings}
                             >
-                                <span className={styles.moreMenuIcon}>
-                                    {'🔄'}
-                                </span>
+                                <img
+                                    className={styles.moreMenuIconImg}
+                                    src={iconAutoCorrect}
+                                    alt=""
+                                />
                                 {intl.formatMessage(
                                     messages.autoCorrectSettings
                                 )}

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback} from 'react';
+import React, {useState, useCallback, useRef, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {defineMessages, useIntl} from 'react-intl';
 import VM from '@smalruby/scratch-vm';
@@ -88,6 +88,16 @@ const messages = defineMessages({
         defaultMessage: 'Enable auto-correct',
         description: 'Tooltip for auto-correct toggle button when OFF'
     },
+    moreOptions: {
+        id: 'gui.rubyToolbar.moreOptions',
+        defaultMessage: 'More options',
+        description: 'Tooltip for three-dot menu button'
+    },
+    autoCorrectSettings: {
+        id: 'gui.rubyToolbar.autoCorrectSettings',
+        defaultMessage: 'Auto-Correct Settings',
+        description: 'Label for auto-correct settings menu item'
+    },
     stage: {
         id: 'gui.rubyToolbar.stage',
         defaultMessage: 'Stage',
@@ -100,6 +110,23 @@ const RubyToolbar = props => {
     const [commandValue, setCommandValue] = useState('');
     const [showDropdown, setShowDropdown] = useState(false);
     const [filteredTargets, setFilteredTargets] = useState([]);
+    const [showMoreMenu, setShowMoreMenu] = useState(false);
+    const moreMenuRef = useRef(null);
+
+    // Close more menu when clicking outside
+    useEffect(() => {
+        if (!showMoreMenu) return () => {};
+        const handleClickOutside = e => {
+            if (moreMenuRef.current &&
+                !moreMenuRef.current.contains(e.target)) {
+                setShowMoreMenu(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [showMoreMenu]);
 
     const getSortedSprites = useCallback(() => {
         if (!props.vm || !props.vm.runtime) {
@@ -306,6 +333,17 @@ const RubyToolbar = props => {
         }
         if (props.onToggleAutoCorrect) {
             props.onToggleAutoCorrect();
+        }
+    }, [props]);
+
+    const handleToggleMoreMenu = useCallback(() => {
+        setShowMoreMenu(prev => !prev);
+    }, []);
+
+    const handleOpenAutoCorrectSettings = useCallback(() => {
+        setShowMoreMenu(false);
+        if (props.onOpenAutoCorrectSettings) {
+            props.onOpenAutoCorrectSettings();
         }
     }, [props]);
 
@@ -519,7 +557,7 @@ const RubyToolbar = props => {
                 </button>
             </div>
 
-            {/* Download Part */}
+            {/* Download & More Part */}
             <div className={styles.toolbarPart}>
                 <button
                     className={styles.iconButton}
@@ -532,6 +570,34 @@ const RubyToolbar = props => {
                         alt=""
                     />
                 </button>
+                <div
+                    className={styles.moreMenuWrapper}
+                    ref={moreMenuRef}
+                >
+                    <button
+                        className={styles.iconButton}
+                        onClick={handleToggleMoreMenu}
+                        aria-label={intl.formatMessage(messages.moreOptions)}
+                        title={intl.formatMessage(messages.moreOptions)}
+                    >
+                        <span className={styles.moreIcon}>{'⋯'}</span>
+                    </button>
+                    {showMoreMenu && (
+                        <div className={styles.moreMenu}>
+                            <div
+                                className={styles.moreMenuItem}
+                                onClick={handleOpenAutoCorrectSettings}
+                            >
+                                <span className={styles.moreMenuIcon}>
+                                    {'🔄'}
+                                </span>
+                                {intl.formatMessage(
+                                    messages.autoCorrectSettings
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </div>
             </div>
         </div>
     );
@@ -552,7 +618,8 @@ RubyToolbar.propTypes = {
     furiganaEnabled: PropTypes.bool,
     onToggleFurigana: PropTypes.func,
     autoCorrectEnabled: PropTypes.bool,
-    onToggleAutoCorrect: PropTypes.func
+    onToggleAutoCorrect: PropTypes.func,
+    onOpenAutoCorrectSettings: PropTypes.func
 };
 
 export default RubyToolbar;

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -35,7 +35,7 @@ import collectMetadata from '../lib/collect-metadata.js';
 import {closeFileMenu} from '../reducers/menus.js';
 import {setAiSaveStatus, clearAiSaveStatus} from '../reducers/koshien-file';
 import AutoCorrectModal from '../components/auto-correct-modal/auto-correct-modal.jsx';
-import {defaultSettings as defaultAutoCorrectSettings} from '../lib/auto-correct';
+import {autoCorrect, defaultSettings as defaultAutoCorrectSettings} from '../lib/auto-correct';
 import styles from './ruby-tab/ruby-tab.css';
 import {loadMonacoLocale} from '../lib/monaco-i18n-helper';
 import {getPrism, loadPrism} from '../lib/prism-parser';
@@ -274,6 +274,10 @@ class RubyTab extends React.Component {
         }
         window.smalruby.stage = vm.runtime ? vm.runtime.getTargetForStage() : null;
         window.smalruby.runtime = vm.runtime;
+        window.smalruby.autoCorrect = {
+            enabled: this.state.autoCorrectEnabled,
+            settings: this.state.autoCorrectSettings
+        };
     }
 
     clearErrors () {
@@ -512,6 +516,42 @@ class RubyTab extends React.Component {
     }
 
     handleEditorChange (value) {
+        if (this._isAutoCorrectUpdate) {
+            // Prevent infinite loop: this change was caused by auto-correct itself
+            this._isAutoCorrectUpdate = false;
+            this.props.onChange(value);
+            return;
+        }
+
+        if (this.state.autoCorrectEnabled && this.editorRef) {
+            const corrected = autoCorrect(value, this.state.autoCorrectSettings);
+            if (corrected !== value) {
+                // Apply corrected text while preserving cursor position
+                this._isAutoCorrectUpdate = true;
+                const position = this.editorRef.getPosition();
+                const model = this.editorRef.getModel();
+                // Calculate cursor offset adjustment
+                const beforeCursor = value.substring(
+                    0, model.getOffsetAt(position)
+                );
+                const correctedBeforeCursor = autoCorrect(
+                    beforeCursor, this.state.autoCorrectSettings
+                );
+                const offsetDiff = beforeCursor.length - correctedBeforeCursor.length;
+
+                // Use setValue to replace the entire content
+                model.setValue(corrected);
+
+                // Restore cursor position adjusted for character width changes
+                const newOffset = model.getOffsetAt(position) - offsetDiff;
+                const newPosition = model.getPositionAt(
+                    Math.max(0, newOffset)
+                );
+                this.editorRef.setPosition(newPosition);
+                return;
+            }
+        }
+
         this.props.onChange(value);
     }
 

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -34,6 +34,8 @@ import GeminiModalHOC from './gemini-modal-hoc.jsx';
 import collectMetadata from '../lib/collect-metadata.js';
 import {closeFileMenu} from '../reducers/menus.js';
 import {setAiSaveStatus, clearAiSaveStatus} from '../reducers/koshien-file';
+import AutoCorrectModal from '../components/auto-correct-modal/auto-correct-modal.jsx';
+import {defaultSettings as defaultAutoCorrectSettings} from '../lib/auto-correct';
 import styles from './ruby-tab/ruby-tab.css';
 import {loadMonacoLocale} from '../lib/monaco-i18n-helper';
 import {getPrism, loadPrism} from '../lib/prism-parser';
@@ -42,6 +44,7 @@ const FONT_SIZES = [8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 36, 40, 48];
 const DEFAULT_FONT_SIZE = 16;
 const FURIGANA_ENABLED_KEY = 'smalruby:furiganaEnabled';
 const AUTO_CORRECT_ENABLED_KEY = 'smalruby:autoCorrectEnabled';
+const AUTO_CORRECT_SETTINGS_KEY = 'smalruby:autoCorrectSettings';
 
 class RubyTab extends React.Component {
     constructor (props) {
@@ -67,6 +70,9 @@ class RubyTab extends React.Component {
             'handleApplyGeminiCode',
             'handleToggleFurigana',
             'handleToggleAutoCorrect',
+            'handleOpenAutoCorrectSettings',
+            'handleCloseAutoCorrectSettings',
+            'handleAutoCorrectSettingChange',
             'updateUndoRedoState'
         ]);
         this.mainTooltipId = 'ruby-downloader-tooltip';
@@ -91,13 +97,27 @@ class RubyTab extends React.Component {
             window.localStorage.getItem(FURIGANA_ENABLED_KEY) !== 'false' : true;
         const savedAutoCorrect = typeof window !== 'undefined' && window.localStorage ?
             window.localStorage.getItem(AUTO_CORRECT_ENABLED_KEY) !== 'false' : true;
+        let savedAutoCorrectSettings = defaultAutoCorrectSettings;
+        if (typeof window !== 'undefined' && window.localStorage) {
+            try {
+                const raw = window.localStorage.getItem(AUTO_CORRECT_SETTINGS_KEY);
+                if (raw) {
+                    savedAutoCorrectSettings = {
+                        ...defaultAutoCorrectSettings,
+                        ...JSON.parse(raw)
+                    };
+                }
+            } catch (_e) { /* use defaults */ }
+        }
         this.state = {
             runningBlockId: null,
             executingLine: null,
             canUndo: false,
             canRedo: false,
             furiganaEnabled: savedFurigana,
-            autoCorrectEnabled: savedAutoCorrect
+            autoCorrectEnabled: savedAutoCorrect,
+            autoCorrectSettings: savedAutoCorrectSettings,
+            showAutoCorrectModal: false
         };
 
         loadMonacoLocale(props.locale);
@@ -629,6 +649,27 @@ class RubyTab extends React.Component {
         this.setState({autoCorrectEnabled: enabled});
     }
 
+    handleOpenAutoCorrectSettings () {
+        this.setState({showAutoCorrectModal: true});
+    }
+
+    handleCloseAutoCorrectSettings () {
+        this.setState({showAutoCorrectModal: false});
+    }
+
+    handleAutoCorrectSettingChange (key, value) {
+        this.setState(prevState => {
+            const newSettings = {...prevState.autoCorrectSettings, [key]: value};
+            if (typeof window !== 'undefined' && window.localStorage) {
+                window.localStorage.setItem(
+                    AUTO_CORRECT_SETTINGS_KEY,
+                    JSON.stringify(newSettings)
+                );
+            }
+            return {autoCorrectSettings: newSettings};
+        });
+    }
+
     handleToggleFurigana () {
         const enabled = !this.state.furiganaEnabled;
         if (typeof window !== 'undefined' && window.localStorage) {
@@ -854,6 +895,7 @@ class RubyTab extends React.Component {
                         onToggleFurigana={this.handleToggleFurigana}
                         autoCorrectEnabled={this.state.autoCorrectEnabled}
                         onToggleAutoCorrect={this.handleToggleAutoCorrect}
+                        onOpenAutoCorrectSettings={this.handleOpenAutoCorrectSettings}
                     />
                     <div className={styles.editorWrapper}>
                         <Editor
@@ -918,6 +960,13 @@ class RubyTab extends React.Component {
                         />
                     </button>
                 </div>
+                {this.state.showAutoCorrectModal && (
+                    <AutoCorrectModal
+                        settings={this.state.autoCorrectSettings}
+                        onSettingChange={this.handleAutoCorrectSettingChange}
+                        onRequestClose={this.handleCloseAutoCorrectSettings}
+                    />
+                )}
             </>
         );
     }

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -41,6 +41,7 @@ import {getPrism, loadPrism} from '../lib/prism-parser';
 const FONT_SIZES = [8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 36, 40, 48];
 const DEFAULT_FONT_SIZE = 16;
 const FURIGANA_ENABLED_KEY = 'smalruby:furiganaEnabled';
+const AUTO_CORRECT_ENABLED_KEY = 'smalruby:autoCorrectEnabled';
 
 class RubyTab extends React.Component {
     constructor (props) {
@@ -65,6 +66,7 @@ class RubyTab extends React.Component {
             'handleDismissBubble',
             'handleApplyGeminiCode',
             'handleToggleFurigana',
+            'handleToggleAutoCorrect',
             'updateUndoRedoState'
         ]);
         this.mainTooltipId = 'ruby-downloader-tooltip';
@@ -87,12 +89,15 @@ class RubyTab extends React.Component {
         this.furiganaLastMs = 0; // last measured render time, used for adaptive debounce
         const savedFurigana = typeof window !== 'undefined' && window.localStorage ?
             window.localStorage.getItem(FURIGANA_ENABLED_KEY) !== 'false' : true;
+        const savedAutoCorrect = typeof window !== 'undefined' && window.localStorage ?
+            window.localStorage.getItem(AUTO_CORRECT_ENABLED_KEY) !== 'false' : true;
         this.state = {
             runningBlockId: null,
             executingLine: null,
             canUndo: false,
             canRedo: false,
-            furiganaEnabled: savedFurigana
+            furiganaEnabled: savedFurigana,
+            autoCorrectEnabled: savedAutoCorrect
         };
 
         loadMonacoLocale(props.locale);
@@ -616,6 +621,14 @@ class RubyTab extends React.Component {
         this.props.onChange(code);
     }
 
+    handleToggleAutoCorrect () {
+        const enabled = !this.state.autoCorrectEnabled;
+        if (typeof window !== 'undefined' && window.localStorage) {
+            window.localStorage.setItem(AUTO_CORRECT_ENABLED_KEY, enabled);
+        }
+        this.setState({autoCorrectEnabled: enabled});
+    }
+
     handleToggleFurigana () {
         const enabled = !this.state.furiganaEnabled;
         if (typeof window !== 'undefined' && window.localStorage) {
@@ -839,6 +852,8 @@ class RubyTab extends React.Component {
                         canRedo={this.state.canRedo}
                         furiganaEnabled={this.state.furiganaEnabled}
                         onToggleFurigana={this.handleToggleFurigana}
+                        autoCorrectEnabled={this.state.autoCorrectEnabled}
+                        onToggleAutoCorrect={this.handleToggleAutoCorrect}
                     />
                     <div className={styles.editorWrapper}>
                         <Editor

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -687,6 +687,21 @@ class RubyTab extends React.Component {
             window.localStorage.setItem(AUTO_CORRECT_ENABLED_KEY, enabled);
         }
         this.setState({autoCorrectEnabled: enabled});
+
+        // When turning ON, immediately apply auto-correct to current content
+        if (enabled && this.editorRef) {
+            const value = this.editorRef.getValue();
+            if (value) {
+                const corrected = autoCorrect(
+                    value, this.state.autoCorrectSettings
+                );
+                if (corrected !== value) {
+                    this._isAutoCorrectUpdate = true;
+                    const model = this.editorRef.getModel();
+                    model.setValue(corrected);
+                }
+            }
+        }
     }
 
     handleOpenAutoCorrectSettings () {

--- a/packages/scratch-gui/src/lib/auto-correct.js
+++ b/packages/scratch-gui/src/lib/auto-correct.js
@@ -1,0 +1,203 @@
+// === Smalruby: This file is Smalruby-specific (fullwidth-to-halfwidth auto-correct for Ruby tab) ===
+
+/**
+ * Default auto-correct settings — all conversions enabled.
+ */
+const defaultSettings = {
+    fullwidthNumbers: true,
+    fullwidthAlpha: true,
+    fullwidthSymbols: true,
+    fullwidthSpace: true,
+    replaceInStrings: true
+};
+
+// Fullwidth ASCII symbols mapped to halfwidth equivalents.
+// Range U+FF01..U+FF5E corresponds to '!'(0x21)..'~'(0x7E).
+// Numbers (FF10-FF19) and letters (FF21-FF3A, FF41-FF5A) are handled separately.
+const FULLWIDTH_SYMBOL_MAP = {};
+for (let i = 0xFF01; i <= 0xFF5E; i++) {
+    const half = String.fromCharCode(i - 0xFF01 + 0x21);
+    const full = String.fromCharCode(i);
+    // Skip digits 0-9
+    if (half >= '0' && half <= '9') continue;
+    // Skip uppercase A-Z
+    if (half >= 'A' && half <= 'Z') continue;
+    // Skip lowercase a-z
+    if (half >= 'a' && half <= 'z') continue;
+    FULLWIDTH_SYMBOL_MAP[full] = half;
+}
+
+/**
+ * Build a regex that matches fullwidth characters according to the given settings.
+ * @param {object} settings - The auto-correct settings.
+ * @returns {RegExp|null} A regex, or null if nothing to match.
+ */
+const buildPattern = settings => {
+    const parts = [];
+    if (settings.fullwidthNumbers) {
+        parts.push('\uFF10-\uFF19'); // ０-９
+    }
+    if (settings.fullwidthAlpha) {
+        parts.push('\uFF21-\uFF3A'); // Ａ-Ｚ
+        parts.push('\uFF41-\uFF5A'); // ａ-ｚ
+    }
+    if (settings.fullwidthSymbols) {
+        // All fullwidth symbols (excluding digits and letters handled above)
+        parts.push('\uFF01-\uFF0F'); // ！ to ／
+        parts.push('\uFF1A-\uFF20'); // ： to ＠
+        parts.push('\uFF3B-\uFF40'); // ［ to ｀
+        parts.push('\uFF5B-\uFF5E'); // ｛ to ～
+    }
+    if (settings.fullwidthSpace) {
+        parts.push('\u3000'); // ideographic space
+    }
+    if (parts.length === 0) return null;
+    return new RegExp(`[${parts.join('')}]`, 'g');
+};
+
+/**
+ * Replace a single fullwidth character with its halfwidth equivalent.
+ * @param {string} ch - A single fullwidth character.
+ * @param {object} settings - The auto-correct settings.
+ * @returns {string} The halfwidth equivalent, or the original character.
+ */
+const replaceChar = (ch, settings) => {
+    const code = ch.charCodeAt(0);
+
+    // Fullwidth digits ０(FF10) - ９(FF19)
+    if (code >= 0xFF10 && code <= 0xFF19) {
+        if (!settings.fullwidthNumbers) return ch;
+        return String.fromCharCode(code - 0xFF10 + 0x30);
+    }
+
+    // Fullwidth uppercase Ａ(FF21) - Ｚ(FF3A)
+    if (code >= 0xFF21 && code <= 0xFF3A) {
+        if (!settings.fullwidthAlpha) return ch;
+        return String.fromCharCode(code - 0xFF21 + 0x41);
+    }
+
+    // Fullwidth lowercase ａ(FF41) - ｚ(FF5A)
+    if (code >= 0xFF41 && code <= 0xFF5A) {
+        if (!settings.fullwidthAlpha) return ch;
+        return String.fromCharCode(code - 0xFF41 + 0x61);
+    }
+
+    // Ideographic space
+    if (code === 0x3000) {
+        if (!settings.fullwidthSpace) return ch;
+        return ' ';
+    }
+
+    // Fullwidth symbols
+    if (settings.fullwidthSymbols && FULLWIDTH_SYMBOL_MAP[ch]) {
+        return FULLWIDTH_SYMBOL_MAP[ch];
+    }
+
+    return ch;
+};
+
+/**
+ * Find string literal regions in Ruby source code using a simple state machine.
+ * Returns an array of [start, end] pairs (inclusive of quote delimiters).
+ * Handles double-quoted and single-quoted strings with escape sequences.
+ * @param {string} code - Ruby source code.
+ * @returns {Array<[number, number]>} Array of [start, end] index pairs.
+ */
+const findStringRegions = code => {
+    const regions = [];
+    let i = 0;
+    while (i < code.length) {
+        const ch = code[i];
+        if (ch === '"' || ch === "'") {
+            const quote = ch;
+            const start = i;
+            i++; // skip opening quote
+            while (i < code.length) {
+                if (code[i] === '\\') {
+                    i += 2; // skip escaped character
+                    continue;
+                }
+                if (code[i] === quote) {
+                    break;
+                }
+                i++;
+            }
+            // i is now at closing quote or end of string
+            regions.push([start, i]);
+            i++; // skip closing quote (or move past end)
+        } else if (ch === '#') {
+            // Skip comment to end of line
+            while (i < code.length && code[i] !== '\n') {
+                i++;
+            }
+        } else {
+            i++;
+        }
+    }
+    return regions;
+};
+
+/**
+ * Check if a given index falls inside any string region.
+ * @param {number} index - Character index in the source.
+ * @param {Array<[number, number]>} regions - String regions.
+ * @returns {boolean} True if inside a string literal.
+ */
+const isInString = (index, regions) => {
+    for (const [start, end] of regions) {
+        if (index > start && index <= end) {
+            return true;
+        }
+    }
+    return false;
+};
+
+/**
+ * Check if a character at the given index is escaped (preceded by an odd number of backslashes).
+ * @param {string} code - The source code.
+ * @param {number} index - The character index.
+ * @returns {boolean} True if the character is escaped.
+ */
+const isEscaped = (code, index) => {
+    let backslashes = 0;
+    let j = index - 1;
+    while (j >= 0 && code[j] === '\\') {
+        backslashes++;
+        j--;
+    }
+    return backslashes % 2 === 1;
+};
+
+/**
+ * Apply fullwidth-to-halfwidth auto-correction to Ruby source code.
+ * @param {string} code - The Ruby source code.
+ * @param {object} settings - The auto-correct settings.
+ * @returns {string} The corrected source code.
+ */
+const autoCorrect = (code, settings) => {
+    if (!code) return code;
+
+    const pattern = buildPattern(settings);
+    if (!pattern) return code;
+
+    // Pre-compute string regions if we need to skip strings
+    const stringRegions = settings.replaceInStrings ? null : findStringRegions(code);
+
+    const result = code.replace(pattern, (match, offset) => {
+        // If replaceInStrings is off, skip characters inside string literals
+        if (stringRegions && isInString(offset, stringRegions)) {
+            return match;
+        }
+
+        // If replaceInStrings is on but char is escaped inside a string, keep it
+        if (settings.replaceInStrings && isEscaped(code, offset)) {
+            return match;
+        }
+
+        return replaceChar(match, settings);
+    });
+
+    return result;
+};
+
+export {autoCorrect, defaultSettings};

--- a/packages/scratch-gui/src/lib/auto-correct.js
+++ b/packages/scratch-gui/src/lib/auto-correct.js
@@ -27,6 +27,15 @@ for (let i = 0xFF01; i <= 0xFF5E; i++) {
     FULLWIDTH_SYMBOL_MAP[full] = half;
 }
 
+// Extra symbols commonly produced by Japanese IME that fall outside FF01-FF5E.
+const EXTRA_SYMBOL_MAP = {
+    '\u201C': '"', // " left double quotation mark
+    '\u201D': '"', // " right double quotation mark
+    '\u2018': "'", // ' left single quotation mark
+    '\u2019': "'", // ' right single quotation mark
+    '\u2212': '-' // − minus sign
+};
+
 /**
  * Build a regex that matches fullwidth characters according to the given settings.
  * @param {object} settings - The auto-correct settings.
@@ -47,6 +56,10 @@ const buildPattern = settings => {
         parts.push('\uFF1A-\uFF20'); // ： to ＠
         parts.push('\uFF3B-\uFF40'); // ［ to ｀
         parts.push('\uFF5B-\uFF5E'); // ｛ to ～
+        // Extra symbols from Japanese IME
+        parts.push('\u201C\u201D'); // "" smart double quotes
+        parts.push('\u2018\u2019'); // '' smart single quotes
+        parts.push('\u2212'); // − minus sign
     }
     if (settings.fullwidthSpace) {
         parts.push('\u3000'); // ideographic space
@@ -88,9 +101,14 @@ const replaceChar = (ch, settings) => {
         return ' ';
     }
 
-    // Fullwidth symbols
+    // Fullwidth symbols (FF01-FF5E range)
     if (settings.fullwidthSymbols && FULLWIDTH_SYMBOL_MAP[ch]) {
         return FULLWIDTH_SYMBOL_MAP[ch];
+    }
+
+    // Extra symbols (smart quotes, minus sign, etc.)
+    if (settings.fullwidthSymbols && EXTRA_SYMBOL_MAP[ch]) {
+        return EXTRA_SYMBOL_MAP[ch];
     }
 
     return ch;
@@ -108,8 +126,10 @@ const findStringRegions = code => {
     let i = 0;
     while (i < code.length) {
         const ch = code[i];
-        if (ch === '"' || ch === "'") {
-            const quote = ch;
+        if (ch === '"' || ch === "'" || ch === '\u201C' || ch === '\u2018') {
+            // Map opening smart quotes to their closing counterpart
+            const closeQuote = ch === '\u201C' ? '\u201D' :
+                ch === '\u2018' ? '\u2019' : ch;
             const start = i;
             i++; // skip opening quote
             while (i < code.length) {
@@ -117,7 +137,7 @@ const findStringRegions = code => {
                     i += 2; // skip escaped character
                     continue;
                 }
-                if (code[i] === quote) {
+                if (code[i] === closeQuote) {
                     break;
                 }
                 i++;
@@ -145,7 +165,8 @@ const findStringRegions = code => {
  */
 const isInString = (index, regions) => {
     for (const [start, end] of regions) {
-        if (index > start && index <= end) {
+        // Exclude both quote delimiters so they remain eligible for conversion
+        if (index > start && index < end) {
             return true;
         }
     }

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -357,6 +357,16 @@ export default {
     'gui.rubyToolbar.aiAssistant': 'スモウルビーせんせい (Gemini)',
     'gui.rubyToolbar.furiganaOn': 'ふりがなをかくす',
     'gui.rubyToolbar.furiganaOff': 'ふりがなをみせる',
+    'gui.rubyToolbar.autoCorrectOn': 'じどうちかんをオフにする',
+    'gui.rubyToolbar.autoCorrectOff': 'じどうちかんをオンにする',
+    'gui.rubyToolbar.moreOptions': 'そのたのオプション',
+    'gui.rubyToolbar.autoCorrectSettings': 'じどうちかんせってい',
+    'gui.autoCorrectModal.title': 'じどうちかんせってい',
+    'gui.autoCorrectModal.fullwidthNumbers': 'ぜんかくすうじ → はんかくすうじ',
+    'gui.autoCorrectModal.fullwidthAlpha': 'ぜんかくアルファベット → はんかくアルファベット',
+    'gui.autoCorrectModal.fullwidthSymbols': 'ぜんかくきごう → はんかくきごう',
+    'gui.autoCorrectModal.fullwidthSpace': 'ぜんかくスペース → はんかくスペース',
+    'gui.autoCorrectModal.replaceInStrings': 'もじれつもおきかえる',
 
     // Gemini modal
     'gui.geminiModal.title': 'スモウルビーせんせい (Gemini)',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -361,6 +361,7 @@ export default {
     'gui.rubyToolbar.autoCorrectOff': 'じどうちかんをオンにする',
     'gui.rubyToolbar.moreOptions': 'そのたのオプション',
     'gui.rubyToolbar.autoCorrectSettings': 'じどうちかんせってい',
+    'gui.rubyToolbar.saveRubyScript': 'ルビースクリプトをほぞん',
     'gui.autoCorrectModal.title': 'じどうちかんせってい',
     'gui.autoCorrectModal.fullwidthNumbers': 'ぜんかくすうじ → はんかくすうじ',
     'gui.autoCorrectModal.fullwidthAlpha': 'ぜんかくアルファベット → はんかくアルファベット',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -361,6 +361,7 @@ export default {
     'gui.rubyToolbar.autoCorrectOff': '自動置換をオンにする',
     'gui.rubyToolbar.moreOptions': 'その他のオプション',
     'gui.rubyToolbar.autoCorrectSettings': '自動置換設定',
+    'gui.rubyToolbar.saveRubyScript': 'ルビースクリプトを保存',
     'gui.autoCorrectModal.title': '自動置換設定',
     'gui.autoCorrectModal.fullwidthNumbers': '全角数字 → 半角数字',
     'gui.autoCorrectModal.fullwidthAlpha': '全角アルファベット → 半角アルファベット',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -357,6 +357,16 @@ export default {
     'gui.rubyToolbar.aiAssistant': 'スモウルビー先生 (Gemini)',
     'gui.rubyToolbar.furiganaOn': 'ふりがなをかくす',
     'gui.rubyToolbar.furiganaOff': 'ふりがなをみせる',
+    'gui.rubyToolbar.autoCorrectOn': '自動置換をオフにする',
+    'gui.rubyToolbar.autoCorrectOff': '自動置換をオンにする',
+    'gui.rubyToolbar.moreOptions': 'その他のオプション',
+    'gui.rubyToolbar.autoCorrectSettings': '自動置換設定',
+    'gui.autoCorrectModal.title': '自動置換設定',
+    'gui.autoCorrectModal.fullwidthNumbers': '全角数字 → 半角数字',
+    'gui.autoCorrectModal.fullwidthAlpha': '全角アルファベット → 半角アルファベット',
+    'gui.autoCorrectModal.fullwidthSymbols': '全角記号 → 半角記号',
+    'gui.autoCorrectModal.fullwidthSpace': '全角スペース → 半角スペース',
+    'gui.autoCorrectModal.replaceInStrings': '文字列も置き換える',
 
     // Gemini modal
     'gui.geminiModal.title': 'スモウルビー先生 (Gemini)',

--- a/packages/scratch-gui/test/integration/auto-correct.test.js
+++ b/packages/scratch-gui/test/integration/auto-correct.test.js
@@ -1,0 +1,150 @@
+import {autoCorrect, defaultSettings} from '../../src/lib/auto-correct';
+
+// Integration tests for auto-correct feature
+// These test realistic Ruby code scenarios end-to-end
+
+describe('auto-correct integration', () => {
+    describe('realistic Ruby code patterns', () => {
+        test('should fix fullwidth quotes in puts statement', () => {
+            const input = 'ｐｕｔｓ（＂こんにちは＂）';
+            const result = autoCorrect(input, defaultSettings);
+            expect(result).toBe('puts("こんにちは")');
+        });
+
+        test('should fix fullwidth assignment with variable', () => {
+            const input = 'ｘ　＝　１０';
+            const result = autoCorrect(input, defaultSettings);
+            expect(result).toBe('x = 10');
+        });
+
+        test('should fix multiline Smalruby program', () => {
+            const input = [
+                'ｓｅｌｆ．Ｘ座標　＝　１００',
+                'ｓｅｌｆ．Ｙ座標　＝　ー５０',
+                'ｐｕｔｓ（ｓｅｌｆ．Ｘ座標）'
+            ].join('\n');
+            const expected = [
+                'self.X座標 = 100',
+                'self.Y座標 = ー50',
+                'puts(self.X座標)'
+            ].join('\n');
+            expect(autoCorrect(input, defaultSettings)).toBe(expected);
+        });
+
+        test('should fix fullwidth comparison operators', () => {
+            const input = 'ｉｆ　ｘ　＞＝　１０';
+            const result = autoCorrect(input, defaultSettings);
+            expect(result).toBe('if x >= 10');
+        });
+
+        test('should fix fullwidth array syntax', () => {
+            const input = '配列　＝　［１，　２，　３］';
+            const result = autoCorrect(input, defaultSettings);
+            expect(result).toBe('配列 = [1, 2, 3]');
+        });
+
+        test('should fix fullwidth hash syntax', () => {
+            const input = 'ハッシュ　＝　｛ＡＢＣ：　１２３｝';
+            const result = autoCorrect(input, defaultSettings);
+            expect(result).toBe('ハッシュ = {ABC: 123}');
+        });
+
+        test('should fix fullwidth method definition', () => {
+            const input = [
+                'ｄｅｆ　ｍｅｔｈｏｄ（ａ，　ｂ）',
+                '　　ａ　＋　ｂ',
+                'ｅｎｄ'
+            ].join('\n');
+            const expected = [
+                'def method(a, b)',
+                '  a + b',
+                'end'
+            ].join('\n');
+            expect(autoCorrect(input, defaultSettings)).toBe(expected);
+        });
+    });
+
+    describe('string content preservation with replaceInStrings off', () => {
+        const settingsNoStrings = {...defaultSettings, replaceInStrings: false};
+
+        test('should not modify string content but fix surrounding code', () => {
+            const input = 'ｐｕｔｓ "ＡＢＣ１２３"';
+            const result = autoCorrect(input, settingsNoStrings);
+            expect(result).toBe('puts "ＡＢＣ１２３"');
+        });
+
+        test('should handle multiple strings on same line', () => {
+            const input = "ｐｕｔｓ 'Ａ' ＋ 'Ｂ'";
+            const result = autoCorrect(input, settingsNoStrings);
+            expect(result).toBe("puts 'Ａ' + 'Ｂ'");
+        });
+
+        test('should handle code between strings', () => {
+            const input = 'ｘ ＝ "Ａ" ＋ ｙ ＋ "Ｂ"';
+            const result = autoCorrect(input, settingsNoStrings);
+            expect(result).toBe('x = "Ａ" + y + "Ｂ"');
+        });
+    });
+
+    describe('selective settings', () => {
+        test('should only convert numbers when only numbers enabled', () => {
+            const settings = {
+                ...defaultSettings,
+                fullwidthAlpha: false,
+                fullwidthSymbols: false,
+                fullwidthSpace: false
+            };
+            const input = 'ｘ　＝　１０';
+            const result = autoCorrect(input, settings);
+            expect(result).toBe('ｘ　＝　10');
+        });
+
+        test('should only convert alpha when only alpha enabled', () => {
+            const settings = {
+                ...defaultSettings,
+                fullwidthNumbers: false,
+                fullwidthSymbols: false,
+                fullwidthSpace: false
+            };
+            const input = 'ｘ　＝　１０';
+            const result = autoCorrect(input, settings);
+            expect(result).toBe('x　＝　１０');
+        });
+    });
+
+    describe('escape handling in strings', () => {
+        test('should preserve escaped fullwidth chars', () => {
+            const input = '"\\１ ＋ ２"';
+            const result = autoCorrect(input, defaultSettings);
+            // \１ stays as-is, but ＋ and ２ are converted
+            expect(result).toBe('"\\１ + 2"');
+        });
+
+        test('should handle double escaped backslash', () => {
+            const input = '"\\\\１"';
+            const result = autoCorrect(input, defaultSettings);
+            // \\\\ is escaped backslash, so １ should be converted
+            expect(result).toBe('"\\\\1"');
+        });
+    });
+
+    describe('performance with large input', () => {
+        test('should handle 1000-line program efficiently', () => {
+            const lines = [];
+            for (let i = 0; i < 1000; i++) {
+                lines.push(`ｘ＿${i}　＝　${i}`);
+            }
+            const input = lines.join('\n');
+            const start = Date.now();
+            const result = autoCorrect(input, defaultSettings);
+            const elapsed = Date.now() - start;
+
+            // Should complete in under 500ms
+            expect(elapsed).toBeLessThan(500);
+            // Verify first and last lines converted
+            const resultLines = result.split('\n');
+            expect(resultLines[0]).toMatch(/^x_0 = 0$/);
+            expect(resultLines[999]).toMatch(/^x_999 = 999$/);
+        });
+    });
+});

--- a/packages/scratch-gui/test/integration/auto-correct.test.js
+++ b/packages/scratch-gui/test/integration/auto-correct.test.js
@@ -49,6 +49,24 @@ describe('auto-correct integration', () => {
             expect(result).toBe('ハッシュ = {ABC: 123}');
         });
 
+        test('should fix smart double quotes in puts statement', () => {
+            const input = 'puts \u201Cハロー\u201D';
+            const result = autoCorrect(input, defaultSettings);
+            expect(result).toBe('puts "ハロー"');
+        });
+
+        test('should fix smart single quotes', () => {
+            const input = "x = \u2018hello\u2019";
+            const result = autoCorrect(input, defaultSettings);
+            expect(result).toBe("x = 'hello'");
+        });
+
+        test('should fix minus sign U+2212', () => {
+            const input = 'result = 10 \u2212 3';
+            const result = autoCorrect(input, defaultSettings);
+            expect(result).toBe('result = 10 - 3');
+        });
+
         test('should fix fullwidth method definition', () => {
             const input = [
                 'ｄｅｆ　ｍｅｔｈｏｄ（ａ，　ｂ）',
@@ -83,6 +101,13 @@ describe('auto-correct integration', () => {
             const input = 'ｘ ＝ "Ａ" ＋ ｙ ＋ "Ｂ"';
             const result = autoCorrect(input, settingsNoStrings);
             expect(result).toBe('x = "Ａ" + y + "Ｂ"');
+        });
+
+        test('should preserve content inside smart-quoted strings', () => {
+            const input = 'ｐｕｔｓ \u201CＡＢＣ\u201D';
+            const result = autoCorrect(input, settingsNoStrings);
+            // Smart quotes become halfwidth, but content inside is preserved
+            expect(result).toBe('puts "ＡＢＣ"');
         });
     });
 

--- a/packages/scratch-gui/test/unit/lib/auto-correct.test.js
+++ b/packages/scratch-gui/test/unit/lib/auto-correct.test.js
@@ -1,0 +1,210 @@
+import {autoCorrect, defaultSettings} from '../../../src/lib/auto-correct';
+
+describe('autoCorrect', () => {
+    const allOn = defaultSettings;
+    const allOff = {
+        fullwidthNumbers: false,
+        fullwidthAlpha: false,
+        fullwidthSymbols: false,
+        fullwidthSpace: false,
+        replaceInStrings: true
+    };
+
+    describe('fullwidth numbers', () => {
+        test('should convert fullwidth digits to halfwidth', () => {
+            expect(autoCorrect('０１２３４５６７８９', allOn)).toBe('0123456789');
+        });
+
+        test('should not convert when fullwidthNumbers is off', () => {
+            const settings = {...allOn, fullwidthNumbers: false};
+            expect(autoCorrect('ｘ = ０', settings)).toBe('x = ０');
+        });
+    });
+
+    describe('fullwidth alphabet', () => {
+        test('should convert fullwidth uppercase to halfwidth', () => {
+            expect(autoCorrect('ＡＢＣＸＹＺ', allOn)).toBe('ABCXYZ');
+        });
+
+        test('should convert fullwidth lowercase to halfwidth', () => {
+            expect(autoCorrect('ａｂｃｘｙｚ', allOn)).toBe('abcxyz');
+        });
+
+        test('should not convert when fullwidthAlpha is off', () => {
+            const settings = {...allOn, fullwidthAlpha: false};
+            expect(autoCorrect('ｘ = 1', settings)).toBe('ｘ = 1');
+        });
+    });
+
+    describe('fullwidth symbols', () => {
+        test('should convert fullwidth double quote', () => {
+            expect(autoCorrect('＂hello＂', allOn)).toBe('"hello"');
+        });
+
+        test('should convert fullwidth single quote', () => {
+            expect(autoCorrect('＇hello＇', allOn)).toBe("'hello'");
+        });
+
+        test('should convert fullwidth parentheses', () => {
+            expect(autoCorrect('（１＋２）', allOn)).toBe('(1+2)');
+        });
+
+        test('should convert fullwidth brackets and braces', () => {
+            expect(autoCorrect('［１，２，３］', allOn)).toBe('[1,2,3]');
+            expect(autoCorrect('｛ａ：１｝', allOn)).toBe('{a:1}');
+        });
+
+        test('should convert fullwidth arithmetic operators', () => {
+            expect(autoCorrect('１＋２－３＊４／５', allOn)).toBe('1+2-3*4/5');
+        });
+
+        test('should convert fullwidth comparison operators', () => {
+            expect(autoCorrect('ｘ＜１０', allOn)).toBe('x<10');
+            expect(autoCorrect('ｘ＞＝５', allOn)).toBe('x>=5');
+            expect(autoCorrect('ｘ＝＝１', allOn)).toBe('x==1');
+        });
+
+        test('should convert fullwidth miscellaneous symbols', () => {
+            expect(autoCorrect('！＠＃＄％＾＆＿～｜', allOn)).toBe('!@#$%^&_~|');
+        });
+
+        test('should convert fullwidth dot, comma, colon, semicolon', () => {
+            expect(autoCorrect('ａ．ｂ，ｃ：ｄ；ｅ', allOn)).toBe('a.b,c:d;e');
+        });
+
+        test('should convert fullwidth backslash and backtick', () => {
+            expect(autoCorrect('＼ｎ', allOn)).toBe('\\n');
+            expect(autoCorrect('｀ｈｅｌｌｏ｀', allOn)).toBe('`hello`');
+        });
+
+        test('should convert fullwidth question mark and exclamation', () => {
+            expect(autoCorrect('ｐｕｔｓ？', allOn)).toBe('puts?');
+        });
+
+        test('should not convert when fullwidthSymbols is off', () => {
+            const settings = {...allOn, fullwidthSymbols: false};
+            expect(autoCorrect('（１）', settings)).toBe('（1）');
+        });
+    });
+
+    describe('fullwidth space', () => {
+        test('should convert fullwidth space to halfwidth', () => {
+            expect(autoCorrect('ｘ　＝　１', allOn)).toBe('x = 1');
+        });
+
+        test('should not convert when fullwidthSpace is off', () => {
+            const settings = {...allOn, fullwidthSpace: false};
+            expect(autoCorrect('x　= 1', settings)).toBe('x　= 1');
+        });
+    });
+
+    describe('string handling (replaceInStrings)', () => {
+        test('should replace inside double-quoted strings when replaceInStrings is on', () => {
+            expect(autoCorrect('"ＡＢＣ"', allOn)).toBe('"ABC"');
+        });
+
+        test('should replace inside single-quoted strings when replaceInStrings is on', () => {
+            expect(autoCorrect("'１２３'", allOn)).toBe("'123'");
+        });
+
+        test('should NOT replace inside double-quoted strings when replaceInStrings is off', () => {
+            const settings = {...allOn, replaceInStrings: false};
+            expect(autoCorrect('x = "ＡＢＣ"', settings)).toBe('x = "ＡＢＣ"');
+        });
+
+        test('should NOT replace inside single-quoted strings when replaceInStrings is off', () => {
+            const settings = {...allOn, replaceInStrings: false};
+            expect(autoCorrect("x = '１２３'", settings)).toBe("x = '１２３'");
+        });
+
+        test('should still replace outside strings when replaceInStrings is off', () => {
+            const settings = {...allOn, replaceInStrings: false};
+            expect(autoCorrect('ｘ = "ＡＢＣ"', settings)).toBe('x = "ＡＢＣ"');
+        });
+
+        test('should handle escaped fullwidth chars in strings (keep original)', () => {
+            // \１ should NOT be replaced even when replaceInStrings is on
+            expect(autoCorrect('"\\１\\２"', allOn)).toBe('"\\１\\２"');
+        });
+
+        test('should replace non-escaped fullwidth but keep escaped ones in same string', () => {
+            expect(autoCorrect('"Ａ\\１Ｂ"', allOn)).toBe('"A\\１B"');
+        });
+
+        test('should handle strings with escaped backslash before fullwidth', () => {
+            // \\\１ means escaped backslash followed by fullwidth 1, so １ should be replaced
+            expect(autoCorrect('"\\\\１"', allOn)).toBe('"\\\\1"');
+        });
+    });
+
+    describe('multiline code', () => {
+        test('should handle multiline Ruby code', () => {
+            const input = 'ｘ　＝　１０\nｐｕｔｓ（ｘ）';
+            const expected = 'x = 10\nputs(x)';
+            expect(autoCorrect(input, allOn)).toBe(expected);
+        });
+
+        test('should handle string spanning context with code around it', () => {
+            const settings = {...allOn, replaceInStrings: false};
+            const input = 'ｘ = "ＡＢＣ"\nｙ = １';
+            const expected = 'x = "ＡＢＣ"\ny = 1';
+            expect(autoCorrect(input, settings)).toBe(expected);
+        });
+    });
+
+    describe('no-op cases', () => {
+        test('should return unchanged text when no fullwidth chars', () => {
+            const input = 'x = 10\nputs(x)';
+            expect(autoCorrect(input, allOn)).toBe(input);
+        });
+
+        test('should return empty string unchanged', () => {
+            expect(autoCorrect('', allOn)).toBe('');
+        });
+
+        test('should not affect Japanese characters (hiragana, katakana, kanji)', () => {
+            const input = 'puts "こんにちは世界"';
+            expect(autoCorrect(input, allOn)).toBe(input);
+        });
+
+        test('should return unchanged when all settings are off', () => {
+            const input = 'ｘ　＝　１０';
+            expect(autoCorrect(input, allOff)).toBe(input);
+        });
+    });
+
+    describe('edge cases', () => {
+        test('should handle unclosed string at end of input', () => {
+            const settings = {...allOn, replaceInStrings: false};
+            // Unclosed string - treat rest as string, don't replace inside
+            const input = 'x = "ＡＢＣ';
+            expect(autoCorrect(input, settings)).toBe('x = "ＡＢＣ');
+        });
+
+        test('should handle escaped quote inside string', () => {
+            const settings = {...allOn, replaceInStrings: false};
+            const input = 'x = "hello\\"ＡＢＣ"';
+            expect(autoCorrect(input, settings)).toBe('x = "hello\\"ＡＢＣ"');
+        });
+
+        test('should handle mixed fullwidth and halfwidth', () => {
+            expect(autoCorrect('x = １0 + ２0', allOn)).toBe('x = 10 + 20');
+        });
+
+        test('should handle comment lines (treat as code, replace normally)', () => {
+            expect(autoCorrect('# ＡＢＣ１２３', allOn)).toBe('# ABC123');
+        });
+    });
+
+    describe('defaultSettings', () => {
+        test('should have all options enabled by default', () => {
+            expect(defaultSettings).toEqual({
+                fullwidthNumbers: true,
+                fullwidthAlpha: true,
+                fullwidthSymbols: true,
+                fullwidthSpace: true,
+                replaceInStrings: true
+            });
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/auto-correct.test.js
+++ b/packages/scratch-gui/test/unit/lib/auto-correct.test.js
@@ -85,6 +85,23 @@ describe('autoCorrect', () => {
             const settings = {...allOn, fullwidthSymbols: false};
             expect(autoCorrect('（１）', settings)).toBe('（1）');
         });
+
+        test('should convert smart double quotes to halfwidth', () => {
+            expect(autoCorrect('puts \u201Cハロー\u201D', allOn)).toBe('puts "ハロー"');
+        });
+
+        test('should convert smart single quotes to halfwidth', () => {
+            expect(autoCorrect("puts \u2018hello\u2019", allOn)).toBe("puts 'hello'");
+        });
+
+        test('should convert minus sign U+2212 to halfwidth hyphen', () => {
+            expect(autoCorrect('x = 10 \u2212 5', allOn)).toBe('x = 10 - 5');
+        });
+
+        test('should not convert smart quotes when fullwidthSymbols is off', () => {
+            const settings = {...allOn, fullwidthSymbols: false};
+            expect(autoCorrect('puts \u201Cハロー\u201D', settings)).toBe('puts \u201Cハロー\u201D');
+        });
     });
 
     describe('fullwidth space', () => {


### PR DESCRIPTION
## Summary

Rubyタブに全角→半角の自動置換機能（Auto Correct）を追加する。初学者が全角ダブルクォートなどを誤入力しても自動的に半角に変換し、構文エラーを防ぐ。

Closes #273

## Implementation Steps

- [x] **Phase 1**: 自動置換ロジック (`auto-correct.js`) — TDD で37テスト作成・実装完了
- [x] **Phase 2**: ツールバーUI — 自動置換ON/OFFトグルボタン追加
- [x] **Phase 3**: スリードットメニュー + 設定モーダル
- [x] **Phase 4**: エディタ統合 — `handleEditorChange` での自動置換実行
- [x] **Phase 5**: Integration Tests — 19テスト + Playwright MCP手動確認
- [x] **Phase 6**: スマートクォート・マイナス記号対応、アイコン間隔修正
- [x] **Phase 7**: OFFからONへのトグル時に即時自動置換を実行
- [x] **Phase 8**: UIリファインメント — ダウンロードをメニューに移動、メニューアイコン統一、モーダルのチェックボックス位置修正

## Test Coverage

- 41 unit tests: fullwidth numbers/alpha/symbols/space conversion, smart quotes, minus sign, string literal handling, escape sequences, multiline code, edge cases
- 19 integration tests: realistic Ruby code patterns, smart quotes, string preservation, selective settings, escape handling, performance (1000-line programs)

## Test Plan

- [x] Unit tests pass (41/41)
- [x] Integration tests pass (19/19)
- [x] Lint passes
- [x] Manual verification with Playwright MCP:
  - `ｘ　＝　１０` → `x = 10` (全角→半角変換)
  - `ｐｕｔｓ（＂こんにちは＂）` → `puts("こんにちは")` (記号変換、日本語保持)
  - `puts "ハロー"` → `puts "ハロー"` (スマートクォート変換)
  - 自動置換OFF→ON時に即時変換
  - スリードットメニューにダウンロード・自動置換設定
  - 設定モーダルのチェックボックス位置修正
  - `window.smalruby.autoCorrect` debug globals
