### PR TITLE
feat: 全拡張機能の Ruby ふりがな対応 + furigana-annotator 分割

### DIFF
--- a/packages/scratch-gui/docs/furigana-mapping.md
+++ b/packages/scratch-gui/docs/furigana-mapping.md
@@ -518,18 +518,19 @@ Ruby tab のふりがな機能（「ふ」ボタン）で表示されるふり�
 | `smalrubot_s1.set_motor_speed("left", 50)` | `スモウルボットS1` `モーター速度を設定` | 「左DCモーターの速度を50にする」 |
 | `smalrubot_s1.led("left", true)` | `スモウルボットS1` `LED設定` | 「左のLEDをオンにする」 |
 
-### 甲子園（Koshien拡張機能）
+### スモウルビー甲子園（Koshien拡張機能）
 
-`koshien` は事前定義レシーバー。レシーバー自体に `甲子園` のふりがなが付く。
+`koshien` は事前定義レシーバー。レシーバー自体に `スモウルビー甲子園` のふりがなが付く。
+座標引数 `"X:Y"` は動的に `x:X,y:Y` のふりがなが付く。
 
 | Ruby | ふりがな | Scratchブロック |
 | ------ | --------- | ------ |
-| `koshien`（レシーバー） | `甲子園` | — |
-| `koshien.connect_game(name: "player1")` | `甲子園` `ゲームに接続` | 「ゲームに接続する」 |
-| `koshien.move_to("0:0")` | `甲子園` `移動する` | 「移動する」 |
-| `koshien.turn_over` | `甲子園` `ターン終了` | 「ターン終了」 |
-| `koshien.calc_route(result: ...)` | `甲子園` `ルート計算` | 「ルート計算」 |
-| `koshien.map("0:0")` | `甲子園` `マップ` | 「マップ」 |
-| `koshien.map_all` | `甲子園` `全マップ` | 「全マップ」 |
-| `koshien.position(x, y)` | `甲子園` `座標` | 「座標」 |
-| `koshien.set_message("hello")` | `甲子園` `メッセージ設定` | 「メッセージ設定」 |
+| `koshien`（レシーバー） | `スモウルビー甲子園` | — |
+| `koshien.connect_game(name: "player1")` | `スモウルビー甲子園` `ゲームに接続` | 「ゲームに接続する」 |
+| `koshien.move_to("0:0")` | `スモウルビー甲子園` `移動する` `x:0,y:0` | 「移動する」 |
+| `koshien.turn_over` | `スモウルビー甲子園` `ターン終了` | 「ターン終了」 |
+| `koshien.calc_route(result: ...)` | `スモウルビー甲子園` `ルート計算` | 「ルート計算」 |
+| `koshien.map("1:2")` | `スモウルビー甲子園` `マップ` `x:1,y:2` | 「マップ」 |
+| `koshien.map_all` | `スモウルビー甲子園` `全マップ` | 「全マップ」 |
+| `koshien.position(x, y)` | `スモウルビー甲子園` `座標` | 「座標」 |
+| `koshien.set_message("hello")` | `スモウルビー甲子園` `メッセージ設定` | 「メッセージ設定」 |

--- a/packages/scratch-gui/docs/furigana-mapping.md
+++ b/packages/scratch-gui/docs/furigana-mapping.md
@@ -2,7 +2,7 @@
 
 Ruby tab のふりがな機能（「ふ」ボタン）で表示されるふりがなの対応表です。
 
-実装: `src/lib/furigana-annotator.js`
+実装: `src/lib/furigana-annotator.js`, `src/lib/furigana-extension-handlers.js`, `src/lib/furigana-call-helpers.js`, `src/lib/furigana-node-handlers.js`, `src/lib/furigana-label-map.js`
 
 ---
 
@@ -424,3 +424,112 @@ Ruby tab のふりがな機能（「ふ」ボタン）で表示されるふり�
 | `self.tempo = ...` | `テンポを設定` | 「テンポを...にする」 |
 | `self.tempo += ...` | `テンポを変える` | 「テンポを...ずつ変える」 |
 | `tempo`（ゲッター） | `テンポ` | 「テンポ」 |
+
+### 翻訳（Translate拡張機能）
+
+| Ruby | ふりがな | Scratchブロック |
+| ------ | --------- | ------ |
+| `translate("hello", "ja")` | `翻訳する` | 「helloをjaに翻訳する」 |
+| `language`（ゲッター） | `言語` | 「言語」 |
+
+### ビデオ（Video Sensing拡張機能）
+
+`video_sensing` は事前定義レシーバー。レシーバー自体に `ビデオ` のふりがなが付く。
+
+| Ruby | ふりがな | Scratchブロック |
+| ------ | --------- | ------ |
+| `video_sensing`（レシーバー） | `ビデオ` | — |
+| `video_sensing.when_video_motion_greater_than(n) do...end` | `ビデオ` `ビデオモーション ＞ のとき` `以下の処理` `ブロック終了` | 「ビデオモーション>nのとき」 |
+| `video_sensing.video_turn("on")` | `ビデオ` `ビデオを切り替える` `オン` | 「ビデオをオンにする」 |
+| `video_sensing.video_turn("off")` | `ビデオ` `ビデオを切り替える` `オフ` | 「ビデオをオフにする」 |
+| `video_sensing.video_turn("on-flipped")` | `ビデオ` `ビデオを切り替える` `左右反転` | 「ビデオを左右反転にする」 |
+| `video_sensing.video_transparency = n` | `ビデオ` `ビデオの透明度を設定` | 「ビデオの透明度をnにする」 |
+| `video_sensing.video_on("motion", "this sprite")` | `ビデオ` `ビデオの値` `動き` `このスプライト` | 「このスプライトのビデオの動き」 |
+
+### 音声合成（Text to Speech拡張機能）
+
+`text2speech` は事前定義レシーバー。レシーバー自体に `音声合成` のふりがなが付く。
+
+| Ruby | ふりがな | Scratchブロック |
+| ------ | --------- | ------ |
+| `text2speech`（レシーバー） | `音声合成` | — |
+| `text2speech.speak("hello")` | `音声合成` `話す` | 「helloと話す」 |
+| `text2speech.voice = "ALTO"` | `音声合成` `声を設定` | 「声をALTOにする」 |
+| `text2speech.language = "ja"` | `音声合成` `言語を設定` | 「言語をjaにする」 |
+
+### マイクロビット（micro:bit More拡張機能）
+
+`microbit` は事前定義レシーバー。レシーバー自体に `マイクロビット` のふりがなが付く。
+
+| Ruby | ふりがな | Scratchブロック |
+| ------ | --------- | ------ |
+| `microbit`（レシーバー） | `マイクロビット` | — |
+| `microbit.when_button_is("A", "down") do...end` | `マイクロビット` `ボタンのとき` `A` | 「ボタンAが押されたとき」 |
+| `microbit.button_pressed?("A")` | `マイクロビット` `ボタンが押されたか` `A` | 「ボタンAが押された」 |
+| `microbit.when("SHAKE") do...end` | `マイクロビット` `のとき` `振られた` | 「振られたとき」 |
+| `microbit.when_tilted("LEFT") do...end` | `マイクロビット` `傾いたとき` `左` | 「左に傾いたとき」 |
+| `microbit.tilted?("FRONT")` | `マイクロビット` `傾いているか` `前` | 「前に傾いた」 |
+| `microbit.tilt_angle("FRONT")` | `マイクロビット` `傾きの角度` `前` | 「前の傾きの角度」 |
+| `microbit.display_pattern(...)` | `マイクロビット` `LEDに表示` | 「LEDパターン表示」 |
+| `microbit.display_text("Hello!")` | `マイクロビット` `テキスト表示` | 「テキスト表示」 |
+| `microbit.clear_display` | `マイクロビット` `LED消去` | 「LED消去」 |
+| `microbit.light_intensity` | `マイクロビット` `明るさ` | 「明るさ」 |
+| `microbit.temperature` | `マイクロビット` `温度` | 「温度」 |
+| `microbit.sound_level` | `マイクロビット` `音の大きさ` | 「音の大きさ」 |
+| `microbit.acceleration("x")` | `マイクロビット` `加速度` `x` | 「x軸の加速度」 |
+| `microbit.magnetic_force("absolute")` | `マイクロビット` `磁力` `絶対値` | 「磁力の絶対値」 |
+| `microbit.play_tone(440, 100)` | `マイクロビット` `音を鳴らす` | 「音を鳴らす」 |
+| `microbit.stop_tone` | `マイクロビット` `音を止める` | 「音を止める」 |
+| `microbit.send_data_to_microbit(data, label)` | `マイクロビット` `データ送信` | 「データ送信」 |
+
+### メッシュ（Mesh拡張機能）
+
+`mesh` は事前定義レシーバー。レシーバー自体に `メッシュ` のふりがなが付く。
+
+| Ruby | ふりがな | Scratchブロック |
+| ------ | --------- | ------ |
+| `mesh`（レシーバー） | `メッシュ` | — |
+| `mesh.sensor_value("x")` | `メッシュ` `センサーの値` | 「xセンサーの値」 |
+
+### メッシュ・従来（Mesh V1拡張機能）
+
+`mesh_v1` は事前定義レシーバー。レシーバー自体に `メッシュ(従来)` のふりがなが付く。
+
+| Ruby | ふりがな | Scratchブロック |
+| ------ | --------- | ------ |
+| `mesh_v1`（レシーバー） | `メッシュ(従来)` | — |
+| `mesh_v1.sensor_value("x")` | `メッシュ(従来)` `センサーの値` | 「xセンサーの値」 |
+
+### スモウルボットS1（Smalrubot S1拡張機能）
+
+`smalrubot_s1` は事前定義レシーバー。レシーバー自体に `スモウルボットS1` のふりがなが付く。
+
+| Ruby | ふりがな | Scratchブロック |
+| ------ | --------- | ------ |
+| `smalrubot_s1`（レシーバー） | `スモウルボットS1` | — |
+| `smalrubot_s1.action("forward")` | `スモウルボットS1` `動作する` `進める` | 「進める」 |
+| `smalrubot_s1.action("backward")` | `スモウルボットS1` `動作する` `バックさせる` | 「バックさせる」 |
+| `smalrubot_s1.action("turnLeft")` | `スモウルボットS1` `動作する` `左に曲げる` | 「左に曲げる」 |
+| `smalrubot_s1.action("turnRight")` | `スモウルボットS1` `動作する` `右に曲げる` | 「右に曲げる」 |
+| `smalrubot_s1.action("stop")` | `スモウルボットS1` `動作する` `止める` | 「止める」 |
+| `smalrubot_s1.bend_arm(90, 1)` | `スモウルボットS1` `アームを曲げる` | 「アームを曲げる」 |
+| `smalrubot_s1.sensor_value("left")` | `スモウルボットS1` `センサーの値` | 「左のセンサー」 |
+| `smalrubot_s1.get_motor_speed("left")` | `スモウルボットS1` `モーター速度` | 「左DCモーターの速度」 |
+| `smalrubot_s1.set_motor_speed("left", 50)` | `スモウルボットS1` `モーター速度を設定` | 「左DCモーターの速度を50にする」 |
+| `smalrubot_s1.led("left", true)` | `スモウルボットS1` `LED設定` | 「左のLEDをオンにする」 |
+
+### 甲子園（Koshien拡張機能）
+
+`koshien` は事前定義レシーバー。レシーバー自体に `甲子園` のふりがなが付く。
+
+| Ruby | ふりがな | Scratchブロック |
+| ------ | --------- | ------ |
+| `koshien`（レシーバー） | `甲子園` | — |
+| `koshien.connect_game(name: "player1")` | `甲子園` `ゲームに接続` | 「ゲームに接続する」 |
+| `koshien.move_to("0:0")` | `甲子園` `移動する` | 「移動する」 |
+| `koshien.turn_over` | `甲子園` `ターン終了` | 「ターン終了」 |
+| `koshien.calc_route(result: ...)` | `甲子園` `ルート計算` | 「ルート計算」 |
+| `koshien.map("0:0")` | `甲子園` `マップ` | 「マップ」 |
+| `koshien.map_all` | `甲子園` `全マップ` | 「全マップ」 |
+| `koshien.position(x, y)` | `甲子園` `座標` | 「座標」 |
+| `koshien.set_message("hello")` | `甲子園` `メッセージ設定` | 「メッセージ設定」 |

--- a/packages/scratch-gui/src/lib/furigana-annotator.js
+++ b/packages/scratch-gui/src/lib/furigana-annotator.js
@@ -8,6 +8,12 @@ import {
 } from './furigana-label-map';
 import {nodeHandlers} from './furigana-node-handlers';
 import {callHelpers} from './furigana-call-helpers';
+import {
+    EXTENSION_HANDLER_MAP,
+    EXTENSION_RECEIVER_LABELS,
+    EXTENSION_STRING_MAPS,
+    extensionHandlers
+} from './furigana-extension-handlers';
 
 /**
  * Annotates Ruby source code with furigana (Japanese reading aids).
@@ -201,15 +207,15 @@ class FuriganaAnnotator {
                 default:
                     break;
                 }
-            } else if (receiverType === 'CallNode') {
+            } else if (receiverType === 'CallNode' || receiverType === 'LocalVariableReadNode') {
                 const innerName = node.receiver.name;
                 const innerRec = node.receiver.receiver;
 
-                if (!innerRec && innerName === 'pen') {
-                    this._annotatePenMethod(node, name);
-                } else if (!innerRec && innerName === 'face_sensing') {
-                    this._annotateFaceSensingMethod(node, name);
-                } else if (innerName === 'now') {
+                // Predefined extension receiver dispatch (pen.xxx, face_sensing.xxx, etc.)
+                if (!innerRec && EXTENSION_HANDLER_MAP[innerName]) {
+                    this[EXTENSION_HANDLER_MAP[innerName]](node, name);
+                } else if (receiverType === 'CallNode' && innerName === 'now') {
+                    // Time.now.xxx chained call
                     const innerRecType = innerRec && typeof innerRec.toJSON === 'function' ?
                         innerRec.toJSON().type : null;
                     if (innerRecType === 'ConstantReadNode' && innerRec.name === 'Time') {
@@ -218,10 +224,6 @@ class FuriganaAnnotator {
                 }
             } else if (receiverType === 'SelfNode') {
                 this._annotateSelfSetter(node, name);
-            } else if (receiverType === 'LocalVariableReadNode' && node.receiver.name === 'pen') {
-                this._annotatePenMethod(node, name);
-            } else if (receiverType === 'LocalVariableReadNode' && node.receiver.name === 'face_sensing') {
-                this._annotateFaceSensingMethod(node, name);
             }
 
             // ---- Operators and conversions (any receiver) ----
@@ -247,10 +249,8 @@ class FuriganaAnnotator {
             this._annotateWhenGreaterThan(node);
         } else if (name === 'rest') {
             this._annotateRest(node);
-        } else if (name === 'pen') {
-            this._addAnnotation(node.messageLoc || node.location, 'ペン');
-        } else if (name === 'face_sensing') {
-            this._addAnnotation(node.messageLoc || node.location, '顔認識');
+        } else if (EXTENSION_RECEIVER_LABELS[name]) {
+            this._addAnnotation(node.messageLoc || node.location, EXTENSION_RECEIVER_LABELS[name]);
         }
 
         // Set unit context for literal arguments
@@ -274,8 +274,8 @@ class FuriganaAnnotator {
         // Explicit child traversal
         if (node.receiver) this._walkNode(node.receiver);
 
-        // Set context-specific string label map for face_sensing args
-        this._setFaceSensingStringMap(node, name);
+        // Set context-specific string label map for extension args
+        this._setExtensionStringMap(node, name);
 
         if (node.arguments_) {
             if (methodUnit) this._argUnit = methodUnit;
@@ -288,6 +288,6 @@ class FuriganaAnnotator {
 }
 
 // Mix in handler methods from separate modules
-Object.assign(FuriganaAnnotator.prototype, nodeHandlers, callHelpers);
+Object.assign(FuriganaAnnotator.prototype, nodeHandlers, callHelpers, extensionHandlers);
 
 export default FuriganaAnnotator;

--- a/packages/scratch-gui/src/lib/furigana-annotator.js
+++ b/packages/scratch-gui/src/lib/furigana-annotator.js
@@ -1,8 +1,13 @@
+// === Smalruby: This file is Smalruby-specific (furigana annotator) ===
+
 import {
     RECEIVER_METHOD_LABELS,
     TOPLEVEL_METHOD_LABELS,
-    TOPLEVEL_PROPERTY_LABELS
+    TOPLEVEL_PROPERTY_LABELS,
+    METHOD_ARG_UNITS
 } from './furigana-label-map';
+import {nodeHandlers} from './furigana-node-handlers';
+import {callHelpers} from './furigana-call-helpers';
 
 /**
  * Annotates Ruby source code with furigana (Japanese reading aids).
@@ -38,20 +43,15 @@ class FuriganaAnnotator {
 
     // ---- Internal helpers ----
 
-    /**
-     * Build UTF-8 byte-based line offsets and a byteToChar mapping.
-     * Prism gives byte offsets, but Monaco uses character (JS) columns.
-     * @param source
-     */
+    /** Build UTF-8 byte-based line offsets and a byteToChar mapping. */
     _buildMappings (source) {
         const encoder = new TextEncoder();
         const bytes = encoder.encode(source);
 
-        // byteToChar[byteIdx] = corresponding JS char index
         this._byteToChar = new Uint32Array(bytes.length + 1);
         let byteIdx = 0;
         let charIdx = 0;
-        for (const codePoint of source) { // iterates Unicode code points
+        for (const codePoint of source) {
             const cpByteLen = encoder.encode(codePoint).length;
             for (let b = 0; b < cpByteLen; b++) {
                 this._byteToChar[byteIdx + b] = charIdx;
@@ -59,12 +59,11 @@ class FuriganaAnnotator {
             byteIdx += cpByteLen;
             charIdx++;
         }
-        this._byteToChar[byteIdx] = charIdx; // sentinel at end
+        this._byteToChar[byteIdx] = charIdx;
 
-        // line byte offsets: _lineOffsets[n] = byte index where line (n+1) starts
         this._lineOffsets = [0];
         for (let i = 0; i < bytes.length; i++) {
-            if (bytes[i] === 0x0a) { // '\n'
+            if (bytes[i] === 0x0a) {
                 this._lineOffsets.push(i + 1);
             }
         }
@@ -83,19 +82,14 @@ class FuriganaAnnotator {
             }
         }
         const lineStartByte = offsets[lo];
-        // Column in JS chars (for correct pixel positioning with Monaco)
         const column = this._byteToChar[byteOffset] - this._byteToChar[lineStartByte];
         return {
-            line: lo + 1, // 1-based
+            line: lo + 1,
             column
         };
     }
 
-    /**
-     * Create a location spanning from the receiver's start to messageLoc's end.
-     * Used for self.xxx so furigana starts above "self." instead of just "xxx".
-     * @param node
-     */
+    /** Location spanning from receiver start to messageLoc end (for self.xxx). */
     _receiverSpanLoc (node) {
         if (!node.receiver || !node.receiver.location || !node.messageLoc) return node.messageLoc;
         const recLoc = node.receiver.location;
@@ -140,13 +134,7 @@ class FuriganaAnnotator {
             t === 'ConcatStringNode';
     }
 
-    /**
-     * Dispatch to _handleXxxNode handler, or fall back to walking children.
-     * Uses node.toJSON().type (a stable string literal) instead of
-     * node.constructor.name, which gets mangled by minification in production
-     * builds (terser renames class names).
-     * @param {object} node - prism AST node
-     */
+    /** Dispatch to _handleXxxNode or fall back to walking children. */
     _walkNode (node) {
         if (!node || typeof node !== 'object') return;
         const typeName = typeof node.toJSON === 'function' ? node.toJSON().type : null;
@@ -159,10 +147,6 @@ class FuriganaAnnotator {
         }
     }
 
-    /**
-     * Walk all child nodes using prism's built-in childNodes() method.
-     * @param {object} node - prism AST node
-     */
     _walkChildren (node) {
         if (typeof node.childNodes === 'function') {
             node.childNodes().forEach(child => {
@@ -171,131 +155,12 @@ class FuriganaAnnotator {
         }
     }
 
-    // ---- Variables ----
-
-    _handleLocalVariableWriteNode (node) {
-        this._addAnnotation(node.nameLoc, `変数${node.name}`);
-        this._addAnnotation(node.operatorLoc, '紐付ける');
-        this._walkNode(node.value);
-    }
-
-    _handleLocalVariableReadNode (node) {
-        this._addAnnotation(node.location, `変数${node.name}`);
-    }
-
-    _handleLocalVariableOperatorWriteNode (node) {
-        this._addAnnotation(node.nameLoc, `変数${node.name}`);
-        this._addAnnotation(node.binaryOperatorLoc, this._opAsgnLabel(node.binaryOperator, node.value));
-        this._walkNode(node.value);
-    }
-
-    _handleInstanceVariableWriteNode (node) {
-        // @name → インスタンス変数name (strip @)
-        this._addAnnotation(node.nameLoc, `インスタンス変数${node.name.slice(1)}`);
-        this._addAnnotation(node.operatorLoc, '紐付ける');
-        this._walkNode(node.value);
-    }
-
-    _handleInstanceVariableReadNode (node) {
-        this._addAnnotation(node.location, `インスタンス変数${node.name.slice(1)}`);
-    }
-
-    _handleInstanceVariableOperatorWriteNode (node) {
-        this._addAnnotation(node.nameLoc, `インスタンス変数${node.name.slice(1)}`);
-        this._addAnnotation(node.binaryOperatorLoc, this._opAsgnLabel(node.binaryOperator, node.value));
-        this._walkNode(node.value);
-    }
-
-    _handleGlobalVariableWriteNode (node) {
-        // $name → グローバル変数name (strip $)
-        this._addAnnotation(node.nameLoc, `グローバル変数${node.name.slice(1)}`);
-        this._addAnnotation(node.operatorLoc, '紐付ける');
-        this._walkNode(node.value);
-    }
-
-    _handleGlobalVariableReadNode (node) {
-        this._addAnnotation(node.location, `グローバル変数${node.name.slice(1)}`);
-    }
-
-    _handleGlobalVariableOperatorWriteNode (node) {
-        this._addAnnotation(node.nameLoc, `グローバル変数${node.name.slice(1)}`);
-        this._addAnnotation(node.binaryOperatorLoc, this._opAsgnLabel(node.binaryOperator, node.value));
-        this._walkNode(node.value);
-    }
-
-    /**
-     * Returns furigana label for operator-assignment (+=, -=, *=, etc.)
-     * @param {string} binaryOperator - e.g. '+', '-', '*', '/', '%', '**'
-     * @param {object} valueNode - prism AST node for the RHS
-     */
-    _opAsgnLabel (binaryOperator, valueNode) {
-        switch (binaryOperator) {
-        case '+':
-            return this._isStringType(valueNode) ? 'と連結' : 'ずつ増やす';
-        case '-':
-            return 'ずつ減らす';
-        case '*':
-            return '倍にする';
-        case '/':
-            return '分の1にする';
-        case '%':
-            return '余りにする';
-        case '**':
-            return 'べき乗にする';
-        default:
-            return binaryOperator;
-        }
-    }
-
-    // ---- Literals ----
-
-    _handleIntegerNode (node) {
-        const text = this._getSourceText(node.location);
-        if (this._argUnit) {
-            this._addAnnotation(node.location, `${text}${this._argUnit}`);
-        } else {
-            this._addAnnotation(node.location, `数値${text}`);
-        }
-    }
-
-    _handleFloatNode (node) {
-        const text = this._getSourceText(node.location);
-        if (this._argUnit) {
-            this._addAnnotation(node.location, `${text}${this._argUnit}`);
-        } else {
-            this._addAnnotation(node.location, `数値${text}`);
-        }
-    }
-
-    _handleTrueNode (node) {
-        this._addAnnotation(node.location, '真');
-    }
-
-    _handleFalseNode (node) {
-        this._addAnnotation(node.location, '偽');
-    }
-
-    _handleStringNode (node) {
-        // unescaped is an object { encoding, validEncoding, value } in this prism version
-        const unescaped = node.unescaped;
-        const content = (unescaped && typeof unescaped === 'object') ?
-            unescaped.value : unescaped;
-        // Check context-specific string label map first (e.g., face_sensing PART/DIRECTION)
-        if (this._stringLabelMap && this._stringLabelMap[content]) {
-            this._addAnnotation(node.location, this._stringLabelMap[content]);
-            return;
-        }
-        const specialLabel = FuriganaAnnotator._SPECIAL_STRING_LABELS[content];
-        this._addAnnotation(node.location, specialLabel || `文字列「${content}」`);
-    }
-
     // ---- Method calls ----
 
     _handleCallNode (node) {
         const name = node.name;
 
         if (node.receiver) {
-            // Method calls with receiver
             const receiverType = typeof node.receiver.toJSON === 'function' ?
                 node.receiver.toJSON().type : null;
             const receiverName = (receiverType === 'ConstantReadNode') ?
@@ -341,13 +206,10 @@ class FuriganaAnnotator {
                 const innerRec = node.receiver.receiver;
 
                 if (!innerRec && innerName === 'pen') {
-                    // ---- pen.xxx (predefined extension receiver) ----
                     this._annotatePenMethod(node, name);
                 } else if (!innerRec && innerName === 'face_sensing') {
-                    // ---- face_sensing.xxx (predefined extension receiver) ----
                     this._annotateFaceSensingMethod(node, name);
                 } else if (innerName === 'now') {
-                    // ---- Chained calls: Time.now.xxx ----
                     const innerRecType = innerRec && typeof innerRec.toJSON === 'function' ?
                         innerRec.toJSON().type : null;
                     if (innerRecType === 'ConstantReadNode' && innerRec.name === 'Time') {
@@ -355,13 +217,10 @@ class FuriganaAnnotator {
                     }
                 }
             } else if (receiverType === 'SelfNode') {
-                // ---- self.attr = value ----
                 this._annotateSelfSetter(node, name);
             } else if (receiverType === 'LocalVariableReadNode' && node.receiver.name === 'pen') {
-                // ---- pen.xxx ----
                 this._annotatePenMethod(node, name);
             } else if (receiverType === 'LocalVariableReadNode' && node.receiver.name === 'face_sensing') {
-                // ---- face_sensing.xxx ----
                 this._annotateFaceSensingMethod(node, name);
             }
 
@@ -375,7 +234,6 @@ class FuriganaAnnotator {
                 this._addAnnotation(node.messageLoc, RECEIVER_METHOD_LABELS[name]);
             }
         } else if (TOPLEVEL_METHOD_LABELS[name]) {
-            // Top-level method calls (no receiver)
             this._addAnnotation(node.messageLoc, TOPLEVEL_METHOD_LABELS[name]);
         } else if (!node.arguments_ && TOPLEVEL_PROPERTY_LABELS[name]) {
             this._addAnnotation(node.messageLoc, TOPLEVEL_PROPERTY_LABELS[name]);
@@ -395,8 +253,8 @@ class FuriganaAnnotator {
             this._addAnnotation(node.messageLoc || node.location, '顔認識');
         }
 
-        // Set unit context for literal arguments of specific methods
-        const methodUnit = FuriganaAnnotator._METHOD_ARG_UNITS[name];
+        // Set unit context for literal arguments
+        const methodUnit = METHOD_ARG_UNITS[name];
 
         // Annotate do...end block keywords
         if (node.block) {
@@ -406,7 +264,6 @@ class FuriganaAnnotator {
                 if (block.openingLoc) {
                     this._addAnnotation(block.openingLoc, '以下の処理');
                 }
-                // loop / times → 繰り返し終了, others → ブロック終了
                 const isRepeat = name === 'loop' || name === 'times';
                 if (block.closingLoc) {
                     this._addAnnotation(block.closingLoc, isRepeat ? '繰り返し終了' : 'ブロック終了');
@@ -417,11 +274,8 @@ class FuriganaAnnotator {
         // Explicit child traversal
         if (node.receiver) this._walkNode(node.receiver);
 
-        // Set context-specific string label map for face_sensing PART/DIRECTION args
-        const fsStringMap = FuriganaAnnotator._FACE_SENSING_STRING_MAP[name];
-        if (fsStringMap && this._isPredefinedReceiver(node, 'face_sensing')) {
-            this._stringLabelMap = fsStringMap;
-        }
+        // Set context-specific string label map for face_sensing args
+        this._setFaceSensingStringMap(node, name);
 
         if (node.arguments_) {
             if (methodUnit) this._argUnit = methodUnit;
@@ -431,469 +285,9 @@ class FuriganaAnnotator {
         if (this._stringLabelMap) this._stringLabelMap = null;
         if (node.block) this._walkNode(node.block);
     }
-
-    // ---- Dynamic label helpers ----
-
-    /**
-     * Returns the string value of the Nth positional argument, or null.
-     * @param {object} callNode
-     * @param {number} index - 0-based
-     */
-    _getArgStringValue (callNode, index) {
-        const args = callNode.arguments_ && callNode.arguments_.arguments_;
-        if (!args || !args[index]) return null;
-        const arg = args[index];
-        const type = typeof arg.toJSON === 'function' ? arg.toJSON().type : null;
-        if (type === 'StringNode') {
-            const u = arg.unescaped;
-            return (u && typeof u === 'object') ? u.value : u;
-        }
-        return null;
-    }
-
-    /**
-     * Returns the source text of the Nth positional argument, or null.
-     * @param {object} callNode
-     * @param {number} index - 0-based
-     */
-    _getArgSourceText (callNode, index) {
-        const args = callNode.arguments_ && callNode.arguments_.arguments_;
-        if (!args || !args[index]) return null;
-        return this._getSourceText(args[index].location);
-    }
-
-    /**
-     * Returns the source text of a keyword argument value by key name, or null.
-     * Handles `method(key: value)` style keyword arguments.
-     * @param {object} callNode
-     * @param {string} key - keyword argument name (e.g. 'secs')
-     */
-    _getKwargSourceText (callNode, key) {
-        const args = callNode.arguments_ && callNode.arguments_.arguments_;
-        if (!args) return null;
-        for (const arg of args) {
-            const type = typeof arg.toJSON === 'function' ? arg.toJSON().type : null;
-            if (type === 'KeywordHashNode') {
-                // Use childNodes() since .elements may not be directly accessible
-                if (typeof arg.childNodes !== 'function') continue;
-                for (const assocNode of arg.childNodes()) {
-                    if (!assocNode) continue;
-                    const assocType = typeof assocNode.toJSON === 'function' ?
-                        assocNode.toJSON().type : null;
-                    if (assocType === 'AssocNode') {
-                        // key is a SymbolNode; use valueLoc for "secs" part of "secs: 1"
-                        const keyNode = assocNode.key;
-                        if (!keyNode) continue;
-                        const keyJ = typeof keyNode.toJSON === 'function' ? keyNode.toJSON() : null;
-                        const keyLoc = keyJ && (keyJ.valueLoc || keyJ.location);
-                        const keyText = this._getSourceText(keyLoc);
-                        if (keyText === key && assocNode.value) {
-                            return this._getSourceText(assocNode.value.location);
-                        }
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    _annotateMathMethod (node, name) {
-        const mathLabels = {
-            sqrt: '平方根',
-            sin: 'sin',
-            cos: 'cos',
-            tan: 'tan',
-            asin: 'asin',
-            acos: 'acos',
-            atan: 'atan',
-            log: 'ln',
-            log10: 'log'
-        };
-        const label = mathLabels[name];
-        if (label) this._addAnnotation(node.messageLoc, label);
-    }
-
-    _annotateTimeNowMethod (node, name) {
-        const timeLabels = {
-            year: '今の年',
-            month: '今の月',
-            day: '今の日',
-            hour: '今の時',
-            min: '今の分',
-            sec: '今の秒',
-            wday: '今の曜日'
-        };
-        const label = timeLabels[name];
-        if (label) this._addAnnotation(node.messageLoc, label);
-    }
-
-    _annotateSelfSetter (node, name) {
-        // name ends with '=' for assignments like self.x = n
-        const selfSetterLabels = {
-            'x=': 'X座標を設定',
-            'y=': 'Y座標を設定',
-            'direction=': '向きを設定',
-            'size=': '大きさを設定',
-            'volume=': '音量を設定',
-            'rotation_style=': '回転スタイルを設定',
-            'instrument=': '楽器を設定',
-            'tempo=': 'テンポを設定',
-            'drag_mode=': 'ドラッグモードを設定'
-        };
-        const label = selfSetterLabels[name];
-        if (label) this._addAnnotation(this._receiverSpanLoc(node), label);
-    }
-
-    _annotatePenMethod (node, name) {
-        const penLabels = {
-            'stamp': 'スタンプ',
-            'down': 'ペンを下ろす',
-            'up': 'ペンを上げる',
-            'size=': 'ペンの太さを設定',
-            'color=': 'ペンの色を設定',
-            'saturation=': '彩度を設定',
-            'brightness=': '明るさを設定',
-            'transparency=': '透明度を設定'
-        };
-        const label = penLabels[name];
-        if (label) this._addAnnotation(node.messageLoc, label);
-    }
-
-    /**
-     * Check if a node's receiver is a predefined extension name (e.g. 'pen', 'face_sensing').
-     * Handles both LocalVariableReadNode (variable defined) and CallNode (no definition).
-     */
-    _isPredefinedReceiver (node, extensionName) {
-        if (!node.receiver) return false;
-        const recType = typeof node.receiver.toJSON === 'function' ?
-            node.receiver.toJSON().type : null;
-        if (recType === 'LocalVariableReadNode' && node.receiver.name === extensionName) return true;
-        if (recType === 'CallNode' && !node.receiver.receiver && node.receiver.name === extensionName) {
-            return true;
-        }
-        return false;
-    }
-
-    _annotateFaceSensingMethod (node, name) {
-        const faceSensingLabels = {
-            'go_to': '行く',
-            'point_in_direction_of_face_tilt': '顔の傾きの方向を向く',
-            'set_size_to_face_size': '大きさを顔の大きさにする',
-            'when_face_tilted': '顔が傾いたとき',
-            'when_this_sprite_touch': '触れたとき',
-            'when_face_detected': '顔が見つかったとき',
-            'face_detected?': '顔が見つかった',
-            'face_tilt': '顔の傾き',
-            'face_size': '顔の大きさ'
-        };
-        const fsLabel = faceSensingLabels[name];
-        if (fsLabel) this._addAnnotation(node.messageLoc, fsLabel);
-
-    }
-
-    _annotateGlide (node) {
-        const secs = this._getKwargSourceText(node, 'secs');
-        const firstArg = node.arguments_ && node.arguments_.arguments_ && node.arguments_.arguments_[0];
-        let xText = null;
-        let yText = null;
-        if (firstArg) {
-            const type = typeof firstArg.toJSON === 'function' ? firstArg.toJSON().type : null;
-            if (type === 'ArrayNode' && firstArg.elements && firstArg.elements.length >= 2) {
-                xText = this._getSourceText(firstArg.elements[0].location);
-                yText = this._getSourceText(firstArg.elements[1].location);
-            }
-        }
-        if (secs !== null && xText !== null && yText !== null) {
-            this._addAnnotation(node.messageLoc, `${secs}秒でx座標を${xText}に、y座標を${yText}に変える`);
-        } else {
-            this._addAnnotation(node.messageLoc, 'なめらかに移動する');
-        }
-    }
-
-    _annotateGoToLayer (node) {
-        const layer = this._getArgStringValue(node, 0);
-        if (layer === 'front') {
-            this._addAnnotation(node.messageLoc, '最前面へ移動する');
-        } else if (layer === 'back') {
-            this._addAnnotation(node.messageLoc, '最背面へ移動する');
-        } else {
-            this._addAnnotation(node.messageLoc, 'レイヤーへ移動する');
-        }
-    }
-
-    _annotateGoLayers (node) {
-        const n = this._getArgSourceText(node, 0);
-        const dir = this._getArgStringValue(node, 1);
-        const nLabel = n === null ? 'n' : n;
-        if (dir === 'forward') {
-            this._addAnnotation(node.messageLoc, `${nLabel}層手前に出す`);
-        } else if (dir === 'backward') {
-            this._addAnnotation(node.messageLoc, `${nLabel}層奥に下げる`);
-        } else {
-            this._addAnnotation(node.messageLoc, 'レイヤーを移動する');
-        }
-    }
-
-    _annotateWhenGreaterThan (node) {
-        const kind = this._getArgStringValue(node, 0);
-        const val = this._getArgSourceText(node, 1);
-        const kindLabel = kind === 'LOUDNESS' ? '音量' : kind === 'TIMER' ? 'タイマー' : kind || '値';
-        const valLabel = val === null ? '' : val;
-        this._addAnnotation(node.messageLoc, `${kindLabel} > ${valLabel} のとき`);
-    }
-
-    _annotateRest (node) {
-        const beats = this._getArgSourceText(node, 0);
-        const beatsLabel = beats === null ? 'n' : beats;
-        this._addAnnotation(node.messageLoc, `${beatsLabel}拍休む`);
-    }
-
-    // ---- self.attr += n (CallOperatorWriteNode) ----
-
-    _handleCallOperatorWriteNode (node) {
-        const receiverType = node.receiver && typeof node.receiver.toJSON === 'function' ?
-            node.receiver.toJSON().type : null;
-        const attrName = node.readName; // e.g. "x" for self.x += 10
-
-        if (receiverType === 'SelfNode') {
-            if (attrName === 'direction') {
-                const dirLabel = node.binaryOperator === '-' ?
-                    '反時計回りに回す' : '時計回りに回す';
-                this._addAnnotation(this._receiverSpanLoc(node), dirLabel);
-            }
-            const selfOpLabels = {
-                x: 'X座標を変える',
-                y: 'Y座標を変える',
-                size: '大きさを変える',
-                volume: '音量を変える',
-                tempo: 'テンポを変える'
-            };
-            const label = selfOpLabels[attrName];
-            if (label) this._addAnnotation(this._receiverSpanLoc(node), label);
-        } else if (this._isPredefinedReceiver(node, 'pen')) {
-            const penOpLabels = {
-                size: 'ペンの太さを変える',
-                color: 'ペンの色を変える'
-            };
-            const label = penOpLabels[attrName];
-            if (label) this._addAnnotation(node.messageLoc, label);
-        }
-        if (node.receiver) this._walkNode(node.receiver);
-        // Set unit context for self.direction +=/-= value
-        if (receiverType === 'SelfNode' && attrName === 'direction') {
-            this._argUnit = '度';
-        }
-        if (node.value) this._walkNode(node.value);
-        this._argUnit = null;
-    }
-
-    // ---- Control flow: if / elsif / else ----
-
-    _handleIfNode (node) {
-        const keyword = this._getSourceText(node.ifKeywordLoc);
-        if (keyword === 'if') {
-            this._addAnnotation(node.ifKeywordLoc, 'もし');
-            // Only the outermost if adds 分岐終了 (elsif shares the same endKeywordLoc)
-            if (node.endKeywordLoc) {
-                this._addAnnotation(node.endKeywordLoc, '分岐終了');
-            }
-        } else if (keyword === 'elsif') {
-            this._addAnnotation(node.ifKeywordLoc, 'ではなく');
-        }
-        this._walkNode(node.predicate);
-        this._walkNode(node.statements);
-        this._walkNode(node.subsequent);
-    }
-
-    _handleElseNode (node) {
-        this._addAnnotation(node.elseKeywordLoc, 'でなければ');
-        this._walkNode(node.statements);
-    }
-
-    // ---- Control flow: until ----
-
-    _handleUntilNode (node) {
-        this._addAnnotation(node.keywordLoc, 'まで繰り返す');
-        if (node.closingLoc) {
-            this._addAnnotation(node.closingLoc, '繰り返し終了');
-        }
-        this._walkNode(node.predicate);
-        this._walkNode(node.statements);
-    }
-
-    // ---- Control flow: while ----
-
-    _handleWhileNode (node) {
-        this._addAnnotation(node.keywordLoc, '真である限り繰り返す');
-        if (node.closingLoc) {
-            this._addAnnotation(node.closingLoc, '繰り返し終了');
-        }
-        this._walkNode(node.predicate);
-        this._walkNode(node.statements);
-    }
-
-    // ---- Method definition ----
-
-    _handleDefNode (node) {
-        this._addAnnotation(node.defKeywordLoc, 'メソッド作成');
-        if (node.nameLoc) {
-            this._addAnnotation(node.nameLoc, `${node.name}という名前`);
-        }
-        if (node.endKeywordLoc) {
-            this._addAnnotation(node.endKeywordLoc, '作成終了');
-        }
-        if (node.parameters) this._walkNode(node.parameters);
-        if (node.body) this._walkNode(node.body);
-    }
-
-    _handleRequiredParameterNode (node) {
-        this._addAnnotation(node.location, `引数${node.name}`);
-    }
-
-    _handleOptionalParameterNode (node) {
-        this._addAnnotation(node.nameLoc || node.location, `引数${node.name}`);
-        this._walkNode(node.value);
-    }
-
-    // ---- return ----
-
-    _handleReturnNode (node) {
-        this._addAnnotation(node.keywordLoc, '呼び出し元に返す');
-        this._walkChildren(node);
-    }
-
-    // ---- class definition ----
-
-    _handleClassNode (node) {
-        this._addAnnotation(node.classKeywordLoc, 'クラス作成');
-        if (node.endKeywordLoc) {
-            this._addAnnotation(node.endKeywordLoc, '作成終了');
-        }
-        this._walkChildren(node);
-    }
-
-    // ---- case / when ----
-
-    _handleCaseNode (node) {
-        this._addAnnotation(node.caseKeywordLoc, '状態分岐');
-        if (node.endKeywordLoc) {
-            this._addAnnotation(node.endKeywordLoc, '分岐終了');
-        }
-        if (node.predicate) this._walkNode(node.predicate);
-        if (node.conditions) node.conditions.forEach(c => this._walkNode(c));
-        if (node.elseClause) this._walkNode(node.elseClause);
-    }
-
-    _handleWhenNode (node) {
-        this._addAnnotation(node.keywordLoc, 'のとき');
-        if (node.conditions) node.conditions.forEach(c => this._walkNode(c));
-        if (node.statements) this._walkNode(node.statements);
-    }
-
-    // ---- Logical operators ----
-
-    _handleAndNode (node) {
-        this._addAnnotation(node.operatorLoc, 'かつ');
-        this._walkNode(node.left);
-        this._walkNode(node.right);
-    }
-
-    _handleOrNode (node) {
-        this._addAnnotation(node.operatorLoc, 'または');
-        this._walkNode(node.left);
-        this._walkNode(node.right);
-    }
 }
 
-/**
- * Special string values used in smalruby that represent UI menu options.
- * These are displayed with descriptive Japanese labels instead of raw 文字列「...」.
- * Labels are sourced from scratch-l10n editor/blocks/ja.json.
- */
-/**
- * Methods whose literal arguments should use a unit suffix instead of 数値/文字列.
- * e.g. move(10) → 「10歩」 instead of 「数値10」
- */
-FuriganaAnnotator._METHOD_ARG_UNITS = {
-    move: '歩',
-    turn_right: '度',
-    turn_left: '度',
-    sleep: '秒'
-};
-
-FuriganaAnnotator._SPECIAL_STRING_LABELS = {
-    // Special sprite/location targets
-    '_mouse_': 'マウスのポインター',
-    '_edge_': '端',
-    '_random_': 'ランダムな場所',
-    '_myself_': '自分自身',
-    // Key names (EVENT_WHENKEYPRESSED_*)
-    'space': 'スペース',
-    'left arrow': '左向き矢印',
-    'right arrow': '右向き矢印',
-    'down arrow': '下向き矢印',
-    'up arrow': '上向き矢印',
-    'any': 'どれかのキー',
-    // Stop options (CONTROL_STOP_*)
-    'all': 'すべて',
-    'this script': 'このスクリプト',
-    'other scripts in sprite': 'スプライトの他のスクリプト',
-    // Rotation styles (MOTION_SETROTATIONSTYLE_*)
-    'all around': '自由に回転',
-    'left-right': '左右のみ',
-    "don't rotate": '回転しない',
-    // Drag modes (SENSING_SETDRAGMODE_*)
-    'draggable': 'できる',
-    'not draggable': 'できない',
-    // Sound effects (SOUND_EFFECTS_*)
-    'PITCH': 'ピッチ',
-    'PAN': '左右にパン',
-    // Graphic effects (LOOKS_EFFECT_*)
-    'color': '色',
-    'fisheye': '魚眼レンズ',
-    'whirl': '渦巻き',
-    'pixelate': 'ピクセル化',
-    'mosaic': 'モザイク',
-    'brightness': '明るさ',
-    'ghost': '幽霊'
-};
-
-/**
- * Maps face_sensing method names to their context-specific string label maps.
- * Only methods with PART or DIRECTION arguments are listed.
- */
-FuriganaAnnotator._FACE_SENSING_STRING_MAP = {
-    go_to: null, // set below after PART_LABELS defined
-    when_this_sprite_touch: null,
-    when_face_tilted: null
-};
-
-/**
- * Context-specific string labels for face_sensing PART menu arguments.
- * Used via _stringLabelMap to avoid polluting global _SPECIAL_STRING_LABELS.
- */
-FuriganaAnnotator._FACE_SENSING_PART_LABELS = {
-    nose: '鼻',
-    mouth: '口',
-    left_eye: '左目',
-    right_eye: '右目',
-    between_eyes: '両目の間',
-    left_ear: '左耳',
-    right_ear: '右耳',
-    top_of_head: '頭のてっぺん'
-};
-
-/**
- * Context-specific string labels for face_sensing DIRECTION menu arguments.
- */
-FuriganaAnnotator._FACE_SENSING_DIRECTION_LABELS = {
-    left: '左',
-    right: '右'
-};
-
-// Wire up the string map references after definitions
-FuriganaAnnotator._FACE_SENSING_STRING_MAP.go_to = FuriganaAnnotator._FACE_SENSING_PART_LABELS;
-FuriganaAnnotator._FACE_SENSING_STRING_MAP.when_this_sprite_touch = FuriganaAnnotator._FACE_SENSING_PART_LABELS;
-FuriganaAnnotator._FACE_SENSING_STRING_MAP.when_face_tilted = FuriganaAnnotator._FACE_SENSING_DIRECTION_LABELS;
+// Mix in handler methods from separate modules
+Object.assign(FuriganaAnnotator.prototype, nodeHandlers, callHelpers);
 
 export default FuriganaAnnotator;

--- a/packages/scratch-gui/src/lib/furigana-call-helpers.js
+++ b/packages/scratch-gui/src/lib/furigana-call-helpers.js
@@ -1,6 +1,7 @@
 // === Smalruby: This file is Smalruby-specific (furigana call helpers) ===
 
 import {FACE_SENSING_STRING_MAP} from './furigana-label-map';
+import {EXTENSION_STRING_MAPS} from './furigana-extension-handlers';
 
 /**
  * Call-related helper methods for FuriganaAnnotator.
@@ -169,15 +170,25 @@ const callHelpers = {
     },
 
     /**
-     * Set context-specific string label map for face_sensing arguments.
-     * Called from _handleCallNode before walking arguments.
+     * Set context-specific string label map for extension arguments.
+     * Checks face_sensing string maps and general extension string maps.
      * @param {object} node - CallNode
      * @param {string} name - method name
      */
-    _setFaceSensingStringMap (node, name) {
+    _setExtensionStringMap (node, name) {
+        // face_sensing string maps (from furigana-label-map)
         const fsStringMap = FACE_SENSING_STRING_MAP[name];
         if (fsStringMap && this._isPredefinedReceiver(node, 'face_sensing')) {
             this._stringLabelMap = fsStringMap;
+            return;
+        }
+        // General extension string maps
+        for (const extName of Object.keys(EXTENSION_STRING_MAPS)) {
+            const extMap = EXTENSION_STRING_MAPS[extName];
+            if (extMap[name] && this._isPredefinedReceiver(node, extName)) {
+                this._stringLabelMap = extMap[name];
+                return;
+            }
         }
     },
 

--- a/packages/scratch-gui/src/lib/furigana-call-helpers.js
+++ b/packages/scratch-gui/src/lib/furigana-call-helpers.js
@@ -1,0 +1,282 @@
+// === Smalruby: This file is Smalruby-specific (furigana call helpers) ===
+
+import {FACE_SENSING_STRING_MAP} from './furigana-label-map';
+
+/**
+ * Call-related helper methods for FuriganaAnnotator.
+ * Covers: argument extraction, method-specific annotations,
+ * extension handler methods, and CallOperatorWriteNode.
+ * These are mixed into FuriganaAnnotator.prototype via Object.assign.
+ */
+const callHelpers = {
+
+    // ---- Argument extraction helpers ----
+
+    /**
+     * Returns the string value of the Nth positional argument, or null.
+     * @param {object} callNode
+     * @param {number} index - 0-based
+     */
+    _getArgStringValue (callNode, index) {
+        const args = callNode.arguments_ && callNode.arguments_.arguments_;
+        if (!args || !args[index]) return null;
+        const arg = args[index];
+        const type = typeof arg.toJSON === 'function' ? arg.toJSON().type : null;
+        if (type === 'StringNode') {
+            const u = arg.unescaped;
+            return (u && typeof u === 'object') ? u.value : u;
+        }
+        return null;
+    },
+
+    /**
+     * Returns the source text of the Nth positional argument, or null.
+     * @param {object} callNode
+     * @param {number} index - 0-based
+     */
+    _getArgSourceText (callNode, index) {
+        const args = callNode.arguments_ && callNode.arguments_.arguments_;
+        if (!args || !args[index]) return null;
+        return this._getSourceText(args[index].location);
+    },
+
+    /**
+     * Returns the source text of a keyword argument value by key name, or null.
+     * @param {object} callNode
+     * @param {string} key - keyword argument name (e.g. 'secs')
+     */
+    _getKwargSourceText (callNode, key) {
+        const args = callNode.arguments_ && callNode.arguments_.arguments_;
+        if (!args) return null;
+        for (const arg of args) {
+            const type = typeof arg.toJSON === 'function' ? arg.toJSON().type : null;
+            if (type === 'KeywordHashNode') {
+                if (typeof arg.childNodes !== 'function') continue;
+                for (const assocNode of arg.childNodes()) {
+                    if (!assocNode) continue;
+                    const assocType = typeof assocNode.toJSON === 'function' ?
+                        assocNode.toJSON().type : null;
+                    if (assocType === 'AssocNode') {
+                        const keyNode = assocNode.key;
+                        if (!keyNode) continue;
+                        const keyJ = typeof keyNode.toJSON === 'function' ? keyNode.toJSON() : null;
+                        const keyLoc = keyJ && (keyJ.valueLoc || keyJ.location);
+                        const keyText = this._getSourceText(keyLoc);
+                        if (keyText === key && assocNode.value) {
+                            return this._getSourceText(assocNode.value.location);
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    },
+
+    // ---- Constant-receiver annotation helpers ----
+
+    _annotateMathMethod (node, name) {
+        const mathLabels = {
+            sqrt: '平方根',
+            sin: 'sin',
+            cos: 'cos',
+            tan: 'tan',
+            asin: 'asin',
+            acos: 'acos',
+            atan: 'atan',
+            log: 'ln',
+            log10: 'log'
+        };
+        const label = mathLabels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateTimeNowMethod (node, name) {
+        const timeLabels = {
+            year: '今の年',
+            month: '今の月',
+            day: '今の日',
+            hour: '今の時',
+            min: '今の分',
+            sec: '今の秒',
+            wday: '今の曜日'
+        };
+        const label = timeLabels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateSelfSetter (node, name) {
+        const selfSetterLabels = {
+            'x=': 'X座標を設定',
+            'y=': 'Y座標を設定',
+            'direction=': '向きを設定',
+            'size=': '大きさを設定',
+            'volume=': '音量を設定',
+            'rotation_style=': '回転スタイルを設定',
+            'instrument=': '楽器を設定',
+            'tempo=': 'テンポを設定',
+            'drag_mode=': 'ドラッグモードを設定'
+        };
+        const label = selfSetterLabels[name];
+        if (label) this._addAnnotation(this._receiverSpanLoc(node), label);
+    },
+
+    // ---- Extension handler helpers ----
+
+    /**
+     * Check if a node's receiver is a predefined extension name.
+     * Handles both LocalVariableReadNode and CallNode patterns.
+     */
+    _isPredefinedReceiver (node, extensionName) {
+        if (!node.receiver) return false;
+        const recType = typeof node.receiver.toJSON === 'function' ?
+            node.receiver.toJSON().type : null;
+        if (recType === 'LocalVariableReadNode' && node.receiver.name === extensionName) return true;
+        if (recType === 'CallNode' && !node.receiver.receiver && node.receiver.name === extensionName) {
+            return true;
+        }
+        return false;
+    },
+
+    _annotatePenMethod (node, name) {
+        const penLabels = {
+            'stamp': 'スタンプ',
+            'down': 'ペンを下ろす',
+            'up': 'ペンを上げる',
+            'size=': 'ペンの太さを設定',
+            'color=': 'ペンの色を設定',
+            'saturation=': '彩度を設定',
+            'brightness=': '明るさを設定',
+            'transparency=': '透明度を設定'
+        };
+        const label = penLabels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateFaceSensingMethod (node, name) {
+        const faceSensingLabels = {
+            'go_to': '行く',
+            'point_in_direction_of_face_tilt': '顔の傾きの方向を向く',
+            'set_size_to_face_size': '大きさを顔の大きさにする',
+            'when_face_tilted': '顔が傾いたとき',
+            'when_this_sprite_touch': '触れたとき',
+            'when_face_detected': '顔が見つかったとき',
+            'face_detected?': '顔が見つかった',
+            'face_tilt': '顔の傾き',
+            'face_size': '顔の大きさ'
+        };
+        const fsLabel = faceSensingLabels[name];
+        if (fsLabel) this._addAnnotation(node.messageLoc, fsLabel);
+    },
+
+    /**
+     * Set context-specific string label map for face_sensing arguments.
+     * Called from _handleCallNode before walking arguments.
+     * @param {object} node - CallNode
+     * @param {string} name - method name
+     */
+    _setFaceSensingStringMap (node, name) {
+        const fsStringMap = FACE_SENSING_STRING_MAP[name];
+        if (fsStringMap && this._isPredefinedReceiver(node, 'face_sensing')) {
+            this._stringLabelMap = fsStringMap;
+        }
+    },
+
+    // ---- Dynamic annotation helpers ----
+
+    _annotateGlide (node) {
+        const secs = this._getKwargSourceText(node, 'secs');
+        const firstArg = node.arguments_ && node.arguments_.arguments_ && node.arguments_.arguments_[0];
+        let xText = null;
+        let yText = null;
+        if (firstArg) {
+            const type = typeof firstArg.toJSON === 'function' ? firstArg.toJSON().type : null;
+            if (type === 'ArrayNode' && firstArg.elements && firstArg.elements.length >= 2) {
+                xText = this._getSourceText(firstArg.elements[0].location);
+                yText = this._getSourceText(firstArg.elements[1].location);
+            }
+        }
+        if (secs !== null && xText !== null && yText !== null) {
+            this._addAnnotation(node.messageLoc, `${secs}秒でx座標を${xText}に、y座標を${yText}に変える`);
+        } else {
+            this._addAnnotation(node.messageLoc, 'なめらかに移動する');
+        }
+    },
+
+    _annotateGoToLayer (node) {
+        const layer = this._getArgStringValue(node, 0);
+        if (layer === 'front') {
+            this._addAnnotation(node.messageLoc, '最前面へ移動する');
+        } else if (layer === 'back') {
+            this._addAnnotation(node.messageLoc, '最背面へ移動する');
+        } else {
+            this._addAnnotation(node.messageLoc, 'レイヤーへ移動する');
+        }
+    },
+
+    _annotateGoLayers (node) {
+        const n = this._getArgSourceText(node, 0);
+        const dir = this._getArgStringValue(node, 1);
+        const nLabel = n === null ? 'n' : n;
+        if (dir === 'forward') {
+            this._addAnnotation(node.messageLoc, `${nLabel}層手前に出す`);
+        } else if (dir === 'backward') {
+            this._addAnnotation(node.messageLoc, `${nLabel}層奥に下げる`);
+        } else {
+            this._addAnnotation(node.messageLoc, 'レイヤーを移動する');
+        }
+    },
+
+    _annotateWhenGreaterThan (node) {
+        const kind = this._getArgStringValue(node, 0);
+        const val = this._getArgSourceText(node, 1);
+        const kindLabel = kind === 'LOUDNESS' ? '音量' : kind === 'TIMER' ? 'タイマー' : kind || '値';
+        const valLabel = val === null ? '' : val;
+        this._addAnnotation(node.messageLoc, `${kindLabel} > ${valLabel} のとき`);
+    },
+
+    _annotateRest (node) {
+        const beats = this._getArgSourceText(node, 0);
+        const beatsLabel = beats === null ? 'n' : beats;
+        this._addAnnotation(node.messageLoc, `${beatsLabel}拍休む`);
+    },
+
+    // ---- self.attr += n (CallOperatorWriteNode) ----
+
+    _handleCallOperatorWriteNode (node) {
+        const receiverType = node.receiver && typeof node.receiver.toJSON === 'function' ?
+            node.receiver.toJSON().type : null;
+        const attrName = node.readName;
+
+        if (receiverType === 'SelfNode') {
+            if (attrName === 'direction') {
+                const dirLabel = node.binaryOperator === '-' ?
+                    '反時計回りに回す' : '時計回りに回す';
+                this._addAnnotation(this._receiverSpanLoc(node), dirLabel);
+            }
+            const selfOpLabels = {
+                x: 'X座標を変える',
+                y: 'Y座標を変える',
+                size: '大きさを変える',
+                volume: '音量を変える',
+                tempo: 'テンポを変える'
+            };
+            const label = selfOpLabels[attrName];
+            if (label) this._addAnnotation(this._receiverSpanLoc(node), label);
+        } else if (this._isPredefinedReceiver(node, 'pen')) {
+            const penOpLabels = {
+                size: 'ペンの太さを変える',
+                color: 'ペンの色を変える'
+            };
+            const label = penOpLabels[attrName];
+            if (label) this._addAnnotation(node.messageLoc, label);
+        }
+        if (node.receiver) this._walkNode(node.receiver);
+        if (receiverType === 'SelfNode' && attrName === 'direction') {
+            this._argUnit = '度';
+        }
+        if (node.value) this._walkNode(node.value);
+        this._argUnit = null;
+    }
+};
+
+export {callHelpers};

--- a/packages/scratch-gui/src/lib/furigana-extension-handlers.js
+++ b/packages/scratch-gui/src/lib/furigana-extension-handlers.js
@@ -1,0 +1,233 @@
+// === Smalruby: This file is Smalruby-specific (furigana extension handlers) ===
+
+/**
+ * Extension-specific furigana handler methods and configuration.
+ * Mixed into FuriganaAnnotator.prototype via Object.assign.
+ */
+
+// ---- Dispatch configuration ----
+
+/**
+ * Maps predefined extension receiver names to their handler method names.
+ */
+const EXTENSION_HANDLER_MAP = {
+    pen: '_annotatePenMethod',
+    face_sensing: '_annotateFaceSensingMethod',
+    video_sensing: '_annotateVideoSensingMethod',
+    text2speech: '_annotateText2SpeechMethod',
+    microbit: '_annotateMicrobitMethod',
+    mesh_v1: '_annotateMeshV1Method',
+    mesh: '_annotateMeshV2Method',
+    smalrubot_s1: '_annotateSmalrubotS1Method',
+    koshien: '_annotateKoshienMethod'
+};
+
+/**
+ * Maps predefined extension receiver names to their Japanese labels.
+ */
+const EXTENSION_RECEIVER_LABELS = {
+    pen: 'ペン',
+    face_sensing: '顔認識',
+    video_sensing: 'ビデオ',
+    text2speech: '音声合成',
+    microbit: 'マイクロビット',
+    mesh_v1: 'メッシュ(従来)',
+    mesh: 'メッシュ',
+    smalrubot_s1: 'スモウルボットS1',
+    koshien: '甲子園'
+};
+
+// ---- Extension-specific string label maps ----
+
+const VIDEO_SENSING_VIDEO_STATE_LABELS = {
+    'on': 'オン',
+    'off': 'オフ',
+    'on-flipped': '左右反転'
+};
+
+const VIDEO_SENSING_VIDEO_ON_LABELS = {
+    'motion': '動き',
+    'direction': '向き',
+    'this sprite': 'このスプライト',
+    'Stage': 'ステージ'
+};
+
+const MICROBIT_BUTTON_LABELS = {
+    A: 'A', B: 'B', any: 'どれか'
+};
+
+const MICROBIT_GESTURE_LABELS = {
+    SHAKE: '振られた', FREEFALL: '落下した'
+};
+
+const MICROBIT_TILT_LABELS = {
+    ANY: 'どれか', FRONT: '前', BACK: '後ろ', LEFT: '左', RIGHT: '右'
+};
+
+const MICROBIT_AXIS_LABELS = {
+    x: 'x', y: 'y', z: 'z', absolute: '絶対値'
+};
+
+const MICROBIT_PULL_MODE_LABELS = {
+    up: 'プルアップ', down: 'プルダウン', none: 'なし'
+};
+
+const SMALRUBOT_S1_ACTION_LABELS = {
+    forward: '進める',
+    backward: 'バックさせる',
+    turnLeft: '左に曲げる',
+    turnRight: '右に曲げる',
+    stop: '止める'
+};
+
+const SMALRUBOT_S1_POSITION_LABELS = {
+    left: '左', right: '右'
+};
+
+/**
+ * Maps extension receiver names → { methodName: stringLabelMap }.
+ * Used to set context-specific _stringLabelMap before walking arguments.
+ */
+const EXTENSION_STRING_MAPS = {
+    video_sensing: {
+        video_turn: VIDEO_SENSING_VIDEO_STATE_LABELS,
+        video_on: VIDEO_SENSING_VIDEO_ON_LABELS
+    },
+    microbit: {
+        'when_button_is': MICROBIT_BUTTON_LABELS,
+        'button_pressed': MICROBIT_BUTTON_LABELS,
+        'button_pressed?': MICROBIT_BUTTON_LABELS,
+        'when': MICROBIT_GESTURE_LABELS,
+        'when_tilted': MICROBIT_TILT_LABELS,
+        'tilted?': MICROBIT_TILT_LABELS,
+        'tilt_angle': MICROBIT_TILT_LABELS,
+        'magnetic_force': MICROBIT_AXIS_LABELS,
+        'acceleration': MICROBIT_AXIS_LABELS,
+        'set_pin_to_input_pull': MICROBIT_PULL_MODE_LABELS
+    },
+    smalrubot_s1: {
+        action: SMALRUBOT_S1_ACTION_LABELS
+    }
+};
+
+// ---- Extension handler methods ----
+
+const extensionHandlers = {
+
+    _annotateVideoSensingMethod (node, name) {
+        const labels = {
+            'when_video_motion_greater_than': 'ビデオモーション ＞ のとき',
+            'video_turn': 'ビデオを切り替える',
+            'video_transparency=': 'ビデオの透明度を設定',
+            'video_on': 'ビデオの値'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateText2SpeechMethod (node, name) {
+        const labels = {
+            'speak': '話す',
+            'voice=': '声を設定',
+            'language=': '言語を設定'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateMicrobitMethod (node, name) {
+        const labels = {
+            'when_microbit': '接続が変わったとき',
+            'when_button_is': 'ボタンのとき',
+            'button_pressed?': 'ボタンが押されたか',
+            'when_pin_is': 'ピンのとき',
+            'pin_is_touched?': 'ピンに触れたか',
+            'when_pin_connected': 'ピンがつながったとき',
+            'when': 'のとき',
+            'when_tilted': '傾いたとき',
+            'tilted?': '傾いているか',
+            'tilt_angle': '傾きの角度',
+            'display_pattern': 'LEDに表示',
+            'display_text': 'テキスト表示',
+            'display_text_delay': 'テキスト表示(遅延)',
+            'clear_display': 'LED消去',
+            'light_intensity': '明るさ',
+            'temperature': '温度',
+            'angle_with_north': '北との角度',
+            'pitch': 'ピッチ',
+            'roll': 'ロール',
+            'sound_level': '音の大きさ',
+            'magnetic_force': '磁力',
+            'acceleration': '加速度',
+            'analog_value': 'アナログ値',
+            'set_pin_to_input_pull': 'ピンのプル設定',
+            'is_pin_high?': 'ピンがHighか',
+            'set_digital': 'デジタル出力',
+            'set_analog': 'アナログ出力',
+            'set_servo': 'サーボ設定',
+            'play_tone': '音を鳴らす',
+            'stop_tone': '音を止める',
+            'listen_event_on': 'イベント監視',
+            'when_catch_at_pin': 'ピンイベントのとき',
+            'value_of': 'イベントの値',
+            'when_data_received_from_microbit': 'データ受信のとき',
+            'send_data_to_microbit': 'データ送信'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateMeshV1Method (node, name) {
+        if (name === 'sensor_value') {
+            this._addAnnotation(node.messageLoc, 'センサーの値');
+        }
+    },
+
+    _annotateMeshV2Method (node, name) {
+        if (name === 'sensor_value') {
+            this._addAnnotation(node.messageLoc, 'センサーの値');
+        }
+    },
+
+    _annotateSmalrubotS1Method (node, name) {
+        const labels = {
+            'action': '動作する',
+            'bend_arm': 'アームを曲げる',
+            'led': 'LED設定',
+            'set_motor_speed': 'モーター速度を設定',
+            'sensor_value': 'センサーの値',
+            'get_motor_speed': 'モーター速度',
+            'arm_calibration=': 'アーム調整'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateKoshienMethod (node, name) {
+        const labels = {
+            connect_game: 'ゲームに接続',
+            move_to: '移動する',
+            turn_over: 'ターン終了',
+            calc_route: 'ルート計算',
+            locate_objects: 'オブジェクト配置',
+            get_map_area: 'マップエリア',
+            map: 'マップ',
+            map_from: 'マップ(変数)',
+            map_all: '全マップ',
+            position: '座標',
+            position_of_x: 'X座標取得',
+            position_of_y: 'Y座標取得',
+            object: 'オブジェクト',
+            set_message: 'メッセージ設定'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    }
+};
+
+export {
+    EXTENSION_HANDLER_MAP,
+    EXTENSION_RECEIVER_LABELS,
+    EXTENSION_STRING_MAPS,
+    extensionHandlers
+};

--- a/packages/scratch-gui/src/lib/furigana-extension-handlers.js
+++ b/packages/scratch-gui/src/lib/furigana-extension-handlers.js
@@ -34,7 +34,7 @@ const EXTENSION_RECEIVER_LABELS = {
     mesh_v1: 'メッシュ(従来)',
     mesh: 'メッシュ',
     smalrubot_s1: 'スモウルボットS1',
-    koshien: '甲子園'
+    koshien: 'スモウルビー甲子園'
 };
 
 // ---- Extension-specific string label maps ----
@@ -85,7 +85,19 @@ const SMALRUBOT_S1_POSITION_LABELS = {
 };
 
 /**
- * Maps extension receiver names → { methodName: stringLabelMap }.
+ * Dynamic label function for koshien position strings ("X:Y" → "x:X,y:Y").
+ * @param {string} content - string literal value
+ * @returns {string|null} furigana label or null
+ */
+const KOSHIEN_POSITION_LABEL_FN = content => {
+    const match = content.match(/^(-?\d+):(-?\d+)$/);
+    if (match) return `x:${match[1]},y:${match[2]}`;
+    return null;
+};
+
+/**
+ * Maps extension receiver names → { methodName: stringLabelMap|function }.
+ * Values can be plain objects (exact match) or functions (dynamic transform).
  * Used to set context-specific _stringLabelMap before walking arguments.
  */
 const EXTENSION_STRING_MAPS = {
@@ -107,6 +119,14 @@ const EXTENSION_STRING_MAPS = {
     },
     smalrubot_s1: {
         action: SMALRUBOT_S1_ACTION_LABELS
+    },
+    koshien: {
+        move_to: KOSHIEN_POSITION_LABEL_FN,
+        get_map_area: KOSHIEN_POSITION_LABEL_FN,
+        map: KOSHIEN_POSITION_LABEL_FN,
+        map_from: KOSHIEN_POSITION_LABEL_FN,
+        position_of_x: KOSHIEN_POSITION_LABEL_FN,
+        position_of_y: KOSHIEN_POSITION_LABEL_FN
     }
 };
 

--- a/packages/scratch-gui/src/lib/furigana-label-map.js
+++ b/packages/scratch-gui/src/lib/furigana-label-map.js
@@ -107,6 +107,8 @@ const TOPLEVEL_METHOD_LABELS = {
     // Music
     'play_drum': 'ドラムを鳴らす',
     'play_note': '音符を鳴らす',
+    // Translate
+    'translate': '翻訳する',
     // Class configuration (set_xxx)
     'set_name': '名前を設定',
     'set_sprite': 'スプライトを設定',
@@ -141,7 +143,8 @@ const TOPLEVEL_PROPERTY_LABELS = {
     loudness: 'マイクの音量',
     days_since_2000: '2000年からの日数',
     user_name: 'ユーザー名',
-    tempo: 'テンポ'
+    tempo: 'テンポ',
+    language: '言語'
 };
 
 /**

--- a/packages/scratch-gui/src/lib/furigana-label-map.js
+++ b/packages/scratch-gui/src/lib/furigana-label-map.js
@@ -144,8 +144,96 @@ const TOPLEVEL_PROPERTY_LABELS = {
     tempo: 'テンポ'
 };
 
+/**
+ * Special string values used in smalruby that represent UI menu options.
+ * Labels are sourced from scratch-l10n editor/blocks/ja.json.
+ */
+const SPECIAL_STRING_LABELS = {
+    // Special sprite/location targets
+    '_mouse_': 'マウスのポインター',
+    '_edge_': '端',
+    '_random_': 'ランダムな場所',
+    '_myself_': '自分自身',
+    // Key names (EVENT_WHENKEYPRESSED_*)
+    'space': 'スペース',
+    'left arrow': '左向き矢印',
+    'right arrow': '右向き矢印',
+    'down arrow': '下向き矢印',
+    'up arrow': '上向き矢印',
+    'any': 'どれかのキー',
+    // Stop options (CONTROL_STOP_*)
+    'all': 'すべて',
+    'this script': 'このスクリプト',
+    'other scripts in sprite': 'スプライトの他のスクリプト',
+    // Rotation styles (MOTION_SETROTATIONSTYLE_*)
+    'all around': '自由に回転',
+    'left-right': '左右のみ',
+    "don't rotate": '回転しない',
+    // Drag modes (SENSING_SETDRAGMODE_*)
+    'draggable': 'できる',
+    'not draggable': 'できない',
+    // Sound effects (SOUND_EFFECTS_*)
+    'PITCH': 'ピッチ',
+    'PAN': '左右にパン',
+    // Graphic effects (LOOKS_EFFECT_*)
+    'color': '色',
+    'fisheye': '魚眼レンズ',
+    'whirl': '渦巻き',
+    'pixelate': 'ピクセル化',
+    'mosaic': 'モザイク',
+    'brightness': '明るさ',
+    'ghost': '幽霊'
+};
+
+/**
+ * Methods whose literal arguments should use a unit suffix instead of 数値/文字列.
+ * e.g. move(10) → 「10歩」 instead of 「数値10」
+ */
+const METHOD_ARG_UNITS = {
+    move: '歩',
+    turn_right: '度',
+    turn_left: '度',
+    sleep: '秒'
+};
+
+/**
+ * Context-specific string labels for face_sensing PART menu arguments.
+ */
+const FACE_SENSING_PART_LABELS = {
+    nose: '鼻',
+    mouth: '口',
+    left_eye: '左目',
+    right_eye: '右目',
+    between_eyes: '両目の間',
+    left_ear: '左耳',
+    right_ear: '右耳',
+    top_of_head: '頭のてっぺん'
+};
+
+/**
+ * Context-specific string labels for face_sensing DIRECTION menu arguments.
+ */
+const FACE_SENSING_DIRECTION_LABELS = {
+    left: '左',
+    right: '右'
+};
+
+/**
+ * Maps face_sensing method names to their context-specific string label maps.
+ */
+const FACE_SENSING_STRING_MAP = {
+    go_to: FACE_SENSING_PART_LABELS,
+    when_this_sprite_touch: FACE_SENSING_PART_LABELS,
+    when_face_tilted: FACE_SENSING_DIRECTION_LABELS
+};
+
 export {
     RECEIVER_METHOD_LABELS,
     TOPLEVEL_METHOD_LABELS,
-    TOPLEVEL_PROPERTY_LABELS
+    TOPLEVEL_PROPERTY_LABELS,
+    SPECIAL_STRING_LABELS,
+    METHOD_ARG_UNITS,
+    FACE_SENSING_PART_LABELS,
+    FACE_SENSING_DIRECTION_LABELS,
+    FACE_SENSING_STRING_MAP
 };

--- a/packages/scratch-gui/src/lib/furigana-node-handlers.js
+++ b/packages/scratch-gui/src/lib/furigana-node-handlers.js
@@ -115,10 +115,18 @@ const nodeHandlers = {
         const unescaped = node.unescaped;
         const content = (unescaped && typeof unescaped === 'object') ?
             unescaped.value : unescaped;
-        // Check context-specific string label map first (e.g., face_sensing PART/DIRECTION)
-        if (this._stringLabelMap && this._stringLabelMap[content]) {
-            this._addAnnotation(node.location, this._stringLabelMap[content]);
-            return;
+        // Check context-specific string label map/function first
+        if (this._stringLabelMap) {
+            if (typeof this._stringLabelMap === 'function') {
+                const fnLabel = this._stringLabelMap(content);
+                if (fnLabel) {
+                    this._addAnnotation(node.location, fnLabel);
+                    return;
+                }
+            } else if (this._stringLabelMap[content]) {
+                this._addAnnotation(node.location, this._stringLabelMap[content]);
+                return;
+            }
         }
         const specialLabel = SPECIAL_STRING_LABELS[content];
         this._addAnnotation(node.location, specialLabel || `文字列「${content}」`);

--- a/packages/scratch-gui/src/lib/furigana-node-handlers.js
+++ b/packages/scratch-gui/src/lib/furigana-node-handlers.js
@@ -1,0 +1,244 @@
+// === Smalruby: This file is Smalruby-specific (furigana node handlers) ===
+
+import {SPECIAL_STRING_LABELS} from './furigana-label-map';
+
+/**
+ * AST node handler methods for FuriganaAnnotator.
+ * Covers: variables, literals, control flow, and logical operators.
+ * These are mixed into FuriganaAnnotator.prototype via Object.assign.
+ */
+const nodeHandlers = {
+
+    // ---- Variables ----
+
+    _handleLocalVariableWriteNode (node) {
+        this._addAnnotation(node.nameLoc, `変数${node.name}`);
+        this._addAnnotation(node.operatorLoc, '紐付ける');
+        this._walkNode(node.value);
+    },
+
+    _handleLocalVariableReadNode (node) {
+        this._addAnnotation(node.location, `変数${node.name}`);
+    },
+
+    _handleLocalVariableOperatorWriteNode (node) {
+        this._addAnnotation(node.nameLoc, `変数${node.name}`);
+        this._addAnnotation(node.binaryOperatorLoc, this._opAsgnLabel(node.binaryOperator, node.value));
+        this._walkNode(node.value);
+    },
+
+    _handleInstanceVariableWriteNode (node) {
+        this._addAnnotation(node.nameLoc, `インスタンス変数${node.name.slice(1)}`);
+        this._addAnnotation(node.operatorLoc, '紐付ける');
+        this._walkNode(node.value);
+    },
+
+    _handleInstanceVariableReadNode (node) {
+        this._addAnnotation(node.location, `インスタンス変数${node.name.slice(1)}`);
+    },
+
+    _handleInstanceVariableOperatorWriteNode (node) {
+        this._addAnnotation(node.nameLoc, `インスタンス変数${node.name.slice(1)}`);
+        this._addAnnotation(node.binaryOperatorLoc, this._opAsgnLabel(node.binaryOperator, node.value));
+        this._walkNode(node.value);
+    },
+
+    _handleGlobalVariableWriteNode (node) {
+        this._addAnnotation(node.nameLoc, `グローバル変数${node.name.slice(1)}`);
+        this._addAnnotation(node.operatorLoc, '紐付ける');
+        this._walkNode(node.value);
+    },
+
+    _handleGlobalVariableReadNode (node) {
+        this._addAnnotation(node.location, `グローバル変数${node.name.slice(1)}`);
+    },
+
+    _handleGlobalVariableOperatorWriteNode (node) {
+        this._addAnnotation(node.nameLoc, `グローバル変数${node.name.slice(1)}`);
+        this._addAnnotation(node.binaryOperatorLoc, this._opAsgnLabel(node.binaryOperator, node.value));
+        this._walkNode(node.value);
+    },
+
+    /**
+     * Returns furigana label for operator-assignment (+=, -=, *=, etc.)
+     * @param {string} binaryOperator - e.g. '+', '-', '*', '/', '%', '**'
+     * @param {object} valueNode - prism AST node for the RHS
+     */
+    _opAsgnLabel (binaryOperator, valueNode) {
+        switch (binaryOperator) {
+        case '+':
+            return this._isStringType(valueNode) ? 'と連結' : 'ずつ増やす';
+        case '-':
+            return 'ずつ減らす';
+        case '*':
+            return '倍にする';
+        case '/':
+            return '分の1にする';
+        case '%':
+            return '余りにする';
+        case '**':
+            return 'べき乗にする';
+        default:
+            return binaryOperator;
+        }
+    },
+
+    // ---- Literals ----
+
+    _handleIntegerNode (node) {
+        const text = this._getSourceText(node.location);
+        if (this._argUnit) {
+            this._addAnnotation(node.location, `${text}${this._argUnit}`);
+        } else {
+            this._addAnnotation(node.location, `数値${text}`);
+        }
+    },
+
+    _handleFloatNode (node) {
+        const text = this._getSourceText(node.location);
+        if (this._argUnit) {
+            this._addAnnotation(node.location, `${text}${this._argUnit}`);
+        } else {
+            this._addAnnotation(node.location, `数値${text}`);
+        }
+    },
+
+    _handleTrueNode (node) {
+        this._addAnnotation(node.location, '真');
+    },
+
+    _handleFalseNode (node) {
+        this._addAnnotation(node.location, '偽');
+    },
+
+    _handleStringNode (node) {
+        const unescaped = node.unescaped;
+        const content = (unescaped && typeof unescaped === 'object') ?
+            unescaped.value : unescaped;
+        // Check context-specific string label map first (e.g., face_sensing PART/DIRECTION)
+        if (this._stringLabelMap && this._stringLabelMap[content]) {
+            this._addAnnotation(node.location, this._stringLabelMap[content]);
+            return;
+        }
+        const specialLabel = SPECIAL_STRING_LABELS[content];
+        this._addAnnotation(node.location, specialLabel || `文字列「${content}」`);
+    },
+
+    // ---- Control flow: if / elsif / else ----
+
+    _handleIfNode (node) {
+        const keyword = this._getSourceText(node.ifKeywordLoc);
+        if (keyword === 'if') {
+            this._addAnnotation(node.ifKeywordLoc, 'もし');
+            if (node.endKeywordLoc) {
+                this._addAnnotation(node.endKeywordLoc, '分岐終了');
+            }
+        } else if (keyword === 'elsif') {
+            this._addAnnotation(node.ifKeywordLoc, 'ではなく');
+        }
+        this._walkNode(node.predicate);
+        this._walkNode(node.statements);
+        this._walkNode(node.subsequent);
+    },
+
+    _handleElseNode (node) {
+        this._addAnnotation(node.elseKeywordLoc, 'でなければ');
+        this._walkNode(node.statements);
+    },
+
+    // ---- Control flow: until ----
+
+    _handleUntilNode (node) {
+        this._addAnnotation(node.keywordLoc, 'まで繰り返す');
+        if (node.closingLoc) {
+            this._addAnnotation(node.closingLoc, '繰り返し終了');
+        }
+        this._walkNode(node.predicate);
+        this._walkNode(node.statements);
+    },
+
+    // ---- Control flow: while ----
+
+    _handleWhileNode (node) {
+        this._addAnnotation(node.keywordLoc, '真である限り繰り返す');
+        if (node.closingLoc) {
+            this._addAnnotation(node.closingLoc, '繰り返し終了');
+        }
+        this._walkNode(node.predicate);
+        this._walkNode(node.statements);
+    },
+
+    // ---- Method definition ----
+
+    _handleDefNode (node) {
+        this._addAnnotation(node.defKeywordLoc, 'メソッド作成');
+        if (node.nameLoc) {
+            this._addAnnotation(node.nameLoc, `${node.name}という名前`);
+        }
+        if (node.endKeywordLoc) {
+            this._addAnnotation(node.endKeywordLoc, '作成終了');
+        }
+        if (node.parameters) this._walkNode(node.parameters);
+        if (node.body) this._walkNode(node.body);
+    },
+
+    _handleRequiredParameterNode (node) {
+        this._addAnnotation(node.location, `引数${node.name}`);
+    },
+
+    _handleOptionalParameterNode (node) {
+        this._addAnnotation(node.nameLoc || node.location, `引数${node.name}`);
+        this._walkNode(node.value);
+    },
+
+    // ---- return ----
+
+    _handleReturnNode (node) {
+        this._addAnnotation(node.keywordLoc, '呼び出し元に返す');
+        this._walkChildren(node);
+    },
+
+    // ---- class definition ----
+
+    _handleClassNode (node) {
+        this._addAnnotation(node.classKeywordLoc, 'クラス作成');
+        if (node.endKeywordLoc) {
+            this._addAnnotation(node.endKeywordLoc, '作成終了');
+        }
+        this._walkChildren(node);
+    },
+
+    // ---- case / when ----
+
+    _handleCaseNode (node) {
+        this._addAnnotation(node.caseKeywordLoc, '状態分岐');
+        if (node.endKeywordLoc) {
+            this._addAnnotation(node.endKeywordLoc, '分岐終了');
+        }
+        if (node.predicate) this._walkNode(node.predicate);
+        if (node.conditions) node.conditions.forEach(c => this._walkNode(c));
+        if (node.elseClause) this._walkNode(node.elseClause);
+    },
+
+    _handleWhenNode (node) {
+        this._addAnnotation(node.keywordLoc, 'のとき');
+        if (node.conditions) node.conditions.forEach(c => this._walkNode(c));
+        if (node.statements) this._walkNode(node.statements);
+    },
+
+    // ---- Logical operators ----
+
+    _handleAndNode (node) {
+        this._addAnnotation(node.operatorLoc, 'かつ');
+        this._walkNode(node.left);
+        this._walkNode(node.right);
+    },
+
+    _handleOrNode (node) {
+        this._addAnnotation(node.operatorLoc, 'または');
+        this._walkNode(node.left);
+        this._walkNode(node.right);
+    }
+};
+
+export {nodeHandlers};

--- a/packages/scratch-gui/test/unit/lib/furigana-annotator.test.js
+++ b/packages/scratch-gui/test/unit/lib/furigana-annotator.test.js
@@ -1267,26 +1267,35 @@ describe('FuriganaAnnotator', () => {
     });
 
     describe('koshien extension (predefined receiver)', () => {
-        test('koshien receiver → 甲子園', () => {
-            expect(labelsAt(annotate('koshien.turn_over'), 1)).toContain('甲子園');
+        test('koshien receiver → スモウルビー甲子園', () => {
+            expect(labelsAt(annotate('koshien.turn_over'), 1)).toContain('スモウルビー甲子園');
         });
         test('koshien.connect_game(name: "player1") → ゲームに接続', () => {
             expect(labelsAt(annotate('koshien.connect_game(name: "player1")'), 1)).toContain('ゲームに接続');
         });
-        test('koshien.move_to("0:0") → 移動する', () => {
-            expect(labelsAt(annotate('koshien.move_to("0:0")'), 1)).toContain('移動する');
+        test('koshien.move_to("0:0") → 移動する + x:0,y:0', () => {
+            const labels = labelsAt(annotate('koshien.move_to("0:0")'), 1);
+            expect(labels).toContain('移動する');
+            expect(labels).toContain('x:0,y:0');
         });
         test('koshien.turn_over → ターン終了', () => {
             expect(labelsAt(annotate('koshien.turn_over'), 1)).toContain('ターン終了');
         });
-        test('koshien.map("0:0") → マップ', () => {
-            expect(labelsAt(annotate('koshien.map("0:0")'), 1)).toContain('マップ');
+        test('koshien.map("1:2") → マップ + x:1,y:2', () => {
+            const labels = labelsAt(annotate('koshien.map("1:2")'), 1);
+            expect(labels).toContain('マップ');
+            expect(labels).toContain('x:1,y:2');
         });
         test('koshien.position(0, 0) → 座標', () => {
             expect(labelsAt(annotate('koshien.position(0, 0)'), 1)).toContain('座標');
         });
         test('koshien.set_message("hello") → メッセージ設定', () => {
             expect(labelsAt(annotate('koshien.set_message("hello")'), 1)).toContain('メッセージ設定');
+        });
+        test('koshien.get_map_area("-1:3") → マップエリア + x:-1,y:3', () => {
+            const labels = labelsAt(annotate('koshien.get_map_area("-1:3")'), 1);
+            expect(labels).toContain('マップエリア');
+            expect(labels).toContain('x:-1,y:3');
         });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/furigana-annotator.test.js
+++ b/packages/scratch-gui/test/unit/lib/furigana-annotator.test.js
@@ -1131,4 +1131,162 @@ describe('FuriganaAnnotator', () => {
             });
         });
     });
+
+    // ---- Extension furigana tests ----
+
+    describe('translate extension', () => {
+        test('translate("hello", "ja") → 翻訳する', () => {
+            expect(labelsAt(annotate('translate("hello", "ja")'), 1)).toContain('翻訳する');
+        });
+        test('language → 言語', () => {
+            expect(labelsAt(annotate('language'), 1)).toContain('言語');
+        });
+    });
+
+    describe('video_sensing extension (predefined receiver)', () => {
+        test('video_sensing receiver → ビデオ', () => {
+            expect(labelsAt(annotate('video_sensing.video_turn("on")'), 1)).toContain('ビデオ');
+        });
+        test('video_sensing.video_turn("on") → ビデオを切り替える + オン', () => {
+            const labels = labelsAt(annotate('video_sensing.video_turn("on")'), 1);
+            expect(labels).toContain('ビデオを切り替える');
+            expect(labels).toContain('オン');
+        });
+        test('video_sensing.video_turn("off") → オフ', () => {
+            expect(labelsAt(annotate('video_sensing.video_turn("off")'), 1)).toContain('オフ');
+        });
+        test('video_sensing.video_turn("on-flipped") → 左右反転', () => {
+            expect(labelsAt(annotate('video_sensing.video_turn("on-flipped")'), 1)).toContain('左右反転');
+        });
+        test('video_sensing.video_transparency = 50 → ビデオの透明度を設定', () => {
+            expect(labelsAt(annotate('video_sensing.video_transparency = 50'), 1))
+                .toContain('ビデオの透明度を設定');
+        });
+        test('video_sensing.video_on("motion", "this sprite") → ビデオの値 + 動き + このスプライト', () => {
+            const labels = labelsAt(annotate('video_sensing.video_on("motion", "this sprite")'), 1);
+            expect(labels).toContain('ビデオの値');
+            expect(labels).toContain('動き');
+            expect(labels).toContain('このスプライト');
+        });
+        test('video_sensing.when_video_motion_greater_than(10) do; end → ビデオモーション ＞ のとき', () => {
+            const labels = labelsAt(annotate('video_sensing.when_video_motion_greater_than(10) do; end'), 1);
+            expect(labels).toContain('ビデオ');
+            expect(labels).toContain('ビデオモーション ＞ のとき');
+        });
+    });
+
+    describe('text2speech extension (predefined receiver)', () => {
+        test('text2speech receiver → 音声合成', () => {
+            expect(labelsAt(annotate('text2speech.speak("hello")'), 1)).toContain('音声合成');
+        });
+        test('text2speech.speak("hello") → 話す', () => {
+            expect(labelsAt(annotate('text2speech.speak("hello")'), 1)).toContain('話す');
+        });
+        test('text2speech.voice = "ALTO" → 声を設定', () => {
+            expect(labelsAt(annotate('text2speech.voice = "ALTO"'), 1)).toContain('声を設定');
+        });
+        test('text2speech.language = "ja" → 言語を設定', () => {
+            expect(labelsAt(annotate('text2speech.language = "ja"'), 1)).toContain('言語を設定');
+        });
+    });
+
+    describe('microbit extension (predefined receiver)', () => {
+        test('microbit receiver → マイクロビット', () => {
+            expect(labelsAt(annotate('microbit.temperature'), 1)).toContain('マイクロビット');
+        });
+        test('microbit.temperature → 温度', () => {
+            expect(labelsAt(annotate('microbit.temperature'), 1)).toContain('温度');
+        });
+        test('microbit.light_intensity → 明るさ', () => {
+            expect(labelsAt(annotate('microbit.light_intensity'), 1)).toContain('明るさ');
+        });
+        test('microbit.button_pressed?("A") → ボタンが押されたか + A', () => {
+            const labels = labelsAt(annotate('microbit.button_pressed?("A")'), 1);
+            expect(labels).toContain('ボタンが押されたか');
+            expect(labels).toContain('A');
+        });
+        test('microbit.when_tilted("LEFT") do; end → 傾いたとき + 左', () => {
+            const labels = labelsAt(annotate('microbit.when_tilted("LEFT") do; end'), 1);
+            expect(labels).toContain('傾いたとき');
+            expect(labels).toContain('左');
+        });
+        test('microbit.display_text("Hello!") → テキスト表示', () => {
+            expect(labelsAt(annotate('microbit.display_text("Hello!")'), 1)).toContain('テキスト表示');
+        });
+        test('microbit.clear_display → LED消去', () => {
+            expect(labelsAt(annotate('microbit.clear_display'), 1)).toContain('LED消去');
+        });
+        test('microbit.acceleration("x") → 加速度 + x', () => {
+            const labels = labelsAt(annotate('microbit.acceleration("x")'), 1);
+            expect(labels).toContain('加速度');
+            expect(labels).toContain('x');
+        });
+        test('microbit.play_tone(440, 100) → 音を鳴らす', () => {
+            expect(labelsAt(annotate('microbit.play_tone(440, 100)'), 1)).toContain('音を鳴らす');
+        });
+        test('microbit.send_data_to_microbit("data", "label") → データ送信', () => {
+            expect(labelsAt(annotate('microbit.send_data_to_microbit("data", "label")'), 1))
+                .toContain('データ送信');
+        });
+    });
+
+    describe('mesh extensions (predefined receiver)', () => {
+        test('mesh_v1.sensor_value("x") → メッシュ(従来) + センサーの値', () => {
+            const labels = labelsAt(annotate('mesh_v1.sensor_value("x")'), 1);
+            expect(labels).toContain('メッシュ(従来)');
+            expect(labels).toContain('センサーの値');
+        });
+        test('mesh.sensor_value("x") → メッシュ + センサーの値', () => {
+            const labels = labelsAt(annotate('mesh.sensor_value("x")'), 1);
+            expect(labels).toContain('メッシュ');
+            expect(labels).toContain('センサーの値');
+        });
+    });
+
+    describe('smalrubot_s1 extension (predefined receiver)', () => {
+        test('smalrubot_s1 receiver → スモウルボットS1', () => {
+            expect(labelsAt(annotate('smalrubot_s1.action("forward")'), 1)).toContain('スモウルボットS1');
+        });
+        test('smalrubot_s1.action("forward") → 動作する + 進める', () => {
+            const labels = labelsAt(annotate('smalrubot_s1.action("forward")'), 1);
+            expect(labels).toContain('動作する');
+            expect(labels).toContain('進める');
+        });
+        test('smalrubot_s1.action("backward") → バックさせる', () => {
+            expect(labelsAt(annotate('smalrubot_s1.action("backward")'), 1)).toContain('バックさせる');
+        });
+        test('smalrubot_s1.sensor_value("left") → センサーの値', () => {
+            expect(labelsAt(annotate('smalrubot_s1.sensor_value("left")'), 1)).toContain('センサーの値');
+        });
+        test('smalrubot_s1.bend_arm(90, 1) → アームを曲げる', () => {
+            expect(labelsAt(annotate('smalrubot_s1.bend_arm(90, 1)'), 1)).toContain('アームを曲げる');
+        });
+        test('smalrubot_s1.get_motor_speed("left") → モーター速度', () => {
+            expect(labelsAt(annotate('smalrubot_s1.get_motor_speed("left")'), 1)).toContain('モーター速度');
+        });
+    });
+
+    describe('koshien extension (predefined receiver)', () => {
+        test('koshien receiver → 甲子園', () => {
+            expect(labelsAt(annotate('koshien.turn_over'), 1)).toContain('甲子園');
+        });
+        test('koshien.connect_game(name: "player1") → ゲームに接続', () => {
+            expect(labelsAt(annotate('koshien.connect_game(name: "player1")'), 1)).toContain('ゲームに接続');
+        });
+        test('koshien.move_to("0:0") → 移動する', () => {
+            expect(labelsAt(annotate('koshien.move_to("0:0")'), 1)).toContain('移動する');
+        });
+        test('koshien.turn_over → ターン終了', () => {
+            expect(labelsAt(annotate('koshien.turn_over'), 1)).toContain('ターン終了');
+        });
+        test('koshien.map("0:0") → マップ', () => {
+            expect(labelsAt(annotate('koshien.map("0:0")'), 1)).toContain('マップ');
+        });
+        test('koshien.position(0, 0) → 座標', () => {
+            expect(labelsAt(annotate('koshien.position(0, 0)'), 1)).toContain('座標');
+        });
+        test('koshien.set_message("hello") → メッセージ設定', () => {
+            expect(labelsAt(annotate('koshien.set_message("hello")'), 1)).toContain('メッセージ設定');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

スモウルビーでデフォルト表示される全拡張機能の Ruby ふりがなに対応。

- `furigana-annotator.js`（900行）を4ファイル（各≤300行）に分割
- 全9拡張の事前定義レシーバーのふりがなを追加（ディスパッチマップパターン）
- translate, language のトップレベルラベルを追加
- 292テスト全パス（254既存 + 38新規）

## 対応拡張機能

| 拡張機能 | レシーバー | 状態 |
|---------|-----------|------|
| pen | `pen` | 対応済み（既存） |
| face_sensing | `face_sensing` | 対応済み（既存） |
| music | `self.` | 対応済み（既存） |
| translate | `self.` | **新規追加** |
| video_sensing | `video_sensing` | **新規追加** |
| text2speech | `text2speech` | **新規追加** |
| microbitMore | `microbit` | **新規追加** |
| mesh (old) | `mesh_v1` | **新規追加** |
| meshV2 | `mesh` | **新規追加** |
| smalrubot_s1 | `smalrubot_s1` | **新規追加** |
| koshien | `koshien` | **新規追加** |

## Changes

- **refactor**: `furigana-annotator.js` → 4ファイルに分割（Object.assign mixin pattern）
  - `furigana-annotator.js` (293行): メインクラス + `_handleCallNode`
  - `furigana-node-handlers.js` (244行): 変数/リテラル/制御構造
  - `furigana-call-helpers.js` (293行): メソッド呼び出しヘルパー
  - `furigana-label-map.js` (242行): ラベルマップ + 静的データ
- **feat**: `furigana-extension-handlers.js` (233行): 拡張機能ハンドラ + ディスパッチ設定
- **docs**: `furigana-mapping.md` に全拡張のふりがな対応表を追加

## Test Plan

- [x] 既存254テスト全パス（分割リファクタリング後の互換性確認）
- [x] 新規38テスト追加（各拡張のふりがなラベル出力確認）
- [ ] CI全テスト通過

Closes #283
