### PR TITLE
refactor: Ruby ↔ ブロック変換テストの再編成（v2メイン化）

### DIFF
--- a/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/class.test.js
@@ -35,12 +35,12 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1');
             expect(result).toContain('end\n');
-            expect(result).toContain('  self.when(:flag_clicked) do');
+            expect(result).toContain('  when_flag_clicked do');
             // Should NOT output @ruby:class as a comment line
             expect(result).not.toContain('# @ruby:class');
         });
@@ -51,7 +51,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Cat');
@@ -65,7 +65,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1');
@@ -83,7 +83,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = sprite2;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite2');
@@ -96,7 +96,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name=Cat'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Cat');
@@ -112,7 +112,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name=Cat'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Cat');
@@ -134,7 +134,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name=Cat,x,y'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Cat');
@@ -147,7 +147,7 @@ describe('RubyGenerator/Class', () => {
         test('no @ruby:class comment does not wrap with class', () => {
             RubyGenerator.cache_.targetCommentTexts = [];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).not.toContain('class ');
@@ -197,7 +197,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:x,y'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_x 100');
@@ -383,7 +383,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:sprite=Dog1'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_sprite "Dog1"');
@@ -407,7 +407,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:sprite=Dog1,x'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_sprite "Dog1"');
@@ -423,7 +423,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:costumes'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_costumes ["Dog1-a", "Dog1-b"]');
@@ -439,7 +439,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:sounds'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_sounds ["Dog1", "Dog2"]');
@@ -455,7 +455,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:costumes,sounds'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_costumes ["Dog1-a", "Dog1-b"]');
@@ -471,7 +471,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).not.toContain('set_sprite');
@@ -488,12 +488,12 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
             // hat code + non-hat code (separated by blank line as in real output)
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n\nmove(10)\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n\nmove(10)\n';
             const result = RubyGenerator.finish(code, {withSpriteNew: true});
 
             expect(result).toContain('class Sprite1 < ::Smalruby3::Sprite');
             // hat code should be inside class
-            expect(result).toContain('  self.when(:flag_clicked) do');
+            expect(result).toContain('  when_flag_clicked do');
             // non-hat code should be outside class and commented out
             expect(result).toMatch(/^# move\(10\)$/m);
         });
@@ -504,7 +504,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n\nmove(10)\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n\nmove(10)\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1');
@@ -532,7 +532,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+            const code = 'when_flag_clicked do\n  switch_backdrop("Arctic")\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Stage');
@@ -546,7 +546,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:current_backdrop'];
 
-            const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+            const code = 'when_flag_clicked do\n  switch_backdrop("Arctic")\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Stage');
@@ -560,7 +560,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:backdrops'];
 
-            const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+            const code = 'when_flag_clicked do\n  switch_backdrop("Arctic")\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Stage');
@@ -574,7 +574,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:sounds'];
 
-            const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+            const code = 'when_flag_clicked do\n  switch_backdrop("Arctic")\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Stage');
@@ -588,7 +588,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:backdrops,sounds'];
 
-            const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+            const code = 'when_flag_clicked do\n  switch_backdrop("Arctic")\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('set_backdrops ["Arctic", "Baseball 1"]');
@@ -616,7 +616,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+            const code = 'when_flag_clicked do\n  switch_backdrop("Arctic")\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Stage');
@@ -632,24 +632,11 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = [];
 
-            const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+            const code = 'when_flag_clicked do\n  switch_backdrop("Arctic")\nend\n';
             const result = RubyGenerator.finish(code, {withSpriteNew: true});
 
             expect(result).toContain('class Stage < ::Smalruby3::Sprite');
             expect(result).not.toContain('Stage.new');
-        });
-
-        test('stage without @ruby:class in version 1 uses Stage.new format', () => {
-            RubyGenerator.init({version: '1'});
-            const {target} = makeMockStageTarget();
-            RubyGenerator.currentTarget_ = target;
-            RubyGenerator.cache_.targetCommentTexts = [];
-
-            const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
-            const result = RubyGenerator.finish(code, {withSpriteNew: true});
-
-            expect(result).toContain('Stage.new');
-            expect(result).not.toContain('class Stage');
         });
 
         test('@ruby:class with withSpriteNew keeps version 2 hat blocks inside class', () => {
@@ -828,60 +815,7 @@ describe('RubyGenerator/Class', () => {
         });
     });
 
-    describe('withSpriteNew (version 1 file output)', () => {
-        test('@ruby:class with withSpriteNew uses Sprite.new instead of class', () => {
-            RubyGenerator.init({version: '1'});
-            const {target, runtime} = makeMockTarget('ネコ', 1);
-            target.runtime = runtime;
-            target.x = 90;
-            target.y = -50;
-            target.direction = 45;
-            target.visible = true;
-            target.size = 100;
-            target.currentCostume = 0;
-            target.rotationStyle = 'all around';
-            target.isStage = false;
-            target.sprite.costumes = [];
-            target.variables = {};
-            RubyGenerator.currentTarget_ = target;
-            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name,x,y,direction'];
-
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-            const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '1'});
-
-            expect(result).toContain('Sprite.new("ネコ"');
-            expect(result).toContain('x: 90');
-            expect(result).toContain('y: -50');
-            expect(result).toContain('direction: 45');
-            expect(result).not.toContain('class ');
-            expect(result).not.toContain('set_name');
-            expect(result).not.toContain('set_x');
-        });
-
-        test('@ruby:class without attributes and withSpriteNew uses Sprite.new with defaults', () => {
-            RubyGenerator.init({version: '1'});
-            const {target, runtime} = makeMockTarget('Sprite1', 1);
-            target.runtime = runtime;
-            target.x = 0;
-            target.y = 0;
-            target.direction = 90;
-            target.visible = true;
-            target.size = 100;
-            target.currentCostume = 0;
-            target.rotationStyle = 'all around';
-            target.isStage = false;
-            target.sprite.costumes = [];
-            target.variables = {};
-            RubyGenerator.currentTarget_ = target;
-            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
-
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-            const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '1'});
-
-            expect(result).toContain('Sprite.new("Sprite1")');
-            expect(result).not.toContain('class ');
-        });
-
+    describe('withSpriteNew (version 2)', () => {
         test('@ruby:class with version 2 still uses class format even with withSpriteNew', () => {
             RubyGenerator.init({version: '2'});
             const {target, runtime} = makeMockTarget('Sprite1', 1);
@@ -899,7 +833,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '2'});
 
             expect(result).toContain('class Sprite1 < ::Smalruby3::Sprite');
@@ -914,7 +848,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:<=//Smalruby3/Sprite'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1 < ::Smalruby3::Sprite');
@@ -926,7 +860,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:<=Smalruby3/Sprite'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1 < Smalruby3::Sprite');
@@ -938,7 +872,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:<=Foo'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1 < Foo');
@@ -950,7 +884,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:<=Sprite'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1 < Sprite');
@@ -962,7 +896,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1\n');
@@ -985,7 +919,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:<=//Smalruby3/Sprite'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '2'});
 
             expect(result).toContain('class Sprite1 < ::Smalruby3::Sprite');
@@ -1007,7 +941,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:<=Foo'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '2'});
 
             expect(result).toContain('class Sprite1 < Foo');
@@ -1029,7 +963,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '2'});
 
             expect(result).toContain('class Sprite1 < ::Smalruby3::Sprite');
@@ -1042,7 +976,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = target;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:<=Foo,x'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Sprite1 < Foo');
@@ -1056,7 +990,7 @@ describe('RubyGenerator/Class', () => {
             RubyGenerator.currentTarget_ = stage;
             RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).toContain('class Stage\n');

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/file-output-patterns.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/file-output-patterns.test.js
@@ -55,164 +55,7 @@ const setupGenerator = (version, target, commentTexts = []) => {
 };
 
 // ============================================================
-// 1. Version 1 - No class (standard v1 output)
-// ============================================================
-describe('Version 1 - No class (standard v1 output)', () => {
-    test('simple hat block without withSpriteNew returns code as-is', () => {
-        const {target} = makeMockTarget('Sprite1');
-        setupGenerator('1', target);
-
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-        const result = RubyGenerator.finish(code, {});
-
-        expect(result).toBe(code);
-        expect(result).not.toContain('class ');
-        expect(result).not.toContain('Sprite.new');
-    });
-
-    test('multiple hat blocks without withSpriteNew', () => {
-        const {target} = makeMockTarget('Sprite1');
-        setupGenerator('1', target);
-
-        const code =
-            'self.when(:flag_clicked) do\n  move(10)\nend\n\n' +
-            'self.when(:flag_clicked) do\n  turn_right(15)\nend\n';
-        const result = RubyGenerator.finish(code, {});
-
-        expect(result).toBe(code);
-        expect(result).not.toContain('class ');
-    });
-
-    test('hat block with withSpriteNew uses Sprite.new format', () => {
-        const {target} = makeMockTarget('Sprite1', 1, {
-            sprite: {name: 'Sprite1', costumes: [], sounds: []}
-        });
-        setupGenerator('1', target);
-
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-        const result = RubyGenerator.finish(code, {withSpriteNew: true});
-
-        expect(result).toContain('Sprite.new("Sprite1")');
-        expect(result).toContain('  self.when(:flag_clicked) do');
-        expect(result).toContain('end\n');
-        expect(result).not.toContain('class ');
-    });
-
-    test('stage target with withSpriteNew uses Stage.new format', () => {
-        const {target} = makeMockStageTarget({
-            x: 0, y: 0, direction: 90, visible: true, size: 100,
-            currentCostume: 0, rotationStyle: 'all around',
-            sprite: {name: 'Stage', costumes: [], sounds: []}
-        });
-        setupGenerator('1', target);
-
-        const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
-        const result = RubyGenerator.finish(code, {withSpriteNew: true});
-
-        expect(result).toContain('Stage.new("Stage")');
-        expect(result).not.toContain('class ');
-    });
-
-    test('empty code returns empty string', () => {
-        const {target} = makeMockTarget('Sprite1');
-        setupGenerator('1', target);
-
-        const result = RubyGenerator.finish('', {});
-
-        expect(result).toBe('');
-    });
-
-    test('empty code with withSpriteNew still wraps with Sprite.new', () => {
-        const {target} = makeMockTarget('Sprite1', 1, {
-            sprite: {name: 'Sprite1', costumes: [], sounds: []}
-        });
-        setupGenerator('1', target);
-
-        const result = RubyGenerator.finish('', {withSpriteNew: true});
-
-        expect(result).toContain('Sprite.new("Sprite1")');
-        expect(result).toContain('do\n');
-        expect(result).toContain('end\n');
-    });
-
-    test('Sprite.new includes non-default attributes', () => {
-        const {target} = makeMockTarget('Cat', 1, {
-            x: 50, y: -30, direction: 45, visible: false, size: 75,
-            sprite: {
-                name: 'Cat',
-                costumes: [{
-                    assetId: 'abc', name: 'costume1',
-                    bitmapResolution: 1, dataFormat: 'svg',
-                    rotationCenterX: 48, rotationCenterY: 50
-                }],
-                sounds: []
-            },
-            rotationStyle: 'left-right'
-        });
-        setupGenerator('1', target);
-
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-        const result = RubyGenerator.finish(code, {withSpriteNew: true});
-
-        expect(result).toContain('Sprite.new("Cat"');
-        expect(result).toContain('x: 50');
-        expect(result).toContain('y: -30');
-        expect(result).toContain('direction: 45');
-        expect(result).toContain('visible: false');
-        expect(result).toContain('size: 75');
-        expect(result).toContain('rotation_style: "left-right"');
-    });
-});
-
-// ============================================================
-// 2. Version 1 - With @ruby:class
-// ============================================================
-describe('Version 1 - With @ruby:class', () => {
-    test('@ruby:class with withSpriteNew uses Sprite.new (NOT class)', () => {
-        const {target} = makeMockTarget('Sprite1', 1, {
-            sprite: {name: 'Sprite1', costumes: [], sounds: []}
-        });
-        setupGenerator('1', target, ['@ruby:class']);
-
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-        const result = RubyGenerator.finish(code, {withSpriteNew: true});
-
-        expect(result).toContain('Sprite.new("Sprite1")');
-        expect(result).not.toContain('class ');
-    });
-
-    test('@ruby:class:x,y with withSpriteNew uses Sprite.new with attributes', () => {
-        const {target} = makeMockTarget('ネコ', 1, {
-            x: 100, y: -50, direction: 45,
-            sprite: {name: 'ネコ', costumes: [], sounds: []}
-        });
-        setupGenerator('1', target, ['@ruby:class:x,y']);
-
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-        const result = RubyGenerator.finish(code, {withSpriteNew: true});
-
-        expect(result).toContain('Sprite.new("ネコ"');
-        expect(result).toContain('x: 100');
-        expect(result).toContain('y: -50');
-        expect(result).toContain('direction: 45');
-        expect(result).not.toContain('class ');
-    });
-
-    test('@ruby:class WITHOUT withSpriteNew does NOT wrap with class in v1', () => {
-        const {target} = makeMockTarget('Sprite1');
-        setupGenerator('1', target, ['@ruby:class']);
-
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-        const result = RubyGenerator.finish(code, {});
-
-        // v1 ignores @ruby:class entirely
-        expect(result).not.toContain('class ');
-        expect(result).toContain('self.when(:flag_clicked)');
-    });
-});
-
-// ============================================================
-// 3. Version 2 - No class, no withSpriteNew (Ruby tab)
+// 1. Version 2 - No class, no withSpriteNew (Ruby tab)
 // ============================================================
 describe('Version 2 - No class, no withSpriteNew (Ruby tab)', () => {
     test('simple hat block returns code as-is', () => {
@@ -259,7 +102,7 @@ describe('Version 2 - No class, no withSpriteNew (Ruby tab)', () => {
 });
 
 // ============================================================
-// 4. Version 2 - No class, WITH withSpriteNew (file output, auto-wrap)
+// 2. Version 2 - No class, WITH withSpriteNew (file output, auto-wrap)
 // ============================================================
 describe('Version 2 - No class, WITH withSpriteNew (auto-wrap)', () => {
     test('simple sprite auto-wraps with class', () => {
@@ -425,14 +268,14 @@ describe('Version 2 - No class, WITH withSpriteNew (auto-wrap)', () => {
 });
 
 // ============================================================
-// 5. Version 2 - With @ruby:class (user wrote class)
+// 3. Version 2 - With @ruby:class (user wrote class)
 // ============================================================
 describe('Version 2 - With @ruby:class', () => {
     test('@ruby:class WITHOUT withSpriteNew -> class format, no inheritance', () => {
         const {target} = makeMockTarget('Sprite1');
         setupGenerator('2', target, ['@ruby:class']);
 
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const code = 'when_flag_clicked do\n  move(10)\nend\n';
         const result = RubyGenerator.finish(code, {});
 
         expect(result).toContain('class Sprite1');
@@ -577,7 +420,7 @@ describe('Version 2 - With @ruby:class', () => {
 });
 
 // ============================================================
-// 6. Version 2 - Hat block format in class with file output
+// 4. Version 2 - Hat block format in class with file output
 // ============================================================
 describe('Version 2 - Hat block format in class', () => {
     test('v2 hat blocks in class with withSpriteNew are inside class', () => {
@@ -642,7 +485,7 @@ describe('Version 2 - Hat block format in class', () => {
 });
 
 // ============================================================
-// 7. Non-hat code in file output
+// 5. Non-hat code in file output
 // ============================================================
 describe('Non-hat code in file output', () => {
     test('non-hat code with withSpriteNew and @ruby:class -> commented out outside class', () => {
@@ -706,7 +549,7 @@ describe('Non-hat code in file output', () => {
 });
 
 // ============================================================
-// 8. Edge cases
+// 6. Edge cases
 // ============================================================
 describe('Edge cases', () => {
     test('sprite at index 2 -> correct Sprite2', () => {
@@ -1288,7 +1131,7 @@ describe('Edge cases', () => {
 });
 
 // ============================================================
-// 9. finishTargets and initTargets
+// 7. finishTargets and initTargets
 // ============================================================
 describe('finishTargets and initTargets', () => {
     test('initTargets sets up requires_ and prepares_', () => {
@@ -1329,7 +1172,7 @@ describe('finishTargets and initTargets', () => {
 });
 
 // ============================================================
-// 10. quote_ edge cases
+// 8. quote_ edge cases
 // ============================================================
 describe('quote_ edge cases', () => {
     test('escapes double quotes', () => {
@@ -1366,7 +1209,7 @@ describe('quote_ edge cases', () => {
 });
 
 // ============================================================
-// 11. spriteNew edge cases
+// 9. spriteNew edge cases
 // ============================================================
 describe('spriteNew edge cases', () => {
     test('returns null for null target', () => {
@@ -1473,7 +1316,7 @@ describe('spriteNew edge cases', () => {
 });
 
 // ============================================================
-// 12. Version comparison edge cases
+// 10. Version comparison edge cases
 // ============================================================
 describe('Version comparison edge cases', () => {
     test('version defaults to "1" when not specified', () => {
@@ -1517,7 +1360,7 @@ describe('Version comparison edge cases', () => {
 });
 
 // ============================================================
-// 12. Extension hat blocks inside class
+// 11. Extension hat blocks inside class
 // ============================================================
 describe('Extension hat blocks inside class', () => {
     test('microbit.when_button_is inside class with @ruby:class', () => {

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/fuzz-hunt.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/fuzz-hunt.test.js
@@ -1,6 +1,6 @@
 /**
  * Aggressive fuzz/random testing to hunt for bugs in RubyGenerator
- * file output (v1/v2, class/no-class, extensions, edge cases).
+ * file output (class/no-class, extensions, edge cases).
  */
 import RubyGenerator from '../../../../src/lib/ruby-generator';
 
@@ -364,38 +364,9 @@ describe('Stage with extension hat blocks', () => {
     });
 });
 
-// ============================================================
-// 6. v1 output - extensions should NOT be in class
-// ============================================================
-describe('v1 output with extensions', () => {
-    test('v1 with withSpriteNew wraps in Sprite.new, not class', () => {
-        const {target} = makeMockTarget('Sprite1', 1, {
-            sprite: {name: 'Sprite1', costumes: [], sounds: []}
-        });
-        setupGenerator('1', target);
-
-        const code = 'microbit.when_button_is("A", "down") do\n  puts("hello")\nend\n';
-        const result = RubyGenerator.finish(code, {withSpriteNew: true});
-
-        expect(result).not.toContain('class ');
-        expect(result).toContain('Sprite.new("Sprite1")');
-        expect(result).toContain('microbit.when_button_is');
-    });
-
-    test('v1 without withSpriteNew returns code as-is', () => {
-        const {target} = makeMockTarget('Sprite1');
-        setupGenerator('1', target);
-
-        const code = 'microbit.when_button_is("A", "down") do\n  puts("hello")\nend\n';
-        const result = RubyGenerator.finish(code, {});
-
-        expect(result).toBe(code);
-        expect(result).not.toContain('class ');
-    });
-});
 
 // ============================================================
-// 7. Attribute edge cases with costume/backdrop 1-based indexing
+// 6. Attribute edge cases with costume/backdrop 1-based indexing
 // ============================================================
 describe('Costume/backdrop 1-based indexing edge cases', () => {
     test('currentCostume=0 should NOT generate set_current_costume', () => {
@@ -480,7 +451,7 @@ describe('Costume/backdrop 1-based indexing edge cases', () => {
 });
 
 // ============================================================
-// 8. Multiple sprites - index calculation
+// 7. Multiple sprites - index calculation
 // ============================================================
 describe('Multiple sprites - index edge cases', () => {
     test('third sprite with invalid name gets Sprite3', () => {
@@ -538,7 +509,7 @@ describe('Multiple sprites - index edge cases', () => {
 });
 
 // ============================================================
-// 9. Attribute combinations - all non-default at once
+// 8. Attribute combinations - all non-default at once
 // ============================================================
 describe('All attributes non-default simultaneously', () => {
     test('sprite with every attribute non-default in auto-wrap', () => {
@@ -606,7 +577,7 @@ describe('All attributes non-default simultaneously', () => {
 });
 
 // ============================================================
-// 10. require/prepare definitions with class
+// 9. require/prepare definitions with class
 // ============================================================
 describe('require/prepare definitions with class', () => {
     test('require goes to requires_ (processed by targetsToCode, not finish)', () => {
@@ -640,7 +611,7 @@ describe('require/prepare definitions with class', () => {
 });
 
 // ============================================================
-// 11. Comments edge cases
+// 10. Comments edge cases
 // ============================================================
 describe('Comments interaction with class', () => {
     test('non-class comment + @ruby:class comment', () => {
@@ -670,7 +641,7 @@ describe('Comments interaction with class', () => {
 });
 
 // ============================================================
-// 12. Empty/minimal code edge cases
+// 11. Empty/minimal code edge cases
 // ============================================================
 describe('Empty and minimal code', () => {
     test('empty code with auto-wrap still generates class with set_xxx', () => {
@@ -720,7 +691,7 @@ describe('Empty and minimal code', () => {
 });
 
 // ============================================================
-// 13. Regex boundary tests - potential false positives/negatives
+// 12. Regex boundary tests - potential false positives/negatives
 // ============================================================
 describe('Regex boundary tests for hat block detection', () => {
     test('method starting with "when" but not a hat block is commented out', () => {
@@ -779,7 +750,7 @@ describe('Regex boundary tests for hat block detection', () => {
 });
 
 // ============================================================
-// 14. Deeply nested / complex code structures
+// 13. Deeply nested / complex code structures
 // ============================================================
 describe('Complex code structures', () => {
     test('hat block with nested if/else', () => {
@@ -825,35 +796,7 @@ describe('Complex code structures', () => {
 });
 
 // ============================================================
-// 15. v1 extension hat blocks (self.when style)
-// ============================================================
-describe('v1 extension hat blocks', () => {
-    test('self.when(:flag_clicked) in v1 without withSpriteNew', () => {
-        const {target} = makeMockTarget('Sprite1');
-        setupGenerator('1', target);
-
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-        const result = RubyGenerator.finish(code, {});
-
-        expect(result).toBe(code);
-    });
-
-    test('self.when(:flag_clicked) in v1 with withSpriteNew', () => {
-        const {target} = makeMockTarget('Sprite1', 1, {
-            sprite: {name: 'Sprite1', costumes: [], sounds: []}
-        });
-        setupGenerator('1', target);
-
-        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
-        const result = RubyGenerator.finish(code, {withSpriteNew: true});
-
-        expect(result).toContain('Sprite.new("Sprite1") do');
-        expect(result).toContain('  self.when(:flag_clicked) do');
-    });
-});
-
-// ============================================================
-// 16. Separator and formatting checks
+// 14. Separator and formatting checks
 // ============================================================
 describe('Class body formatting', () => {
     test('set_xxx and hat blocks separated by blank line', () => {
@@ -898,7 +841,7 @@ describe('Class body formatting', () => {
 });
 
 // ============================================================
-// 17. @ruby:class with explicit name= and sprite=
+// 15. @ruby:class with explicit name= and sprite=
 // ============================================================
 describe('@ruby:class with explicit name= and sprite=', () => {
     test('name=CustomName preserves class name', () => {
@@ -937,7 +880,7 @@ describe('@ruby:class with explicit name= and sprite=', () => {
 });
 
 // ============================================================
-// 18. Stress test - many hat blocks
+// 16. Stress test - many hat blocks
 // ============================================================
 describe('Stress tests', () => {
     test('10 different hat blocks all inside class', () => {

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/method-return.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/method-return.test.js
@@ -43,11 +43,11 @@ describe('RubyGenerator/MethodReturn', () => {
         RubyGenerator.currentTarget.comments = comments;
         // Trigger currentTarget setter
         RubyGenerator.currentTarget = RubyGenerator.currentTarget;
-        return RubyGenerator.targetToCode(RubyGenerator.currentTarget);
+        return RubyGenerator.targetToCode(RubyGenerator.currentTarget, {version: '2'});
     };
 
     describe('Method Return Values', () => {
-        test('def self.add(x, y)', () => {
+        test('def add(x, y)', () => {
             const blocks = {
                 b1: {
                     id: 'b1',
@@ -92,7 +92,7 @@ describe('RubyGenerator/MethodReturn', () => {
             };
             const code = generateCode(blocks, ['b1'], comments);
             // With @ruby:return comment, this is an implicit return - output just the value
-            expect(code).toBe('def self.add(x, y)\n  x + y\nend\n');
+            expect(code).toBe('def add(x, y)\n  x + y\nend\n');
         });
 
         test('standalone add(1, 2)', () => {
@@ -219,7 +219,7 @@ describe('RubyGenerator/MethodReturn', () => {
             };
             const code = generateCode(blocks, ['b1'], {});
             // Without @ruby:return comment, output normal variable assignment
-            expect(code).toBe('def self.add(x, y)\n  @_return_add = x + y\nend\n');
+            expect(code).toBe('def add(x, y)\n  @_return_add = x + y\nend\n');
         });
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/module.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/module.test.js
@@ -47,7 +47,7 @@ describe('RubyGenerator/Module', () => {
                 Utils: ['def add(a, b)\n  a + b\nend\n']
             };
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             // module...end should appear before class
@@ -81,7 +81,7 @@ describe('RubyGenerator/Module', () => {
                 Helpers: ['def greet\n  say("hello")\nend\n']
             };
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             // Both modules should appear
@@ -107,7 +107,7 @@ describe('RubyGenerator/Module', () => {
 
             RubyGenerator._moduleMethodCodes = {};
 
-            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const code = 'when_flag_clicked do\n  move(10)\nend\n';
             const result = RubyGenerator.finish(code, {});
 
             expect(result).not.toContain('module ');

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/v1/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/v1/class.test.js
@@ -1,0 +1,106 @@
+import RubyGenerator from '../../../../../src/lib/ruby-generator';
+
+describe('RubyGenerator/Class (v1)', () => {
+    beforeEach(() => {
+        RubyGenerator.init({version: '1'});
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.requires_ = {};
+        RubyGenerator.prepares_ = {};
+        RubyGenerator.cache_ = {
+            targetCommentTexts: [],
+            comments: {}
+        };
+    });
+
+    const makeMockTarget = (name, index = 1) => {
+        const targets = [];
+        const stage = {isStage: true};
+        for (let i = 0; i < index; i++) {
+            targets.push({isStage: false, sprite: {name: `OtherSprite${i + 1}`}});
+        }
+        const target = targets[index - 1];
+        target.sprite = {name: name};
+        targets.unshift(stage);
+        return {
+            target,
+            runtime: {targets}
+        };
+    };
+
+    const makeMockStageTarget = () => {
+        const stage = {
+            isStage: true,
+            sprite: {name: 'Stage', costumes: [], sounds: []},
+            currentCostume: 0,
+            variables: {}
+        };
+        const runtime = {targets: [stage]};
+        stage.runtime = runtime;
+        return {target: stage, runtime};
+    };
+
+    test('stage without @ruby:class in version 1 uses Stage.new format', () => {
+        const {target} = makeMockStageTarget();
+        RubyGenerator.currentTarget_ = target;
+        RubyGenerator.cache_.targetCommentTexts = [];
+
+        const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+        const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+        expect(result).toContain('Stage.new');
+        expect(result).not.toContain('class Stage');
+    });
+
+    describe('withSpriteNew (version 1 file output)', () => {
+        test('@ruby:class with withSpriteNew uses Sprite.new instead of class', () => {
+            const {target, runtime} = makeMockTarget('ネコ', 1);
+            target.runtime = runtime;
+            target.x = 90;
+            target.y = -50;
+            target.direction = 45;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.isStage = false;
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class:name,x,y,direction'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '1'});
+
+            expect(result).toContain('Sprite.new("ネコ"');
+            expect(result).toContain('x: 90');
+            expect(result).toContain('y: -50');
+            expect(result).toContain('direction: 45');
+            expect(result).not.toContain('class ');
+            expect(result).not.toContain('set_name');
+            expect(result).not.toContain('set_x');
+        });
+
+        test('@ruby:class without attributes and withSpriteNew uses Sprite.new with defaults', () => {
+            const {target, runtime} = makeMockTarget('Sprite1', 1);
+            target.runtime = runtime;
+            target.x = 0;
+            target.y = 0;
+            target.direction = 90;
+            target.visible = true;
+            target.size = 100;
+            target.currentCostume = 0;
+            target.rotationStyle = 'all around';
+            target.isStage = false;
+            target.sprite.costumes = [];
+            target.variables = {};
+            RubyGenerator.currentTarget_ = target;
+            RubyGenerator.cache_.targetCommentTexts = ['@ruby:class'];
+
+            const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+            const result = RubyGenerator.finish(code, {withSpriteNew: true, version: '1'});
+
+            expect(result).toContain('Sprite.new("Sprite1")');
+            expect(result).not.toContain('class ');
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/v1/file-output-patterns.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/v1/file-output-patterns.test.js
@@ -1,0 +1,200 @@
+import RubyGenerator from '../../../../../src/lib/ruby-generator';
+
+// --- Helpers ---
+
+const makeMockTarget = (name, index = 1, overrides = {}) => {
+    const targets = [];
+    const stage = {isStage: true, sprite: {name: 'Stage', costumes: [], sounds: []}};
+    for (let i = 0; i < index; i++) {
+        targets.push({
+            isStage: false,
+            sprite: {name: `OtherSprite${i + 1}`, costumes: [], sounds: []}
+        });
+    }
+    const target = targets[index - 1];
+    Object.assign(target, {
+        x: 0, y: 0, direction: 90, visible: true, size: 100,
+        currentCostume: 0, rotationStyle: 'all around', variables: {},
+        ...overrides
+    });
+    target.sprite = {name, costumes: [], sounds: [], ...overrides.sprite};
+    targets.unshift(stage);
+    target.runtime = {targets};
+    return {target, runtime: {targets}};
+};
+
+const makeMockStageTarget = (overrides = {}) => {
+    const stage = {
+        isStage: true,
+        sprite: {name: 'Stage', costumes: [], sounds: [], ...overrides.sprite},
+        currentCostume: 0, variables: {},
+        ...overrides
+    };
+    stage.sprite = {name: overrides.spriteName || 'Stage', costumes: [], sounds: [], ...overrides.sprite};
+    const runtime = {targets: [stage]};
+    stage.runtime = runtime;
+    return {target: stage, runtime};
+};
+
+const setupGenerator = (version, target, commentTexts = []) => {
+    RubyGenerator.init({version});
+    RubyGenerator.definitions_ = {};
+    RubyGenerator.requires_ = {};
+    RubyGenerator.prepares_ = {};
+    RubyGenerator.cache_ = {
+        targetCommentTexts: commentTexts,
+        comments: {}
+    };
+    RubyGenerator.currentTarget_ = target;
+};
+
+describe('Version 1 - No class (standard v1 output)', () => {
+    test('simple hat block without withSpriteNew returns code as-is', () => {
+        const {target} = makeMockTarget('Sprite1');
+        setupGenerator('1', target);
+
+        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const result = RubyGenerator.finish(code, {});
+
+        expect(result).toBe(code);
+        expect(result).not.toContain('class ');
+        expect(result).not.toContain('Sprite.new');
+    });
+
+    test('multiple hat blocks without withSpriteNew', () => {
+        const {target} = makeMockTarget('Sprite1');
+        setupGenerator('1', target);
+
+        const code =
+            'self.when(:flag_clicked) do\n  move(10)\nend\n\n' +
+            'self.when(:flag_clicked) do\n  turn_right(15)\nend\n';
+        const result = RubyGenerator.finish(code, {});
+
+        expect(result).toBe(code);
+        expect(result).not.toContain('class ');
+    });
+
+    test('hat block with withSpriteNew uses Sprite.new format', () => {
+        const {target} = makeMockTarget('Sprite1', 1, {
+            sprite: {name: 'Sprite1', costumes: [], sounds: []}
+        });
+        setupGenerator('1', target);
+
+        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+        expect(result).toContain('Sprite.new("Sprite1")');
+        expect(result).toContain('  self.when(:flag_clicked) do');
+        expect(result).toContain('end\n');
+        expect(result).not.toContain('class ');
+    });
+
+    test('stage target with withSpriteNew uses Stage.new format', () => {
+        const {target} = makeMockStageTarget({
+            x: 0, y: 0, direction: 90, visible: true, size: 100,
+            currentCostume: 0, rotationStyle: 'all around',
+            sprite: {name: 'Stage', costumes: [], sounds: []}
+        });
+        setupGenerator('1', target);
+
+        const code = 'self.when(:flag_clicked) do\n  switch_backdrop("Arctic")\nend\n';
+        const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+        expect(result).toContain('Stage.new("Stage")');
+        expect(result).not.toContain('class ');
+    });
+
+    test('empty code returns empty string', () => {
+        const {target} = makeMockTarget('Sprite1');
+        setupGenerator('1', target);
+
+        const result = RubyGenerator.finish('', {});
+
+        expect(result).toBe('');
+    });
+
+    test('empty code with withSpriteNew still wraps with Sprite.new', () => {
+        const {target} = makeMockTarget('Sprite1', 1, {
+            sprite: {name: 'Sprite1', costumes: [], sounds: []}
+        });
+        setupGenerator('1', target);
+
+        const result = RubyGenerator.finish('', {withSpriteNew: true});
+
+        expect(result).toContain('Sprite.new("Sprite1")');
+        expect(result).toContain('do\n');
+        expect(result).toContain('end\n');
+    });
+
+    test('Sprite.new includes non-default attributes', () => {
+        const {target} = makeMockTarget('Cat', 1, {
+            x: 50, y: -30, direction: 45, visible: false, size: 75,
+            sprite: {
+                name: 'Cat',
+                costumes: [{
+                    assetId: 'abc', name: 'costume1',
+                    bitmapResolution: 1, dataFormat: 'svg',
+                    rotationCenterX: 48, rotationCenterY: 50
+                }],
+                sounds: []
+            },
+            rotationStyle: 'left-right'
+        });
+        setupGenerator('1', target);
+
+        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+        expect(result).toContain('Sprite.new("Cat"');
+        expect(result).toContain('x: 50');
+        expect(result).toContain('y: -30');
+        expect(result).toContain('direction: 45');
+        expect(result).toContain('visible: false');
+        expect(result).toContain('size: 75');
+        expect(result).toContain('rotation_style: "left-right"');
+    });
+});
+
+describe('Version 1 - With @ruby:class', () => {
+    test('@ruby:class with withSpriteNew uses Sprite.new (NOT class)', () => {
+        const {target} = makeMockTarget('Sprite1', 1, {
+            sprite: {name: 'Sprite1', costumes: [], sounds: []}
+        });
+        setupGenerator('1', target, ['@ruby:class']);
+
+        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+        expect(result).toContain('Sprite.new("Sprite1")');
+        expect(result).not.toContain('class ');
+    });
+
+    test('@ruby:class:x,y with withSpriteNew uses Sprite.new with attributes', () => {
+        const {target} = makeMockTarget('ネコ', 1, {
+            x: 100, y: -50, direction: 45,
+            sprite: {name: 'ネコ', costumes: [], sounds: []}
+        });
+        setupGenerator('1', target, ['@ruby:class:x,y']);
+
+        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+        expect(result).toContain('Sprite.new("ネコ"');
+        expect(result).toContain('x: 100');
+        expect(result).toContain('y: -50');
+        expect(result).toContain('direction: 45');
+        expect(result).not.toContain('class ');
+    });
+
+    test('@ruby:class WITHOUT withSpriteNew does NOT wrap with class in v1', () => {
+        const {target} = makeMockTarget('Sprite1');
+        setupGenerator('1', target, ['@ruby:class']);
+
+        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const result = RubyGenerator.finish(code, {});
+
+        // v1 ignores @ruby:class entirely
+        expect(result).not.toContain('class ');
+        expect(result).toContain('self.when(:flag_clicked)');
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/v1/fuzz-hunt.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/v1/fuzz-hunt.test.js
@@ -1,0 +1,98 @@
+/**
+ * V1-specific fuzz/random tests for RubyGenerator file output.
+ * Extracted from fuzz-hunt.test.js.
+ */
+import RubyGenerator from '../../../../../src/lib/ruby-generator';
+
+// --- Helpers ---
+
+const makeMockTarget = (name, index = 1, overrides = {}) => {
+    const targets = [];
+    const stage = {isStage: true, sprite: {name: 'Stage', costumes: [], sounds: []}};
+    for (let i = 0; i < index; i++) {
+        targets.push({
+            isStage: false,
+            sprite: {name: `OtherSprite${i + 1}`, costumes: [], sounds: []}
+        });
+    }
+    const target = targets[index - 1];
+    Object.assign(target, {
+        x: 0, y: 0, direction: 90, visible: true, size: 100,
+        currentCostume: 0, rotationStyle: 'all around', variables: {},
+        ...overrides
+    });
+    target.sprite = {name, costumes: [], sounds: [], ...overrides.sprite};
+    targets.unshift(stage);
+    target.runtime = {targets};
+    return {target, runtime: {targets}};
+};
+
+const setupGenerator = (version, target, commentTexts = []) => {
+    RubyGenerator.init({version});
+    RubyGenerator.definitions_ = {};
+    RubyGenerator.requires_ = {};
+    RubyGenerator.prepares_ = {};
+    RubyGenerator.cache_ = {
+        targetCommentTexts: commentTexts,
+        comments: {}
+    };
+    RubyGenerator.currentTarget_ = target;
+};
+
+// ============================================================
+// v1 output - extensions should NOT be in class
+// ============================================================
+describe('v1 output with extensions', () => {
+    test('v1 with withSpriteNew wraps in Sprite.new, not class', () => {
+        const {target} = makeMockTarget('Sprite1', 1, {
+            sprite: {name: 'Sprite1', costumes: [], sounds: []}
+        });
+        setupGenerator('1', target);
+
+        const code = 'microbit.when_button_is("A", "down") do\n  puts("hello")\nend\n';
+        const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+        expect(result).not.toContain('class ');
+        expect(result).toContain('Sprite.new("Sprite1")');
+        expect(result).toContain('microbit.when_button_is');
+    });
+
+    test('v1 without withSpriteNew returns code as-is', () => {
+        const {target} = makeMockTarget('Sprite1');
+        setupGenerator('1', target);
+
+        const code = 'microbit.when_button_is("A", "down") do\n  puts("hello")\nend\n';
+        const result = RubyGenerator.finish(code, {});
+
+        expect(result).toBe(code);
+        expect(result).not.toContain('class ');
+    });
+});
+
+// ============================================================
+// v1 extension hat blocks (self.when style)
+// ============================================================
+describe('v1 extension hat blocks', () => {
+    test('self.when(:flag_clicked) in v1 without withSpriteNew', () => {
+        const {target} = makeMockTarget('Sprite1');
+        setupGenerator('1', target);
+
+        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const result = RubyGenerator.finish(code, {});
+
+        expect(result).toBe(code);
+    });
+
+    test('self.when(:flag_clicked) in v1 with withSpriteNew', () => {
+        const {target} = makeMockTarget('Sprite1', 1, {
+            sprite: {name: 'Sprite1', costumes: [], sounds: []}
+        });
+        setupGenerator('1', target);
+
+        const code = 'self.when(:flag_clicked) do\n  move(10)\nend\n';
+        const result = RubyGenerator.finish(code, {withSpriteNew: true});
+
+        expect(result).toContain('Sprite.new("Sprite1") do');
+        expect(result).toContain('  self.when(:flag_clicked) do');
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class-error-message.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class-error-message.test.js
@@ -27,7 +27,7 @@ describe('Class error message', () => {
     test('error message does not contain source code newlines', async () => {
         // Class syntax requires version 2
         const converter = new RubyToBlocksConverter(null, {version: 2});
-        const code = 'class Sprite1\n  self.when(:flag_clicked) do\n    move(10)\n  end\n  move(10)\nend';
+        const code = 'class Sprite1\n  when_flag_clicked do\n    move(10)\n  end\n  move(10)\nend';
         await converter.targetCodeToBlocks(target, code);
         expect(converter.errors.length).toBeGreaterThan(0);
         // The error part (before \n hint) should not contain newlines from source code
@@ -36,7 +36,7 @@ describe('Class error message', () => {
     });
 
     test('error source is truncated', async () => {
-        const converter = new RubyToBlocksConverter(null);
+        const converter = new RubyToBlocksConverter(null, {version: '2'});
         const code = 'when_key_pressed("invalid") do\nend';
         await converter.targetCodeToBlocks(target, code);
         expect(converter.errors.length).toBeGreaterThan(0);
@@ -45,7 +45,7 @@ describe('Class error message', () => {
     });
 
     test('top-level wrongInstruction error has SOURCE expanded', async () => {
-        const converter = new RubyToBlocksConverter(null);
+        const converter = new RubyToBlocksConverter(null, {version: '2'});
         const code = 'when_key_pressed("invalid") do\nend';
         await converter.targetCodeToBlocks(target, code);
         expect(converter.errors.length).toBeGreaterThan(0);

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/class.test.js
@@ -26,13 +26,13 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class Sprite1 with when_flag_clicked', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `);
@@ -48,21 +48,21 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class with multiple event handlers', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
 
-                  self.when(:key_pressed, "space") do
+                  when_key_pressed("space") do
                     move(20)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
 
-                self.when(:key_pressed, "space") do
+                when_key_pressed("space") do
                   move(20)
                 end
             `);
@@ -77,7 +77,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class with top-level statements outside', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -85,7 +85,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 bounce_if_on_edge
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
 
@@ -117,13 +117,13 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class with superclass < ::Smalruby3::Sprite preserves superclass in comment', async () => {
             code = `
                 class Sprite1 < ::Smalruby3::Sprite
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `);
@@ -138,13 +138,13 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class with superclass < Smalruby3::Sprite preserves superclass in comment', async () => {
             code = `
                 class Sprite1 < Smalruby3::Sprite
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `);
@@ -159,13 +159,13 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class with superclass < Sprite preserves superclass in comment', async () => {
             code = `
                 class Sprite1 < Sprite
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `);
@@ -180,13 +180,13 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class with superclass < Foo preserves superclass in comment', async () => {
             code = `
                 class Sprite1 < Foo
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `);
@@ -201,13 +201,13 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class without superclass has no <= in comment', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `);
@@ -219,33 +219,19 @@ describe('RubyToBlocksConverter/Class', () => {
             expect(targetComments[0].text).toEqual('@ruby:class');
         });
 
-        test('class definition is rejected in version 1', async () => {
-            const v1Converter = new RubyToBlocksConverter(null, {version: '1'});
-            code = `
-                class Sprite1
-                  self.when(:flag_clicked) do
-                    move(10)
-                  end
-                end
-            `;
-            const res = await v1Converter.targetCodeToBlocks(target, code);
-            expect(res).toBeFalsy();
-            expect(v1Converter.errors).toHaveLength(1);
-            expect(v1Converter.errors[0].text).toContain('version 1');
-        });
     });
 
     describe('class name and set_name', () => {
         test('class Cat changes sprite name and generates @ruby:class:name=Cat', async () => {
             code = `
                 class Cat
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `);
@@ -267,13 +253,13 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_name "ネコ"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
             `;
             expected = await rubyToExpected(converter, target, `
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `);
@@ -295,7 +281,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_name "ネコ"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -313,7 +299,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class Sprite1 without set_name generates @ruby:class', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -338,7 +324,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_y -50
                   set_direction 180
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -364,7 +350,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_visible false
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -388,7 +374,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_size 50
                   set_current_costume 2
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -412,7 +398,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_rotation_style "left-right"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -441,7 +427,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_current_costume 2
                   set_rotation_style "left-right"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -461,7 +447,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Cat
                   set_x 100
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -486,7 +472,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_name "ネコ"
                   set_x 100
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -510,7 +496,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Cat
                   set_name "ネコ"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -532,7 +518,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class Cat without set_name generates @ruby:class:name=Cat', async () => {
             code = `
                 class Cat
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -555,7 +541,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_name "ネコ"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -576,7 +562,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Cat
                   set_x 100
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -598,7 +584,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('set_xxx without class generates error', async () => {
             code = `
                 set_x 100
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `;
@@ -672,7 +658,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_sprite "Dog1"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -696,7 +682,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_costumes ["Dog1-a", "Dog1-b"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -719,7 +705,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_sounds ["Dog1", "Dog2"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -743,7 +729,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_costumes ["Dog1-a", "Dog1-b"]
                   set_sounds ["Dog1", "Dog2"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -768,7 +754,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_sprite "Dog1"
                   set_x 100
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -792,7 +778,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_sprite "Dog1"
                   set_costumes ["Dog1-a", "Dog1-b"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -807,7 +793,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_sprite "Dog1"
                   set_sounds ["Dog1", "Dog2"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -821,7 +807,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_sprite "NonExistentSprite999"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -835,7 +821,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_costumes ["Dog1-a", "NonExistentCostume999"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -849,7 +835,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_sounds ["Dog1", "NonExistentSound999"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -863,7 +849,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_sprite "Dog1"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -882,7 +868,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_costumes ["Dog1-a", "Dog1-b"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -901,7 +887,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_sounds ["Dog1", "Dog2"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -918,7 +904,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('set_sprite outside class generates error', async () => {
             code = `
                 set_sprite "Dog1"
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `;
@@ -929,7 +915,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('set_costumes outside class generates error', async () => {
             code = `
                 set_costumes ["Dog1-a", "Dog1-b"]
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `;
@@ -940,7 +926,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('set_sounds outside class generates error', async () => {
             code = `
                 set_sounds ["Dog1", "Dog2"]
-                self.when(:flag_clicked) do
+                when_flag_clicked do
                   move(10)
                 end
             `;
@@ -973,7 +959,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('error message reports the specific statement, not the class', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                   move(10)
@@ -993,7 +979,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('hat block inside class is allowed', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1010,7 +996,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     move(10)
                   end
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     func
                   end
                 end
@@ -1023,7 +1009,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('hat block with non-hat statement after it inside class is allowed', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                     bounce_if_on_edge
                   end
@@ -1047,7 +1033,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class Sprite1 applies sprite name Sprite1', async () => {
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1065,7 +1051,7 @@ describe('RubyToBlocksConverter/Class', () => {
         test('class Cat applies sprite name Cat', async () => {
             code = `
                 class Cat
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1083,7 +1069,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_name "ネコ"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1102,7 +1088,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_x 100
                   set_y -50
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1121,7 +1107,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_direction 180
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1140,7 +1126,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_visible false
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1158,7 +1144,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_size 50
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1176,7 +1162,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_rotation_style "left-right"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1194,7 +1180,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_current_costume 2
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1214,7 +1200,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_sprite "Dog1"
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1237,7 +1223,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_costumes ["Dog1-a", "Dog1-b"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1258,7 +1244,7 @@ describe('RubyToBlocksConverter/Class', () => {
                 class Sprite1
                   set_sounds ["Dog1", "Dog2"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1281,7 +1267,7 @@ describe('RubyToBlocksConverter/Class', () => {
                   set_costumes ["Dog1-a", "Dog1-b"]
                   set_sounds ["Dog1", "Dog2"]
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1302,7 +1288,7 @@ describe('RubyToBlocksConverter/Class', () => {
             spriteTarget.y = 20;
             code = `
                 class Sprite1
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -1324,13 +1310,13 @@ describe('RubyToBlocksConverter/Class', () => {
             test('class Stage < ::Smalruby3::Stage is accepted (no <= in comment)', async () => {
                 code = `
                     class Stage < ::Smalruby3::Stage
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
                 `;
                 expected = await rubyToExpected(converter, target, `
-                    self.when(:flag_clicked) do
+                    when_flag_clicked do
                       switch_backdrop("Arctic")
                     end
                 `);
@@ -1345,13 +1331,13 @@ describe('RubyToBlocksConverter/Class', () => {
             test('class Stage < Smalruby3::Stage is accepted (no <= in comment)', async () => {
                 code = `
                     class Stage < Smalruby3::Stage
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
                 `;
                 expected = await rubyToExpected(converter, target, `
-                    self.when(:flag_clicked) do
+                    when_flag_clicked do
                       switch_backdrop("Arctic")
                     end
                 `);
@@ -1366,7 +1352,7 @@ describe('RubyToBlocksConverter/Class', () => {
             test('class Stage < Foo is rejected', async () => {
                 code = `
                     class Stage < Foo
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1381,13 +1367,13 @@ describe('RubyToBlocksConverter/Class', () => {
             test('class Stage with when_flag_clicked', async () => {
                 code = `
                     class Stage
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
                 `;
                 expected = await rubyToExpected(converter, target, `
-                    self.when(:flag_clicked) do
+                    when_flag_clicked do
                       switch_backdrop("Arctic")
                     end
                 `);
@@ -1421,7 +1407,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     class Stage
                       set_current_backdrop 1
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1444,7 +1430,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     class Stage
                       set_backdrops ["Arctic", "Baseball 1"]
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1467,7 +1453,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     class Stage
                       set_sounds ["Dog1", "Dog2"]
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1486,7 +1472,7 @@ describe('RubyToBlocksConverter/Class', () => {
                       set_backdrops ["Arctic", "Baseball 1"]
                       set_sounds ["Dog1", "Dog2"]
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1510,7 +1496,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     class Stage
                       set_name "ステージ"
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1684,7 +1670,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     class Stage
                       set_name "ステージ"
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1702,7 +1688,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     class Stage
                       set_current_backdrop 2
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1721,7 +1707,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     class Stage
                       set_backdrops ["Arctic", "Baseball 1"]
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end
@@ -1742,7 +1728,7 @@ describe('RubyToBlocksConverter/Class', () => {
                     class Stage
                       set_sounds ["Dog1", "Dog2"]
 
-                      self.when(:flag_clicked) do
+                      when_flag_clicked do
                         switch_backdrop("Arctic")
                       end
                     end

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control1.test.js
@@ -9,7 +9,7 @@ describe('RubyToBlocksConverter/Control', () => {
     let code;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
     });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control2.test.js
@@ -10,7 +10,7 @@ describe('RubyToBlocksConverter/Control', () => {
     let code;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
     });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control3.test.js
@@ -11,7 +11,7 @@ describe('RubyToBlocksConverter/Control', () => {
     let code;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
     });
@@ -173,17 +173,10 @@ describe('RubyToBlocksConverter/Control', () => {
     describe('control_start_as_clone', () => {
         test('invalid', async () => {
             const cases1 = [
-                'self.when(:start_as_a_clone)',
-                'self.when(:start_as_a_clone, 1)'
+                'when_start_as_a_clone',
+                'when_start_as_a_clone(1) {}'
             ];
             for (const s of cases1) {
-                await convertAndExpectRubyBlockError(converter, target, s);
-            }
-
-            const cases2 = [
-                '12.when(:start_as_a_clone) {}'
-            ];
-            for (const s of cases2) {
                 await convertAndExpectRubyBlockError(converter, target, s);
             }
         });
@@ -203,7 +196,7 @@ describe('RubyToBlocksConverter/Control', () => {
         test('sprite-only clone blocks should throw error on stage', async () => {
             const spriteOnlyCommands = [
                 'delete_this_clone',
-                'self.when_start_as_a_clone {}'
+                'when_start_as_a_clone {}'
             ];
 
             for (const command of spriteOnlyCommands) {
@@ -235,7 +228,7 @@ describe('RubyToBlocksConverter/Control', () => {
         test('all blocks should work on sprite', async () => {
             const allCommands = [
                 'delete_this_clone',
-                'self.when_start_as_a_clone {}',
+                'when_start_as_a_clone {}',
                 'create_clone("Sprite1")',
                 'sleep(1)',
                 'repeat(3) {}',

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control4.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control4.test.js
@@ -9,7 +9,7 @@ describe('RubyToBlocksConverter/Control/unless', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/error-message-hints.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/error-message-hints.test.js
@@ -4,7 +4,7 @@ describe('Error message resolution hints', () => {
     const target = null;
 
     test('wrongInstruction error includes hint', async () => {
-        const converter = new RubyToBlocksConverter(null);
+        const converter = new RubyToBlocksConverter(null, {version: '2'});
         const code = 'when_key_pressed("invalid") do\nend';
         await converter.targetCodeToBlocks(target, code);
         expect(converter.errors.length).toBeGreaterThan(0);
@@ -23,7 +23,7 @@ describe('Error message resolution hints', () => {
     test('conditionIsNotBoolean error includes hint', async () => {
         // Class syntax requires version 2
         const converter = new RubyToBlocksConverter(null, {version: 2});
-        const code = 'class Sprite1\n  self.when(:flag_clicked) do\n    if 42\n      move(10)\n    end\n  end\nend';
+        const code = 'class Sprite1\n  when_flag_clicked do\n    if 42\n      move(10)\n    end\n  end\nend';
         await converter.targetCodeToBlocks(target, code);
         expect(converter.errors.length).toBeGreaterThan(0);
         expect(converter.errors[0].text).toMatch(/comparison operator|==|<|>/);
@@ -34,7 +34,7 @@ describe('Error message resolution hints', () => {
         const converter = new RubyToBlocksConverter(null, {version: 2});
         const code = [
             'class Sprite1',
-            '  self.when(:flag_clicked) do',
+            '  when_flag_clicked do',
             '    def my_proc',
             '      123',
             '    end',

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/event-backward-compat.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/event-backward-compat.test.js
@@ -1,0 +1,77 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+
+describe('RubyToBlocksConverter/Event backward compatibility (v1 syntax in v2 mode)', () => {
+    let converter;
+    let target;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null, {version: '2'});
+        target = null;
+    });
+
+    test('self.when(:flag_clicked) is accepted', async () => {
+        const code = `
+            self.when(:flag_clicked) do
+              move(10)
+            end
+        `;
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('self.when(:key_pressed, "space") is accepted', async () => {
+        const code = `
+            self.when(:key_pressed, "space") do
+              move(10)
+            end
+        `;
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('self.when(:clicked) is accepted', async () => {
+        const code = `
+            self.when(:clicked) do
+              move(10)
+            end
+        `;
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('self.when(:backdrop_switches, "backdrop1") is accepted', async () => {
+        const code = `
+            self.when(:backdrop_switches, "backdrop1") do
+              move(10)
+            end
+        `;
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('self.when(:greater_than, "loudness", 10) is accepted', async () => {
+        const code = `
+            self.when(:greater_than, "loudness", 10) do
+              move(10)
+            end
+        `;
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('self.when(:receive, "msg1") is accepted', async () => {
+        const code = `
+            self.when(:receive, "msg1") do
+              move(10)
+            end
+        `;
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/event.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/event.test.js
@@ -86,6 +86,20 @@ describe('RubyToBlocksConverter/Event', () => {
         });
     });
 
+    describe('event_whenstageclicked', () => {
+        test('valid with stage target', async () => {
+            const stageTarget = {isStage: true};
+            code = `
+                when_clicked do
+                  switch_backdrop("backdrop1")
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(stageTarget, code);
+            expect(converter.errors).toHaveLength(0);
+            expect(res).toBeTruthy();
+        });
+    });
+
     describe('event_whenbackdropswitchesto', () => {
         test('invalid', async () => {
             const cases = [

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/face_sensing.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/face_sensing.test.js
@@ -10,7 +10,7 @@ describe('RubyToBlocksConverter/FaceSensing', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/get-block-id-for-line.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/get-block-id-for-line.test.js
@@ -5,7 +5,7 @@ describe('RubyToBlocksConverter.getBlockIdForLine', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = {
             isStage: false,
             variables: {},

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/gets.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/gets.test.js
@@ -12,7 +12,7 @@ describe('RubyToBlocksConverter/Gets', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/index.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/index.test.js
@@ -12,7 +12,7 @@ describe('RubyToBlocksConverter', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;
@@ -93,14 +93,14 @@ describe('RubyToBlocksConverter', () => {
 
             test('hats', async () => {
                 code = `
-                    self.when(:flag_clicked) {}
-                    self.when(:flag_clicked) {}
-                    self.when(:flag_clicked) {}
+                    when_flag_clicked {}
+                    when_flag_clicked {}
+                    when_flag_clicked {}
                 `;
                 expected = [
-                    (await rubyToExpected(converter, target, 'self.when(:flag_clicked) {}'))[0],
-                    (await rubyToExpected(converter, target, 'self.when(:flag_clicked) {}'))[0],
-                    (await rubyToExpected(converter, target, 'self.when(:flag_clicked) {}'))[0]
+                    (await rubyToExpected(converter, target, 'when_flag_clicked {}'))[0],
+                    (await rubyToExpected(converter, target, 'when_flag_clicked {}'))[0],
+                    (await rubyToExpected(converter, target, 'when_flag_clicked {}'))[0]
                 ];
                 await convertAndExpectToEqualBlocks(converter, target, code, expected);
             });
@@ -128,7 +128,7 @@ describe('RubyToBlocksConverter', () => {
                     y
                     size
                     move(10)
-                    self.when(:flag_clicked) {}
+                    when_flag_clicked {}
                     bounce_if_on_edge
                     forever {}
                     move(10)
@@ -141,7 +141,7 @@ describe('RubyToBlocksConverter', () => {
                     (await rubyToExpected(converter, target, 'y'))[0],
                     (await rubyToExpected(converter, target, 'size'))[0],
                     (await rubyToExpected(converter, target, 'move(10)'))[0],
-                    (await rubyToExpected(converter, target, 'self.when(:flag_clicked) {}'))[0],
+                    (await rubyToExpected(converter, target, 'when_flag_clicked {}'))[0],
                     (await rubyToExpected(converter, target, 'bounce_if_on_edge; forever {}'))[0],
                     (await rubyToExpected(converter, target, 'move(10)'))[0],
                     (await rubyToExpected(converter, target, 'x'))[0]

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/koshien.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/koshien.test.js
@@ -11,7 +11,7 @@ describe('RubyToBlocksConverter/Koshien', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks1.test.js
@@ -15,7 +15,7 @@ describe('RubyToBlocksConverter/Looks', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks2.test.js
@@ -15,7 +15,7 @@ describe('RubyToBlocksConverter/Looks', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks3.test.js
@@ -15,7 +15,7 @@ describe('RubyToBlocksConverter/Looks', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks4.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks4.test.js
@@ -15,7 +15,7 @@ describe('RubyToBlocksConverter/Looks', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks5.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks5.test.js
@@ -15,7 +15,7 @@ describe('RubyToBlocksConverter/Looks', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks6.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/looks/looks6.test.js
@@ -15,7 +15,7 @@ describe('RubyToBlocksConverter/Looks', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/makeymakey.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/makeymakey.test.js
@@ -11,7 +11,7 @@ describe('RubyToBlocksConverter/MakeyMakey', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/mesh.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/mesh.test.js
@@ -11,7 +11,7 @@ describe('RubyToBlocksConverter/Mesh', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/mesh_v2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/mesh_v2.test.js
@@ -9,7 +9,7 @@ describe('RubyToBlocksConverter/MeshV2', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/microbit_more.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/microbit_more.test.js
@@ -12,7 +12,7 @@ describe('RubyToBlocksConverter/MicrobitMore', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/module.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/module.test.js
@@ -21,7 +21,7 @@ describe('RubyToBlocksConverter/Module', () => {
                 class Sprite1
                   include Utils
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -90,7 +90,7 @@ describe('RubyToBlocksConverter/Module', () => {
                 class Sprite1
                   include Utils
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -129,7 +129,7 @@ describe('RubyToBlocksConverter/Module', () => {
                   include Utils
                   include Helpers
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end
@@ -160,29 +160,13 @@ describe('RubyToBlocksConverter/Module', () => {
         });
     });
 
-    describe('v1 restrictions', () => {
-        test('module in v1 throws error', async () => {
-            const converterV1 = new RubyToBlocksConverter(null, {version: '1'});
-            const code = `
-                module Utils
-                  def add(a, b)
-                    a + b
-                  end
-                end
-            `;
-            const result = await converterV1.targetCodeToBlocks(target, code);
-            expect(result).toBeFalsy();
-            expect(converterV1.errors.length).toBeGreaterThan(0);
-        });
-    });
-
     describe('error handling', () => {
         test('include with undefined module throws error', async () => {
             const code = `
                 class Sprite1
                   include NonExistent
 
-                  self.when(:flag_clicked) do
+                  when_flag_clicked do
                     move(10)
                   end
                 end

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion1.test.js
@@ -12,7 +12,7 @@ describe('RubyToBlocksConverter/Motion', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion2.test.js
@@ -12,7 +12,7 @@ describe('RubyToBlocksConverter/Motion', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/motion/motion3.test.js
@@ -12,7 +12,7 @@ describe('RubyToBlocksConverter/Motion', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/music.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/music.test.js
@@ -1,0 +1,146 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectToEqualBlocks,
+    convertAndExpectRubyBlockError,
+    expectedInfo
+} from '../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/Music', () => {
+    let converter;
+    let target;
+    let code;
+    let expected;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null, {version: '2'});
+        target = null;
+        code = null;
+        expected = null;
+    });
+
+    test('music_playDrumForBeats', async () => {
+        code = 'play_drum(drum: 1, beats: 0.25)';
+        expected = [
+            {
+                opcode: 'music_playDrumForBeats',
+                inputs: [
+                    {
+                        name: 'DRUM',
+                        block: {opcode: 'music_menu_DRUM', fields: [{name: 'DRUM', value: '1'}], shadow: true}
+                    },
+                    {
+                        name: 'BEATS',
+                        block: expectedInfo.makeNumber(0.25)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('music_restForBeats', async () => {
+        code = 'rest(0.25)';
+        expected = [
+            {
+                opcode: 'music_restForBeats',
+                inputs: [
+                    {
+                        name: 'BEATS',
+                        block: expectedInfo.makeNumber(0.25)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('music_playNoteForBeats', async () => {
+        code = 'play_note(note: 60, beats: 0.25)';
+        expected = [
+            {
+                opcode: 'music_playNoteForBeats',
+                inputs: [
+                    {
+                        name: 'NOTE',
+                        block: {opcode: 'note', fields: [{name: 'NOTE', value: '60'}], shadow: true}
+                    },
+                    {
+                        name: 'BEATS',
+                        block: expectedInfo.makeNumber(0.25)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('music_setInstrument', async () => {
+        code = 'self.instrument = 1';
+        expected = [
+            {
+                opcode: 'music_setInstrument',
+                inputs: [
+                    {
+                        name: 'INSTRUMENT',
+                        block: {
+                            opcode: 'music_menu_INSTRUMENT',
+                            fields: [{name: 'INSTRUMENT', value: '1'}],
+                            shadow: true
+                        }
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('music_setTempo', async () => {
+        code = 'self.tempo = 120';
+        expected = [
+            {
+                opcode: 'music_setTempo',
+                inputs: [
+                    {
+                        name: 'TEMPO',
+                        block: expectedInfo.makeNumber(120)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('music_changeTempo', async () => {
+        code = 'self.tempo += 20';
+        expected = [
+            {
+                opcode: 'music_changeTempo',
+                inputs: [
+                    {
+                        name: 'TEMPO',
+                        block: expectedInfo.makeNumber(20)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('music_getTempo (as value block)', async () => {
+        code = 'say(tempo)';
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('invalid', async () => {
+        for (const s of [
+            'play_drum(1)',
+            'play_drum(drum: 1)',
+            'rest("abc")',
+            'play_note(note: 60)'
+        ]) {
+            await convertAndExpectRubyBlockError(converter, target, s);
+        }
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/my-blocks-backward-compat.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/my-blocks-backward-compat.test.js
@@ -1,0 +1,86 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectToEqualBlocks,
+    expectedInfo
+} from '../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/My Blocks backward compatibility (def self.method in v2 mode)', () => {
+    let converter;
+    let target;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null, {version: '2'});
+        target = null;
+    });
+
+    test('def self.method_name is accepted', async () => {
+        const code = `
+            def self.made_block
+            end
+        `;
+        const expected = [
+            {
+                opcode: 'procedures_definition',
+                inputs: [
+                    {
+                        name: 'custom_block',
+                        block: {
+                            opcode: 'procedures_prototype',
+                            mutation: {
+                                proccode: 'made_block',
+                                arguments: []
+                            },
+                            shadow: true
+                        }
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('def self.method_name with arguments is accepted', async () => {
+        const code = `
+            def self.made_block(arg1, arg2)
+              move(10)
+            end
+        `;
+        const expected = [
+            {
+                opcode: 'procedures_definition',
+                inputs: [
+                    {
+                        name: 'custom_block',
+                        block: {
+                            opcode: 'procedures_prototype',
+                            mutation: {
+                                proccode: 'made_block %s %s',
+                                arguments: [
+                                    {
+                                        name: 'arg1',
+                                        type: 'string_number'
+                                    },
+                                    {
+                                        name: 'arg2',
+                                        type: 'string_number'
+                                    }
+                                ]
+                            },
+                            shadow: true
+                        }
+                    }
+                ],
+                next: {
+                    opcode: 'motion_movesteps',
+                    inputs: [
+                        {
+                            name: 'STEPS',
+                            block: expectedInfo.makeNumber(10)
+                        }
+                    ]
+                }
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/my-blocks/my-blocks1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/my-blocks/my-blocks1.test.js
@@ -10,13 +10,13 @@ describe('RubyToBlocksConverter/My Blocks', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 
     test('procedures_definition,procedures_prototype no arguments', async () => {
         const code = `
-            def self.made_block
+            def made_block
             end
         `;
         const expected = [
@@ -42,7 +42,7 @@ describe('RubyToBlocksConverter/My Blocks', () => {
 
     test('procedures_definition,procedures_prototype', async () => {
         const code = `
-            def self.made_block(arg1, arg2)
+            def made_block(arg1, arg2)
               move(10)
             end
         `;
@@ -87,7 +87,7 @@ describe('RubyToBlocksConverter/My Blocks', () => {
 
     test('argument_reporter_string_number', async () => {
         const code = `
-            def self.made_block(arg1, arg2)
+            def made_block(arg1, arg2)
               move(arg1)
             end
         `;
@@ -141,7 +141,7 @@ describe('RubyToBlocksConverter/My Blocks', () => {
 
     test('argument_reporter_boolean,argument_reporter_string_number', async () => {
         const code = `
-            def self.made_block(arg1, arg2)
+            def made_block(arg1, arg2)
               move(arg1)
               if arg2
                 bounce_if_on_edge

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/arithmetic-add-subtract.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/arithmetic-add-subtract.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;
@@ -222,7 +222,7 @@ describe('RubyToBlocksConverter/Operators', () => {
             code = 'a = "Hello"\na + true';
             await convertAndExpectRubyBlockError(converter, target, code);
 
-            converter = new RubyToBlocksConverter(null);
+            converter = new RubyToBlocksConverter(null, {version: '2'});
             code = 'a = "Hello"\na + false';
             await convertAndExpectRubyBlockError(converter, target, code);
         });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/arithmetic-multiply-divide-random.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/arithmetic-multiply-divide-random.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/comparison-compound.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/comparison-compound.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/comparison-equality.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/comparison-equality.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/comparison-not-equals.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/comparison-not-equals.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/literals.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/literals.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/logical.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/logical.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/math-operators.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/math-operators.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/string.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/string.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/type-conversion.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/type-conversion.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Operators', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/pen.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/pen.test.js
@@ -13,7 +13,7 @@ describe('RubyToBlocksConverter/Pen', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/round-trip.test.js
@@ -6,7 +6,7 @@ describe('Ruby Round Trip', () => {
     let converter;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
     });
 
     const expectRoundTrip = async (code, expectedRuby = null) => {
@@ -46,10 +46,10 @@ describe('Ruby Round Trip', () => {
             }
         };
 
-        RubyGenerator.init();
+        RubyGenerator.init({version: '2'});
         RubyGenerator.currentTarget = target;
-        
-        const generatedRuby = RubyGenerator.targetToCode(target);
+
+        const generatedRuby = RubyGenerator.targetToCode(target, {version: '2'});
         expect(generatedRuby.trim()).toEqual((expectedRuby || code).trim());
     };
 
@@ -119,13 +119,13 @@ describe('Ruby Round Trip', () => {
 
     test('return statement in method', async () => {
         await expectRoundTrip(`
-def self.add(a, b)
+def add(a, b)
   return a + b
 end
 `.trim());
 
         await expectRoundTrip(`
-def self.div(a, b)
+def div(a, b)
   if b == 0
     return 0
   end
@@ -134,7 +134,7 @@ end
 `.trim());
 
         await expectRoundTrip(`
-def self.check(x)
+def check(x)
   if x < 0
     return "negative"
   end
@@ -266,9 +266,7 @@ end
 
         test('complex program with while and boolean variable', async () => {
             await expectRoundTrip(
-                'when_flag_clicked do\n  @game_on = true\n  while @game_on\n    go_to("_random_")\n    @game_on = false\n  end\nend',
-                // v1 generator outputs self.when(:flag_clicked) format
-                'self.when(:flag_clicked) do\n  @game_on = true\n  while @game_on\n    go_to("_random_")\n    @game_on = false\n  end\nend'
+                'when_flag_clicked do\n  @game_on = true\n  while @game_on\n    go_to("_random_")\n    @game_on = false\n  end\nend'
             );
         });
     });
@@ -337,55 +335,54 @@ end
 
         test('basic class Sprite1 round trip', async () => {
             await expectClassRoundTrip(
-                `class Sprite1\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
                 `class Sprite1\n  when_flag_clicked do\n    move(10)\n  end\nend`
             );
         });
 
         test('class Cat round trip', async () => {
             await expectClassRoundTrip(
-                `class Cat\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
                 `class Cat\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                null,
                 {name: 'Cat'}
             );
         });
 
         test('class with set_name round trip', async () => {
             await expectClassRoundTrip(
-                `class Sprite1\n  set_name "ネコ"\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
                 `class Sprite1\n  set_name "ネコ"\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                null,
                 {name: 'ネコ'}
             );
         });
 
         test('class with set_x and set_y round trip', async () => {
             await expectClassRoundTrip(
-                `class Sprite1\n  set_x 100\n  set_y -50\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
                 `class Sprite1\n  set_x 100\n  set_y -50\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                null,
                 {x: 100, y: -50}
             );
         });
 
         test('class with name and set_x round trip', async () => {
             await expectClassRoundTrip(
-                `class Cat\n  set_x 90\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
                 `class Cat\n  set_x 90\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                null,
                 {name: 'Cat', x: 90}
             );
         });
 
         test('class Cat with set_name round trip preserves class name', async () => {
             await expectClassRoundTrip(
-                `class Cat\n  set_name "ネコ"\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
                 `class Cat\n  set_name "ネコ"\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                null,
                 {name: 'ネコ'}
             );
         });
 
         test('class Cat with set_name and set_x round trip', async () => {
             await expectClassRoundTrip(
-                `class Cat\n  set_name "ネコ"\n  set_x 100\n\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
                 `class Cat\n  set_name "ネコ"\n  set_x 100\n\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                null,
                 {name: 'ネコ', x: 100}
             );
         });
@@ -394,8 +391,8 @@ end
             // Even though sprite has non-default x,y, they should NOT appear
             // because the class had no set_xxx calls (comment is @ruby:class)
             await expectClassRoundTrip(
-                `class Sprite1\n  self.when(:flag_clicked) do\n    move(10)\n  end\nend`,
                 `class Sprite1\n  when_flag_clicked do\n    move(10)\n  end\nend`,
+                null,
                 {x: 100, y: -50}
             );
         });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/ruby.test.js
@@ -8,7 +8,7 @@ describe('RubyToBlocksConverter/Ruby', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing1.test.js
@@ -14,7 +14,7 @@ describe('RubyToBlocksConverter/Sensing', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing2.test.js
@@ -14,7 +14,7 @@ describe('RubyToBlocksConverter/Sensing', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing3.test.js
@@ -14,7 +14,7 @@ describe('RubyToBlocksConverter/Sensing', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing4.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing4.test.js
@@ -14,7 +14,7 @@ describe('RubyToBlocksConverter/Sensing', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing5.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sensing/sensing5.test.js
@@ -14,7 +14,7 @@ describe('RubyToBlocksConverter/Sensing', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/smalrubot_s1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/smalrubot_s1.test.js
@@ -12,7 +12,7 @@ describe('RubyToBlocksConverter/SmalrubotS1', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sound/sound1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sound/sound1.test.js
@@ -14,7 +14,7 @@ describe('RubyToBlocksConverter/Sound', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sound/sound2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/sound/sound2.test.js
@@ -14,7 +14,7 @@ describe('RubyToBlocksConverter/Sound', () => {
     let expected;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
         code = null;
         expected = null;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/text2speech.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/text2speech.test.js
@@ -1,0 +1,66 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectToEqualBlocks,
+    convertAndExpectRubyBlockError,
+    expectedInfo
+} from '../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/Text2Speech', () => {
+    let converter;
+    let target;
+    let code;
+    let expected;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null, {version: '2'});
+        target = null;
+        code = null;
+        expected = null;
+    });
+
+    test('text2speech_speakAndWait', async () => {
+        code = 'text2speech.speak("hello")';
+        expected = [
+            {
+                opcode: 'text2speech_speakAndWait',
+                inputs: [
+                    {
+                        name: 'WORDS',
+                        block: expectedInfo.makeText('hello')
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('text2speech_setVoice', async () => {
+        code = 'text2speech.voice = "alto"';
+        expected = [
+            {
+                opcode: 'text2speech_setVoice',
+                inputs: [
+                    {
+                        name: 'VOICE',
+                        block: {
+                            opcode: 'text2speech_menu_voices',
+                            fields: [{name: 'voices', value: 'ALTO'}],
+                            shadow: true
+                        }
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('invalid', async () => {
+        for (const s of [
+            'text2speech.speak(1)',
+            'text2speech.voice = 1',
+            'text2speech.voice = "invalid_voice"'
+        ]) {
+            await convertAndExpectRubyBlockError(converter, target, s);
+        }
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/translate.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/translate.test.js
@@ -1,0 +1,34 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectRubyBlockError
+} from '../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/Translate', () => {
+    let converter;
+    let target;
+    let code;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null, {version: '2'});
+        target = null;
+        code = null;
+    });
+
+    test('translate_getTranslate', async () => {
+        code = 'say(translate("hello", "ja"))';
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('translate_getViewerLanguage', async () => {
+        code = 'say(language)';
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('invalid', async () => {
+        await convertAndExpectRubyBlockError(converter, target, 'translate("hello")');
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/class.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/class.test.js
@@ -1,0 +1,24 @@
+import RubyToBlocksConverter from '../../../../../src/lib/ruby-to-blocks-converter';
+
+describe('RubyToBlocksConverter/Class (v1)', () => {
+    let target;
+
+    beforeEach(() => {
+        target = null;
+    });
+
+    test('class definition is rejected in version 1', async () => {
+        const v1Converter = new RubyToBlocksConverter(null, {version: '1'});
+        const code = `
+            class Sprite1
+              self.when(:flag_clicked) do
+                move(10)
+              end
+            end
+        `;
+        const res = await v1Converter.targetCodeToBlocks(target, code);
+        expect(res).toBeFalsy();
+        expect(v1Converter.errors).toHaveLength(1);
+        expect(v1Converter.errors[0].text).toContain('version 1');
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/event.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/event.test.js
@@ -1,17 +1,17 @@
-import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import RubyToBlocksConverter from '../../../../../src/lib/ruby-to-blocks-converter';
 import {
     convertAndExpectToEqualBlocks,
     convertAndExpectRubyBlockError,
     rubyToExpected
-} from '../../../helpers/expect-to-equal-blocks';
+} from '../../../../helpers/expect-to-equal-blocks';
 
-describe('RubyToBlocksConverter/Event', () => {
+describe('RubyToBlocksConverter/Event (v1)', () => {
     let converter;
     let target;
     let code;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null, {version: '2'});
+        converter = new RubyToBlocksConverter(null, {version: '1'});
         target = null;
         code = null;
     });
@@ -19,17 +19,24 @@ describe('RubyToBlocksConverter/Event', () => {
     describe('event_whenflagclicked', () => {
         test('invalid', async () => {
             const cases = [
-                'when_flag_clicked',
-                'when_flag_clicked(1) {}'
+                'self.when(:flag_clicked)',
+                'self.when(:flag_clicked, 1)'
             ];
             for (const s of cases) {
+                await convertAndExpectRubyBlockError(converter, target, s);
+            }
+
+            const cases2 = [
+                '12.when(:flag_clicked) {}'
+            ];
+            for (const s of cases2) {
                 await convertAndExpectRubyBlockError(converter, target, s);
             }
         });
 
         test('valid with block body', async () => {
             code = `
-                when_flag_clicked do
+                self.when(:flag_clicked) do
                   move(10)
                 end
             `;
@@ -42,18 +49,25 @@ describe('RubyToBlocksConverter/Event', () => {
     describe('event_whenkeypressed', () => {
         test('invalid', async () => {
             const cases = [
-                'when_key_pressed',
-                'when_key_pressed(1) {}',
-                'when_key_pressed("space", 1) {}'
+                'self.when(:key_pressed)',
+                'self.when(:key_pressed, 1)',
+                'self.when(:key_pressed, "space", 1)'
             ];
             for (const s of cases) {
+                await convertAndExpectRubyBlockError(converter, target, s);
+            }
+
+            const cases2 = [
+                '12.when(:key_pressed, "space") {}'
+            ];
+            for (const s of cases2) {
                 await convertAndExpectRubyBlockError(converter, target, s);
             }
         });
 
         test('valid with block body', async () => {
             code = `
-                when_key_pressed("space") do
+                self.when(:key_pressed, "space") do
                   move(10)
                 end
             `;
@@ -66,66 +80,117 @@ describe('RubyToBlocksConverter/Event', () => {
     describe('event_whenthisspriteclicked', () => {
         test('invalid', async () => {
             const cases = [
-                'when_clicked',
-                'when_clicked(1) {}'
+                'self.when(:this_sprite_clicked)',
+                'self.when(:this_sprite_clicked, 1)'
             ];
             for (const s of cases) {
+                await convertAndExpectRubyBlockError(converter, target, s);
+            }
+
+            const cases2 = [
+                '12.when(:this_sprite_clicked) {}'
+            ];
+            for (const s of cases2) {
                 await convertAndExpectRubyBlockError(converter, target, s);
             }
         });
 
         test('valid with block body', async () => {
             code = `
-                when_clicked do
+                self.when(:clicked) do
                   move(10)
                 end
             `;
             const res = await converter.targetCodeToBlocks(target, code);
             expect(converter.errors).toHaveLength(0);
             expect(res).toBeTruthy();
+        });
+    });
+
+    describe('event_whenstageclicked', () => {
+        test('invalid', async () => {
+            const cases = [
+                'self.when(:stage_clicked)',
+                'self.when(:stage_clicked, 1)'
+            ];
+            for (const s of cases) {
+                await convertAndExpectRubyBlockError(converter, target, s);
+            }
+
+            const cases2 = [
+                '12.when(:stage_clicked) {}'
+            ];
+            for (const s of cases2) {
+                await convertAndExpectRubyBlockError(converter, target, s);
+            }
+        });
+
+        test('error', async () => {
+            code = `
+                self.when(:stage_clicked) do
+                  move(10)
+                end
+            `;
+            const res = await converter.targetCodeToBlocks(target, code);
+            expect(converter.errors).toHaveLength(1);
+            expect(res).toBeFalsy();
         });
     });
 
     describe('event_whenbackdropswitchesto', () => {
         test('invalid', async () => {
             const cases = [
-                'when_backdrop_switches',
-                'when_backdrop_switches(1) {}',
-                'when_backdrop_switches("backdrop1", 1) {}'
+                'self.when(:backdrop_switches_to)',
+                'self.when(:backdrop_switches_to, 1)',
+                'self.when(:backdrop_switches_to, "backdrop1", 1)'
             ];
             for (const s of cases) {
                 await convertAndExpectRubyBlockError(converter, target, s);
             }
+
+            const cases2 = [
+                '12.when(:backdrop_switches_to, "backdrop1") {}'
+            ];
+            for (const s of cases2) {
+                await convertAndExpectRubyBlockError(converter, target, s);
+            }
         });
 
-        test('valid with block body', async () => {
+        test('error', async () => {
             code = `
-                when_backdrop_switches("backdrop1") do
+                self.when(:backdrop_switches_to, "backdrop1") do
                   move(10)
                 end
             `;
             const res = await converter.targetCodeToBlocks(target, code);
-            expect(converter.errors).toHaveLength(0);
-            expect(res).toBeTruthy();
+            expect(converter.errors).toHaveLength(1);
+            expect(res).toBeFalsy();
         });
     });
 
     describe('event_whengreaterthan', () => {
         test('invalid', async () => {
             const cases = [
-                'when_greater_than',
-                'when_greater_than(1) {}',
-                'when_greater_than("loudness", 1)',
-                'when_greater_than("loudness", 10, 1) {}'
+                'self.when(:greater_than)',
+                'self.when(:greater_than, 1)',
+                'self.when(:greater_than, "loudness", 1)',
+                'self.when(:greater_than, "loudness", 10, 1)'
             ];
             for (const s of cases) {
+                await convertAndExpectRubyBlockError(converter, target, s);
+            }
+
+            const cases2 = [
+                '12.when(:greater_than, "loudness", 10) {}'
+            ];
+            for (const s of cases2) {
                 await convertAndExpectRubyBlockError(converter, target, s);
             }
         });
 
         test('valid with block body', async () => {
             code = `
-                when_greater_than("loudness", 10) do
+                self.when(:greater_than, "loudness", 10) do
                   move(10)
                 end
             `;
@@ -138,18 +203,25 @@ describe('RubyToBlocksConverter/Event', () => {
     describe('event_whenbroadcastreceived', () => {
         test('invalid', async () => {
             const cases = [
-                'when_receive',
-                'when_receive(1) {}',
-                'when_receive("msg1", 1) {}'
+                'self.when(:receive)',
+                'self.when(:receive, 1)',
+                'self.when(:receive, "msg1", 1)'
             ];
             for (const s of cases) {
+                await convertAndExpectRubyBlockError(converter, target, s);
+            }
+
+            const cases2 = [
+                '12.when(:receive, "msg1") {}'
+            ];
+            for (const s of cases2) {
                 await convertAndExpectRubyBlockError(converter, target, s);
             }
         });
 
         test('valid with block body', async () => {
             code = `
-                when_receive("msg1") do
+                self.when(:receive, "msg1") do
                   move(10)
                 end
             `;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/method-return/method-return2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/method-return/method-return2.test.js
@@ -1,8 +1,8 @@
-import RubyToBlocksConverter from '../../../../../src/lib/ruby-to-blocks-converter';
+import RubyToBlocksConverter from '../../../../../../src/lib/ruby-to-blocks-converter';
 import {
     convertAndExpectToEqualBlocks,
     expectedInfo
-} from '../../../../helpers/expect-to-equal-blocks';
+} from '../../../../../helpers/expect-to-equal-blocks';
 import Variable from '@smalruby/scratch-vm/src/engine/variable';
 import Blocks from '@smalruby/scratch-vm/src/engine/blocks';
 
@@ -301,7 +301,7 @@ describe('RubyToBlocksConverter/Method Return', () => {
 
         test('explicit return variable assignment should NOT add @ruby:return comment', async () => {
             const code = `
-                def add(a, b)
+                def self.add(a, b)
                   @_return_add_ = a + b
                 end
             `;

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/module.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/module.test.js
@@ -1,0 +1,23 @@
+import RubyToBlocksConverter from '../../../../../src/lib/ruby-to-blocks-converter';
+
+describe('RubyToBlocksConverter/Module (v1)', () => {
+    let target;
+
+    beforeEach(() => {
+        target = null;
+    });
+
+    test('module in v1 throws error', async () => {
+        const converterV1 = new RubyToBlocksConverter(null, {version: '1'});
+        const code = `
+            module Utils
+              def add(a, b)
+                a + b
+              end
+            end
+        `;
+        const result = await converterV1.targetCodeToBlocks(target, code);
+        expect(result).toBeFalsy();
+        expect(converterV1.errors.length).toBeGreaterThan(0);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/my-blocks/my-blocks1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/my-blocks/my-blocks1.test.js
@@ -1,25 +1,22 @@
-import RubyToBlocksConverter from '../../../../../src/lib/ruby-to-blocks-converter';
+import RubyToBlocksConverter from '../../../../../../src/lib/ruby-to-blocks-converter';
 import {
     convertAndExpectToEqualBlocks,
     rubyToExpected,
     expectedInfo
-} from '../../../../helpers/expect-to-equal-blocks';
+} from '../../../../../helpers/expect-to-equal-blocks';
 
-describe('RubyToBlocksConverter/My Blocks', () => {
+describe('RubyToBlocksConverter/My Blocks (v1)', () => {
     let converter;
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null, {version: '2'});
+        converter = new RubyToBlocksConverter(null, {version: '1'});
         target = null;
     });
 
-    test('argument_reporter_boolean,argument_reporter_string_number 2', async () => {
+    test('procedures_definition,procedures_prototype no arguments', async () => {
         const code = `
-            def made_block(arg1)
-              move(arg1)
-              if arg1
-              end
+            def self.made_block
             end
         `;
         const expected = [
@@ -31,11 +28,42 @@ describe('RubyToBlocksConverter/My Blocks', () => {
                         block: {
                             opcode: 'procedures_prototype',
                             mutation: {
-                                proccode: 'made_block %b',
+                                proccode: 'made_block',
+                                arguments: []
+                            },
+                            shadow: true
+                        }
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('procedures_definition,procedures_prototype', async () => {
+        const code = `
+            def self.made_block(arg1, arg2)
+              move(10)
+            end
+        `;
+        const expected = [
+            {
+                opcode: 'procedures_definition',
+                inputs: [
+                    {
+                        name: 'custom_block',
+                        block: {
+                            opcode: 'procedures_prototype',
+                            mutation: {
+                                proccode: 'made_block %s %s',
                                 arguments: [
                                     {
                                         name: 'arg1',
-                                        type: 'boolean'
+                                        type: 'string_number'
+                                    },
+                                    {
+                                        name: 'arg2',
+                                        type: 'string_number'
                                     }
                                 ]
                             },
@@ -48,52 +76,19 @@ describe('RubyToBlocksConverter/My Blocks', () => {
                     inputs: [
                         {
                             name: 'STEPS',
-                            block: {
-                                opcode: 'argument_reporter_boolean',
-                                fields: [
-                                    {
-                                        name: 'VALUE',
-                                        value: 'arg1'
-                                    }
-                                ]
-                            },
-                            shadow: expectedInfo.makeNumber(10)
+                            block: expectedInfo.makeNumber(10)
                         }
-                    ],
-                    next: {
-                        opcode: 'control_if',
-                        inputs: [
-                            {
-                                name: 'CONDITION',
-                                block: {
-                                    opcode: 'argument_reporter_boolean',
-                                    fields: [
-                                        {
-                                            name: 'VALUE',
-                                            value: 'arg1'
-                                        }
-                                    ]
-                                }
-                            }
-                        ],
-                        branches: []
-                    }
+                    ]
                 }
             }
         ];
         await convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
 
-    test('argument_reporter_boolean,argument_reporter_string_number 3', async () => {
+    test('argument_reporter_string_number', async () => {
         const code = `
-            def made_block(arg1)
+            def self.made_block(arg1, arg2)
               move(arg1)
-            end
-
-            def made_block2(arg1)
-              move(arg1)
-              if arg1
-              end
             end
         `;
         const expected = [
@@ -105,10 +100,14 @@ describe('RubyToBlocksConverter/My Blocks', () => {
                         block: {
                             opcode: 'procedures_prototype',
                             mutation: {
-                                proccode: 'made_block %s',
+                                proccode: 'made_block %s %s',
                                 arguments: [
                                     {
                                         name: 'arg1',
+                                        type: 'string_number'
+                                    },
+                                    {
+                                        name: 'arg2',
                                         type: 'string_number'
                                     }
                                 ]
@@ -135,78 +134,19 @@ describe('RubyToBlocksConverter/My Blocks', () => {
                         }
                     ]
                 }
-            },
-            {
-                opcode: 'procedures_definition',
-                inputs: [
-                    {
-                        name: 'custom_block',
-                        block: {
-                            opcode: 'procedures_prototype',
-                            mutation: {
-                                proccode: 'made_block2 %b',
-                                arguments: [
-                                    {
-                                        name: 'arg1',
-                                        type: 'boolean'
-                                    }
-                                ]
-                            },
-                            shadow: true
-                        }
-                    }
-                ],
-                next: {
-                    opcode: 'motion_movesteps',
-                    inputs: [
-                        {
-                            name: 'STEPS',
-                            block: {
-                                opcode: 'argument_reporter_boolean',
-                                fields: [
-                                    {
-                                        name: 'VALUE',
-                                        value: 'arg1'
-                                    }
-                                ]
-                            },
-                            shadow: expectedInfo.makeNumber(10)
-                        }
-                    ],
-                    next: {
-                        opcode: 'control_if',
-                        inputs: [
-                            {
-                                name: 'CONDITION',
-                                block: {
-                                    opcode: 'argument_reporter_boolean',
-                                    fields: [
-                                        {
-                                            name: 'VALUE',
-                                            value: 'arg1'
-                                        }
-                                    ]
-                                }
-                            }
-                        ],
-                        branches: []
-                    }
-                }
             }
         ];
         await convertAndExpectToEqualBlocks(converter, target, code, expected);
     });
 
-    test('procedures_call', async () => {
+    test('argument_reporter_boolean,argument_reporter_string_number', async () => {
         const code = `
-            def made_block(arg1, arg2)
+            def self.made_block(arg1, arg2)
               move(arg1)
               if arg2
                 bounce_if_on_edge
               end
             end
-
-            made_block(12, touching?("_edge_"))
         `;
         const expected = [
             {
@@ -270,16 +210,6 @@ describe('RubyToBlocksConverter/My Blocks', () => {
                             (await rubyToExpected(converter, target, 'bounce_if_on_edge'))[0]
                         ]
                     }
-                }
-            },
-            {
-                opcode: 'procedures_call',
-                mutation: {
-                    proccode: 'made_block %s %b',
-                    argument_blocks: [
-                        expectedInfo.makeText('12'),
-                        (await rubyToExpected(converter, target, 'touching?("_edge_")'))[0]
-                    ]
                 }
             }
         ];

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/my-blocks/my-blocks2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/my-blocks/my-blocks2.test.js
@@ -1,22 +1,22 @@
-import RubyToBlocksConverter from '../../../../../src/lib/ruby-to-blocks-converter';
+import RubyToBlocksConverter from '../../../../../../src/lib/ruby-to-blocks-converter';
 import {
     convertAndExpectToEqualBlocks,
     rubyToExpected,
     expectedInfo
-} from '../../../../helpers/expect-to-equal-blocks';
+} from '../../../../../helpers/expect-to-equal-blocks';
 
-describe('RubyToBlocksConverter/My Blocks', () => {
+describe('RubyToBlocksConverter/My Blocks (v1)', () => {
     let converter;
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null, {version: '2'});
+        converter = new RubyToBlocksConverter(null, {version: '1'});
         target = null;
     });
 
     test('argument_reporter_boolean,argument_reporter_string_number 2', async () => {
         const code = `
-            def made_block(arg1)
+            def self.made_block(arg1)
               move(arg1)
               if arg1
               end
@@ -86,11 +86,11 @@ describe('RubyToBlocksConverter/My Blocks', () => {
 
     test('argument_reporter_boolean,argument_reporter_string_number 3', async () => {
         const code = `
-            def made_block(arg1)
+            def self.made_block(arg1)
               move(arg1)
             end
 
-            def made_block2(arg1)
+            def self.made_block2(arg1)
               move(arg1)
               if arg1
               end
@@ -199,7 +199,7 @@ describe('RubyToBlocksConverter/My Blocks', () => {
 
     test('procedures_call', async () => {
         const code = `
-            def made_block(arg1, arg2)
+            def self.made_block(arg1, arg2)
               move(arg1)
               if arg2
                 bounce_if_on_edge

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/my-blocks/my-blocks3.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1/my-blocks/my-blocks3.test.js
@@ -1,22 +1,22 @@
-import RubyToBlocksConverter from '../../../../../src/lib/ruby-to-blocks-converter';
+import RubyToBlocksConverter from '../../../../../../src/lib/ruby-to-blocks-converter';
 import {
     convertAndExpectToEqualBlocks,
     rubyToExpected,
     expectedInfo
-} from '../../../../helpers/expect-to-equal-blocks';
+} from '../../../../../helpers/expect-to-equal-blocks';
 
-describe('RubyToBlocksConverter/My Blocks', () => {
+describe('RubyToBlocksConverter/My Blocks (v1)', () => {
     let converter;
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null, {version: '2'});
+        converter = new RubyToBlocksConverter(null, {version: '1'});
         target = null;
     });
 
     test('procedures_call 2', async () => {
         const code = `
-            def made_block(arg1)
+            def self.made_block(arg1)
             end
 
             made_block(12)
@@ -58,7 +58,7 @@ describe('RubyToBlocksConverter/My Blocks', () => {
 
     test('procedures_call recursive', async () => {
         const code = `
-            def made_block(arg1)
+            def self.made_block(arg1)
               made_block(arg1 - 1)
             end
 
@@ -132,7 +132,7 @@ describe('RubyToBlocksConverter/My Blocks', () => {
     describe('error if argument type miss match', () => {
         test('defined string_number, call boolean', async () => {
             const code = `
-                def made_block(arg1, arg2)
+                def self.made_block(arg1, arg2)
                   if arg2
                   end
                 end
@@ -147,7 +147,7 @@ describe('RubyToBlocksConverter/My Blocks', () => {
 
         test('defined boolean, call string_number', async () => {
             const code = `
-                def made_block(arg1, arg2)
+                def self.made_block(arg1, arg2)
                 end
 
                 made_block(:symbol, 1)

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-data-type.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-data-type.test.js
@@ -9,7 +9,7 @@ describe('RubyToBlocksConverter/Variables/dataType', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-global1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-global1.test.js
@@ -10,7 +10,7 @@ describe('RubyToBlocksConverter/Variables', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-global2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-global2.test.js
@@ -10,7 +10,7 @@ describe('RubyToBlocksConverter/Variables', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-instance1.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-instance1.test.js
@@ -10,7 +10,7 @@ describe('RubyToBlocksConverter/Variables', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-instance2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-instance2.test.js
@@ -10,7 +10,7 @@ describe('RubyToBlocksConverter/Variables', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-scope.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/variables/variables-scope.test.js
@@ -5,7 +5,7 @@ describe('RubyToBlocksConverter/Variables', () => {
     let target;
 
     beforeEach(() => {
-        converter = new RubyToBlocksConverter(null);
+        converter = new RubyToBlocksConverter(null, {version: '2'});
         target = null;
     });
 

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/video.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/video.test.js
@@ -1,0 +1,83 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectToEqualBlocks,
+    convertAndExpectRubyBlockError,
+    expectedInfo
+} from '../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/Video', () => {
+    let converter;
+    let target;
+    let code;
+    let expected;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null, {version: '2'});
+        target = null;
+        code = null;
+        expected = null;
+    });
+
+    test('videoSensing_whenMotionGreaterThan', async () => {
+        code = `
+            video_sensing.when_video_motion_greater_than(10) do
+              say("motion!")
+            end
+        `;
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('videoSensing_videoOn (as value block)', async () => {
+        code = 'say(video_sensing.video_on("motion", "this sprite"))';
+        const res = await converter.targetCodeToBlocks(target, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(res).toBeTruthy();
+    });
+
+    test('videoSensing_videoToggle', async () => {
+        code = 'video_sensing.video_turn("on")';
+        expected = [
+            {
+                opcode: 'videoSensing_videoToggle',
+                inputs: [
+                    {
+                        name: 'VIDEO_STATE',
+                        block: {
+                            opcode: 'videoSensing_menu_VIDEO_STATE',
+                            fields: [{name: 'VIDEO_STATE', value: 'on'}],
+                            shadow: true
+                        }
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('videoSensing_setVideoTransparency', async () => {
+        code = 'video_sensing.video_transparency = 50';
+        expected = [
+            {
+                opcode: 'videoSensing_setVideoTransparency',
+                inputs: [
+                    {
+                        name: 'TRANSPARENCY',
+                        block: expectedInfo.makeNumber(50)
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('invalid', async () => {
+        for (const s of [
+            'video_sensing.video_turn("invalid_state")',
+            'video_sensing.video_transparency = "abc"'
+        ]) {
+            await convertAndExpectRubyBlockError(converter, target, s);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Ruby ↔ ブロック変換テストの再編成。V2をメインにし、V1テストを`v1/`サブディレクトリに分離。

- V1固有テストを`v1/`ディレクトリに抽出（ruby-to-blocks-converter, ruby-generator両方）
- メインテストをV2構文に更新（`self.when(:flag_clicked)` → `when_flag_clicked`、`def self.method` → `def method`）
- V2モードでのV1後方互換性テストを`*-backward-compat.test.js`に分離
- 未カバーの拡張ブロック（music, text2speech, translate, video）とevent_whenstageclickedのテスト追加

Closes #297

## Implementation Steps

- [x] Phase 1: ruby-to-blocks-converter テスト再編成
- [x] Phase 2: ruby-generator テスト再編成
- [x] Phase 3: round-trip テスト再編成（Phase 1で完了）
- [x] Phase 4: 未カバーのコアブロックopcode用テスト追加
- [x] Phase 5: 未カバーの拡張ブロックopcode用テスト追加

## Changes Made

### ruby-to-blocks-converter (Phase 1)
- 55ファイルでコンバーター初期化を`{version: '2'}`に更新
- event.test.js: V2構文に書き換え
- v1/event.test.js: V1テストをコピー
- event-backward-compat.test.js: V2モードでV1構文を受け入れるテスト
- my-blocks/*.test.js: `def self.method` → `def method`
- v1/my-blocks/*.test.js: V1テストをコピー
- my-blocks-backward-compat.test.js: V2モードで`def self.`を受け入れるテスト
- class.test.js, module.test.js, round-trip.test.js: V2構文に更新
- v1/class.test.js, v1/module.test.js: V1テストを抽出

### ruby-generator (Phase 2)
- class.test.js: V1テストをv1/class.test.jsに抽出、V2構文に更新
- file-output-patterns.test.js: V1セクション2つをv1/file-output-patterns.test.jsに抽出
- fuzz-hunt.test.js: V1セクション2つをv1/fuzz-hunt.test.jsに抽出
- module.test.js: `self.when` → `when_flag_clicked`に更新
- method-return.test.js: `{version: '2'}`追加、`def self.add` → `def add`

### Coverage追加 (Phase 4-5)
- event.test.js: `event_whenstageclicked`テスト追加
- music.test.js (新規): playDrum, rest, playNote, setInstrument, setTempo, changeTempo, getTempo
- text2speech.test.js (新規): speakAndWait, setVoice
- translate.test.js (新規): getTranslate, getViewerLanguage
- video.test.js (新規): whenMotionGreaterThan, videoOn, videoToggle, setVideoTransparency

## Test Plan

- [x] 全ruby-to-blocks-converterユニットテストがパス
- [x] 全ruby-generatorユニットテストがパス
- [x] V1テスト（v1/ディレクトリ）がパス
- [x] 後方互換性テストがパス
- [x] 新規拡張テストがパス
- [x] lintパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
