### PR TITLE
refactor: ruby tab関連コードのリファクタリング（関数コンポーネント化） #275

### DIFF
--- a/packages/scratch-gui/src/components/ruby-toolbar/messages.js
+++ b/packages/scratch-gui/src/components/ruby-toolbar/messages.js
@@ -1,0 +1,98 @@
+// === Smalruby: This file is Smalruby-specific (Ruby toolbar i18n messages) ===
+
+import {defineMessages} from 'react-intl';
+
+const messages = defineMessages({
+    executeLine: {
+        id: 'gui.rubyToolbar.executeLine',
+        defaultMessage: 'Execute current line',
+        description: 'Tooltip for execute line button'
+    },
+    stopExecution: {
+        id: 'gui.rubyToolbar.stopExecution',
+        defaultMessage: 'Stop execution',
+        description: 'Tooltip for stop execution button'
+    },
+    search: {
+        id: 'gui.rubyToolbar.search',
+        defaultMessage: 'Search',
+        description: 'Tooltip for search button'
+    },
+    undo: {
+        id: 'gui.rubyToolbar.undo',
+        defaultMessage: 'Undo',
+        description: 'Tooltip for undo button'
+    },
+    redo: {
+        id: 'gui.rubyToolbar.redo',
+        defaultMessage: 'Redo',
+        description: 'Tooltip for redo button'
+    },
+    prevSprite: {
+        id: 'gui.rubyToolbar.prevSprite',
+        defaultMessage: 'Previous sprite',
+        description: 'Tooltip for previous sprite button'
+    },
+    nextSprite: {
+        id: 'gui.rubyToolbar.nextSprite',
+        defaultMessage: 'Next sprite',
+        description: 'Tooltip for next sprite button'
+    },
+    commandPlaceholder: {
+        id: 'gui.rubyToolbar.commandPlaceholder',
+        defaultMessage: 'Search sprites by name',
+        description: 'Placeholder for command input'
+    },
+    download: {
+        id: 'gui.rubyToolbar.download',
+        defaultMessage: 'Download Ruby code',
+        description: 'Tooltip for download button'
+    },
+    aiAssistant: {
+        id: 'gui.rubyToolbar.aiAssistant',
+        defaultMessage: 'Smalruby Teacher (Gemini)',
+        description: 'Tooltip for AI assistant button'
+    },
+    furiganaOn: {
+        id: 'gui.rubyToolbar.furiganaOn',
+        defaultMessage: 'Hide furigana',
+        description: 'Tooltip for furigana toggle button when ON'
+    },
+    furiganaOff: {
+        id: 'gui.rubyToolbar.furiganaOff',
+        defaultMessage: 'Show furigana',
+        description: 'Tooltip for furigana toggle button when OFF'
+    },
+    autoCorrectOn: {
+        id: 'gui.rubyToolbar.autoCorrectOn',
+        defaultMessage: 'Disable auto-correct',
+        description: 'Tooltip for auto-correct toggle button when ON'
+    },
+    autoCorrectOff: {
+        id: 'gui.rubyToolbar.autoCorrectOff',
+        defaultMessage: 'Enable auto-correct',
+        description: 'Tooltip for auto-correct toggle button when OFF'
+    },
+    moreOptions: {
+        id: 'gui.rubyToolbar.moreOptions',
+        defaultMessage: 'More options',
+        description: 'Tooltip for three-dot menu button'
+    },
+    autoCorrectSettings: {
+        id: 'gui.rubyToolbar.autoCorrectSettings',
+        defaultMessage: 'Auto-Correct Settings',
+        description: 'Label for auto-correct settings menu item'
+    },
+    saveRubyScript: {
+        id: 'gui.rubyToolbar.saveRubyScript',
+        defaultMessage: 'Save Ruby script',
+        description: 'Label for save Ruby script menu item'
+    },
+    stage: {
+        id: 'gui.rubyToolbar.stage',
+        defaultMessage: 'Stage',
+        description: 'Name for stage target'
+    }
+});
+
+export default messages;

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -1,9 +1,10 @@
 import React, {useState, useCallback, useRef, useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {defineMessages, useIntl} from 'react-intl';
+import {useIntl} from 'react-intl';
 import VM from '@smalruby/scratch-vm';
 
 import styles from './ruby-toolbar.css';
+import messages from './messages.js';
 
 import iconPlay from './icon--play.svg';
 import iconStop from './icon--stop.svg';
@@ -16,99 +17,6 @@ import iconDownload from './icon--download.svg';
 import iconAI from './icon--ai.svg';
 import iconFurigana from './icon--furigana.svg';
 import iconAutoCorrect from './icon--auto-correct.svg';
-
-const messages = defineMessages({
-    executeLine: {
-        id: 'gui.rubyToolbar.executeLine',
-        defaultMessage: 'Execute current line',
-        description: 'Tooltip for execute line button'
-    },
-    stopExecution: {
-        id: 'gui.rubyToolbar.stopExecution',
-        defaultMessage: 'Stop execution',
-        description: 'Tooltip for stop execution button'
-    },
-    search: {
-        id: 'gui.rubyToolbar.search',
-        defaultMessage: 'Search',
-        description: 'Tooltip for search button'
-    },
-    undo: {
-        id: 'gui.rubyToolbar.undo',
-        defaultMessage: 'Undo',
-        description: 'Tooltip for undo button'
-    },
-    redo: {
-        id: 'gui.rubyToolbar.redo',
-        defaultMessage: 'Redo',
-        description: 'Tooltip for redo button'
-    },
-    prevSprite: {
-        id: 'gui.rubyToolbar.prevSprite',
-        defaultMessage: 'Previous sprite',
-        description: 'Tooltip for previous sprite button'
-    },
-    nextSprite: {
-        id: 'gui.rubyToolbar.nextSprite',
-        defaultMessage: 'Next sprite',
-        description: 'Tooltip for next sprite button'
-    },
-    commandPlaceholder: {
-        id: 'gui.rubyToolbar.commandPlaceholder',
-        defaultMessage: 'Search sprites by name',
-        description: 'Placeholder for command input'
-    },
-    download: {
-        id: 'gui.rubyToolbar.download',
-        defaultMessage: 'Download Ruby code',
-        description: 'Tooltip for download button'
-    },
-    aiAssistant: {
-        id: 'gui.rubyToolbar.aiAssistant',
-        defaultMessage: 'Smalruby Teacher (Gemini)',
-        description: 'Tooltip for AI assistant button'
-    },
-    furiganaOn: {
-        id: 'gui.rubyToolbar.furiganaOn',
-        defaultMessage: 'Hide furigana',
-        description: 'Tooltip for furigana toggle button when ON'
-    },
-    furiganaOff: {
-        id: 'gui.rubyToolbar.furiganaOff',
-        defaultMessage: 'Show furigana',
-        description: 'Tooltip for furigana toggle button when OFF'
-    },
-    autoCorrectOn: {
-        id: 'gui.rubyToolbar.autoCorrectOn',
-        defaultMessage: 'Disable auto-correct',
-        description: 'Tooltip for auto-correct toggle button when ON'
-    },
-    autoCorrectOff: {
-        id: 'gui.rubyToolbar.autoCorrectOff',
-        defaultMessage: 'Enable auto-correct',
-        description: 'Tooltip for auto-correct toggle button when OFF'
-    },
-    moreOptions: {
-        id: 'gui.rubyToolbar.moreOptions',
-        defaultMessage: 'More options',
-        description: 'Tooltip for three-dot menu button'
-    },
-    autoCorrectSettings: {
-        id: 'gui.rubyToolbar.autoCorrectSettings',
-        defaultMessage: 'Auto-Correct Settings',
-        description: 'Label for auto-correct settings menu item'
-    },
-    saveRubyScript: {
-        id: 'gui.rubyToolbar.saveRubyScript',
-        defaultMessage: 'Save Ruby script',
-        description: 'Label for save Ruby script menu item'
-    },
-    stage: {
-        id: 'gui.rubyToolbar.stage',
-        defaultMessage: 'Stage',
-        description: 'Name for stage target'
-    }
-});
 
 const RubyToolbar = props => {
     const intl = useIntl();

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -5,14 +5,13 @@ import VM from '@smalruby/scratch-vm';
 
 import styles from './ruby-toolbar.css';
 import messages from './messages.js';
+import TargetSelector from './target-selector.jsx';
 
 import iconPlay from './icon--play.svg';
 import iconStop from './icon--stop.svg';
 import iconSearch from './icon--search.svg';
 import iconUndo from './icon--undo.svg';
 import iconRedo from './icon--redo.svg';
-import iconBack from './icon--back.svg';
-import iconForward from './icon--forward.svg';
 import iconDownload from './icon--download.svg';
 import iconAI from './icon--ai.svg';
 import iconFurigana from './icon--furigana.svg';
@@ -20,9 +19,6 @@ import iconAutoCorrect from './icon--auto-correct.svg';
 
 const RubyToolbar = props => {
     const intl = useIntl();
-    const [commandValue, setCommandValue] = useState('');
-    const [showDropdown, setShowDropdown] = useState(false);
-    const [filteredTargets, setFilteredTargets] = useState([]);
     const [showMoreMenu, setShowMoreMenu] = useState(false);
     const moreMenuRef = useRef(null);
 
@@ -41,212 +37,46 @@ const RubyToolbar = props => {
         };
     }, [showMoreMenu]);
 
-    const getSortedSprites = useCallback(() => {
-        if (!props.vm || !props.vm.runtime) {
-            return [];
-        }
-        const targets = props.vm.runtime.targets;
-        const sprites = targets
-            .filter(t => !t.isStage)
-            .sort((a, b) => a.getLayerOrder() - b.getLayerOrder());
-        return sprites;
-    }, [props.vm]);
-
-    const getAllTargets = useCallback(() => {
-        if (!props.vm || !props.vm.runtime) {
-            return [];
-        }
-        const stage = props.vm.runtime.targets.find(t => t.isStage);
-        const sprites = getSortedSprites();
-        return stage ? [stage, ...sprites] : sprites;
-    }, [props.vm, getSortedSprites]);
-
-    const getCurrentSpriteIndex = useCallback(() => {
-        const sprites = getSortedSprites();
-        const currentId = props.editingTarget?.id;
-        return sprites.findIndex(s => s.id === currentId);
-    }, [getSortedSprites, props.editingTarget]);
-
-    const getTargetName = useCallback(target => {
-        if (!target) {
-            return '';
-        }
-        if (target.isStage) {
-            return intl.formatMessage(messages.stage);
-        }
-        if (typeof target.getName === 'function') {
-            return target.getName();
-        }
-        if (target.sprite && target.sprite.name) {
-            return target.sprite.name;
-        }
-        return target.name || '';
-    }, [intl]);
-
     const handleSearch = useCallback(() => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
+        if (props.onDismissBubble) props.onDismissBubble();
         if (props.editorRef) {
-            // Trigger Monaco Editor's search action
             props.editorRef.trigger('keyboard', 'actions.find', null);
         }
     }, [props]);
 
     const handleUndo = useCallback(() => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
+        if (props.onDismissBubble) props.onDismissBubble();
         if (props.editorRef) {
             props.editorRef.trigger('keyboard', 'undo', null);
         }
     }, [props]);
 
     const handleRedo = useCallback(() => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
+        if (props.onDismissBubble) props.onDismissBubble();
         if (props.editorRef) {
             props.editorRef.trigger('keyboard', 'redo', null);
         }
     }, [props]);
 
-    const handlePrevSprite = useCallback(() => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
-
-        const sprites = getSortedSprites();
-        const currentIndex = getCurrentSpriteIndex();
-
-        if (props.editingTarget?.isStage) {
-            return;
-        }
-
-        if (currentIndex === 0) {
-            const stage = props.vm.runtime.targets.find(t => t.isStage);
-            if (stage) {
-                props.onSelectTarget(stage.id);
-            }
-        } else if (currentIndex > 0) {
-            props.onSelectTarget(sprites[currentIndex - 1].id);
-        }
-    }, [getSortedSprites, getCurrentSpriteIndex, props]);
-
-    const handleNextSprite = useCallback(() => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
-
-        const sprites = getSortedSprites();
-        const currentIndex = getCurrentSpriteIndex();
-
-        if (props.editingTarget?.isStage) {
-            if (sprites.length > 0) {
-                props.onSelectTarget(sprites[0].id);
-            }
-        } else if (currentIndex >= 0 && currentIndex < sprites.length - 1) {
-            props.onSelectTarget(sprites[currentIndex + 1].id);
-        }
-    }, [getSortedSprites, getCurrentSpriteIndex, props]);
-
-    const handleCommandChange = useCallback(e => {
-        const value = e.target.value;
-        setCommandValue(value);
-
-        if (value.startsWith('>')) {
-            // Command mode - TODO: implement Monaco command palette
-            setShowDropdown(false);
-        } else {
-            // Sprite search mode
-            const allTargets = getAllTargets();
-            const filtered = allTargets.filter(target => {
-                const name = getTargetName(target).toLowerCase();
-                return name.includes(value.toLowerCase());
-            });
-            setShowDropdown(value.length > 0 && filtered.length > 0);
-            setFilteredTargets(filtered);
-        }
-    }, [getAllTargets, getTargetName]);
-
-    const handleCommandFocus = useCallback(() => {
-        if (commandValue && !commandValue.startsWith('>')) {
-            const allTargets = getAllTargets();
-            const filtered = allTargets.filter(target => {
-                const name = getTargetName(target).toLowerCase();
-                return name.includes(commandValue.toLowerCase());
-            });
-            setShowDropdown(filtered.length > 0);
-            setFilteredTargets(filtered);
-        }
-    }, [commandValue, getAllTargets, getTargetName]);
-
-    const handleCommandBlur = useCallback(() => {
-        // Delay to allow click on dropdown item
-        setTimeout(() => {
-            setShowDropdown(false);
-        }, 200);
-    }, []);
-
-    const handleSelectTarget = useCallback(targetId => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
-        props.onSelectTarget(targetId);
-        setCommandValue('');
-        setShowDropdown(false);
-    }, [props]);
-
-    const handleCommandKeyDown = useCallback(e => {
-        if (e.key === 'Escape') {
-            setCommandValue('');
-            setShowDropdown(false);
-            e.target.blur();
-        } else if (e.key === 'Enter' && !e.isComposing && filteredTargets.length > 0) {
-            handleSelectTarget(filteredTargets[0].id);
-        }
-    }, [filteredTargets, handleSelectTarget]);
-
-    const handleSelectTargetFromDropdown = useCallback(e => {
-        const targetId = e.currentTarget.dataset.targetId;
-        handleSelectTarget(targetId);
-    }, [handleSelectTarget]);
-
     const handleDownload = useCallback(() => {
         setShowMoreMenu(false);
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
-        if (props.onDownload) {
-            props.onDownload();
-        }
+        if (props.onDismissBubble) props.onDismissBubble();
+        if (props.onDownload) props.onDownload();
     }, [props]);
 
     const handleOpenAI = useCallback(() => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
-        if (props.onOpenGeminiModal) {
-            props.onOpenGeminiModal();
-        }
+        if (props.onDismissBubble) props.onDismissBubble();
+        if (props.onOpenGeminiModal) props.onOpenGeminiModal();
     }, [props]);
 
     const handleToggleFurigana = useCallback(() => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
-        if (props.onToggleFurigana) {
-            props.onToggleFurigana();
-        }
+        if (props.onDismissBubble) props.onDismissBubble();
+        if (props.onToggleFurigana) props.onToggleFurigana();
     }, [props]);
 
     const handleToggleAutoCorrect = useCallback(() => {
-        if (props.onDismissBubble) {
-            props.onDismissBubble();
-        }
-        if (props.onToggleAutoCorrect) {
-            props.onToggleAutoCorrect();
-        }
+        if (props.onDismissBubble) props.onDismissBubble();
+        if (props.onToggleAutoCorrect) props.onToggleAutoCorrect();
     }, [props]);
 
     const handleToggleMoreMenu = useCallback(() => {
@@ -255,61 +85,14 @@ const RubyToolbar = props => {
 
     const handleOpenAutoCorrectSettings = useCallback(() => {
         setShowMoreMenu(false);
-        if (props.onOpenAutoCorrectSettings) {
-            props.onOpenAutoCorrectSettings();
-        }
+        if (props.onOpenAutoCorrectSettings) props.onOpenAutoCorrectSettings();
     }, [props]);
 
     const handleExecuteLine = useCallback(() => {
-        if (!props.editorRef) {
-            return;
-        }
-
-        // Get current cursor position
+        if (!props.editorRef) return;
         const position = props.editorRef.getPosition();
-        const lineNumber = position.lineNumber;
-
-        // Trigger conversion and execution
-        if (props.onExecuteLine) {
-            props.onExecuteLine(lineNumber);
-        }
+        if (props.onExecuteLine) props.onExecuteLine(position.lineNumber);
     }, [props]);
-
-    const canGoPrev = useCallback(() => {
-        if (props.editingTarget?.isStage) {
-            return false;
-        }
-        const currentIndex = getCurrentSpriteIndex();
-        return currentIndex >= 0;
-    }, [props.editingTarget, getCurrentSpriteIndex]);
-
-    const canGoNext = useCallback(() => {
-        const sprites = getSortedSprites();
-        if (sprites.length === 0) {
-            return false;
-        }
-        if (props.editingTarget?.isStage) {
-            return true;
-        }
-        const currentIndex = getCurrentSpriteIndex();
-        return currentIndex >= 0 && currentIndex < sprites.length - 1;
-    }, [getSortedSprites, props.editingTarget, getCurrentSpriteIndex]);
-
-    const highlightMatch = useCallback((text, query) => {
-        if (!query) return text;
-        const index = text.toLowerCase().indexOf(query.toLowerCase());
-        if (index === -1) return text;
-
-        return (
-            <>
-                {text.substring(0, index)}
-                <span className={styles.highlight}>
-                    {text.substring(index, index + query.length)}
-                </span>
-                {text.substring(index + query.length)}
-            </>
-        );
-    }, []);
 
     return (
         <div className={styles.toolbar}>
@@ -319,8 +102,12 @@ const RubyToolbar = props => {
                     className={styles.iconButton}
                     onClick={handleExecuteLine}
                     disabled={!props.editorRef}
-                    aria-label={intl.formatMessage(props.isRunning ? messages.stopExecution : messages.executeLine)}
-                    title={intl.formatMessage(props.isRunning ? messages.stopExecution : messages.executeLine)}
+                    aria-label={intl.formatMessage(
+                        props.isRunning ? messages.stopExecution : messages.executeLine
+                    )}
+                    title={intl.formatMessage(
+                        props.isRunning ? messages.stopExecution : messages.executeLine
+                    )}
                 >
                     <img
                         src={props.isRunning ? iconStop : iconPlay}
@@ -374,11 +161,17 @@ const RubyToolbar = props => {
             {/* Furigana Toggle & Auto Correct Toggle */}
             <div className={`${styles.toolbarPart} ${styles.modDashedBorder}`}>
                 <button
-                    className={`${styles.furiganaButton} ${props.furiganaEnabled ? styles.furiganaButtonActive : ''}`}
+                    className={`${styles.furiganaButton} ${
+                        props.furiganaEnabled ? styles.furiganaButtonActive : ''
+                    }`}
                     onClick={handleToggleFurigana}
-                    aria-label={intl.formatMessage(props.furiganaEnabled ? messages.furiganaOn : messages.furiganaOff)}
+                    aria-label={intl.formatMessage(
+                        props.furiganaEnabled ? messages.furiganaOn : messages.furiganaOff
+                    )}
                     aria-pressed={props.furiganaEnabled}
-                    title={intl.formatMessage(props.furiganaEnabled ? messages.furiganaOn : messages.furiganaOff)}
+                    title={intl.formatMessage(
+                        props.furiganaEnabled ? messages.furiganaOn : messages.furiganaOff
+                    )}
                 >
                     <img
                         src={iconFurigana}
@@ -407,56 +200,12 @@ const RubyToolbar = props => {
 
             {/* Navigation & Command Part */}
             <div className={`${styles.toolbarPart} ${styles.modDashedBorder} ${styles.modCenter}`}>
-                <button
-                    className={styles.iconButton}
-                    onClick={handlePrevSprite}
-                    disabled={!canGoPrev()}
-                    aria-label={intl.formatMessage(messages.prevSprite)}
-                    title={intl.formatMessage(messages.prevSprite)}
-                >
-                    <img
-                        src={iconBack}
-                        alt=""
-                    />
-                </button>
-                <button
-                    className={styles.iconButton}
-                    onClick={handleNextSprite}
-                    disabled={!canGoNext()}
-                    aria-label={intl.formatMessage(messages.nextSprite)}
-                    title={intl.formatMessage(messages.nextSprite)}
-                >
-                    <img
-                        src={iconForward}
-                        alt=""
-                    />
-                </button>
-                <div className={styles.commandWrapper}>
-                    <input
-                        className={styles.commandInput}
-                        type="text"
-                        value={commandValue}
-                        onChange={handleCommandChange}
-                        onFocus={handleCommandFocus}
-                        onBlur={handleCommandBlur}
-                        onKeyDown={handleCommandKeyDown}
-                        placeholder={intl.formatMessage(messages.commandPlaceholder)}
-                    />
-                    {showDropdown && (
-                        <div className={styles.dropdown}>
-                            {filteredTargets.map(target => (
-                                <div
-                                    key={target.id}
-                                    className={styles.dropdownItem}
-                                    data-target-id={target.id}
-                                    onMouseDown={handleSelectTargetFromDropdown}
-                                >
-                                    {highlightMatch(getTargetName(target), commandValue)}
-                                </div>
-                            ))}
-                        </div>
-                    )}
-                </div>
+                <TargetSelector
+                    editingTarget={props.editingTarget}
+                    vm={props.vm}
+                    onSelectTarget={props.onSelectTarget}
+                    onDismissBubble={props.onDismissBubble}
+                />
                 <button
                     className={styles.iconButton}
                     onClick={handleOpenAI}
@@ -495,9 +244,7 @@ const RubyToolbar = props => {
                                     src={iconDownload}
                                     alt=""
                                 />
-                                {intl.formatMessage(
-                                    messages.saveRubyScript
-                                )}
+                                {intl.formatMessage(messages.saveRubyScript)}
                             </div>
                             <div
                                 className={styles.moreMenuItem}
@@ -508,9 +255,7 @@ const RubyToolbar = props => {
                                     src={iconAutoCorrect}
                                     alt=""
                                 />
-                                {intl.formatMessage(
-                                    messages.autoCorrectSettings
-                                )}
+                                {intl.formatMessage(messages.autoCorrectSettings)}
                             </div>
                         </div>
                     )}

--- a/packages/scratch-gui/src/components/ruby-toolbar/target-selector.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/target-selector.jsx
@@ -1,0 +1,228 @@
+// === Smalruby: This file is Smalruby-specific (target selector for Ruby toolbar) ===
+
+import React, {useState, useCallback} from 'react';
+import PropTypes from 'prop-types';
+import {useIntl} from 'react-intl';
+import VM from '@smalruby/scratch-vm';
+
+import styles from './ruby-toolbar.css';
+import messages from './messages.js';
+
+import iconBack from './icon--back.svg';
+import iconForward from './icon--forward.svg';
+
+const TargetSelector = props => {
+    const intl = useIntl();
+    const [commandValue, setCommandValue] = useState('');
+    const [showDropdown, setShowDropdown] = useState(false);
+    const [filteredTargets, setFilteredTargets] = useState([]);
+
+    const getSortedSprites = useCallback(() => {
+        if (!props.vm || !props.vm.runtime) {
+            return [];
+        }
+        return props.vm.runtime.targets
+            .filter(t => !t.isStage)
+            .sort((a, b) => a.getLayerOrder() - b.getLayerOrder());
+    }, [props.vm]);
+
+    const getAllTargets = useCallback(() => {
+        if (!props.vm || !props.vm.runtime) {
+            return [];
+        }
+        const stage = props.vm.runtime.targets.find(t => t.isStage);
+        const sprites = getSortedSprites();
+        return stage ? [stage, ...sprites] : sprites;
+    }, [props.vm, getSortedSprites]);
+
+    const getCurrentSpriteIndex = useCallback(() => {
+        const sprites = getSortedSprites();
+        const currentId = props.editingTarget?.id;
+        return sprites.findIndex(s => s.id === currentId);
+    }, [getSortedSprites, props.editingTarget]);
+
+    const getTargetName = useCallback(target => {
+        if (!target) return '';
+        if (target.isStage) return intl.formatMessage(messages.stage);
+        if (typeof target.getName === 'function') return target.getName();
+        if (target.sprite && target.sprite.name) return target.sprite.name;
+        return target.name || '';
+    }, [intl]);
+
+    const handlePrevSprite = useCallback(() => {
+        if (props.onDismissBubble) props.onDismissBubble();
+        const sprites = getSortedSprites();
+        const currentIndex = getCurrentSpriteIndex();
+
+        if (props.editingTarget?.isStage) return;
+
+        if (currentIndex === 0) {
+            const stage = props.vm.runtime.targets.find(t => t.isStage);
+            if (stage) props.onSelectTarget(stage.id);
+        } else if (currentIndex > 0) {
+            props.onSelectTarget(sprites[currentIndex - 1].id);
+        }
+    }, [getSortedSprites, getCurrentSpriteIndex, props]);
+
+    const handleNextSprite = useCallback(() => {
+        if (props.onDismissBubble) props.onDismissBubble();
+        const sprites = getSortedSprites();
+        const currentIndex = getCurrentSpriteIndex();
+
+        if (props.editingTarget?.isStage) {
+            if (sprites.length > 0) props.onSelectTarget(sprites[0].id);
+        } else if (currentIndex >= 0 && currentIndex < sprites.length - 1) {
+            props.onSelectTarget(sprites[currentIndex + 1].id);
+        }
+    }, [getSortedSprites, getCurrentSpriteIndex, props]);
+
+    const handleSelectTarget = useCallback(targetId => {
+        if (props.onDismissBubble) props.onDismissBubble();
+        props.onSelectTarget(targetId);
+        setCommandValue('');
+        setShowDropdown(false);
+    }, [props]);
+
+    const handleCommandChange = useCallback(e => {
+        const value = e.target.value;
+        setCommandValue(value);
+
+        if (value.startsWith('>')) {
+            setShowDropdown(false);
+        } else {
+            const allTargets = getAllTargets();
+            const filtered = allTargets.filter(target => {
+                const name = getTargetName(target).toLowerCase();
+                return name.includes(value.toLowerCase());
+            });
+            setShowDropdown(value.length > 0 && filtered.length > 0);
+            setFilteredTargets(filtered);
+        }
+    }, [getAllTargets, getTargetName]);
+
+    const handleCommandFocus = useCallback(() => {
+        if (commandValue && !commandValue.startsWith('>')) {
+            const allTargets = getAllTargets();
+            const filtered = allTargets.filter(target => {
+                const name = getTargetName(target).toLowerCase();
+                return name.includes(commandValue.toLowerCase());
+            });
+            setShowDropdown(filtered.length > 0);
+            setFilteredTargets(filtered);
+        }
+    }, [commandValue, getAllTargets, getTargetName]);
+
+    const handleCommandBlur = useCallback(() => {
+        setTimeout(() => {
+            setShowDropdown(false);
+        }, 200);
+    }, []);
+
+    const handleCommandKeyDown = useCallback(e => {
+        if (e.key === 'Escape') {
+            setCommandValue('');
+            setShowDropdown(false);
+            e.target.blur();
+        } else if (e.key === 'Enter' && !e.isComposing && filteredTargets.length > 0) {
+            handleSelectTarget(filteredTargets[0].id);
+        }
+    }, [filteredTargets, handleSelectTarget]);
+
+    const handleSelectTargetFromDropdown = useCallback(e => {
+        const targetId = e.currentTarget.dataset.targetId;
+        handleSelectTarget(targetId);
+    }, [handleSelectTarget]);
+
+    const canGoPrev = useCallback(() => {
+        if (props.editingTarget?.isStage) return false;
+        const currentIndex = getCurrentSpriteIndex();
+        return currentIndex >= 0;
+    }, [props.editingTarget, getCurrentSpriteIndex]);
+
+    const canGoNext = useCallback(() => {
+        const sprites = getSortedSprites();
+        if (sprites.length === 0) return false;
+        if (props.editingTarget?.isStage) return true;
+        const currentIndex = getCurrentSpriteIndex();
+        return currentIndex >= 0 && currentIndex < sprites.length - 1;
+    }, [getSortedSprites, props.editingTarget, getCurrentSpriteIndex]);
+
+    const highlightMatch = useCallback((text, query) => {
+        if (!query) return text;
+        const index = text.toLowerCase().indexOf(query.toLowerCase());
+        if (index === -1) return text;
+        return (
+            <>
+                {text.substring(0, index)}
+                <span className={styles.highlight}>
+                    {text.substring(index, index + query.length)}
+                </span>
+                {text.substring(index + query.length)}
+            </>
+        );
+    }, []);
+
+    return (
+        <>
+            <button
+                className={styles.iconButton}
+                onClick={handlePrevSprite}
+                disabled={!canGoPrev()}
+                aria-label={intl.formatMessage(messages.prevSprite)}
+                title={intl.formatMessage(messages.prevSprite)}
+            >
+                <img
+                    src={iconBack}
+                    alt=""
+                />
+            </button>
+            <button
+                className={styles.iconButton}
+                onClick={handleNextSprite}
+                disabled={!canGoNext()}
+                aria-label={intl.formatMessage(messages.nextSprite)}
+                title={intl.formatMessage(messages.nextSprite)}
+            >
+                <img
+                    src={iconForward}
+                    alt=""
+                />
+            </button>
+            <div className={styles.commandWrapper}>
+                <input
+                    className={styles.commandInput}
+                    type="text"
+                    value={commandValue}
+                    onChange={handleCommandChange}
+                    onFocus={handleCommandFocus}
+                    onBlur={handleCommandBlur}
+                    onKeyDown={handleCommandKeyDown}
+                    placeholder={intl.formatMessage(messages.commandPlaceholder)}
+                />
+                {showDropdown && (
+                    <div className={styles.dropdown}>
+                        {filteredTargets.map(target => (
+                            <div
+                                key={target.id}
+                                className={styles.dropdownItem}
+                                data-target-id={target.id}
+                                onMouseDown={handleSelectTargetFromDropdown}
+                            >
+                                {highlightMatch(getTargetName(target), commandValue)}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </>
+    );
+};
+
+TargetSelector.propTypes = {
+    editingTarget: PropTypes.object,
+    vm: PropTypes.instanceOf(VM).isRequired,
+    onSelectTarget: PropTypes.func.isRequired,
+    onDismissBubble: PropTypes.func
+};
+
+export default TargetSelector;

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -39,12 +39,14 @@ import {autoCorrect, defaultSettings as defaultAutoCorrectSettings} from '../lib
 import styles from './ruby-tab/ruby-tab.css';
 import {loadMonacoLocale} from '../lib/monaco-i18n-helper';
 import {getPrism, loadPrism} from '../lib/prism-parser';
-
-const FONT_SIZES = [8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 36, 40, 48];
-const DEFAULT_FONT_SIZE = 16;
-const FURIGANA_ENABLED_KEY = 'smalruby:furiganaEnabled';
-const AUTO_CORRECT_ENABLED_KEY = 'smalruby:autoCorrectEnabled';
-const AUTO_CORRECT_SETTINGS_KEY = 'smalruby:autoCorrectSettings';
+import {
+    FONT_SIZES,
+    DEFAULT_FONT_SIZE,
+    FURIGANA_ENABLED_KEY,
+    AUTO_CORRECT_ENABLED_KEY,
+    AUTO_CORRECT_SETTINGS_KEY
+} from './ruby-tab/constants';
+import updateDebugGlobals from './ruby-tab/debug-globals';
 
 class RubyTab extends React.Component {
     constructor (props) {
@@ -264,20 +266,10 @@ class RubyTab extends React.Component {
     }
 
     _updateDebugGlobals () {
-        if (!window.smalruby) window.smalruby = {};
-        const vm = this.props.vm;
-        window.smalruby.vm = vm;
-        if (vm.editingTarget) {
-            window.smalruby.sprite = vm.editingTarget;
-            window.smalruby.blocks = vm.editingTarget.blocks;
-            window.smalruby.comments = vm.editingTarget.comments;
-        }
-        window.smalruby.stage = vm.runtime ? vm.runtime.getTargetForStage() : null;
-        window.smalruby.runtime = vm.runtime;
-        window.smalruby.autoCorrect = {
+        updateDebugGlobals(this.props.vm, {
             enabled: this.state.autoCorrectEnabled,
             settings: this.state.autoCorrectSettings
-        };
+        });
     }
 
     clearErrors () {

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -49,6 +49,13 @@ import {
     AUTO_CORRECT_SETTINGS_KEY
 } from './ruby-tab/constants';
 import updateDebugGlobals from './ruby-tab/debug-globals';
+import {
+    clearDecoration,
+    highlightLine,
+    highlightLineRange,
+    findExecutableLine
+} from './ruby-tab/execution-highlighter';
+import {showBubble, dismissBubble, removeBubble} from './ruby-tab/visual-report-bubble';
 
 class RubyTab extends React.Component {
     constructor (props) {
@@ -233,11 +240,10 @@ class RubyTab extends React.Component {
         this.props.vm.removeListener('SCRIPT_GLOW_OFF', this.handleScriptGlowOff);
         this.props.vm.removeListener('VISUAL_REPORT', this.handleVisualReport);
         this.handleDismissBubble();
-        if (this.bubbleRef) {
-            document.body.removeChild(this.bubbleRef);
-            this.bubbleRef = null;
-        }
-        this.clearExecutingLineHighlight();
+        removeBubble(this.bubbleRef);
+        this.bubbleRef = null;
+        clearDecoration(this.executingLineDecoration);
+        this.executingLineDecoration = null;
         if (this.resizeObserver) {
             this.resizeObserver.disconnect();
         }
@@ -542,7 +548,8 @@ class RubyTab extends React.Component {
     handleScriptGlowOff (data) {
         if (this.state.runningBlockId === data.id) {
             this.setState({runningBlockId: null, executingLine: null});
-            this.clearExecutingLineHighlight();
+            clearDecoration(this.executingLineDecoration);
+            this.executingLineDecoration = null;
         }
     }
 
@@ -550,40 +557,11 @@ class RubyTab extends React.Component {
         if (this.props.activeTabIndex !== RUBY_TAB_INDEX) {
             return;
         }
-
-        const button = document.querySelector('button[aria-label*="カーソル行を実行"]') ||
-                       document.querySelector('button[aria-label*="Execute current line"]') ||
-                       document.querySelector('button[aria-label*="実行を停止"]') ||
-                       document.querySelector('button[aria-label*="Stop execution"]');
-        if (!button) {
-            return;
-        }
-
-        const rect = button.getBoundingClientRect();
-
-        if (!this.bubbleRef) {
-            this.bubbleRef = document.createElement('div');
-            this.bubbleRef.className = styles.valueReportBubble;
-            document.body.appendChild(this.bubbleRef);
-        }
-
-        this.bubbleRef.textContent = String(data.value);
-
-        const x = rect.right + 10;
-        const y = rect.top;
-
-        this.bubbleRef.style.left = `${x}px`;
-        this.bubbleRef.style.top = `${y}px`;
-
-        requestAnimationFrame(() => {
-            this.bubbleRef.classList.add(styles.visible);
-        });
+        this.bubbleRef = showBubble(this.bubbleRef, data.value);
     }
 
     handleDismissBubble () {
-        if (this.bubbleRef) {
-            this.bubbleRef.classList.remove(styles.visible);
-        }
+        dismissBubble(this.bubbleRef);
     }
 
     handleApplyGeminiCode (code) {
@@ -686,50 +664,18 @@ class RubyTab extends React.Component {
         }, delay);
     }
 
-    clearExecutingLineHighlight () {
-        if (this.executingLineDecoration) {
-            this.executingLineDecoration.clear();
-            this.executingLineDecoration = null;
-        }
-    }
-
     highlightExecutingLine (lineNumber) {
-        if (!this.editorRef || !this.monacoRef) {
-            return;
-        }
-
-        this.clearExecutingLineHighlight();
-
-        this.executingLineDecoration = this.editorRef.createDecorationsCollection([{
-            range: new this.monacoRef.Range(lineNumber, 1, lineNumber, 1),
-            options: {
-                isWholeLine: true,
-                className: 'executing-line'
-            }
-        }]);
-
-        // Scroll to the executing line
-        this.editorRef.revealLineInCenter(lineNumber);
+        if (!this.editorRef || !this.monacoRef) return;
+        this.executingLineDecoration = highlightLine(
+            this.editorRef, this.monacoRef, lineNumber, this.executingLineDecoration
+        );
     }
 
     highlightExecutingLineRange (startLine, endLine) {
-        if (!this.editorRef || !this.monacoRef) {
-            return;
-        }
-
-        this.clearExecutingLineHighlight();
-
-        this.executingLineDecoration = this.editorRef.createDecorationsCollection([{
-            range: new this.monacoRef.Range(startLine, 1, endLine, 1),
-            options: {
-                isWholeLine: true,
-                className: 'executing-line'
-            }
-        }]);
-
-        // Scroll to reveal the range (center on the middle line)
-        const middleLine = Math.floor((startLine + endLine) / 2);
-        this.editorRef.revealLineInCenter(middleLine);
+        if (!this.editorRef || !this.monacoRef) return;
+        this.executingLineDecoration = highlightLineRange(
+            this.editorRef, this.monacoRef, startLine, endLine, this.executingLineDecoration
+        );
     }
 
     async handleExecuteLine (lineNumber) {
@@ -747,20 +693,9 @@ class RubyTab extends React.Component {
 
         // Find the actual line to execute (skip empty lines)
         const rubyCode = this.props.rubyCode.code;
-        const lines = rubyCode.split('\n');
-        let targetLine = lineNumber;
+        const targetLine = findExecutableLine(rubyCode, lineNumber);
 
-        // If the current line is empty or whitespace-only, search upwards for a non-empty line
-        while (targetLine >= 1) {
-            const line = lines[targetLine - 1]; // Convert to 0-indexed
-            if (line && line.trim() !== '') {
-                break;
-            }
-            targetLine--;
-        }
-
-        // If no non-empty line found, cannot execute
-        if (targetLine < 1) {
+        if (!targetLine) {
             // eslint-disable-next-line no-console
             console.warn('[handleExecuteLine] No non-empty line found');
             this.props.onShowAlert('cannotExecuteLine');

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -1,6 +1,5 @@
-import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState, useRef, useCallback, useEffect} from 'react';
 import {injectIntl} from 'react-intl';
 import intlShape from '../lib/intlShape.js';
 import {connect} from 'react-redux';
@@ -57,819 +56,833 @@ import {
 } from './ruby-tab/execution-highlighter';
 import {showBubble, dismissBubble, removeBubble} from './ruby-tab/visual-report-bubble';
 
-class RubyTab extends React.Component {
-    constructor (props) {
-        super(props);
-        bindAll(this, [
-            'setContainerRef',
-            'handleEditorDidMount',
-            'handleEditorChange',
-            'handleZoomIn',
-            'handleZoomOut',
-            'handleZoomReset',
-            'getSaveToComputerHandler',
-            'getSaveAIHandler',
-            'handleAISaveFinished',
-            'handleAISaveError',
-            'handleSelectTarget',
-            'handleDownload',
-            'handleExecuteLine',
-            'handleScriptGlowOn',
-            'handleScriptGlowOff',
-            'handleVisualReport',
-            'handleDismissBubble',
-            'handleApplyGeminiCode',
-            'handleToggleFurigana',
-            'handleToggleAutoCorrect',
-            'handleOpenAutoCorrectSettings',
-            'handleCloseAutoCorrectSettings',
-            'handleAutoCorrectSettingChange',
-            'updateUndoRedoState'
-        ]);
-        this.mainTooltipId = 'ruby-downloader-tooltip';
-        this.editorRef = null;
-        this.monacoRef = null;
-        this.containerRef = null;
-        this.resizeObserver = null;
-        this.completionProvider = null;
-        this.lastProcessedVersion = props.rubyVersion;
-        this.downloadCallbackRef = null;
-        this.executingLineDecoration = null;
-        this.contentChangeListener = null;
-        this.pasteMutationObserver = null;
-        this.bodyMutationObserver = null;
-        this.bubbleRef = null;
-        this.quickFixProvider = new QuickFixProvider();
-        this.furiganaAnnotator = new FuriganaAnnotator();
-        this.furiganaRenderer = new FuriganaRenderer();
-        this.furiganaDebounceTimer = null;
-        this.furiganaLastMs = 0; // last measured render time, used for adaptive debounce
-        const savedFurigana = typeof window !== 'undefined' && window.localStorage ?
-            window.localStorage.getItem(FURIGANA_ENABLED_KEY) !== 'false' : true;
-        const savedAutoCorrect = typeof window !== 'undefined' && window.localStorage ?
-            window.localStorage.getItem(AUTO_CORRECT_ENABLED_KEY) !== 'false' : true;
-        let savedAutoCorrectSettings = defaultAutoCorrectSettings;
-        if (typeof window !== 'undefined' && window.localStorage) {
-            try {
-                const raw = window.localStorage.getItem(AUTO_CORRECT_SETTINGS_KEY);
-                if (raw) {
-                    savedAutoCorrectSettings = {
-                        ...defaultAutoCorrectSettings,
-                        ...JSON.parse(raw)
-                    };
-                }
-            } catch (_e) { /* use defaults */ }
-        }
-        this.state = {
-            runningBlockId: null,
-            executingLine: null,
-            canUndo: false,
-            canRedo: false,
-            furiganaEnabled: savedFurigana,
-            autoCorrectEnabled: savedAutoCorrect,
-            autoCorrectSettings: savedAutoCorrectSettings,
-            showAutoCorrectModal: false
-        };
+// === Initialization helpers ===
 
-        loadMonacoLocale(props.locale);
+const loadBool = (key, defaultVal) => {
+    if (typeof window !== 'undefined' && window.localStorage) {
+        return window.localStorage.getItem(key) !== 'false';
+    }
+    return defaultVal;
+};
+
+const loadAutoCorrectSettings = () => {
+    if (typeof window !== 'undefined' && window.localStorage) {
+        try {
+            const raw = window.localStorage.getItem(AUTO_CORRECT_SETTINGS_KEY);
+            if (raw) return {...defaultAutoCorrectSettings, ...JSON.parse(raw)};
+        } catch (_e) { /* use defaults */ }
+    }
+    return defaultAutoCorrectSettings;
+};
+
+// === Component ===
+
+const RubyTab = props => {
+    const {
+        vm, intl, rubyCode, rubyVersion, locale,
+        activeTabIndex, isVisible, editingTarget, blocksTabVisible,
+        onChange, updateRubyCodeErrorsState, updateRubyCodeTargetState,
+        targetCodeToBlocks: targetCodeToBlocksHOC,
+        onRevertRubyVersion, onShowAlert, onDismissAlert,
+        onRequestCloseFile, onProjectTelemetryEvent,
+        onSetAiSaveStatus, onClearAiSaveStatus,
+        onFontSizeChange, onMarkRubyTabUsed,
+        onOpenGeminiModal, onRegisterGeminiApply
+    } = props;
+
+    // --- State ---
+    const [runningBlockId, setRunningBlockId] = useState(null);
+    const [executingLine, setExecutingLine] = useState(null); // set by execution, read for future use
+    void executingLine;
+    const [canUndo, setCanUndo] = useState(false);
+    const [canRedo, setCanRedo] = useState(false);
+    const [furiganaEnabled, setFuriganaEnabled] = useState(
+        () => loadBool(FURIGANA_ENABLED_KEY, true)
+    );
+    const [autoCorrectEnabled, setAutoCorrectEnabled] = useState(
+        () => loadBool(AUTO_CORRECT_ENABLED_KEY, true)
+    );
+    const [autoCorrectSettings, setAutoCorrectSettings] = useState(loadAutoCorrectSettings);
+    const [showAutoCorrectModal, setShowAutoCorrectModal] = useState(false);
+
+    // --- Instance refs ---
+    const editorRef = useRef(null);
+    const monacoRef = useRef(null);
+    const containerRef = useRef(null);
+    const resizeObserverRef = useRef(null);
+    const completionProviderManagerRef = useRef(null);
+    const lastProcessedVersionRef = useRef(rubyVersion);
+    const downloadCallbackRef = useRef(null);
+    const executingLineDecorationRef = useRef(null);
+    const contentChangeListenerRef = useRef(null);
+    const configChangeListenerRef = useRef(null);
+    const pasteMutationObserverRef = useRef(null);
+    const bodyMutationObserverRef = useRef(null);
+    const bubbleElRef = useRef(null);
+    const quickFixProviderRef = useRef(null);
+    const furiganaAnnotatorRef = useRef(null);
+    const furiganaRendererRef = useRef(null);
+    const furiganaDebounceTimerRef = useRef(null);
+    const furiganaLastMsRef = useRef(0);
+    const isAutoCorrectUpdateRef = useRef(false);
+
+    // Lazy initialization of heavy objects
+    if (!quickFixProviderRef.current) quickFixProviderRef.current = new QuickFixProvider();
+    if (!furiganaAnnotatorRef.current) furiganaAnnotatorRef.current = new FuriganaAnnotator();
+    if (!furiganaRendererRef.current) furiganaRendererRef.current = new FuriganaRenderer();
+
+    // --- State/Props refs for stable callbacks ---
+    const runningBlockIdRef = useRef(runningBlockId);
+    runningBlockIdRef.current = runningBlockId;
+    const furiganaEnabledRef = useRef(furiganaEnabled);
+    furiganaEnabledRef.current = furiganaEnabled;
+    const autoCorrectEnabledRef = useRef(autoCorrectEnabled);
+    autoCorrectEnabledRef.current = autoCorrectEnabled;
+    const autoCorrectSettingsRef = useRef(autoCorrectSettings);
+    autoCorrectSettingsRef.current = autoCorrectSettings;
+    const activeTabIndexRef = useRef(activeTabIndex);
+    activeTabIndexRef.current = activeTabIndex;
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+    const intlRef = useRef(intl);
+    intlRef.current = intl;
+    const vmRef = useRef(vm);
+    vmRef.current = vm;
+    const onRegisterGeminiApplyRef = useRef(onRegisterGeminiApply);
+    onRegisterGeminiApplyRef.current = onRegisterGeminiApply;
+
+    // Load Monaco locale synchronously before first render
+    const localeLoadedRef = useRef(false);
+    if (!localeLoadedRef.current) {
+        loadMonacoLocale(locale);
+        localeLoadedRef.current = true;
     }
 
-    componentDidMount () {
-        this.props.vm.addListener('SCRIPT_GLOW_ON', this.handleScriptGlowOn);
-        this.props.vm.addListener('SCRIPT_GLOW_OFF', this.handleScriptGlowOff);
-        this.props.vm.addListener('VISUAL_REPORT', this.handleVisualReport);
+    // --- Helper functions ---
 
-        // Expose debug globals for Playwright MCP and browser console
-        window.smalruby = window.smalruby || {};
-        window.smalruby.vm = this.props.vm;
-        this._updateDebugGlobals();
-    }
+    const clearErrors = () => {
+        if (editorRef.current && monacoRef.current) {
+            monacoRef.current.editor.setModelMarkers(
+                editorRef.current.getModel(), 'smalruby', []
+            );
+            editorRef.current.trigger('source', 'closeMarkersNavigation');
+        }
+        if (rubyCode.errors.length > 0) {
+            updateRubyCodeErrorsState([]);
+        }
+        onDismissAlert('convertRubyToBlocksError');
+        onDismissAlert('rubyVersionChangeFailed');
+    };
 
-    componentDidUpdate (prevProps) {
-        if (this.props.rubyVersion !== prevProps.rubyVersion) {
-            if (this.props.rubyVersion === this.lastProcessedVersion) {
-                return;
-            }
-            this.handleRubyVersionChange(prevProps.rubyVersion, this.props.rubyVersion);
-        }
-
-        if (this.props.locale !== prevProps.locale) {
-            loadMonacoLocale(this.props.locale);
-        }
-
-        if (prevProps.activeTabIndex === RUBY_TAB_INDEX &&
-            this.props.activeTabIndex !== RUBY_TAB_INDEX) {
-            this.handleDismissBubble();
-        }
-
-        if (prevProps.isVisible && !this.props.isVisible) {
-            if (this.editorRef && this.monacoRef) {
-                this.clearErrors();
-            }
-        }
-
-        if (this.props.rubyCode.code !== prevProps.rubyCode.code && !this.props.rubyCode.modified) {
-            this.clearErrors();
-        }
-
-        if (this.props.rubyCode.errors !== prevProps.rubyCode.errors) {
-            this.showErrors(this.props.rubyCode.errors);
-        }
-
-        let modified = this.props.rubyCode.modified;
-        if (modified) {
-            const targetId = this.props.rubyCode.target ? this.props.rubyCode.target.id : null;
-            const changedTarget =
-                this.props.vm.editingTarget && this.props.rubyCode.target &&
-                  this.props.vm.editingTarget.id !== targetId;
-            if (changedTarget || this.props.blocksTabVisible) {
-                this.props.targetCodeToBlocks(this.props.intl).then(converter => {
-                    if (converter.result) {
-                        converter.apply().then(() => {
-                            modified = false;
-
-                            this.clearErrors();
-
-                            if (!modified) {
-                                const editingTargetChanged = this.props.editingTarget &&
-                                    this.props.editingTarget !== prevProps.editingTarget;
-                                if ((this.props.isVisible && !prevProps.isVisible) || editingTargetChanged) {
-                                    this.props.updateRubyCodeTargetState(
-                                        this.props.vm.editingTarget,
-                                        this.props.rubyVersion
-                                    );
-                                }
-                            }
-
-                            if (this.props.isVisible && !prevProps.isVisible) {
-                                if (this.editorRef) {
-                                    this.editorRef.focus();
-                                    this.editorRef.layout();
-                                }
-                            }
-                        });
-                        return;
-                    }
-                    this.showErrors(converter.errors);
-                });
-            }
-        }
-
-        if (!modified) {
-            const editingTargetChanged = this.props.editingTarget &&
-                this.props.editingTarget !== prevProps.editingTarget;
-            if ((this.props.isVisible && !prevProps.isVisible) || editingTargetChanged) {
-                this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, this.props.rubyVersion);
-            }
-        }
-
-        if (this.props.isVisible && !prevProps.isVisible) {
-            if (this.editorRef) {
-                this.editorRef.focus();
-                this.editorRef.layout();
-            }
-            // Mark Ruby tab as used for tutorial onboarding
-            this.props.onMarkRubyTabUsed();
-        }
-
-        this._updateDebugGlobals();
-    }
-
-    componentWillUnmount () {
-        this.props.vm.removeListener('SCRIPT_GLOW_ON', this.handleScriptGlowOn);
-        this.props.vm.removeListener('SCRIPT_GLOW_OFF', this.handleScriptGlowOff);
-        this.props.vm.removeListener('VISUAL_REPORT', this.handleVisualReport);
-        this.handleDismissBubble();
-        removeBubble(this.bubbleRef);
-        this.bubbleRef = null;
-        clearDecoration(this.executingLineDecoration);
-        this.executingLineDecoration = null;
-        if (this.resizeObserver) {
-            this.resizeObserver.disconnect();
-        }
-        if (this.completionProviderManager) {
-            this.completionProviderManager.dispose();
-            this.completionProviderManager = null;
-        }
-        if (this.contentChangeListener) {
-            this.contentChangeListener.dispose();
-            this.contentChangeListener = null;
-        }
-        if (this.configChangeListener) {
-            this.configChangeListener.dispose();
-            this.configChangeListener = null;
-        }
-        if (this.pasteMutationObserver) {
-            this.pasteMutationObserver.disconnect();
-            this.pasteMutationObserver = null;
-        }
-        if (this.bodyMutationObserver) {
-            this.bodyMutationObserver.disconnect();
-            this.bodyMutationObserver = null;
-        }
-        if (this.furiganaDebounceTimer) {
-            clearTimeout(this.furiganaDebounceTimer);
-            this.furiganaDebounceTimer = null;
-        }
-    }
-
-    _updateDebugGlobals () {
-        updateDebugGlobals(this.props.vm, {
-            enabled: this.state.autoCorrectEnabled,
-            settings: this.state.autoCorrectSettings
-        });
-    }
-
-    clearErrors () {
-        if (this.editorRef && this.monacoRef) {
-            this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', []);
-            // Close any active widgets (peek view, hover, etc.)
-            this.editorRef.trigger('source', 'closeMarkersNavigation');
-        }
-        if (this.props.rubyCode.errors.length > 0) {
-            this.props.updateRubyCodeErrorsState([]);
-        }
-        this.props.onDismissAlert('convertRubyToBlocksError');
-        this.props.onDismissAlert('rubyVersionChangeFailed');
-    }
-
-    showErrors (errors) {
-        if (this.editorRef && this.monacoRef) {
+    const showErrors = errors => {
+        if (editorRef.current && monacoRef.current) {
             const markers = errors.map(err => ({
                 startLineNumber: err.row + 1,
                 startColumn: err.column + 1,
                 endLineNumber: err.row + 1,
                 endColumn: (err.source ? err.column + err.source.length + 1 : 1000),
                 message: err.text,
-                severity: this.monacoRef.MarkerSeverity.Error
+                severity: monacoRef.current.MarkerSeverity.Error
             }));
-            this.monacoRef.editor.setModelMarkers(this.editorRef.getModel(), 'smalruby', markers);
+            monacoRef.current.editor.setModelMarkers(
+                editorRef.current.getModel(), 'smalruby', markers
+            );
             if (markers.length > 0) {
                 const error = errors[0];
-                this.editorRef.setPosition({lineNumber: error.row + 1, column: error.column + 1});
-                this.editorRef.focus();
-                this.editorRef.trigger('source', 'editor.action.marker.next');
-            }
-        }
-    }
-
-    async handleRubyVersionChange (oldVersion, newVersion) {
-        this.lastProcessedVersion = newVersion;
-        if (this.props.rubyCode.modified) {
-            const converter = await this.props.targetCodeToBlocks(this.props.intl);
-            if (converter.result) {
-                converter.apply().then(() => {
-                    this.clearErrors();
-                    this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
+                editorRef.current.setPosition({
+                    lineNumber: error.row + 1, column: error.column + 1
                 });
-            } else {
-                this.lastProcessedVersion = oldVersion;
-                this.props.onRevertRubyVersion(oldVersion);
-                this.props.onShowAlert('rubyVersionChangeFailed');
-                this.showErrors(converter.errors);
+                editorRef.current.focus();
+                editorRef.current.trigger('source', 'editor.action.marker.next');
             }
-        } else {
-            this.clearErrors();
-            this.props.updateRubyCodeTargetState(this.props.vm.editingTarget, newVersion);
         }
-    }
+    };
 
-    setContainerRef (ref) {
-        this.containerRef = ref;
-    }
+    const renderFurigana = () => {
+        if (!editorRef.current || !monacoRef.current) return;
+        const code = editorRef.current.getValue() || '';
+        const prism = getPrism();
+        if (prism) {
+            const t0 = performance.now();
+            const parseResult = prism.parse(code);
+            const annotations = furiganaAnnotatorRef.current.annotate(code, parseResult);
+            furiganaRendererRef.current.render(
+                editorRef.current, monacoRef.current, annotations
+            );
+            furiganaLastMsRef.current = performance.now() - t0;
+        } else {
+            loadPrism().then(loadedPrism => {
+                if (!furiganaEnabledRef.current) return;
+                if (!editorRef.current || !monacoRef.current) return;
+                const currentCode = editorRef.current.getValue() || '';
+                const t0 = performance.now();
+                const parseResult = loadedPrism.parse(currentCode);
+                const annotations = furiganaAnnotatorRef.current.annotate(
+                    currentCode, parseResult
+                );
+                furiganaRendererRef.current.render(
+                    editorRef.current, monacoRef.current, annotations
+                );
+                furiganaLastMsRef.current = performance.now() - t0;
+            });
+        }
+    };
 
-    handleEditorDidMount (editor, monaco) {
-        this.editorRef = editor;
-        this.monacoRef = monaco;
+    const scheduleFuriganaUpdate = () => {
+        if (furiganaDebounceTimerRef.current) {
+            clearTimeout(furiganaDebounceTimerRef.current);
+        }
+        const delay = Math.max(50, furiganaLastMsRef.current * 2);
+        furiganaDebounceTimerRef.current = setTimeout(() => {
+            furiganaDebounceTimerRef.current = null;
+            if (furiganaEnabledRef.current) {
+                renderFurigana();
+            }
+        }, delay);
+    };
 
+    const updateUndoRedoState = () => {
+        if (!editorRef.current) return;
+        const model = editorRef.current.getModel();
+        if (!model) return;
+        const undoRedoService = model._undoRedoService;
+        if (undoRedoService && typeof undoRedoService.canUndo === 'function') {
+            const resource = model.uri;
+            setCanUndo(undoRedoService.canUndo(resource));
+            setCanRedo(undoRedoService.canRedo(resource));
+        }
+    };
+
+    const doHighlightLine = lineNumber => {
+        if (!editorRef.current || !monacoRef.current) return;
+        executingLineDecorationRef.current = highlightLine(
+            editorRef.current, monacoRef.current,
+            lineNumber, executingLineDecorationRef.current
+        );
+    };
+
+    const doHighlightLineRange = (startLine, endLine) => {
+        if (!editorRef.current || !monacoRef.current) return;
+        executingLineDecorationRef.current = highlightLineRange(
+            editorRef.current, monacoRef.current,
+            startLine, endLine, executingLineDecorationRef.current
+        );
+    };
+
+    // --- Stable VM event handlers ---
+
+    const handleScriptGlowOn = useCallback(data => {
+        setRunningBlockId(data.id);
+    }, []);
+
+    const handleScriptGlowOff = useCallback(data => {
+        if (runningBlockIdRef.current === data.id) {
+            setRunningBlockId(null);
+            setExecutingLine(null);
+            clearDecoration(executingLineDecorationRef.current);
+            executingLineDecorationRef.current = null;
+        }
+    }, []);
+
+    const handleVisualReport = useCallback(data => {
+        if (activeTabIndexRef.current !== RUBY_TAB_INDEX) return;
+        bubbleElRef.current = showBubble(bubbleElRef.current, data.value);
+    }, []);
+
+    const handleDismissBubbleStable = useCallback(() => {
+        dismissBubble(bubbleElRef.current);
+    }, []);
+
+    const handleApplyGeminiCode = useCallback(code => {
+        onChangeRef.current(code);
+    }, []);
+
+    // --- Stable Editor callbacks ---
+
+    const handleEditorChange = useCallback(value => {
+        if (isAutoCorrectUpdateRef.current) {
+            isAutoCorrectUpdateRef.current = false;
+            onChangeRef.current(value);
+            return;
+        }
+        if (autoCorrectEnabledRef.current && editorRef.current) {
+            const corrected = autoCorrect(value, autoCorrectSettingsRef.current);
+            if (corrected !== value) {
+                isAutoCorrectUpdateRef.current = true;
+                const position = editorRef.current.getPosition();
+                const model = editorRef.current.getModel();
+                const beforeCursor = value.substring(
+                    0, model.getOffsetAt(position)
+                );
+                const correctedBeforeCursor = autoCorrect(
+                    beforeCursor, autoCorrectSettingsRef.current
+                );
+                const offsetDiff = beforeCursor.length - correctedBeforeCursor.length;
+                model.setValue(corrected);
+                const newOffset = model.getOffsetAt(position) - offsetDiff;
+                const newPosition = model.getPositionAt(
+                    Math.max(0, newOffset)
+                );
+                editorRef.current.setPosition(newPosition);
+                return;
+            }
+        }
+        onChangeRef.current(value);
+    }, []);
+
+    const handleEditorDidMount = useCallback((editor, monaco) => {
+        editorRef.current = editor;
+        monacoRef.current = monaco;
         window.monacoEditor = editor;
         window.monaco = monaco;
 
-        // Set up custom paste action and hide broken duplicate
-        const pasteLabel = this.props.intl.formatMessage({
+        const pasteLabel = intlRef.current.formatMessage({
             id: 'gui.rubyTab.paste',
             defaultMessage: 'Paste'
         });
         registerCustomPasteAction(editor, pasteLabel);
         const observers = setupPasteDuplicateHider();
-        this.pasteMutationObserver = observers.pasteMutationObserver;
-        this.bodyMutationObserver = observers.bodyMutationObserver;
+        pasteMutationObserverRef.current = observers.pasteMutationObserver;
+        bodyMutationObserverRef.current = observers.bodyMutationObserver;
 
-        // Register language, completion, and quick fix providers
-        this.completionProviderManager = registerLanguageAndProviders(
-            monaco, editor, this.props.vm,
-            this.quickFixProvider, this.completionProviderManager
+        completionProviderManagerRef.current = registerLanguageAndProviders(
+            monaco, editor, vmRef.current,
+            quickFixProviderRef.current, completionProviderManagerRef.current
         );
 
-        if (this.containerRef) {
-            this.resizeObserver = new ResizeObserver(() => {
+        if (containerRef.current) {
+            resizeObserverRef.current = new ResizeObserver(() => {
                 editor.layout();
             });
-            this.resizeObserver.observe(this.containerRef);
+            resizeObserverRef.current.observe(containerRef.current);
         }
 
-        this.contentChangeListener = editor.onDidChangeModelContent(() => {
-            this.updateUndoRedoState();
-            if (this.state.furiganaEnabled) {
-                this._scheduleFuriganaUpdate();
+        contentChangeListenerRef.current = editor.onDidChangeModelContent(() => {
+            updateUndoRedoState();
+            if (furiganaEnabledRef.current) {
+                scheduleFuriganaUpdate();
             }
         });
 
-        // Re-render furigana when editor font configuration changes (e.g. zoom)
-        this.configChangeListener = editor.onDidChangeConfiguration(e => {
+        configChangeListenerRef.current = editor.onDidChangeConfiguration(e => {
             if (e.hasChanged(monaco.editor.EditorOption.fontInfo)) {
-                if (this.state.furiganaEnabled) {
-                    this._renderFurigana();
+                if (furiganaEnabledRef.current) {
+                    renderFurigana();
                 }
             }
         });
 
-        // Restore furigana if it was enabled in the previous session
-        if (this.state.furiganaEnabled) {
-            this._renderFurigana();
+        if (furiganaEnabledRef.current) {
+            renderFurigana();
         }
 
         editor.onDidChangeCursorPosition(() => {
-            this.handleDismissBubble();
+            dismissBubble(bubbleElRef.current);
         });
 
         editor.onMouseDown(() => {
-            this.handleDismissBubble();
+            dismissBubble(bubbleElRef.current);
         });
 
-        this.updateUndoRedoState();
+        updateUndoRedoState();
 
-        // Register the apply callback with GeminiModalHOC
-        if (this.props.onRegisterGeminiApply) {
-            this.props.onRegisterGeminiApply(this.handleApplyGeminiCode);
+        if (onRegisterGeminiApplyRef.current) {
+            onRegisterGeminiApplyRef.current(handleApplyGeminiCode);
         }
-    }
+    }, [handleApplyGeminiCode]);
 
-    updateUndoRedoState () {
-        if (!this.editorRef) {
-            return;
-        }
+    // --- UI event handlers (useCallback for react/jsx-no-bind) ---
 
-        const model = this.editorRef.getModel();
-        if (!model) {
-            return;
-        }
-
-        // Access internal _undoRedoService to check undo/redo state
-        // Note: This uses private API which may change in future Monaco Editor versions
-        const undoRedoService = model._undoRedoService;
-        if (undoRedoService && typeof undoRedoService.canUndo === 'function') {
-            const resource = model.uri;
-            const canUndo = undoRedoService.canUndo(resource);
-            const canRedo = undoRedoService.canRedo(resource);
-
-            this.setState({
-                canUndo,
-                canRedo
-            });
-        }
-    }
-
-    handleEditorChange (value) {
-        if (this._isAutoCorrectUpdate) {
-            // Prevent infinite loop: this change was caused by auto-correct itself
-            this._isAutoCorrectUpdate = false;
-            this.props.onChange(value);
-            return;
-        }
-
-        if (this.state.autoCorrectEnabled && this.editorRef) {
-            const corrected = autoCorrect(value, this.state.autoCorrectSettings);
-            if (corrected !== value) {
-                // Apply corrected text while preserving cursor position
-                this._isAutoCorrectUpdate = true;
-                const position = this.editorRef.getPosition();
-                const model = this.editorRef.getModel();
-                // Calculate cursor offset adjustment
-                const beforeCursor = value.substring(
-                    0, model.getOffsetAt(position)
-                );
-                const correctedBeforeCursor = autoCorrect(
-                    beforeCursor, this.state.autoCorrectSettings
-                );
-                const offsetDiff = beforeCursor.length - correctedBeforeCursor.length;
-
-                // Use setValue to replace the entire content
-                model.setValue(corrected);
-
-                // Restore cursor position adjusted for character width changes
-                const newOffset = model.getOffsetAt(position) - offsetDiff;
-                const newPosition = model.getPositionAt(
-                    Math.max(0, newOffset)
-                );
-                this.editorRef.setPosition(newPosition);
-                return;
-            }
-        }
-
-        this.props.onChange(value);
-    }
-
-    handleZoomIn () {
-        const currentSize = this.props.rubyCode.fontSize || DEFAULT_FONT_SIZE;
+    const handleZoomIn = useCallback(() => {
+        const currentSize = rubyCode.fontSize || DEFAULT_FONT_SIZE;
         const nextSize = FONT_SIZES.find(s => s > currentSize);
-        if (nextSize) {
-            this.props.onFontSizeChange(nextSize);
-        }
-    }
+        if (nextSize) onFontSizeChange(nextSize);
+    }, [rubyCode.fontSize, onFontSizeChange]);
 
-    handleZoomOut () {
-        const currentSize = this.props.rubyCode.fontSize || DEFAULT_FONT_SIZE;
+    const handleZoomOut = useCallback(() => {
+        const currentSize = rubyCode.fontSize || DEFAULT_FONT_SIZE;
         const prevSize = FONT_SIZES.slice().reverse()
             .find(s => s < currentSize);
-        if (prevSize) {
-            this.props.onFontSizeChange(prevSize);
-        }
-    }
+        if (prevSize) onFontSizeChange(prevSize);
+    }, [rubyCode.fontSize, onFontSizeChange]);
 
-    handleZoomReset () {
-        this.props.onFontSizeChange(DEFAULT_FONT_SIZE);
-    }
+    const handleZoomReset = useCallback(() => {
+        onFontSizeChange(DEFAULT_FONT_SIZE);
+    }, [onFontSizeChange]);
 
-    getSaveToComputerHandler (downloadProjectCallback) {
-        return () => {
-            this.props.onRequestCloseFile();
+    const handleSelectTarget = useCallback(targetId => {
+        const target = vm.runtime.getTargetById(targetId);
+        if (target) vm.setEditingTarget(target.id);
+    }, [vm]);
+
+    const getSaveToComputerHandler = useCallback(
+        downloadProjectCallback => () => {
+            onRequestCloseFile();
             downloadProjectCallback();
-            if (this.props.onProjectTelemetryEvent) {
-                const metadata = collectMetadata(this.props.vm, this.props.projectTitle, this.props.locale);
-                this.props.onProjectTelemetryEvent('projectDidSave', metadata);
+            if (onProjectTelemetryEvent) {
+                const metadata = collectMetadata(
+                    vm, props.projectTitle, locale
+                );
+                onProjectTelemetryEvent('projectDidSave', metadata);
             }
-        };
-    }
+        },
+        [onRequestCloseFile, onProjectTelemetryEvent, vm, props.projectTitle, locale]
+    );
 
-    getSaveAIHandler (downloadProjectCallback) {
-        return () => {
-            // Set AI save status to 'saving'
-            this.props.onSetAiSaveStatus('saving');
-            // Call download callback
-            downloadProjectCallback();
-        };
-    }
-
-    handleAISaveFinished () {
-        // Set AI save status to 'saved'
-        this.props.onSetAiSaveStatus('saved');
-        // Clear status after 3 seconds
-        setTimeout(() => {
-            this.props.onClearAiSaveStatus();
-        }, 3000);
-    }
-
-    handleAISaveError () {
-        // Clear AI save status
-        this.props.onClearAiSaveStatus();
-    }
-
-    handleSelectTarget (targetId) {
-        // Set editing target in VM
-        const target = this.props.vm.runtime.getTargetById(targetId);
-        if (target) {
-            this.props.vm.setEditingTarget(target.id);
-        }
-    }
-
-    handleDownload () {
-        // Trigger Ruby code download
-        if (this.downloadCallbackRef) {
-            const handler = this.getSaveToComputerHandler(this.downloadCallbackRef);
+    const handleDownload = useCallback(() => {
+        if (downloadCallbackRef.current) {
+            const handler = getSaveToComputerHandler(downloadCallbackRef.current);
             handler();
         }
-    }
+    }, [getSaveToComputerHandler]);
 
-    handleScriptGlowOn (data) {
-        this.setState({runningBlockId: data.id});
-    }
+    const handleAISaveFinished = useCallback(() => {
+        onSetAiSaveStatus('saved');
+        setTimeout(() => {
+            onClearAiSaveStatus();
+        }, 3000);
+    }, [onSetAiSaveStatus, onClearAiSaveStatus]);
 
-    handleScriptGlowOff (data) {
-        if (this.state.runningBlockId === data.id) {
-            this.setState({runningBlockId: null, executingLine: null});
-            clearDecoration(this.executingLineDecoration);
-            this.executingLineDecoration = null;
-        }
-    }
+    const handleAISaveError = useCallback(() => {
+        onClearAiSaveStatus();
+    }, [onClearAiSaveStatus]);
 
-    handleVisualReport (data) {
-        if (this.props.activeTabIndex !== RUBY_TAB_INDEX) {
-            return;
-        }
-        this.bubbleRef = showBubble(this.bubbleRef, data.value);
-    }
+    const handleToggleFurigana = useCallback(() => {
+        setFuriganaEnabled(prev => {
+            const enabled = !prev;
+            if (typeof window !== 'undefined' && window.localStorage) {
+                window.localStorage.setItem(FURIGANA_ENABLED_KEY, enabled);
+            }
+            return enabled;
+        });
+    }, []);
 
-    handleDismissBubble () {
-        dismissBubble(this.bubbleRef);
-    }
-
-    handleApplyGeminiCode (code) {
-        this.props.onChange(code);
-    }
-
-    handleToggleAutoCorrect () {
-        const enabled = !this.state.autoCorrectEnabled;
-        if (typeof window !== 'undefined' && window.localStorage) {
-            window.localStorage.setItem(AUTO_CORRECT_ENABLED_KEY, enabled);
-        }
-        this.setState({autoCorrectEnabled: enabled});
-
-        // When turning ON, immediately apply auto-correct to current content
-        if (enabled && this.editorRef) {
-            const value = this.editorRef.getValue();
-            if (value) {
-                const corrected = autoCorrect(
-                    value, this.state.autoCorrectSettings
-                );
-                if (corrected !== value) {
-                    this._isAutoCorrectUpdate = true;
-                    const model = this.editorRef.getModel();
-                    model.setValue(corrected);
+    const handleToggleAutoCorrect = useCallback(() => {
+        setAutoCorrectEnabled(prev => {
+            const enabled = !prev;
+            if (typeof window !== 'undefined' && window.localStorage) {
+                window.localStorage.setItem(AUTO_CORRECT_ENABLED_KEY, enabled);
+            }
+            if (enabled && editorRef.current) {
+                const value = editorRef.current.getValue();
+                if (value) {
+                    const corrected = autoCorrect(
+                        value, autoCorrectSettingsRef.current
+                    );
+                    if (corrected !== value) {
+                        isAutoCorrectUpdateRef.current = true;
+                        const model = editorRef.current.getModel();
+                        model.setValue(corrected);
+                    }
                 }
             }
-        }
-    }
+            return enabled;
+        });
+    }, []);
 
-    handleOpenAutoCorrectSettings () {
-        this.setState({showAutoCorrectModal: true});
-    }
+    const handleOpenAutoCorrectSettings = useCallback(() => {
+        setShowAutoCorrectModal(true);
+    }, []);
 
-    handleCloseAutoCorrectSettings () {
-        this.setState({showAutoCorrectModal: false});
-    }
+    const handleCloseAutoCorrectSettings = useCallback(() => {
+        setShowAutoCorrectModal(false);
+    }, []);
 
-    handleAutoCorrectSettingChange (key, value) {
-        this.setState(prevState => {
-            const newSettings = {...prevState.autoCorrectSettings, [key]: value};
+    const handleAutoCorrectSettingChange = useCallback((key, value) => {
+        setAutoCorrectSettings(prev => {
+            const newSettings = {...prev, [key]: value};
             if (typeof window !== 'undefined' && window.localStorage) {
                 window.localStorage.setItem(
                     AUTO_CORRECT_SETTINGS_KEY,
                     JSON.stringify(newSettings)
                 );
             }
-            return {autoCorrectSettings: newSettings};
+            return newSettings;
         });
-    }
+    }, []);
 
-    handleToggleFurigana () {
-        const enabled = !this.state.furiganaEnabled;
-        if (typeof window !== 'undefined' && window.localStorage) {
-            window.localStorage.setItem(FURIGANA_ENABLED_KEY, enabled);
-        }
-        this.setState({furiganaEnabled: enabled}, () => {
-            if (!this.editorRef || !this.monacoRef) return;
-            if (enabled) {
-                this._renderFurigana();
+    const handleRubyVersionChange = async (oldVersion, newVersion) => {
+        lastProcessedVersionRef.current = newVersion;
+        if (rubyCode.modified) {
+            const converter = await targetCodeToBlocksHOC(intl);
+            if (converter.result) {
+                converter.apply().then(() => {
+                    clearErrors();
+                    updateRubyCodeTargetState(vm.editingTarget, newVersion);
+                });
             } else {
-                this.furiganaRenderer.clear(this.editorRef);
+                lastProcessedVersionRef.current = oldVersion;
+                onRevertRubyVersion(oldVersion);
+                onShowAlert('rubyVersionChangeFailed');
+                showErrors(converter.errors);
             }
-        });
-    }
-
-    _renderFurigana () {
-        if (!this.editorRef || !this.monacoRef) return;
-        const prism = getPrism();
-        if (prism) {
-            const code = this.props.rubyCode.code || '';
-            const t0 = performance.now();
-            const parseResult = prism.parse(code);
-            const annotations = this.furiganaAnnotator.annotate(code, parseResult);
-            this.furiganaRenderer.render(this.editorRef, this.monacoRef, annotations);
-            this.furiganaLastMs = performance.now() - t0;
         } else {
-            loadPrism().then(loadedPrism => {
-                if (!this.state.furiganaEnabled || !this.editorRef || !this.monacoRef) return;
-                const code = this.props.rubyCode.code || '';
-                const t0 = performance.now();
-                const parseResult = loadedPrism.parse(code);
-                const annotations = this.furiganaAnnotator.annotate(code, parseResult);
-                this.furiganaRenderer.render(this.editorRef, this.monacoRef, annotations);
-                this.furiganaLastMs = performance.now() - t0;
-            });
+            clearErrors();
+            updateRubyCodeTargetState(vm.editingTarget, newVersion);
         }
-    }
+    };
 
-    _scheduleFuriganaUpdate () {
-        if (this.furiganaDebounceTimer) {
-            clearTimeout(this.furiganaDebounceTimer);
-        }
-        // Wait 2x the last render time (minimum 50ms) so typing never races with rendering
-        const delay = Math.max(50, this.furiganaLastMs * 2);
-        this.furiganaDebounceTimer = setTimeout(() => {
-            this.furiganaDebounceTimer = null;
-            if (this.state.furiganaEnabled) {
-                this._renderFurigana();
-            }
-        }, delay);
-    }
-
-    highlightExecutingLine (lineNumber) {
-        if (!this.editorRef || !this.monacoRef) return;
-        this.executingLineDecoration = highlightLine(
-            this.editorRef, this.monacoRef, lineNumber, this.executingLineDecoration
-        );
-    }
-
-    highlightExecutingLineRange (startLine, endLine) {
-        if (!this.editorRef || !this.monacoRef) return;
-        this.executingLineDecoration = highlightLineRange(
-            this.editorRef, this.monacoRef, startLine, endLine, this.executingLineDecoration
-        );
-    }
-
-    async handleExecuteLine (lineNumber) {
-        // If already running, stop it
-        if (this.state.runningBlockId) {
-            this.props.vm.runtime.toggleScript(this.state.runningBlockId, {
-                target: this.props.vm.editingTarget,
+    const handleExecuteLine = useCallback(async lineNumber => {
+        if (runningBlockIdRef.current) {
+            vm.runtime.toggleScript(runningBlockIdRef.current, {
+                target: vm.editingTarget,
                 stackClick: true
             });
             return;
         }
 
-        // Clear any previous errors before starting a new execution
-        this.clearErrors();
+        clearErrors();
 
-        // Find the actual line to execute (skip empty lines)
-        const rubyCode = this.props.rubyCode.code;
-        const targetLine = findExecutableLine(rubyCode, lineNumber);
+        const code = rubyCode.code;
+        const targetLine = findExecutableLine(code, lineNumber);
 
         if (!targetLine) {
             // eslint-disable-next-line no-console
             console.warn('[handleExecuteLine] No non-empty line found');
-            this.props.onShowAlert('cannotExecuteLine');
+            onShowAlert('cannotExecuteLine');
             return;
         }
 
         const converter = await targetCodeToBlocks(
-            this.props.vm,
-            this.props.rubyCode.target,
-            rubyCode,
-            this.props.intl,
-            {version: this.props.rubyVersion}
+            vm, rubyCode.target, code, intl,
+            {version: rubyVersion}
         );
 
         if (!converter.result) {
-            this.props.onShowAlert('convertRubyToBlocksError');
-            this.props.updateRubyCodeErrorsState(converter.errors);
-            this.showErrors(converter.errors);
+            onShowAlert('convertRubyToBlocksError');
+            updateRubyCodeErrorsState(converter.errors);
+            showErrors(converter.errors);
             return;
         }
 
         converter.apply()
             .then(() => {
                 const blockId = converter.getBlockIdForLine(targetLine);
-
                 if (!blockId) {
                     // eslint-disable-next-line no-console
-                    console.warn(`[handleExecuteLine] No executable block found at line ${targetLine}`);
-                    this.props.onShowAlert('cannotExecuteLine');
+                    console.warn(
+                        `[handleExecuteLine] No executable block at line ${targetLine}`
+                    );
+                    onShowAlert('cannotExecuteLine');
                     return;
                 }
 
-                // Execute from top of block stack (like Scratch's behavior)
-                const topBlockId = this.props.vm.editingTarget.blocks.getTopLevelScript(blockId);
-
+                const topBlockId = vm.editingTarget.blocks.getTopLevelScript(blockId);
                 if (!topBlockId) {
                     // eslint-disable-next-line no-console
-                    console.warn(`[handleExecuteLine] Could not find top-level block for blockId ${blockId}`);
-                    this.props.onShowAlert('cannotExecuteLine');
+                    console.warn(
+                        `[handleExecuteLine] No top-level block for ${blockId}`
+                    );
+                    onShowAlert('cannotExecuteLine');
                     return;
                 }
 
-                const blocks = this.props.vm.editingTarget.blocks;
-                const lineRange = converter.getLineRangeForTopLevelScript(topBlockId, blocks);
+                const blocks = vm.editingTarget.blocks;
+                const lineRange = converter.getLineRangeForTopLevelScript(
+                    topBlockId, blocks
+                );
 
+                setExecutingLine(targetLine);
                 if (lineRange) {
-                    this.setState({executingLine: targetLine});
-                    this.highlightExecutingLineRange(lineRange.startLine, lineRange.endLine);
+                    doHighlightLineRange(lineRange.startLine, lineRange.endLine);
                 } else {
-                    // Fallback to single line highlight
-                    this.setState({executingLine: targetLine});
-                    this.highlightExecutingLine(targetLine);
+                    doHighlightLine(targetLine);
                 }
 
-                this.props.vm.runtime.toggleScript(topBlockId, {
-                    target: this.props.vm.editingTarget,
+                vm.runtime.toggleScript(topBlockId, {
+                    target: vm.editingTarget,
                     stackClick: true
                 });
             })
             .catch(error => {
                 // eslint-disable-next-line no-console
                 console.error('[handleExecuteLine] Apply error:', error);
-                this.props.onShowAlert('convertRubyToBlocksError');
+                onShowAlert('convertRubyToBlocksError');
             });
-    }
+    }, [vm, rubyCode, intl, rubyVersion, onShowAlert, updateRubyCodeErrorsState, onDismissAlert]);
 
-    render () {
-        const {
-            rubyCode,
-            vm
-        } = this.props;
-        const {
-            code,
-            fontSize
-        } = rubyCode;
+    const renderDownloaderChildren = useCallback((_, downloadProjectCallback) => {
+        downloadCallbackRef.current = downloadProjectCallback;
+        return null;
+    }, []);
 
-        return (
-            <>
-                <div
-                    ref={this.setContainerRef}
-                    className={styles.editorContainer}
-                >
-                    <RubyToolbar
-                        editingTarget={vm.editingTarget}
-                        vm={vm}
-                        editorRef={this.editorRef}
-                        onSelectTarget={this.handleSelectTarget}
-                        onDownload={this.handleDownload}
-                        onExecuteLine={this.handleExecuteLine}
-                        onDismissBubble={this.handleDismissBubble}
-                        onOpenGeminiModal={this.props.onOpenGeminiModal}
-                        isRunning={!!this.state.runningBlockId}
-                        canUndo={this.state.canUndo}
-                        canRedo={this.state.canRedo}
-                        furiganaEnabled={this.state.furiganaEnabled}
-                        onToggleFurigana={this.handleToggleFurigana}
-                        autoCorrectEnabled={this.state.autoCorrectEnabled}
-                        onToggleAutoCorrect={this.handleToggleAutoCorrect}
-                        onOpenAutoCorrectSettings={this.handleOpenAutoCorrectSettings}
+    // --- Effects ---
+
+    // Mount + Unmount
+    useEffect(() => {
+        vm.addListener('SCRIPT_GLOW_ON', handleScriptGlowOn);
+        vm.addListener('SCRIPT_GLOW_OFF', handleScriptGlowOff);
+        vm.addListener('VISUAL_REPORT', handleVisualReport);
+
+        window.smalruby = window.smalruby || {};
+        window.smalruby.vm = vm;
+        updateDebugGlobals(vm, {
+            enabled: autoCorrectEnabledRef.current,
+            settings: autoCorrectSettingsRef.current
+        });
+
+        return () => {
+            vm.removeListener('SCRIPT_GLOW_ON', handleScriptGlowOn);
+            vm.removeListener('SCRIPT_GLOW_OFF', handleScriptGlowOff);
+            vm.removeListener('VISUAL_REPORT', handleVisualReport);
+            dismissBubble(bubbleElRef.current);
+            removeBubble(bubbleElRef.current);
+            bubbleElRef.current = null;
+            clearDecoration(executingLineDecorationRef.current);
+            executingLineDecorationRef.current = null;
+            if (resizeObserverRef.current) resizeObserverRef.current.disconnect();
+            if (completionProviderManagerRef.current) {
+                completionProviderManagerRef.current.dispose();
+                completionProviderManagerRef.current = null;
+            }
+            if (contentChangeListenerRef.current) {
+                contentChangeListenerRef.current.dispose();
+                contentChangeListenerRef.current = null;
+            }
+            if (configChangeListenerRef.current) {
+                configChangeListenerRef.current.dispose();
+                configChangeListenerRef.current = null;
+            }
+            if (pasteMutationObserverRef.current) {
+                pasteMutationObserverRef.current.disconnect();
+                pasteMutationObserverRef.current = null;
+            }
+            if (bodyMutationObserverRef.current) {
+                bodyMutationObserverRef.current.disconnect();
+                bodyMutationObserverRef.current = null;
+            }
+            if (furiganaDebounceTimerRef.current) {
+                clearTimeout(furiganaDebounceTimerRef.current);
+                furiganaDebounceTimerRef.current = null;
+            }
+        };
+    }, [vm, handleScriptGlowOn, handleScriptGlowOff, handleVisualReport]);
+
+    // Locale change
+    useEffect(() => {
+        loadMonacoLocale(locale);
+    }, [locale]);
+
+    // Furigana toggle effect
+    useEffect(() => {
+        if (!editorRef.current || !monacoRef.current) return;
+        if (furiganaEnabled) {
+            renderFurigana();
+        } else {
+            furiganaRendererRef.current.clear(editorRef.current);
+        }
+    }, [furiganaEnabled]);
+
+    // componentDidUpdate equivalent
+    const prevPropsRef = useRef(null);
+    useEffect(() => {
+        const prev = prevPropsRef.current;
+        const savePrev = () => {
+            prevPropsRef.current = {
+                rubyVersion,
+                locale,
+                activeTabIndex,
+                isVisible,
+                editingTarget,
+                rubyCode,
+                blocksTabVisible
+            };
+        };
+
+        if (!prev) {
+            savePrev();
+            return;
+        }
+
+        // Ruby version change
+        if (rubyVersion !== prev.rubyVersion) {
+            if (rubyVersion === lastProcessedVersionRef.current) {
+                savePrev();
+                return;
+            }
+            handleRubyVersionChange(prev.rubyVersion, rubyVersion);
+        }
+
+        // Tab switch away → dismiss bubble
+        if (prev.activeTabIndex === RUBY_TAB_INDEX &&
+            activeTabIndex !== RUBY_TAB_INDEX) {
+            handleDismissBubbleStable();
+        }
+
+        // Visibility off → clear errors
+        if (prev.isVisible && !isVisible) {
+            if (editorRef.current && monacoRef.current) {
+                clearErrors();
+            }
+        }
+
+        // Code change (not modified) → clear errors
+        if (rubyCode.code !== prev.rubyCode.code && !rubyCode.modified) {
+            clearErrors();
+        }
+
+        // Error display
+        if (rubyCode.errors !== prev.rubyCode.errors) {
+            showErrors(rubyCode.errors);
+        }
+
+        // Modified → convert to blocks
+        let modified = rubyCode.modified;
+        if (modified) {
+            const targetId = rubyCode.target ? rubyCode.target.id : null;
+            const changedTarget = vm.editingTarget && rubyCode.target &&
+                vm.editingTarget.id !== targetId;
+            if (changedTarget || blocksTabVisible) {
+                targetCodeToBlocksHOC(intl).then(converter => {
+                    if (converter.result) {
+                        converter.apply().then(() => {
+                            modified = false;
+                            clearErrors();
+                            if (!modified) {
+                                const etChanged = editingTarget &&
+                                    editingTarget !== prev.editingTarget;
+                                if ((isVisible && !prev.isVisible) || etChanged) {
+                                    updateRubyCodeTargetState(
+                                        vm.editingTarget, rubyVersion
+                                    );
+                                }
+                            }
+                            if (isVisible && !prev.isVisible) {
+                                if (editorRef.current) {
+                                    editorRef.current.focus();
+                                    editorRef.current.layout();
+                                }
+                            }
+                        });
+                        return;
+                    }
+                    showErrors(converter.errors);
+                });
+            }
+        }
+
+        if (!modified) {
+            const etChanged = editingTarget &&
+                editingTarget !== prev.editingTarget;
+            if ((isVisible && !prev.isVisible) || etChanged) {
+                updateRubyCodeTargetState(vm.editingTarget, rubyVersion);
+            }
+        }
+
+        if (isVisible && !prev.isVisible) {
+            if (editorRef.current) {
+                editorRef.current.focus();
+                editorRef.current.layout();
+            }
+            onMarkRubyTabUsed();
+        }
+
+        updateDebugGlobals(vm, {
+            enabled: autoCorrectEnabled,
+            settings: autoCorrectSettings
+        });
+        savePrev();
+    });
+
+    // --- Render ---
+
+    const {code, fontSize} = rubyCode;
+
+    return (
+        <>
+            <div
+                ref={containerRef}
+                className={styles.editorContainer}
+            >
+                <RubyToolbar
+                    editingTarget={vm.editingTarget}
+                    vm={vm}
+                    editorRef={editorRef.current}
+                    onSelectTarget={handleSelectTarget}
+                    onDownload={handleDownload}
+                    onExecuteLine={handleExecuteLine}
+                    onDismissBubble={handleDismissBubbleStable}
+                    onOpenGeminiModal={onOpenGeminiModal}
+                    isRunning={!!runningBlockId}
+                    canUndo={canUndo}
+                    canRedo={canRedo}
+                    furiganaEnabled={furiganaEnabled}
+                    onToggleFurigana={handleToggleFurigana}
+                    autoCorrectEnabled={autoCorrectEnabled}
+                    onToggleAutoCorrect={handleToggleAutoCorrect}
+                    onOpenAutoCorrectSettings={handleOpenAutoCorrectSettings}
+                />
+                <div className={styles.editorWrapper}>
+                    <Editor
+                        key={locale}
+                        height="100%"
+                        language="smalruby"
+                        onMount={handleEditorDidMount}
+                        onChange={handleEditorChange}
+                        options={{
+                            fontSize: fontSize || DEFAULT_FONT_SIZE,
+                            fontFamily: 'Monaco, Menlo, Consolas, ' +
+                                '"source-code-pro", monospace',
+                            minimap: {enabled: false},
+                            renderWhitespace: 'all',
+                            scrollBeyondLastLine: true,
+                            tabSize: 2,
+                            fixedOverflowWidgets: true,
+                            wordBasedSuggestions: 'off',
+                            autoIndent: 'full'
+                        }}
+                        theme="vs"
+                        value={code}
+                        width="100%"
                     />
-                    <div className={styles.editorWrapper}>
-                        <Editor
-                            key={this.props.locale}
-                            height="100%"
-                            language="smalruby"
-                            onMount={this.handleEditorDidMount}
-                            onChange={this.handleEditorChange}
-                            options={{
-                                fontSize: fontSize || DEFAULT_FONT_SIZE,
-                                fontFamily: 'Monaco, Menlo, Consolas, "source-code-pro", monospace',
-                                minimap: {enabled: false},
-                                renderWhitespace: 'all',
-                                scrollBeyondLastLine: true,
-                                tabSize: 2,
-                                fixedOverflowWidgets: true,
-                                wordBasedSuggestions: 'off',
-                                autoIndent: 'full'
-                            }}
-                            theme="vs"
-                            value={code}
-                            width="100%"
-                        />
-                    </div>
                 </div>
-                {/* Hidden RubyDownloader for storing download callback */}
-                <RubyDownloader
-                    onSaveError={this.handleAISaveError}
-                    onSaveFinished={this.handleAISaveFinished}
+            </div>
+            {/* Hidden RubyDownloader for storing download callback */}
+            <RubyDownloader
+                onSaveError={handleAISaveError}
+                onSaveFinished={handleAISaveFinished}
+            >
+                {renderDownloaderChildren}
+            </RubyDownloader>
+            <div className={styles.zoomControlsWrapper}>
+                <button
+                    className={styles.zoomButton}
+                    onClick={handleZoomIn}
                 >
-                    {(_, downloadProjectCallback) => {
-                        this.downloadCallbackRef = downloadProjectCallback;
-                        return null;
-                    }}
-                </RubyDownloader>
-                <div className={styles.zoomControlsWrapper}>
-                    <button
-                        className={styles.zoomButton}
-                        onClick={this.handleZoomIn}
-                    >
-                        <img
-                            src="./static/blocks-media/default/zoom-in.svg"
-                            className={styles.zoomIcon}
-                        />
-                    </button>
-                    <button
-                        className={styles.zoomButton}
-                        onClick={this.handleZoomOut}
-                    >
-                        <img
-                            src="./static/blocks-media/default/zoom-out.svg"
-                            className={styles.zoomIcon}
-                        />
-                    </button>
-                    <button
-                        className={styles.zoomButton}
-                        onClick={this.handleZoomReset}
-                    >
-                        <img
-                            src="./static/blocks-media/default/zoom-reset.svg"
-                            className={styles.zoomIcon}
-                        />
-                    </button>
-                </div>
-                {this.state.showAutoCorrectModal && (
-                    <AutoCorrectModal
-                        settings={this.state.autoCorrectSettings}
-                        onSettingChange={this.handleAutoCorrectSettingChange}
-                        onRequestClose={this.handleCloseAutoCorrectSettings}
+                    <img
+                        src="./static/blocks-media/default/zoom-in.svg"
+                        className={styles.zoomIcon}
                     />
-                )}
-            </>
-        );
-    }
-}
+                </button>
+                <button
+                    className={styles.zoomButton}
+                    onClick={handleZoomOut}
+                >
+                    <img
+                        src="./static/blocks-media/default/zoom-out.svg"
+                        className={styles.zoomIcon}
+                    />
+                </button>
+                <button
+                    className={styles.zoomButton}
+                    onClick={handleZoomReset}
+                >
+                    <img
+                        src="./static/blocks-media/default/zoom-reset.svg"
+                        className={styles.zoomIcon}
+                    />
+                </button>
+            </div>
+            {showAutoCorrectModal && (
+                <AutoCorrectModal
+                    settings={autoCorrectSettings}
+                    onSettingChange={handleAutoCorrectSettingChange}
+                    onRequestClose={handleCloseAutoCorrectSettings}
+                />
+            )}
+        </>
+    );
+};
 
 RubyTab.propTypes = {
     blocksTabVisible: PropTypes.bool,

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -21,10 +21,12 @@ import {BLOCKS_TAB_INDEX, RUBY_TAB_INDEX} from '../reducers/editor-tab';
 import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
 import {targetCodeToBlocks} from '../lib/ruby-to-blocks-converter';
 
-import CompletionProviderManager from './ruby-tab/completion-provider-manager';
-import SnippetsCompleter from './ruby-tab/snippets-completer';
 import QuickFixProvider from './ruby-tab/quick-fix-provider';
-import {smalrubyLanguage, smalrubyLanguageConfiguration} from './ruby-tab/smalruby-mode';
+import {
+    registerCustomPasteAction,
+    setupPasteDuplicateHider,
+    registerLanguageAndProviders
+} from './ruby-tab/editor-setup';
 
 import RubyDownloader from './ruby-downloader.jsx';
 import RubyToolbar from '../components/ruby-toolbar/ruby-toolbar.jsx';
@@ -337,106 +339,21 @@ class RubyTab extends React.Component {
         window.monacoEditor = editor;
         window.monaco = monaco;
 
-        // Custom paste action for Monaco Editor v0.55.1 standalone environment
-        editor.addAction({
-            id: 'smalruby.paste',
-            label: this.props.intl.formatMessage({
-                id: 'gui.rubyTab.paste',
-                defaultMessage: 'Paste'
-            }),
-            contextMenuGroupId: '9_cutcopypaste',
-            contextMenuOrder: 4,
-            precondition: '!editorReadonly',
-            run: async ed => {
-                try {
-                    const text = await navigator.clipboard.readText();
-                    if (text) {
-                        ed.trigger('keyboard', 'type', {text});
-                    }
-                } catch (err) {
-                    // eslint-disable-next-line no-console
-                    console.error('Smalruby custom paste error:', err);
-                }
-            }
+        // Set up custom paste action and hide broken duplicate
+        const pasteLabel = this.props.intl.formatMessage({
+            id: 'gui.rubyTab.paste',
+            defaultMessage: 'Paste'
         });
+        registerCustomPasteAction(editor, pasteLabel);
+        const observers = setupPasteDuplicateHider();
+        this.pasteMutationObserver = observers.pasteMutationObserver;
+        this.bodyMutationObserver = observers.bodyMutationObserver;
 
-        // Hide original (broken) Paste action in Monaco Editor v0.55.1 context menu.
-        // Monaco renders context menus in a Shadow DOM (.shadow-root-host).
-        // The aria-label is on .action-label (child), NOT on .action-item itself.
-        // We use a MutationObserver to hide the broken original paste item each time
-        // the menu opens. We also call hideDuplicatePaste() immediately on setup because
-        // the shadow host may be created lazily (on first right-click), at which point
-        // menu items are already in the DOM before the observer starts watching.
-        const hideDuplicatePaste = shadowRoot => {
-            const pasteLabels = Array.from(shadowRoot.querySelectorAll(
-                '.action-label[aria-label="Paste"], .action-label[aria-label="貼り付け"]'
-            ));
-            if (pasteLabels.length >= 2) {
-                // Hide the first item (original broken Monaco paste action)
-                const firstPasteItem = pasteLabels[0].closest('.action-item');
-                if (firstPasteItem) {
-                    firstPasteItem.style.display = 'none';
-                }
-            }
-        };
-
-        const setupPasteMutationObserver = host => {
-            if (this.pasteMutationObserver) return;
-
-            this.pasteMutationObserver = new MutationObserver(() => {
-                hideDuplicatePaste(host.shadowRoot);
-            });
-            this.pasteMutationObserver.observe(host.shadowRoot, {
-                childList: true,
-                subtree: true
-            });
-
-            // Run immediately in case menu items are already in the DOM
-            // (this happens when the shadow host is created on first right-click,
-            // at which point all items are added before our observer starts watching)
-            hideDuplicatePaste(host.shadowRoot);
-        };
-
-        const shadowRootHost = document.querySelector('.shadow-root-host');
-        if (shadowRootHost && shadowRootHost.shadowRoot) {
-            setupPasteMutationObserver(shadowRootHost);
-        } else {
-            this.bodyMutationObserver = new MutationObserver(() => {
-                const host = document.querySelector('.shadow-root-host');
-                if (host && host.shadowRoot) {
-                    setupPasteMutationObserver(host);
-                    this.bodyMutationObserver.disconnect();
-                    this.bodyMutationObserver = null;
-                }
-            });
-            this.bodyMutationObserver.observe(document.body, {
-                childList: true,
-                subtree: true
-            });
-        }
-
-        // Register Smalruby language
-        monaco.languages.register({id: 'smalruby'});
-        monaco.languages.setMonarchTokensProvider('smalruby', smalrubyLanguage);
-        monaco.languages.setLanguageConfiguration('smalruby', smalrubyLanguageConfiguration);
-
-        if (!this.completionProviderManager) {
-            this.completionProviderManager = new CompletionProviderManager();
-            const completer = new SnippetsCompleter(this.props.vm);
-            this.completionProviderManager.register(monaco, 'smalruby', {
-                provideCompletionItems: (model, position, context, token) => (
-                    completer.provideCompletionItems(model, position, context, token, monaco)
-                )
-            });
-        }
-
-        // Register quick fix provider for conversion errors
-        this.quickFixProvider.setVM(this.props.vm);
-        monaco.languages.registerCodeActionProvider('smalruby', {
-            provideCodeActions: (model, range, ctx, token) => (
-                this.quickFixProvider.provideCodeActions(model, range, ctx, token)
-            )
-        });
+        // Register language, completion, and quick fix providers
+        this.completionProviderManager = registerLanguageAndProviders(
+            monaco, editor, this.props.vm,
+            this.quickFixProvider, this.completionProviderManager
+        );
 
         if (this.containerRef) {
             this.resizeObserver = new ResizeObserver(() => {

--- a/packages/scratch-gui/src/containers/ruby-tab/constants.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/constants.js
@@ -1,0 +1,15 @@
+// === Smalruby: This file is Smalruby-specific (Ruby tab constants) ===
+
+const FONT_SIZES = [8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 36, 40, 48];
+const DEFAULT_FONT_SIZE = 16;
+const FURIGANA_ENABLED_KEY = 'smalruby:furiganaEnabled';
+const AUTO_CORRECT_ENABLED_KEY = 'smalruby:autoCorrectEnabled';
+const AUTO_CORRECT_SETTINGS_KEY = 'smalruby:autoCorrectSettings';
+
+export {
+    FONT_SIZES,
+    DEFAULT_FONT_SIZE,
+    FURIGANA_ENABLED_KEY,
+    AUTO_CORRECT_ENABLED_KEY,
+    AUTO_CORRECT_SETTINGS_KEY
+};

--- a/packages/scratch-gui/src/containers/ruby-tab/debug-globals.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/debug-globals.js
@@ -1,0 +1,21 @@
+// === Smalruby: This file is Smalruby-specific (debug globals for Playwright MCP) ===
+
+/**
+ * Update window.smalruby debug globals for browser console and Playwright MCP.
+ * @param {object} vm - The Scratch VM instance.
+ * @param {object} autoCorrectState - { enabled, settings } for auto-correct.
+ */
+const updateDebugGlobals = (vm, autoCorrectState) => {
+    if (!window.smalruby) window.smalruby = {};
+    window.smalruby.vm = vm;
+    if (vm.editingTarget) {
+        window.smalruby.sprite = vm.editingTarget;
+        window.smalruby.blocks = vm.editingTarget.blocks;
+        window.smalruby.comments = vm.editingTarget.comments;
+    }
+    window.smalruby.stage = vm.runtime ? vm.runtime.getTargetForStage() : null;
+    window.smalruby.runtime = vm.runtime;
+    window.smalruby.autoCorrect = autoCorrectState;
+};
+
+export default updateDebugGlobals;

--- a/packages/scratch-gui/src/containers/ruby-tab/editor-setup.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/editor-setup.js
@@ -1,0 +1,132 @@
+// === Smalruby: This file is Smalruby-specific (Monaco editor setup for Ruby tab) ===
+
+import CompletionProviderManager from './completion-provider-manager';
+import SnippetsCompleter from './snippets-completer';
+import {smalrubyLanguage, smalrubyLanguageConfiguration} from './smalruby-mode';
+
+/**
+ * Register a custom paste action that uses the Clipboard API.
+ * Monaco Editor v0.55.1 standalone has a broken built-in paste action.
+ * @param {object} editor - Monaco editor instance.
+ * @param {string} pasteLabel - Localized label for the paste action.
+ */
+const registerCustomPasteAction = (editor, pasteLabel) => {
+    editor.addAction({
+        id: 'smalruby.paste',
+        label: pasteLabel,
+        contextMenuGroupId: '9_cutcopypaste',
+        contextMenuOrder: 4,
+        precondition: '!editorReadonly',
+        run: async ed => {
+            try {
+                const text = await navigator.clipboard.readText();
+                if (text) {
+                    ed.trigger('keyboard', 'type', {text});
+                }
+            } catch (err) {
+                // eslint-disable-next-line no-console
+                console.error('Smalruby custom paste error:', err);
+            }
+        }
+    });
+};
+
+/**
+ * Hide the original (broken) Paste action in Monaco Editor v0.55.1 context menu.
+ * Monaco renders context menus in a Shadow DOM (.shadow-root-host).
+ * Returns MutationObserver references for cleanup.
+ * @returns {{ pasteMutationObserver: MutationObserver|null, bodyMutationObserver: MutationObserver|null }} Observer refs for cleanup.
+ */
+const setupPasteDuplicateHider = () => {
+    let pasteMutationObserver = null;
+    let bodyMutationObserver = null;
+
+    const hideDuplicatePaste = shadowRoot => {
+        const pasteLabels = Array.from(shadowRoot.querySelectorAll(
+            '.action-label[aria-label="Paste"], .action-label[aria-label="貼り付け"]'
+        ));
+        if (pasteLabels.length >= 2) {
+            const firstPasteItem = pasteLabels[0].closest('.action-item');
+            if (firstPasteItem) {
+                firstPasteItem.style.display = 'none';
+            }
+        }
+    };
+
+    const setupObserver = host => {
+        if (pasteMutationObserver) return;
+
+        pasteMutationObserver = new MutationObserver(() => {
+            hideDuplicatePaste(host.shadowRoot);
+        });
+        pasteMutationObserver.observe(host.shadowRoot, {
+            childList: true,
+            subtree: true
+        });
+        hideDuplicatePaste(host.shadowRoot);
+    };
+
+    const shadowRootHost = document.querySelector('.shadow-root-host');
+    if (shadowRootHost && shadowRootHost.shadowRoot) {
+        setupObserver(shadowRootHost);
+    } else {
+        bodyMutationObserver = new MutationObserver(() => {
+            const host = document.querySelector('.shadow-root-host');
+            if (host && host.shadowRoot) {
+                setupObserver(host);
+                bodyMutationObserver.disconnect();
+                bodyMutationObserver = null;
+            }
+        });
+        bodyMutationObserver.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    }
+
+    return {pasteMutationObserver, bodyMutationObserver};
+};
+
+/**
+ * Register the Smalruby language mode, completion provider, and quick fix provider.
+ * @param {object} monaco - Monaco namespace.
+ * @param {object} editor - Monaco editor instance.
+ * @param {object} vm - Scratch VM instance.
+ * @param {object} quickFixProvider - QuickFixProvider instance.
+ * @param {object|null} existingManager - Existing CompletionProviderManager to reuse.
+ * @returns {object} CompletionProviderManager instance.
+ */
+const registerLanguageAndProviders = (monaco, editor, vm, quickFixProvider, existingManager) => {
+    // Register Smalruby language
+    monaco.languages.register({id: 'smalruby'});
+    monaco.languages.setMonarchTokensProvider('smalruby', smalrubyLanguage);
+    monaco.languages.setLanguageConfiguration('smalruby', smalrubyLanguageConfiguration);
+
+    // Set up completion provider
+    let completionProviderManager = existingManager;
+    if (!completionProviderManager) {
+        completionProviderManager = new CompletionProviderManager();
+        const completer = new SnippetsCompleter(vm);
+        completionProviderManager.register(monaco, 'smalruby', {
+            provideCompletionItems: (model, position, context, token) => (
+                completer.provideCompletionItems(model, position, context, token, monaco)
+            )
+        });
+    }
+
+    // Register quick fix provider for conversion errors
+    quickFixProvider.setVM(vm);
+    monaco.languages.registerCodeActionProvider('smalruby', {
+        provideCodeActions: (model, range, ctx, token) => (
+            quickFixProvider.provideCodeActions(model, range, ctx, token)
+        )
+    });
+
+    return completionProviderManager;
+};
+
+export {
+    registerCustomPasteAction,
+    setupPasteDuplicateHider,
+    registerLanguageAndProviders
+};

--- a/packages/scratch-gui/src/containers/ruby-tab/editor-setup.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/editor-setup.js
@@ -35,7 +35,8 @@ const registerCustomPasteAction = (editor, pasteLabel) => {
  * Hide the original (broken) Paste action in Monaco Editor v0.55.1 context menu.
  * Monaco renders context menus in a Shadow DOM (.shadow-root-host).
  * Returns MutationObserver references for cleanup.
- * @returns {{ pasteMutationObserver: MutationObserver|null, bodyMutationObserver: MutationObserver|null }} Observer refs for cleanup.
+ * @returns {object} Observer refs for cleanup:
+ *   { pasteMutationObserver: MutationObserver|null, bodyMutationObserver: MutationObserver|null }.
  */
 const setupPasteDuplicateHider = () => {
     let pasteMutationObserver = null;

--- a/packages/scratch-gui/src/containers/ruby-tab/execution-highlighter.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/execution-highlighter.js
@@ -1,0 +1,86 @@
+// === Smalruby: This file is Smalruby-specific (execution line highlighting) ===
+
+/**
+ * Clear an existing executing line decoration.
+ * @param {object|null} decoration - The decoration collection to clear.
+ */
+const clearDecoration = decoration => {
+    if (decoration) {
+        decoration.clear();
+    }
+};
+
+/**
+ * Highlight a single executing line in the editor.
+ * @param {object} editor - Monaco editor instance.
+ * @param {object} monaco - Monaco namespace.
+ * @param {number} lineNumber - The line number to highlight.
+ * @param {object|null} existingDecoration - Existing decoration to clear first.
+ * @returns {object} New decoration collection.
+ */
+const highlightLine = (editor, monaco, lineNumber, existingDecoration) => {
+    clearDecoration(existingDecoration);
+
+    const decoration = editor.createDecorationsCollection([{
+        range: new monaco.Range(lineNumber, 1, lineNumber, 1),
+        options: {
+            isWholeLine: true,
+            className: 'executing-line'
+        }
+    }]);
+
+    editor.revealLineInCenter(lineNumber);
+    return decoration;
+};
+
+/**
+ * Highlight a range of executing lines in the editor.
+ * @param {object} editor - Monaco editor instance.
+ * @param {object} monaco - Monaco namespace.
+ * @param {number} startLine - Start line number.
+ * @param {number} endLine - End line number.
+ * @param {object|null} existingDecoration - Existing decoration to clear first.
+ * @returns {object} New decoration collection.
+ */
+const highlightLineRange = (editor, monaco, startLine, endLine, existingDecoration) => {
+    clearDecoration(existingDecoration);
+
+    const decoration = editor.createDecorationsCollection([{
+        range: new monaco.Range(startLine, 1, endLine, 1),
+        options: {
+            isWholeLine: true,
+            className: 'executing-line'
+        }
+    }]);
+
+    const middleLine = Math.floor((startLine + endLine) / 2);
+    editor.revealLineInCenter(middleLine);
+    return decoration;
+};
+
+/**
+ * Find the nearest non-empty line at or above the given line number.
+ * @param {string} code - The full source code.
+ * @param {number} lineNumber - The starting line number (1-based).
+ * @returns {number|null} The line number of the nearest non-empty line, or null if none found.
+ */
+const findExecutableLine = (code, lineNumber) => {
+    const lines = code.split('\n');
+    let targetLine = lineNumber;
+
+    while (targetLine >= 1) {
+        const line = lines[targetLine - 1];
+        if (line && line.trim() !== '') {
+            return targetLine;
+        }
+        targetLine--;
+    }
+    return null;
+};
+
+export {
+    clearDecoration,
+    highlightLine,
+    highlightLineRange,
+    findExecutableLine
+};

--- a/packages/scratch-gui/src/containers/ruby-tab/visual-report-bubble.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/visual-report-bubble.js
@@ -1,0 +1,73 @@
+// === Smalruby: This file is Smalruby-specific (visual report bubble for line execution) ===
+
+import styles from './ruby-tab.css';
+
+/**
+ * Find the execute/stop button in the toolbar to anchor the bubble.
+ * @returns {Element|null} The button element.
+ */
+const findAnchorButton = () => (
+    document.querySelector('button[aria-label*="カーソル行を実行"]') ||
+    document.querySelector('button[aria-label*="Execute current line"]') ||
+    document.querySelector('button[aria-label*="実行を停止"]') ||
+    document.querySelector('button[aria-label*="Stop execution"]')
+);
+
+/**
+ * Show a visual report bubble next to the execute button.
+ * Creates the bubble DOM element if it doesn't exist yet.
+ * @param {HTMLElement|null} bubbleRef - Existing bubble element, or null to create new.
+ * @param {*} value - The value to display in the bubble.
+ * @returns {HTMLElement|null} The bubble element (possibly newly created), or null if no anchor.
+ */
+const showBubble = (bubbleRef, value) => {
+    const button = findAnchorButton();
+    if (!button) {
+        return bubbleRef;
+    }
+
+    const rect = button.getBoundingClientRect();
+    let bubble = bubbleRef;
+
+    if (!bubble) {
+        bubble = document.createElement('div');
+        bubble.className = styles.valueReportBubble;
+        document.body.appendChild(bubble);
+    }
+
+    bubble.textContent = String(value);
+    bubble.style.left = `${rect.right + 10}px`;
+    bubble.style.top = `${rect.top}px`;
+
+    requestAnimationFrame(() => {
+        bubble.classList.add(styles.visible);
+    });
+
+    return bubble;
+};
+
+/**
+ * Dismiss (hide) the visual report bubble.
+ * @param {HTMLElement|null} bubbleRef - The bubble element.
+ */
+const dismissBubble = bubbleRef => {
+    if (bubbleRef) {
+        bubbleRef.classList.remove(styles.visible);
+    }
+};
+
+/**
+ * Remove the bubble element from the DOM.
+ * @param {HTMLElement|null} bubbleRef - The bubble element.
+ */
+const removeBubble = bubbleRef => {
+    if (bubbleRef) {
+        document.body.removeChild(bubbleRef);
+    }
+};
+
+export {
+    showBubble,
+    dismissBubble,
+    removeBubble
+};

--- a/packages/scratch-gui/src/lib/furigana-annotator.js
+++ b/packages/scratch-gui/src/lib/furigana-annotator.js
@@ -1,3 +1,9 @@
+import {
+    RECEIVER_METHOD_LABELS,
+    TOPLEVEL_METHOD_LABELS,
+    TOPLEVEL_PROPERTY_LABELS
+} from './furigana-label-map';
+
 /**
  * Annotates Ruby source code with furigana (Japanese reading aids).
  *
@@ -35,6 +41,7 @@ class FuriganaAnnotator {
     /**
      * Build UTF-8 byte-based line offsets and a byteToChar mapping.
      * Prism gives byte offsets, but Monaco uses character (JS) columns.
+     * @param source
      */
     _buildMappings (source) {
         const encoder = new TextEncoder();
@@ -87,6 +94,7 @@ class FuriganaAnnotator {
     /**
      * Create a location spanning from the receiver's start to messageLoc's end.
      * Used for self.xxx so furigana starts above "self." instead of just "xxx".
+     * @param node
      */
     _receiverSpanLoc (node) {
         if (!node.receiver || !node.receiver.location || !node.messageLoc) return node.messageLoc;
@@ -340,338 +348,29 @@ class FuriganaAnnotator {
             }
 
             // ---- Operators and conversions (any receiver) ----
-            switch (name) {
-            case 'to_i':
-                this._addAnnotation(node.messageLoc, '整数化');
-                break;
-            case 'to_f':
-                this._addAnnotation(node.messageLoc, '浮動小数点数化');
-                break;
-            case 'to_s':
-                this._addAnnotation(node.messageLoc, '文字列化');
-                break;
-            case '+':
+            if (name === '+') {
                 this._addAnnotation(
                     node.messageLoc,
                     this._isStringType(node.receiver) ? '連結' : '足す'
                 );
-                break;
-            case '-':
-                this._addAnnotation(node.messageLoc, '引く');
-                break;
-            case '*':
-                this._addAnnotation(node.messageLoc, '掛ける');
-                break;
-            case '/':
-                this._addAnnotation(node.messageLoc, '割る');
-                break;
-            case '%':
-                this._addAnnotation(node.messageLoc, '余り');
-                break;
-            case '**':
-                this._addAnnotation(node.messageLoc, 'べき乗');
-                break;
-            case '+@':
-                this._addAnnotation(node.messageLoc, '正');
-                break;
-            case '-@':
-                this._addAnnotation(node.messageLoc, '負');
-                break;
-            case '<=':
-                this._addAnnotation(node.messageLoc, '以下');
-                break;
-            case '>=':
-                this._addAnnotation(node.messageLoc, '以上');
-                break;
-            case '<':
-                this._addAnnotation(node.messageLoc, '小さい');
-                break;
-            case '>':
-                this._addAnnotation(node.messageLoc, '大きい');
-                break;
-            case '==':
-                this._addAnnotation(node.messageLoc, '等しい');
-                break;
-            case '!=':
-                this._addAnnotation(node.messageLoc, '等しくない');
-                break;
-            case '!':
-                this._addAnnotation(node.messageLoc, 'ではない');
-                break;
-            // ---- Numeric / String methods ----
-            case 'round':
-                this._addAnnotation(node.messageLoc, '四捨五入');
-                break;
-            case 'abs':
-                this._addAnnotation(node.messageLoc, '絶対値');
-                break;
-            case 'floor':
-                this._addAnnotation(node.messageLoc, '切り捨て');
-                break;
-            case 'ceil':
-                this._addAnnotation(node.messageLoc, '切り上げ');
-                break;
-            case 'length':
-                this._addAnnotation(node.messageLoc, '長さ');
-                break;
-            case 'include?':
-                this._addAnnotation(node.messageLoc, '含むか');
-                break;
-            // ---- Control ----
-            case 'times':
-                this._addAnnotation(node.messageLoc, '回繰り返す');
-                break;
-            // ---- List operations ----
-            case 'push':
-                this._addAnnotation(node.messageLoc, '追加する');
-                break;
-            case 'delete_at':
-                this._addAnnotation(node.messageLoc, '削除する');
-                break;
-            case 'insert':
-                this._addAnnotation(node.messageLoc, '挿入する');
-                break;
-            case 'index':
-                this._addAnnotation(node.messageLoc, '検索する');
-                break;
-            case 'clear':
-                this._addAnnotation(node.messageLoc, '全削除する');
-                break;
-            default:
-                break;
+            } else if (RECEIVER_METHOD_LABELS[name]) {
+                this._addAnnotation(node.messageLoc, RECEIVER_METHOD_LABELS[name]);
             }
-        } else {
+        } else if (TOPLEVEL_METHOD_LABELS[name]) {
             // Top-level method calls (no receiver)
-            switch (name) {
-            // ---- Standard I/O (legacy) ----
-            case 'puts':
-            case 'print':
-                this._addAnnotation(node.messageLoc, '表示する');
-                break;
-            case 'gets':
-                this._addAnnotation(node.messageLoc, '入力する');
-                break;
-            case 'wait':
-                this._addAnnotation(node.messageLoc, '待つ');
-                break;
-            // ---- Motion ----
-            case 'move':
-                this._addAnnotation(node.messageLoc, '動かす');
-                break;
-            case 'turn_right':
-                this._addAnnotation(node.messageLoc, '右に回す');
-                break;
-            case 'turn_left':
-                this._addAnnotation(node.messageLoc, '左に回す');
-                break;
-            case 'go_to':
-                this._addAnnotation(node.messageLoc, '移動する');
-                break;
-            case 'glide':
-                this._annotateGlide(node);
-                break;
-            case 'point_towards':
-                this._addAnnotation(node.messageLoc, '向く');
-                break;
-            case 'bounce_if_on_edge':
-                this._addAnnotation(node.messageLoc, '端で跳ね返る');
-                break;
-            // ---- Motion property getters ----
-            case 'x':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, 'X座標');
-                break;
-            case 'y':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, 'Y座標');
-                break;
-            case 'direction':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, '向き');
-                break;
-            // ---- Looks ----
-            case 'say':
-                this._addAnnotation(node.messageLoc, '言う');
-                break;
-            case 'think':
-                this._addAnnotation(node.messageLoc, '考える');
-                break;
-            case 'switch_costume':
-                this._addAnnotation(node.messageLoc, 'コスチュームにする');
-                break;
-            case 'next_costume':
-                this._addAnnotation(node.messageLoc, '次のコスチュームにする');
-                break;
-            case 'switch_backdrop':
-                this._addAnnotation(node.messageLoc, '背景にする');
-                break;
-            case 'switch_backdrop_and_wait':
-                this._addAnnotation(node.messageLoc, '背景にして待つ');
-                break;
-            case 'next_backdrop':
-                this._addAnnotation(node.messageLoc, '次の背景にする');
-                break;
-            case 'set_effect':
-                this._addAnnotation(node.messageLoc, '画像効果を設定');
-                break;
-            case 'change_effect_by':
-                this._addAnnotation(node.messageLoc, '画像効果を変える');
-                break;
-            case 'clear_graphic_effects':
-                this._addAnnotation(node.messageLoc, '画像効果をなくす');
-                break;
-            case 'show':
-                this._addAnnotation(node.messageLoc, '表示する');
-                break;
-            case 'hide':
-                this._addAnnotation(node.messageLoc, '隠す');
-                break;
-            case 'go_to_layer':
-                this._annotateGoToLayer(node);
-                break;
-            case 'go_layers':
-                this._annotateGoLayers(node);
-                break;
-            // ---- Looks property getters ----
-            case 'costume_number':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, 'コスチューム番号');
-                break;
-            case 'costume_name':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, 'コスチューム名');
-                break;
-            case 'backdrop_number':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, '背景番号');
-                break;
-            case 'backdrop_name':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, '背景名');
-                break;
-            case 'size':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, '大きさ');
-                break;
-            // ---- Sound ----
-            case 'play':
-                this._addAnnotation(node.messageLoc, '音を鳴らす');
-                break;
-            case 'play_until_done':
-                this._addAnnotation(node.messageLoc, '音が終わるまで鳴らす');
-                break;
-            case 'stop_all_sounds':
-                this._addAnnotation(node.messageLoc, '音をすべて止める');
-                break;
-            case 'change_sound_effect_by':
-                this._addAnnotation(node.messageLoc, '音の効果を変える');
-                break;
-            case 'set_sound_effect':
-                this._addAnnotation(node.messageLoc, '音の効果を設定');
-                break;
-            case 'clear_sound_effects':
-                this._addAnnotation(node.messageLoc, '音の効果をなくす');
-                break;
-            case 'volume':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, '音量');
-                break;
-            // ---- Events ----
-            case 'when_flag_clicked':
-                this._addAnnotation(node.messageLoc, '旗が押されたとき');
-                break;
-            case 'when_key_pressed':
-                this._addAnnotation(node.messageLoc, 'キーが押されたとき');
-                break;
-            case 'when_clicked':
-                this._addAnnotation(node.messageLoc, 'クリックされたとき');
-                break;
-            case 'when_backdrop_switches':
-                this._addAnnotation(node.messageLoc, '背景が切り替わったとき');
-                break;
-            case 'when_greater_than':
-                this._annotateWhenGreaterThan(node);
-                break;
-            case 'when_receive':
-                this._addAnnotation(node.messageLoc, '受け取ったとき');
-                break;
-            case 'broadcast':
-                this._addAnnotation(node.messageLoc, '送る');
-                break;
-            case 'broadcast_and_wait':
-                this._addAnnotation(node.messageLoc, '送って待つ');
-                break;
-            // ---- Control ----
-            case 'sleep':
-                this._addAnnotation(node.messageLoc, '秒待つ');
-                break;
-            case 'loop':
-                this._addAnnotation(node.messageLoc, 'ずっと繰り返す');
-                break;
-            case 'stop':
-                this._addAnnotation(node.messageLoc, '止める');
-                break;
-            case 'create_clone':
-                this._addAnnotation(node.messageLoc, 'クローンを作る');
-                break;
-            case 'delete_this_clone':
-                this._addAnnotation(node.messageLoc, 'このクローンを削除');
-                break;
-            case 'when_start_as_a_clone':
-                this._addAnnotation(node.messageLoc, 'クローンされたとき');
-                break;
-            // ---- Sensing ----
-            case 'touching?':
-                this._addAnnotation(node.messageLoc, '触れているか');
-                break;
-            case 'touching_color?':
-                this._addAnnotation(node.messageLoc, '色に触れているか');
-                break;
-            case 'color_is_touching_color?':
-                this._addAnnotation(node.messageLoc, '色が色に触れているか');
-                break;
-            case 'distance':
-                this._addAnnotation(node.messageLoc, '距離');
-                break;
-            case 'ask':
-                this._addAnnotation(node.messageLoc, '質問する');
-                break;
-            case 'answer':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, '答え');
-                break;
-            case 'loudness':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, 'マイクの音量');
-                break;
-            case 'days_since_2000':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, '2000年からの日数');
-                break;
-            case 'user_name':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, 'ユーザー名');
-                break;
-            // ---- Operators ----
-            case 'rand':
-                this._addAnnotation(node.messageLoc, '乱数');
-                break;
-            // ---- Data ----
-            case 'show_variable':
-                this._addAnnotation(node.messageLoc, '変数を表示');
-                break;
-            case 'hide_variable':
-                this._addAnnotation(node.messageLoc, '変数を隠す');
-                break;
-            case 'show_list':
-                this._addAnnotation(node.messageLoc, 'リストを表示');
-                break;
-            case 'hide_list':
-                this._addAnnotation(node.messageLoc, 'リストを隠す');
-                break;
-            // ---- Music ----
-            case 'play_drum':
-                this._addAnnotation(node.messageLoc, 'ドラムを鳴らす');
-                break;
-            case 'rest':
-                this._annotateRest(node);
-                break;
-            case 'play_note':
-                this._addAnnotation(node.messageLoc, '音符を鳴らす');
-                break;
-            case 'tempo':
-                if (!node.arguments_) this._addAnnotation(node.messageLoc, 'テンポ');
-                break;
-            default:
-                break;
-            }
+            this._addAnnotation(node.messageLoc, TOPLEVEL_METHOD_LABELS[name]);
+        } else if (!node.arguments_ && TOPLEVEL_PROPERTY_LABELS[name]) {
+            this._addAnnotation(node.messageLoc, TOPLEVEL_PROPERTY_LABELS[name]);
+        } else if (name === 'glide') {
+            this._annotateGlide(node);
+        } else if (name === 'go_to_layer') {
+            this._annotateGoToLayer(node);
+        } else if (name === 'go_layers') {
+            this._annotateGoLayers(node);
+        } else if (name === 'when_greater_than') {
+            this._annotateWhenGreaterThan(node);
+        } else if (name === 'rest') {
+            this._annotateRest(node);
         }
 
         // Explicit child traversal

--- a/packages/scratch-gui/src/lib/furigana-label-map.js
+++ b/packages/scratch-gui/src/lib/furigana-label-map.js
@@ -1,0 +1,137 @@
+// === Smalruby: This file is Smalruby-specific (furigana label mappings) ===
+
+/**
+ * Simple method-name → furigana label mappings for operator/conversion calls
+ * (any receiver). Used by FuriganaAnnotator._handleCallNode.
+ */
+const RECEIVER_METHOD_LABELS = {
+    'to_i': '整数化',
+    'to_f': '浮動小数点数化',
+    'to_s': '文字列化',
+    '-': '引く',
+    '*': '掛ける',
+    '/': '割る',
+    '%': '余り',
+    '**': 'べき乗',
+    '+@': '正',
+    '-@': '負',
+    '<=': '以下',
+    '>=': '以上',
+    '<': '小さい',
+    '>': '大きい',
+    '==': '等しい',
+    '!=': '等しくない',
+    '!': 'ではない',
+    // Numeric / String methods
+    'round': '四捨五入',
+    'abs': '絶対値',
+    'floor': '切り捨て',
+    'ceil': '切り上げ',
+    'length': '長さ',
+    'include?': '含むか',
+    // Control
+    'times': '回繰り返す',
+    // List operations
+    'push': '追加する',
+    'delete_at': '削除する',
+    'insert': '挿入する',
+    'index': '検索する',
+    'clear': '全削除する'
+};
+
+/**
+ * Simple method-name → furigana label mappings for top-level calls
+ * (no receiver). Used by FuriganaAnnotator._handleCallNode.
+ */
+const TOPLEVEL_METHOD_LABELS = {
+    // Standard I/O
+    'puts': '表示する',
+    'print': '表示する',
+    'gets': '入力する',
+    'wait': '待つ',
+    // Motion
+    'move': '動かす',
+    'turn_right': '右に回す',
+    'turn_left': '左に回す',
+    'go_to': '移動する',
+    'point_towards': '向く',
+    'bounce_if_on_edge': '端で跳ね返る',
+    // Looks
+    'say': '言う',
+    'think': '考える',
+    'switch_costume': 'コスチュームにする',
+    'next_costume': '次のコスチュームにする',
+    'switch_backdrop': '背景にする',
+    'switch_backdrop_and_wait': '背景にして待つ',
+    'next_backdrop': '次の背景にする',
+    'set_effect': '画像効果を設定',
+    'change_effect_by': '画像効果を変える',
+    'clear_graphic_effects': '画像効果をなくす',
+    'show': '表示する',
+    'hide': '隠す',
+    // Sound
+    'play': '音を鳴らす',
+    'play_until_done': '音が終わるまで鳴らす',
+    'stop_all_sounds': '音をすべて止める',
+    'change_sound_effect_by': '音の効果を変える',
+    'set_sound_effect': '音の効果を設定',
+    'clear_sound_effects': '音の効果をなくす',
+    // Events
+    'when_flag_clicked': '旗が押されたとき',
+    'when_key_pressed': 'キーが押されたとき',
+    'when_clicked': 'クリックされたとき',
+    'when_backdrop_switches': '背景が切り替わったとき',
+    'when_receive': '受け取ったとき',
+    'broadcast': '送る',
+    'broadcast_and_wait': '送って待つ',
+    // Control
+    'sleep': '秒待つ',
+    'loop': 'ずっと繰り返す',
+    'stop': '止める',
+    'create_clone': 'クローンを作る',
+    'delete_this_clone': 'このクローンを削除',
+    'when_start_as_a_clone': 'クローンされたとき',
+    // Sensing
+    'touching?': '触れているか',
+    'touching_color?': '色に触れているか',
+    'color_is_touching_color?': '色が色に触れているか',
+    'distance': '距離',
+    'ask': '質問する',
+    // Operators
+    'rand': '乱数',
+    // Data
+    'show_variable': '変数を表示',
+    'hide_variable': '変数を隠す',
+    'show_list': 'リストを表示',
+    'hide_list': 'リストを隠す',
+    // Music
+    'play_drum': 'ドラムを鳴らす',
+    'play_note': '音符を鳴らす'
+};
+
+/**
+ * Property-getter method names that should only be annotated when
+ * called without arguments (no receiver version).
+ */
+const TOPLEVEL_PROPERTY_LABELS = {
+    x: 'X座標',
+    y: 'Y座標',
+    direction: '向き',
+    costume_number: 'コスチューム番号',
+    costume_name: 'コスチューム名',
+    backdrop_number: '背景番号',
+    backdrop_name: '背景名',
+    size: '大きさ',
+    volume: '音量',
+    answer: '答え',
+    loudness: 'マイクの音量',
+    days_since_2000: '2000年からの日数',
+    user_name: 'ユーザー名',
+    tempo: 'テンポ'
+};
+
+export {
+    RECEIVER_METHOD_LABELS,
+    TOPLEVEL_METHOD_LABELS,
+    TOPLEVEL_PROPERTY_LABELS
+};


### PR DESCRIPTION
## Summary

Ruby tab 関連コードのリファクタリング Phase 1〜5 + 関数コンポーネント化（#275）

各ファイルをおおむね300行以下に分割し、最終的に `ruby-tab.jsx` を関数コンポーネントに変換する。

## Implementation Steps

- [x] Phase 1: 定数・純粋ヘルパー・ツールバーメッセージの抽出
- [x] Phase 2: エディタセットアップロジックの抽出
- [x] Phase 3: 実行ハイライト・カーソル行実行の抽出
- [x] Phase 4: ターゲットセレクターの分離（ruby-toolbar）
- [x] Phase 5: ふりがなマッピングデータの分離
- [x] Phase 6: `ruby-tab.jsx` を関数コンポーネントに変換

## Current Line Counts

| File | Before | After |
|------|--------|-------|
| `ruby-tab.jsx` | 1088 → 932 | 878 (functional) |
| `ruby-toolbar.jsx` | 634 | 275 |
| `furigana-annotator.js` | 1058 | 755 |

## Test Plan

- [x] lint pass (all phases)
- [x] 関連ユニットテスト pass（auto-correct: 41, furigana-annotator: 224）
- [ ] CI pass
- [ ] Playwright MCP でデグレ確認

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

