### PR TITLE
feat: validate Ruby code by block conversion before saving

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -239,6 +239,7 @@ class MenuBar extends React.Component {
             'getSaveAIAsHandler',
             'getTestAIHandler',
             'handleAISaveFinished',
+            'handleTestAISaveFinished',
             'handleAISaveAsFinished',
             'handleAISaveError',
             'restoreOptionMessage',
@@ -411,14 +412,14 @@ class MenuBar extends React.Component {
     }
     getTestAIHandler (downloadProjectCallback) {
         return () => {
-            // Option B: Save after displaying the modal
-            // Open the Koshien test modal
-            this.props.onOpenKoshienTestModal();
-            // Set AI save status to 'saving'
+            // Save first, then open modal via onSaveFinished callback
             this.props.onSetAiSaveStatus('saving');
-            // Call download callback
             downloadProjectCallback();
         };
+    }
+    handleTestAISaveFinished () {
+        this.handleAISaveFinished();
+        this.props.onOpenKoshienTestModal();
     }
     handleAISaveAsFinished () {
         // Set AI save status to 'saved'
@@ -1143,7 +1144,7 @@ class MenuBar extends React.Component {
                                     <MenuSection>
                                         <RubyDownloader
                                             onSaveError={this.handleAISaveError}
-                                            onSaveFinished={this.handleAISaveFinished}
+                                            onSaveFinished={this.handleTestAISaveFinished}
                                         >
                                             {(className, downloadProjectCallback) => (
                                                 <MenuItem

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -101,7 +101,9 @@ import {
     toggleSettingsMenu
 } from '../../reducers/menus';
 
-import {updateRubyCodeTarget} from '../../reducers/ruby-code';
+import {updateRubyCodeTarget, updateRubyCodeErrors} from '../../reducers/ruby-code';
+import {activateTab, RUBY_TAB_INDEX} from '../../reducers/editor-tab';
+import {showAlertWithTimeout} from '../../reducers/alerts';
 
 import collectMetadata from '../../lib/collect-metadata';
 import {PLATFORM} from '../../lib/platform';
@@ -242,6 +244,7 @@ class MenuBar extends React.Component {
             'handleTestAISaveFinished',
             'handleAISaveAsFinished',
             'handleAISaveError',
+            'handleConversionError',
             'restoreOptionMessage',
             'handleClickLoadFromUrl',
             'handleSaveDirectlyToGoogleDrive',
@@ -432,6 +435,11 @@ class MenuBar extends React.Component {
     handleAISaveError () {
         // Clear AI save status
         this.props.onClearAiSaveStatus();
+    }
+    handleConversionError (errors) {
+        this.props.onActivateRubyTab();
+        this.props.onShowConvertRubyToBlocksErrorAlert();
+        this.props.onUpdateRubyCodeErrors(errors);
     }
     handleClickLoadFromUrl () {
         if (this.props.onStartSelectingUrlLoad) {
@@ -1106,6 +1114,7 @@ class MenuBar extends React.Component {
                                 >
                                     <MenuSection>
                                         <RubyDownloader
+                                            onConversionError={this.handleConversionError}
                                             onSaveError={this.handleAISaveError}
                                             onSaveFinished={this.handleAISaveFinished}
                                         >
@@ -1124,6 +1133,7 @@ class MenuBar extends React.Component {
                                         </RubyDownloader>
                                         <RubyDownloader
                                             forceFilePicker
+                                            onConversionError={this.handleConversionError}
                                             onSaveError={this.handleAISaveError}
                                             onSaveFinished={this.handleAISaveAsFinished}
                                         >
@@ -1143,6 +1153,7 @@ class MenuBar extends React.Component {
                                     </MenuSection>
                                     <MenuSection>
                                         <RubyDownloader
+                                            onConversionError={this.handleConversionError}
                                             onSaveError={this.handleAISaveError}
                                             onSaveFinished={this.handleTestAISaveFinished}
                                         >
@@ -1518,6 +1529,7 @@ MenuBar.propTypes = {
     onClickLogin: PropTypes.func,
     onClickLogo: PropTypes.func,
     onOpenTipsLibrary: PropTypes.func,
+    onActivateRubyTab: PropTypes.func,
     onActivateTutorial: PropTypes.func,
     showTutorialTooltip: PropTypes.bool,
     onClickMeshV2: PropTypes.func,
@@ -1556,6 +1568,7 @@ MenuBar.propTypes = {
     onSaveDirectlyToGoogleDrive: PropTypes.func,
     onSetAiSaveStatus: PropTypes.func,
     onSetMeshV2Domain: PropTypes.func,
+    onShowConvertRubyToBlocksErrorAlert: PropTypes.func,
     onClearAiSaveStatus: PropTypes.func,
     onStartSelectingUrlLoad: PropTypes.func,
     onToggleLoginOpen: PropTypes.func,
@@ -1568,6 +1581,7 @@ MenuBar.propTypes = {
     settingsMenuOpen: PropTypes.bool,
     shouldSaveBeforeTransition: PropTypes.func,
     showComingSoon: PropTypes.bool,
+    onUpdateRubyCodeErrors: PropTypes.func,
     updateRubyCodeTargetState: PropTypes.func,
     username: PropTypes.string,
     avatarBadge: PropTypes.number,
@@ -1686,7 +1700,10 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     onSeeCommunity: ownProps.onSeeCommunity ?? (() => dispatch(setPlayer(true))),
     onSetTimeTravelMode: mode => dispatch(setTimeTravel(mode)),
     updateRubyCodeTargetState: target => dispatch(updateRubyCodeTarget(target)),
-    onStartSelectingUrlLoad: () => dispatch(openUrlLoaderModal())
+    onStartSelectingUrlLoad: () => dispatch(openUrlLoaderModal()),
+    onActivateRubyTab: () => dispatch(activateTab(RUBY_TAB_INDEX)),
+    onShowConvertRubyToBlocksErrorAlert: () => showAlertWithTimeout(dispatch, 'convertRubyToBlocksError'),
+    onUpdateRubyCodeErrors: errors => dispatch(updateRubyCodeErrors(errors))
 });
 
 export default compose(

--- a/packages/scratch-gui/src/containers/ruby-downloader.jsx
+++ b/packages/scratch-gui/src/containers/ruby-downloader.jsx
@@ -6,8 +6,9 @@ import {connect} from 'react-redux';
 import {projectTitleInitialState} from '../reducers/project-title';
 import RubyGenerator from '../lib/ruby-generator';
 import VM from '@smalruby/scratch-vm';
-import {rubyCodeShape} from '../reducers/ruby-code';
+import {rubyCodeShape, convertedRubyCode} from '../reducers/ruby-code';
 import {setKoshienFileHandle, clearKoshienFileHandle} from '../reducers/koshien-file';
+import {targetCodeToBlocks} from '../lib/ruby-to-blocks-converter';
 
 class RubyDownloader extends React.Component {
     constructor (props) {
@@ -15,11 +16,52 @@ class RubyDownloader extends React.Component {
         bindAll(this, [
             'downloadProject',
             'saveWithFileSystemAPI',
-            'supportsFileSystemAPI'
+            'supportsFileSystemAPI',
+            'validateAndConvert'
         ]);
     }
     supportsFileSystemAPI () {
         return 'showSaveFilePicker' in window;
+    }
+    /**
+     * Validate Ruby code by converting to blocks. If conversion succeeds,
+     * apply blocks to update sprite/stage state (round-trip).
+     * @param {boolean} converted - set to true after successful conversion
+     * @returns {Promise<boolean>} true if conversion succeeded or was unnecessary
+     */
+    async validateAndConvert () {
+        if (!this.props.rubyCode.modified) {
+            return true;
+        }
+        try {
+            const converter = await targetCodeToBlocks(
+                this.props.vm,
+                this.props.rubyCode.target,
+                this.props.rubyCode.code,
+                this.props.intl,
+                {version: this.props.rubyVersion}
+            );
+            if (!converter.result) {
+                if (this.props.onConversionError) {
+                    this.props.onConversionError(converter.errors);
+                }
+                if (this.props.onSaveError) {
+                    this.props.onSaveError(
+                        new Error('Ruby to blocks conversion failed')
+                    );
+                }
+                return false;
+            }
+            await converter.apply();
+            this.props.onConvertedRubyCode();
+            return true;
+        } catch (err) {
+            console.error('Error during Ruby to blocks conversion:', err);
+            if (this.props.onSaveError) {
+                this.props.onSaveError(err);
+            }
+            return false;
+        }
     }
     saveRuby () {
         const idToTarget = {};
@@ -36,6 +78,9 @@ class RubyDownloader extends React.Component {
             withSpriteNew: true,
             version: this.props.rubyVersion
         };
+        // After validateAndConvert, blocks are already applied and
+        // rubyCode.modified is reset, so targetsCode is not needed.
+        // This branch remains for safety in non-validated paths.
         if (this.props.rubyCode.modified) {
             options.targetsCode = {
                 [this.props.rubyCode.target.id]: this.props.rubyCode.code
@@ -84,10 +129,14 @@ class RubyDownloader extends React.Component {
             }
         }
     }
-    downloadProject () {
+    async downloadProject () {
+        // Validate and convert Ruby code to blocks before saving
+        const valid = await this.validateAndConvert();
+        if (!valid) return;
+
         // Use File System Access API if available (Chrome/Edge)
         if (this.supportsFileSystemAPI()) {
-            this.saveWithFileSystemAPI();
+            await this.saveWithFileSystemAPI();
             return;
         }
 
@@ -135,7 +184,12 @@ RubyDownloader.propTypes = {
     children: PropTypes.func,
     className: PropTypes.string,
     forceFilePicker: PropTypes.bool,
+    intl: PropTypes.shape({
+        formatMessage: PropTypes.func
+    }),
     koshienFileHandle: PropTypes.shape({}),
+    onConversionError: PropTypes.func,
+    onConvertedRubyCode: PropTypes.func,
     onSaveFinished: PropTypes.func,
     onSaveError: PropTypes.func,
     onSetKoshienFileHandle: PropTypes.func,
@@ -167,7 +221,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onSetKoshienFileHandle: fileHandle => dispatch(setKoshienFileHandle(fileHandle)),
-    onClearKoshienFileHandle: () => dispatch(clearKoshienFileHandle())
+    onClearKoshienFileHandle: () => dispatch(clearKoshienFileHandle()),
+    onConvertedRubyCode: () => dispatch(convertedRubyCode())
 });
 
 export default connect(

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -447,6 +447,12 @@ const RubyTab = props => {
         onClearAiSaveStatus();
     }, [onClearAiSaveStatus]);
 
+    const handleConversionError = useCallback(errors => {
+        onShowAlert('convertRubyToBlocksError');
+        updateRubyCodeErrorsState(errors);
+        showErrors(errors);
+    }, [onShowAlert, updateRubyCodeErrorsState]); // showErrors uses refs, safe in stale closure
+
     const handleToggleFurigana = useCallback(() => {
         setFuriganaEnabled(prev => {
             const enabled = !prev;
@@ -839,6 +845,7 @@ const RubyTab = props => {
             </div>
             {/* Hidden RubyDownloader for storing download callback */}
             <RubyDownloader
+                onConversionError={handleConversionError}
                 onSaveError={handleAISaveError}
                 onSaveFinished={handleAISaveFinished}
             >

--- a/packages/scratch-gui/test/unit/containers/ruby-downloader.test.jsx
+++ b/packages/scratch-gui/test/unit/containers/ruby-downloader.test.jsx
@@ -200,6 +200,83 @@ describe('RubyDownloader Container', () => {
             expect(onSaveFinished).not.toHaveBeenCalled();
         });
 
+        test('does not write file when conversion fails', async () => {
+            mockTargetCodeToBlocks.mockResolvedValue({
+                result: false,
+                errors: [{row: 1, column: 0, message: 'error'}]
+            });
+
+            store = createStore({
+                rubyCode: {
+                    modified: true,
+                    code: 'bad code',
+                    target: {id: 'target', blocks: {}}
+                }
+            });
+
+            const {getByText} = render(
+                <Provider store={store}>
+                    <RubyDownloader
+                        onConversionError={jest.fn()}
+                        onSaveError={jest.fn()}
+                    >
+                        {(className, downloadProject) => (
+                            <button onClick={downloadProject}>Download</button>
+                        )}
+                    </RubyDownloader>
+                </Provider>
+            );
+
+            fireEvent.click(getByText('Download'));
+
+            await waitFor(() => {
+                expect(mockTargetCodeToBlocks).toHaveBeenCalled();
+            });
+
+            // File System API should not be called
+            expect(mockWritable.write).not.toHaveBeenCalled();
+        });
+
+        test('writes file after successful conversion round-trip', async () => {
+            const mockApply = jest.fn(() => Promise.resolve());
+            mockTargetCodeToBlocks.mockResolvedValue({
+                result: true,
+                errors: [],
+                apply: mockApply
+            });
+
+            store = createStore({
+                rubyCode: {
+                    modified: true,
+                    code: 'puts "hello"',
+                    target: {id: 'target', blocks: {}}
+                }
+            });
+            const onSaveFinished = jest.fn();
+
+            const {getByText} = render(
+                <Provider store={store}>
+                    <RubyDownloader onSaveFinished={onSaveFinished}>
+                        {(className, downloadProject) => (
+                            <button onClick={downloadProject}>Download</button>
+                        )}
+                    </RubyDownloader>
+                </Provider>
+            );
+
+            fireEvent.click(getByText('Download'));
+
+            await waitFor(() => {
+                expect(onSaveFinished).toHaveBeenCalled();
+            });
+
+            // Conversion was applied
+            expect(mockApply).toHaveBeenCalled();
+            // File was written via File System API
+            expect(mockWritable.write).toHaveBeenCalled();
+            expect(mockWritable.close).toHaveBeenCalled();
+        });
+
         test('dispatches convertedRubyCode after successful conversion', async () => {
             const mockApply = jest.fn(() => Promise.resolve());
             mockTargetCodeToBlocks.mockResolvedValue({

--- a/packages/scratch-gui/test/unit/containers/ruby-downloader.test.jsx
+++ b/packages/scratch-gui/test/unit/containers/ruby-downloader.test.jsx
@@ -4,15 +4,48 @@ import {Provider} from 'react-redux';
 import configureStore from 'redux-mock-store';
 import RubyDownloader from '../../../src/containers/ruby-downloader';
 import _RubyGenerator from '../../../src/lib/ruby-generator';
+import {targetCodeToBlocks as _targetCodeToBlocks} from '../../../src/lib/ruby-to-blocks-converter';
 
 jest.mock('../../../src/lib/ruby-generator', () => ({
     targetsToCode: jest.fn(() => 'mocked ruby code')
 }));
 
+jest.mock('../../../src/lib/ruby-to-blocks-converter', () => ({
+    targetCodeToBlocks: jest.fn(),
+    NullRubyToBlocksConverter: {result: true, errors: [], apply: () => Promise.resolve()}
+}));
+
+const mockTargetCodeToBlocks = _targetCodeToBlocks;
+
 describe('RubyDownloader Container', () => {
     const mockStore = configureStore();
     let store;
     let vm;
+    let mockWritable;
+
+    const createStore = (overrides = {}) => mockStore({
+        scratchGui: {
+            koshienFile: {
+                fileHandle: null
+            },
+            projectTitle: 'project',
+            targets: {
+                sprites: {},
+                stage: {id: 'stage', blocks: {}}
+            },
+            vm: vm,
+            rubyCode: {
+                modified: false,
+                code: '',
+                target: {id: 'target', blocks: {}},
+                ...overrides.rubyCode
+            },
+            settings: {
+                rubyVersion: '1',
+                ...overrides.settings
+            }
+        }
+    });
 
     beforeEach(() => {
         vm = {
@@ -22,29 +55,17 @@ describe('RubyDownloader Container', () => {
                 ]
             }
         };
-        store = mockStore({
-            scratchGui: {
-                koshienFile: {
-                    fileHandle: null
-                },
-                projectTitle: 'project',
-                targets: {
-                    sprites: {},
-                    stage: {id: 'stage', blocks: {}}
-                },
-                vm: vm,
-                rubyCode: {
-                    modified: false,
-                    code: '',
-                    target: {id: 'target', blocks: {}}
-                },
-                settings: {
-                    rubyVersion: '1'
-                }
-            }
-        });
-        // Mock showSaveFilePicker
-        window.showSaveFilePicker = jest.fn();
+        store = createStore();
+
+        mockWritable = {
+            write: jest.fn(() => Promise.resolve()),
+            close: jest.fn(() => Promise.resolve())
+        };
+        window.showSaveFilePicker = jest.fn(() => Promise.resolve({
+            createWritable: jest.fn(() => Promise.resolve(mockWritable))
+        }));
+
+        mockTargetCodeToBlocks.mockReset();
     });
 
     test('calls onSaveError when showSaveFilePicker rejects', async () => {
@@ -68,6 +89,153 @@ describe('RubyDownloader Container', () => {
 
         await waitFor(() => {
             expect(onSaveError).toHaveBeenCalledWith(error);
+        });
+    });
+
+    describe('block conversion validation before save', () => {
+        test('skips conversion when rubyCode is not modified', async () => {
+            store = createStore({rubyCode: {modified: false, code: '', target: {id: 'target'}}});
+            const onSaveFinished = jest.fn();
+
+            const {getByText} = render(
+                <Provider store={store}>
+                    <RubyDownloader onSaveFinished={onSaveFinished}>
+                        {(className, downloadProject) => (
+                            <button onClick={downloadProject}>Download</button>
+                        )}
+                    </RubyDownloader>
+                </Provider>
+            );
+
+            fireEvent.click(getByText('Download'));
+
+            await waitFor(() => {
+                expect(onSaveFinished).toHaveBeenCalled();
+            });
+            expect(mockTargetCodeToBlocks).not.toHaveBeenCalled();
+        });
+
+        test('calls targetCodeToBlocks and apply when rubyCode is modified', async () => {
+            const mockApply = jest.fn(() => Promise.resolve());
+            mockTargetCodeToBlocks.mockResolvedValue({
+                result: true,
+                errors: [],
+                apply: mockApply
+            });
+
+            store = createStore({
+                rubyCode: {
+                    modified: true,
+                    code: 'puts "hello"',
+                    target: {id: 'target', blocks: {}}
+                }
+            });
+            const onSaveFinished = jest.fn();
+
+            const {getByText} = render(
+                <Provider store={store}>
+                    <RubyDownloader onSaveFinished={onSaveFinished}>
+                        {(className, downloadProject) => (
+                            <button onClick={downloadProject}>Download</button>
+                        )}
+                    </RubyDownloader>
+                </Provider>
+            );
+
+            fireEvent.click(getByText('Download'));
+
+            await waitFor(() => {
+                expect(mockTargetCodeToBlocks).toHaveBeenCalledWith(
+                    vm,
+                    {id: 'target', blocks: {}},
+                    'puts "hello"',
+                    undefined,
+                    {version: '1'}
+                );
+            });
+            expect(mockApply).toHaveBeenCalled();
+            await waitFor(() => {
+                expect(onSaveFinished).toHaveBeenCalled();
+            });
+        });
+
+        test('aborts save and calls onConversionError when conversion fails', async () => {
+            const errors = [{row: 1, column: 0, message: 'syntax error'}];
+            mockTargetCodeToBlocks.mockResolvedValue({
+                result: false,
+                errors: errors
+            });
+
+            store = createStore({
+                rubyCode: {
+                    modified: true,
+                    code: 'invalid code',
+                    target: {id: 'target', blocks: {}}
+                }
+            });
+            const onSaveFinished = jest.fn();
+            const onSaveError = jest.fn();
+            const onConversionError = jest.fn();
+
+            const {getByText} = render(
+                <Provider store={store}>
+                    <RubyDownloader
+                        onConversionError={onConversionError}
+                        onSaveError={onSaveError}
+                        onSaveFinished={onSaveFinished}
+                    >
+                        {(className, downloadProject) => (
+                            <button onClick={downloadProject}>Download</button>
+                        )}
+                    </RubyDownloader>
+                </Provider>
+            );
+
+            fireEvent.click(getByText('Download'));
+
+            await waitFor(() => {
+                expect(onConversionError).toHaveBeenCalledWith(errors);
+            });
+            expect(onSaveError).toHaveBeenCalled();
+            expect(onSaveFinished).not.toHaveBeenCalled();
+        });
+
+        test('dispatches convertedRubyCode after successful conversion', async () => {
+            const mockApply = jest.fn(() => Promise.resolve());
+            mockTargetCodeToBlocks.mockResolvedValue({
+                result: true,
+                errors: [],
+                apply: mockApply
+            });
+
+            store = createStore({
+                rubyCode: {
+                    modified: true,
+                    code: 'puts "hello"',
+                    target: {id: 'target', blocks: {}}
+                }
+            });
+
+            const {getByText} = render(
+                <Provider store={store}>
+                    <RubyDownloader>
+                        {(className, downloadProject) => (
+                            <button onClick={downloadProject}>Download</button>
+                        )}
+                    </RubyDownloader>
+                </Provider>
+            );
+
+            fireEvent.click(getByText('Download'));
+
+            await waitFor(() => {
+                expect(mockApply).toHaveBeenCalled();
+            });
+
+            const actions = store.getActions();
+            expect(actions).toContainEqual(
+                expect.objectContaining({type: 'smalruby3-gui/ruby-code/CONVERTED_RUBYCODE'})
+            );
         });
     });
 });


### PR DESCRIPTION
## Summary

Closes #287

Ruby タブの「ルビースクリプトを保存」実行前に、Ruby コードを命令ブロックに変換してバリデーションし、エラーがなければラウンドトリップでスプライト/ステージの状態を更新してから保存する。スモウルビー甲子園メニューも同様。

## Implementation Steps

- [x] **Phase 1**: `RubyDownloader` に変換バリデーション追加
- [x] **Phase 2**: 「AIを試す」の実行順序変更（保存→モーダル表示）
- [x] **Phase 3**: エラー時のユーザーフィードバック改善（Ruby タブアクティブ化・アラート表示）
- [x] **Phase Final**: テスト追加

## Changes Made

### Phase 1: `RubyDownloader` に変換バリデーション追加
- `RubyDownloader` に `validateAndConvert()` メソッド追加
- `downloadProject()` を async 化し、保存前に変換バリデーションを実行
- 変換失敗時は `onConversionError` / `onSaveError` コールバックで保存中断
- 変換成功時は `converter.apply()` → `convertedRubyCode()` dispatch でラウンドトリップ完了

### Phase 2: 「AIを試す」の実行順序変更
- `getTestAIHandler` からモーダル表示を削除
- `handleTestAISaveFinished` メソッド追加（保存完了後にモーダル表示）
- Test AI の `RubyDownloader` の `onSaveFinished` に `handleTestAISaveFinished` を設定

### Phase 3: エラー時のユーザーフィードバック改善
- menu-bar に `handleConversionError` メソッド追加（Ruby タブアクティブ化 + アラート表示 + エラー状態更新）
- ruby-tab に `handleConversionError` コールバック追加（Monaco エディタでのエラーハイライト）
- 全ての `RubyDownloader` インスタンスに `onConversionError` prop を設定

### Phase Final: テスト追加
- ファイル書き込みが変換失敗時にブロックされることを検証するテスト
- ラウンドトリップ変換成功後のファイル書き込みを検証するテスト

## Test Coverage

- Unit tests: `ruby-downloader.test.jsx` (7 tests)
  - ファイルピッカーのエラーハンドリング
  - 未変更時の変換スキップ
  - 変更時の変換＋apply呼び出し
  - 変換失敗時の中断＋onConversionError呼び出し
  - 変換失敗時のファイル書き込みなし
  - 変換成功後のファイル書き込み
  - convertedRubyCode Redux action の dispatch
- Lint: pass (warnings only)
