### PR TITLE
feat: enhance face_sensing furigana with predefined extension receiver

### DIFF
--- a/packages/scratch-gui/src/lib/furigana-annotator.js
+++ b/packages/scratch-gui/src/lib/furigana-annotator.js
@@ -280,6 +280,11 @@ class FuriganaAnnotator {
         const unescaped = node.unescaped;
         const content = (unescaped && typeof unescaped === 'object') ?
             unescaped.value : unescaped;
+        // Check context-specific string label map first (e.g., face_sensing PART/DIRECTION)
+        if (this._stringLabelMap && this._stringLabelMap[content]) {
+            this._addAnnotation(node.location, this._stringLabelMap[content]);
+            return;
+        }
         const specialLabel = FuriganaAnnotator._SPECIAL_STRING_LABELS[content];
         this._addAnnotation(node.location, specialLabel || `文字列「${content}」`);
     }
@@ -332,15 +337,14 @@ class FuriganaAnnotator {
                     break;
                 }
             } else if (receiverType === 'CallNode') {
-                // ---- Chained calls: Time.now.xxx ----
-                const innerReceiver = node.receiver;
-                const innerReceiverType = typeof innerReceiver.toJSON === 'function' ?
-                    innerReceiver.toJSON().type : null;
-                // Check if it's Time.now chain: outer.name is year/month/etc,
-                // node.receiver is CallNode(name=now, receiver=ConstantReadNode(Time))
                 const innerName = node.receiver.name;
-                if (innerName === 'now') {
-                    const innerRec = node.receiver.receiver;
+                const innerRec = node.receiver.receiver;
+
+                if (!innerRec && innerName === 'face_sensing') {
+                    // ---- face_sensing.xxx (predefined extension receiver) ----
+                    this._annotateFaceSensingMethod(node, name);
+                } else if (innerName === 'now') {
+                    // ---- Chained calls: Time.now.xxx ----
                     const innerRecType = innerRec && typeof innerRec.toJSON === 'function' ?
                         innerRec.toJSON().type : null;
                     if (innerRecType === 'ConstantReadNode' && innerRec.name === 'Time') {
@@ -382,6 +386,8 @@ class FuriganaAnnotator {
             this._annotateWhenGreaterThan(node);
         } else if (name === 'rest') {
             this._annotateRest(node);
+        } else if (name === 'face_sensing') {
+            this._addAnnotation(node.messageLoc || node.location, '顔認識');
         }
 
         // Set unit context for literal arguments of specific methods
@@ -405,11 +411,19 @@ class FuriganaAnnotator {
 
         // Explicit child traversal
         if (node.receiver) this._walkNode(node.receiver);
+
+        // Set context-specific string label map for face_sensing PART/DIRECTION args
+        const fsStringMap = FuriganaAnnotator._FACE_SENSING_STRING_MAP[name];
+        if (fsStringMap && this._isFaceSensingReceiver(node)) {
+            this._stringLabelMap = fsStringMap;
+        }
+
         if (node.arguments_) {
             if (methodUnit) this._argUnit = methodUnit;
             node.arguments_.arguments_.forEach(arg => this._walkNode(arg));
             if (methodUnit) this._argUnit = null;
         }
+        if (this._stringLabelMap) this._stringLabelMap = null;
         if (node.block) this._walkNode(node.block);
     }
 
@@ -540,20 +554,32 @@ class FuriganaAnnotator {
         if (label) this._addAnnotation(node.messageLoc, label);
     }
 
+    _isFaceSensingReceiver (node) {
+        if (!node.receiver) return false;
+        const recType = typeof node.receiver.toJSON === 'function' ?
+            node.receiver.toJSON().type : null;
+        if (recType === 'LocalVariableReadNode' && node.receiver.name === 'face_sensing') return true;
+        if (recType === 'CallNode' && !node.receiver.receiver && node.receiver.name === 'face_sensing') {
+            return true;
+        }
+        return false;
+    }
+
     _annotateFaceSensingMethod (node, name) {
         const faceSensingLabels = {
-            'go_to': '～へ移動',
+            'go_to': '行く',
             'point_in_direction_of_face_tilt': '顔の傾きの方向を向く',
-            'set_size_to_face_size': '顔の大きさに合わせる',
+            'set_size_to_face_size': '大きさを顔の大きさにする',
             'when_face_tilted': '顔が傾いたとき',
-            'when_this_sprite_touch': '～に触れたとき',
+            'when_this_sprite_touch': '触れたとき',
             'when_face_detected': '顔が見つかったとき',
-            'face_detected?': '顔が見つかったか',
+            'face_detected?': '顔が見つかった',
             'face_tilt': '顔の傾き',
             'face_size': '顔の大きさ'
         };
         const fsLabel = faceSensingLabels[name];
         if (fsLabel) this._addAnnotation(node.messageLoc, fsLabel);
+
     }
 
     _annotateGlide (node) {
@@ -822,5 +848,43 @@ FuriganaAnnotator._SPECIAL_STRING_LABELS = {
     'brightness': '明るさ',
     'ghost': '幽霊'
 };
+
+/**
+ * Maps face_sensing method names to their context-specific string label maps.
+ * Only methods with PART or DIRECTION arguments are listed.
+ */
+FuriganaAnnotator._FACE_SENSING_STRING_MAP = {
+    go_to: null, // set below after PART_LABELS defined
+    when_this_sprite_touch: null,
+    when_face_tilted: null
+};
+
+/**
+ * Context-specific string labels for face_sensing PART menu arguments.
+ * Used via _stringLabelMap to avoid polluting global _SPECIAL_STRING_LABELS.
+ */
+FuriganaAnnotator._FACE_SENSING_PART_LABELS = {
+    nose: '鼻',
+    mouth: '口',
+    left_eye: '左目',
+    right_eye: '右目',
+    between_eyes: '両目の間',
+    left_ear: '左耳',
+    right_ear: '右耳',
+    top_of_head: '頭のてっぺん'
+};
+
+/**
+ * Context-specific string labels for face_sensing DIRECTION menu arguments.
+ */
+FuriganaAnnotator._FACE_SENSING_DIRECTION_LABELS = {
+    left: '左',
+    right: '右'
+};
+
+// Wire up the string map references after definitions
+FuriganaAnnotator._FACE_SENSING_STRING_MAP.go_to = FuriganaAnnotator._FACE_SENSING_PART_LABELS;
+FuriganaAnnotator._FACE_SENSING_STRING_MAP.when_this_sprite_touch = FuriganaAnnotator._FACE_SENSING_PART_LABELS;
+FuriganaAnnotator._FACE_SENSING_STRING_MAP.when_face_tilted = FuriganaAnnotator._FACE_SENSING_DIRECTION_LABELS;
 
 export default FuriganaAnnotator;

--- a/packages/scratch-gui/test/unit/lib/furigana-annotator.test.js
+++ b/packages/scratch-gui/test/unit/lib/furigana-annotator.test.js
@@ -708,39 +708,71 @@ describe('FuriganaAnnotator', () => {
         });
     });
 
-    describe('face_sensing methods (face_sensing local variable receiver)', () => {
-        test('face_sensing.go_to annotates as ～へ移動', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.go_to("nose")'), 2)).toContain('～へ移動');
+    describe('face_sensing methods (predefined extension receiver)', () => {
+        test('face_sensing.go_to("nose") annotates face_sensing as 顔認識, go_to as 行く, "nose" as 鼻', () => {
+            const labels = labelsAt(annotate('face_sensing.go_to("nose")'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('行く');
+            expect(labels).toContain('鼻');
+        });
+        test('face_sensing.go_to("left_eye") annotates "left_eye" as 左目', () => {
+            const labels = labelsAt(annotate('face_sensing.go_to("left_eye")'), 1);
+            expect(labels).toContain('左目');
+        });
+        test('face_sensing.go_to("top_of_head") annotates "top_of_head" as 頭のてっぺん', () => {
+            const labels = labelsAt(annotate('face_sensing.go_to("top_of_head")'), 1);
+            expect(labels).toContain('頭のてっぺん');
         });
         test('face_sensing.point_in_direction_of_face_tilt annotates as 顔の傾きの方向を向く', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.point_in_direction_of_face_tilt'), 2))
-                .toContain('顔の傾きの方向を向く');
+            const labels = labelsAt(annotate('face_sensing.point_in_direction_of_face_tilt'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('顔の傾きの方向を向く');
         });
-        test('face_sensing.set_size_to_face_size annotates as 顔の大きさに合わせる', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.set_size_to_face_size'), 2))
-                .toContain('顔の大きさに合わせる');
+        test('face_sensing.set_size_to_face_size annotates as 大きさを顔の大きさにする', () => {
+            const labels = labelsAt(annotate('face_sensing.set_size_to_face_size'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('大きさを顔の大きさにする');
         });
-        test('face_sensing.when_face_tilted annotates as 顔が傾いたとき', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.when_face_tilted("left") do; end'), 2))
-                .toContain('顔が傾いたとき');
+        test('face_sensing.when_face_tilted("left") annotates as 顔が傾いたとき with 左', () => {
+            const labels = labelsAt(annotate('face_sensing.when_face_tilted("left") do; end'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('顔が傾いたとき');
+            expect(labels).toContain('左');
         });
-        test('face_sensing.when_this_sprite_touch annotates as ～に触れたとき', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.when_this_sprite_touch("nose") do; end'), 2))
-                .toContain('～に触れたとき');
+        test('face_sensing.when_face_tilted("right") annotates "right" as 右', () => {
+            const labels = labelsAt(annotate('face_sensing.when_face_tilted("right") do; end'), 1);
+            expect(labels).toContain('右');
+        });
+        test('face_sensing.when_this_sprite_touch("nose") annotates as 触れたとき with 鼻', () => {
+            const labels = labelsAt(annotate('face_sensing.when_this_sprite_touch("nose") do; end'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('触れたとき');
+            expect(labels).toContain('鼻');
         });
         test('face_sensing.when_face_detected annotates as 顔が見つかったとき', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.when_face_detected do; end'), 2))
-                .toContain('顔が見つかったとき');
+            const labels = labelsAt(annotate('face_sensing.when_face_detected do; end'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('顔が見つかったとき');
         });
-        test('face_sensing.face_detected? annotates as 顔が見つかったか', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.face_detected?'), 2))
-                .toContain('顔が見つかったか');
+        test('face_sensing.face_detected? annotates as 顔が見つかった', () => {
+            const labels = labelsAt(annotate('face_sensing.face_detected?'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('顔が見つかった');
         });
         test('face_sensing.face_tilt annotates as 顔の傾き', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.face_tilt'), 2)).toContain('顔の傾き');
+            const labels = labelsAt(annotate('face_sensing.face_tilt'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('顔の傾き');
         });
         test('face_sensing.face_size annotates as 顔の大きさ', () => {
-            expect(labelsAt(annotate('face_sensing = 1\nface_sensing.face_size'), 2)).toContain('顔の大きさ');
+            const labels = labelsAt(annotate('face_sensing.face_size'), 1);
+            expect(labels).toContain('顔認識');
+            expect(labels).toContain('顔の大きさ');
+        });
+        test('PART string labels do not leak to non-face_sensing context', () => {
+            const labels = labelsAt(annotate('go_to("nose")'), 1);
+            expect(labels).not.toContain('鼻');
+            expect(labels).toContain('文字列「nose」');
         });
     });
 


### PR DESCRIPTION
## Summary

face_sensing拡張のふりがなを、事前定義された拡張機能レシーバーとして特別扱いするように改善します。

- `face_sensing` を変数定義なしで使えるように対応（prismではレシーバーなしのCallNodeとして解析）
- `face_sensing` 自体に「顔認識」のふりがなを付与
- メソッドラベルを命令ブロックのラベルに合わせて更新（`～へ移動` → `行く`、`顔の大きさに合わせる` → `大きさを顔の大きさにする` 等）
- PART引数（`"nose"` → `鼻`、`"left_eye"` → `左目` 等）とDIRECTION引数（`"left"` → `左`、`"right"` → `右`）のコンテキスト限定ラベルを追加

### ふりがな表示例

```ruby
# 顔認識        行く   鼻
  face_sensing.go_to("nose")
# 顔認識        顔が傾いたとき 左  以下の処理
  face_sensing.when_face_tilted("left") do
# ブロック終了
  end
```

## Changes Made

- `packages/scratch-gui/src/lib/furigana-annotator.js`
  - `_handleCallNode`: CallNode receiverの`face_sensing`検出を追加
  - no-receiver branchに`face_sensing` → `顔認識`を追加
  - `_isFaceSensingReceiver`: ヘルパー追加
  - `_annotateFaceSensingMethod`: ラベル更新
  - `_handleStringNode`: `_stringLabelMap`コンテキスト対応
  - `_FACE_SENSING_PART_LABELS`, `_FACE_SENSING_DIRECTION_LABELS`, `_FACE_SENSING_STRING_MAP`: 静的マップ追加
- `packages/scratch-gui/test/unit/lib/furigana-annotator.test.js`
  - 変数定義不要なテストに書き換え（13テスト）
  - PART/DIRECTIONラベル、リーク防止テスト追加

## Test Plan

- [x] 254 unit tests pass (furigana-annotator)
- [x] lint pass
- [ ] CI pass
- [ ] Playwright MCP で preview URL でのふりがな表示確認

Related: #279
