### PR TITLE
feat: preserve Ruby comments through block conversion round-trip

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/index.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/index.js
@@ -675,10 +675,19 @@ RubyGenerator.scrub_ = function (block, code) {
     }
 
     let commentCode = '';
+    let isInlineComment = false;
     if (!this.isConnectedValue(block)) {
         let comment = this.getCommentText(block);
-        if (comment && !comment.startsWith('@ruby:')) {
-            commentCode += `${this.prefixLines(comment, '# ')}\n`;
+        if (comment) {
+            isInlineComment = comment.split('\n').some(line => line === '@ruby:comment_position:inline');
+            const filteredComment = comment.split('\n')
+                .filter(line => !line.startsWith('@ruby:'))
+                .join('\n');
+            if (filteredComment.trim().length > 0) {
+                if (!isInlineComment) {
+                    commentCode += `${this.prefixLines(filteredComment, '# ')}\n`;
+                }
+            }
         }
         const inputs = this.getInputs(block);
         for (const name in inputs) {
@@ -715,6 +724,14 @@ RubyGenerator.scrub_ = function (block, code) {
         }
         endCode = 'end\n';
         delete block.isStatement;
+    }
+    if (isInlineComment && !this.isConnectedValue(block)) {
+        const inlineComment = this.getCommentText(block).split('\n')
+            .filter(line => !line.startsWith('@ruby:'))
+            .join(' ');
+        if (inlineComment.trim().length > 0 && code.endsWith('\n')) {
+            code = `${code.slice(0, -1)} # ${inlineComment.trim()}\n`;
+        }
     }
     return commentCode + code + nextCode + endCode;
 };

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -452,8 +452,28 @@ class RubyToBlocksConverter extends Visitor {
             return [];
         }
 
-        // Build offset-to-line mapping
-        const lineStarts = [0]; // line 1 starts at offset 0
+        // Prism WASM reports byte offsets (UTF-8), but JavaScript strings use
+        // UTF-16 char indices. Build a byte→char mapping to convert between them.
+        const sourceBytes = new TextEncoder().encode(sourceCode);
+        const byteToChar = new Int32Array(sourceBytes.length + 1);
+        {
+            let ci = 0;
+            let bi = 0;
+            while (ci < sourceCode.length) {
+                const cp = sourceCode.codePointAt(ci);
+                const charLen = cp > 0xFFFF ? 2 : 1; // surrogate pair in UTF-16
+                const byteLen = cp <= 0x7F ? 1 : cp <= 0x7FF ? 2 : cp <= 0xFFFF ? 3 : 4;
+                for (let b = 0; b < byteLen; b++) {
+                    byteToChar[bi + b] = ci;
+                }
+                bi += byteLen;
+                ci += charLen;
+            }
+            byteToChar[bi] = ci; // end sentinel
+        }
+
+        // Build char-offset-to-line mapping
+        const lineStarts = [0]; // line 1 starts at char offset 0
         for (let i = 0; i < sourceCode.length; i++) {
             if (sourceCode[i] === '\n') {
                 lineStarts.push(i + 1);
@@ -469,14 +489,18 @@ class RubyToBlocksConverter extends Visitor {
         };
 
         return parseResult.comments.map(comment => {
-            const startOffset = comment.location.startOffset;
-            const length = comment.location.length;
-            const rawText = sourceCode.substring(startOffset, startOffset + length);
-            const line = offsetToLine(startOffset);
+            const startByte = comment.location.startOffset;
+            const lengthBytes = comment.location.length;
+            // Convert byte offsets to char offsets
+            const startCharOffset = startByte in byteToChar ? byteToChar[startByte] : 0;
+            const endByte = startByte + lengthBytes;
+            const endCharOffset = endByte in byteToChar ? byteToChar[endByte] : sourceCode.length;
+            const rawText = sourceCode.substring(startCharOffset, endCharOffset);
+            const line = offsetToLine(startCharOffset);
             const lineStart = lineStarts[line - 1];
 
             // Check if there's non-whitespace before this comment on the same line
-            const textBeforeOnLine = sourceCode.substring(lineStart, startOffset);
+            const textBeforeOnLine = sourceCode.substring(lineStart, startCharOffset);
             const isTrailing = textBeforeOnLine.trim().length > 0;
 
             let type;
@@ -495,7 +519,7 @@ class RubyToBlocksConverter extends Visitor {
                 }
             }
 
-            return {type, text, line, startOffset, endOffset: startOffset + length, isTrailing};
+            return {type, text, line, startOffset: startCharOffset, endOffset: endCharOffset, isTrailing};
         });
     }
 
@@ -510,6 +534,27 @@ class RubyToBlocksConverter extends Visitor {
         if (sourceComments.length === 0) {
             return;
         }
+
+        // Build a map from start line to block ID.
+        // Unlike lineToNodeMap (which uses a range/shallowest strategy), this maps only
+        // lines where a node actually STARTS, preferring the most specific (smallest range) node.
+        // This ensures "# comment\nloop do" attaches to the loop block, not a parent block.
+        const lineStartBlockMap = new Map();
+        for (const [node, blockId] of this._context.nodeToBlockMap.entries()) {
+            const startLine = this._getNodeStartLine(node);
+            if (startLine === null) continue;
+            const endLine = this._getNodeEndLine(node) || startLine;
+            const range = endLine - startLine;
+            const existing = lineStartBlockMap.get(startLine);
+            if (!existing || range < existing.range) {
+                lineStartBlockMap.set(startLine, {blockId, range});
+            }
+        }
+
+        const findBlockForLine = line => {
+            const entry = lineStartBlockMap.get(line);
+            return entry ? entry.blockId : null;
+        };
 
         // Group consecutive non-trailing comments that share adjacent lines
         const groups = [];
@@ -535,7 +580,8 @@ class RubyToBlocksConverter extends Visitor {
             if (group.isTrailing) {
                 // Trailing (inline) comment: attach to block on the same line
                 const comment = group.comments[0];
-                const blockId = this._findBlockIdForLine(comment.line);
+                const blockId = findBlockForLine(comment.line) ||
+                    this._findBlockIdForLine(comment.line);
                 if (blockId) {
                     this._mergeUserComment(blockId, text, true);
                 } else {
@@ -554,7 +600,7 @@ class RubyToBlocksConverter extends Visitor {
                 if (isBeforeContainer) {
                     this._createComment(text, null);
                 } else {
-                    const blockId = this._findBlockIdForLine(nextCodeLine);
+                    const blockId = findBlockForLine(nextCodeLine);
                     if (blockId) {
                         this._mergeUserComment(blockId, text, false);
                     } else {
@@ -567,7 +613,8 @@ class RubyToBlocksConverter extends Visitor {
                                     (r.type === 'ClassNode' || r.type === 'ModuleNode' || r.type === 'DefNode')
                             );
                             if (hitContainer) break;
-                            const scanBlockId = this._findBlockIdForLine(scanLine);
+                            const scanBlockId = findBlockForLine(scanLine) ||
+                                this._findBlockIdForLine(scanLine);
                             if (scanBlockId) {
                                 this._mergeUserComment(scanBlockId, text, false);
                                 found = true;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -438,6 +438,64 @@ class RubyToBlocksConverter extends Visitor {
     }
 
     /**
+     * Extract comments from prism parse result and return structured data.
+     * @param {object} parseResult - The prism parse result
+     * @param {string} sourceCode - The original source code
+     * @returns {Array<object>} Array of comment objects with type, text, line, isTrailing
+     */
+    _extractSourceComments (parseResult, sourceCode) {
+        if (!parseResult.comments || parseResult.comments.length === 0) {
+            return [];
+        }
+
+        // Build offset-to-line mapping
+        const lineStarts = [0]; // line 1 starts at offset 0
+        for (let i = 0; i < sourceCode.length; i++) {
+            if (sourceCode[i] === '\n') {
+                lineStarts.push(i + 1);
+            }
+        }
+        const offsetToLine = offset => {
+            for (let i = lineStarts.length - 1; i >= 0; i--) {
+                if (offset >= lineStarts[i]) {
+                    return i + 1; // 1-based line numbers
+                }
+            }
+            return 1;
+        };
+
+        return parseResult.comments.map(comment => {
+            const startOffset = comment.location.startOffset;
+            const length = comment.location.length;
+            const rawText = sourceCode.substring(startOffset, startOffset + length);
+            const line = offsetToLine(startOffset);
+            const lineStart = lineStarts[line - 1];
+
+            // Check if there's non-whitespace before this comment on the same line
+            const textBeforeOnLine = sourceCode.substring(lineStart, startOffset);
+            const isTrailing = textBeforeOnLine.trim().length > 0;
+
+            let type;
+            let text;
+            if (comment.type === 1) {
+                // EmbDocComment: =begin\n...\n=end\n
+                type = 'embdoc';
+                text = rawText.replace(/^=begin\n?/, '').replace(/\n?=end\n?$/, '');
+            } else {
+                // InlineComment: # ...
+                type = 'inline';
+                // Strip '# ' or '#' prefix
+                text = rawText.replace(/^#/, '');
+                if (text.startsWith(' ')) {
+                    text = text.substring(1);
+                }
+            }
+
+            return {type, text, line, startOffset, endOffset: startOffset + length, isTrailing};
+        });
+    }
+
+    /**
      * Convert a ConstantReadNode or ConstantPathNode to its full path string.
      * e.g. ConstantReadNode "Foo" -> "Foo"
      * e.g. ConstantPathNode(ConstantPathNode(null, "Smalruby3"), "Sprite") -> "::Smalruby3::Sprite"

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -323,6 +323,10 @@ class RubyToBlocksConverter extends Visitor {
                     this._context.extensionIDs.add(extensionID);
                 }
             });
+
+            // Associate source comments with blocks
+            this._associateSourceComments(parseResult, code);
+
             return true;
         } catch (e) {
             let error;
@@ -493,6 +497,138 @@ class RubyToBlocksConverter extends Visitor {
 
             return {type, text, line, startOffset, endOffset: startOffset + length, isTrailing};
         });
+    }
+
+    /**
+     * Associate extracted source comments with blocks or create workspace comments.
+     * Called after all blocks have been created in targetCodeToBlocks.
+     * @param {object} parseResult - The prism parse result
+     * @param {string} sourceCode - The original source code
+     */
+    _associateSourceComments (parseResult, sourceCode) {
+        const sourceComments = this._extractSourceComments(parseResult, sourceCode);
+        if (sourceComments.length === 0) {
+            return;
+        }
+
+        // Group consecutive non-trailing comments that share adjacent lines
+        const groups = [];
+        let currentGroup = null;
+        for (const comment of sourceComments) {
+            if (comment.isTrailing) {
+                // Trailing comments are always individual
+                groups.push({comments: [comment], isTrailing: true});
+                currentGroup = null;
+            } else if (currentGroup && comment.line === currentGroup.endLine + 1) {
+                // Consecutive comment on next line
+                currentGroup.comments.push(comment);
+                currentGroup.endLine = comment.line;
+            } else {
+                currentGroup = {comments: [comment], isTrailing: false, endLine: comment.line};
+                groups.push(currentGroup);
+            }
+        }
+
+        for (const group of groups) {
+            const text = group.comments.map(c => c.text).join('\n');
+
+            if (group.isTrailing) {
+                // Trailing (inline) comment: attach to block on the same line
+                const comment = group.comments[0];
+                const blockId = this._findBlockIdForLine(comment.line);
+                if (blockId) {
+                    this._mergeUserComment(blockId, text, true);
+                } else {
+                    this._createComment(text, null);
+                }
+            } else {
+                // Preceding comment: attach to block on the next code line
+                const nextCodeLine = group.endLine + 1;
+
+                // Check if next line is a class/module/def start
+                // In that case, create a target-level comment (describes the definition, not a block)
+                const isBeforeContainer = this._context.containerNodeRanges.some(
+                    r => r.startLine === nextCodeLine &&
+                        (r.type === 'ClassNode' || r.type === 'ModuleNode' || r.type === 'DefNode')
+                );
+                if (isBeforeContainer) {
+                    this._createComment(text, null);
+                } else {
+                    const blockId = this._findBlockIdForLine(nextCodeLine);
+                    if (blockId) {
+                        this._mergeUserComment(blockId, text, false);
+                    } else {
+                        // No block found on next line - try scanning further down
+                        // but stop at container node boundaries
+                        let found = false;
+                        for (let scanLine = nextCodeLine + 1; scanLine <= nextCodeLine + 5; scanLine++) {
+                            const hitContainer = this._context.containerNodeRanges.some(
+                                r => r.startLine === scanLine &&
+                                    (r.type === 'ClassNode' || r.type === 'ModuleNode' || r.type === 'DefNode')
+                            );
+                            if (hitContainer) break;
+                            const scanBlockId = this._findBlockIdForLine(scanLine);
+                            if (scanBlockId) {
+                                this._mergeUserComment(scanBlockId, text, false);
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
+                            // Target-level (workspace) comment
+                            this._createComment(text, null);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Find the block ID associated with a given source line number.
+     * Uses lineToNodeMap and nodeToBlockMap.
+     * @param {number} line - 1-based line number
+     * @returns {string|null} The block ID, or null if not found
+     */
+    _findBlockIdForLine (line) {
+        const entry = this._context.lineToNodeMap.get(line);
+        if (!entry) {
+            return null;
+        }
+        const blockId = this._context.nodeToBlockMap.get(entry.node);
+        return blockId || null;
+    }
+
+    /**
+     * Merge a user comment with an existing block comment, or create a new one.
+     * User comment text is placed before any `@ruby:` metadata lines.
+     * @param {string} blockId - The block ID to attach the comment to
+     * @param {string} userText - The user comment text
+     * @param {boolean} isInline - Whether this is an inline (trailing) comment
+     */
+    _mergeUserComment (blockId, userText, isInline) {
+        const block = this._context.blocks[blockId];
+        if (!block) {
+            return;
+        }
+
+        const inlineMarker = isInline ? '@ruby:comment_position:inline\n' : '';
+
+        if (block.comment) {
+            // Block already has a comment - merge
+            const existingComment = this._context.comments[block.comment];
+            if (existingComment) {
+                // Put user text before metadata lines
+                const lines = existingComment.text.split('\n');
+                const metadataLines = lines.filter(l => l.startsWith('@ruby:'));
+                const newText = `${inlineMarker}${userText}\n${metadataLines.join('\n')}`;
+                existingComment.text = newText;
+            }
+        } else {
+            // Create new comment for this block
+            const commentText = isInline ? `${inlineMarker}${userText}` : userText;
+            block.comment = this._createComment(commentText, block.id);
+        }
     }
 
     /**

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -247,14 +247,18 @@ class RubyToBlocksConverter extends Visitor {
         this._setTarget(target);
         this._loadVariables(target);
         this._context.sourceCode = code;
+        this._buildByteToCharMap();
         try {
             const prism = RubyParser.getPrism() || await RubyParser.loadPrism();
             const parseResult = prism.parse(code);
             if (parseResult.errors.length > 0) {
                 parseResult.errors.forEach(e => {
                     const translatedMessage = this._prismErrorTranslator.translate(e.message);
+                    // Prism error locations have startOffset (byte-based) but not startLine/startColumn.
+                    // Compute line/column from the byte offset using our byte→char mapping.
+                    const loc = this._getLoc({location: e.location});
                     this._context.errors.push(this._toErrorAnnotation(
-                        e.location.startLine, e.location.startColumn, translatedMessage
+                        loc.line, loc.column, translatedMessage
                     ));
                 });
                 return false;
@@ -452,24 +456,10 @@ class RubyToBlocksConverter extends Visitor {
             return [];
         }
 
-        // Prism WASM reports byte offsets (UTF-8), but JavaScript strings use
-        // UTF-16 char indices. Build a byte→char mapping to convert between them.
-        const sourceBytes = new TextEncoder().encode(sourceCode);
-        const byteToChar = new Int32Array(sourceBytes.length + 1);
-        {
-            let ci = 0;
-            let bi = 0;
-            while (ci < sourceCode.length) {
-                const cp = sourceCode.codePointAt(ci);
-                const charLen = cp > 0xFFFF ? 2 : 1; // surrogate pair in UTF-16
-                const byteLen = cp <= 0x7F ? 1 : cp <= 0x7FF ? 2 : cp <= 0xFFFF ? 3 : 4;
-                for (let b = 0; b < byteLen; b++) {
-                    byteToChar[bi + b] = ci;
-                }
-                bi += byteLen;
-                ci += charLen;
-            }
-            byteToChar[bi] = ci; // end sentinel
+        // Ensure sourceCode and byteToChar map are available for _byteOffsetToCharOffset
+        if (this._context.sourceCode !== sourceCode) {
+            this._context.sourceCode = sourceCode;
+            this._context.byteToChar = null; // force rebuild
         }
 
         // Build char-offset-to-line mapping
@@ -491,10 +481,9 @@ class RubyToBlocksConverter extends Visitor {
         return parseResult.comments.map(comment => {
             const startByte = comment.location.startOffset;
             const lengthBytes = comment.location.length;
-            // Convert byte offsets to char offsets
-            const startCharOffset = startByte in byteToChar ? byteToChar[startByte] : 0;
-            const endByte = startByte + lengthBytes;
-            const endCharOffset = endByte in byteToChar ? byteToChar[endByte] : sourceCode.length;
+            // Convert byte offsets to char offsets using shared mapping
+            const startCharOffset = this._byteOffsetToCharOffset(startByte);
+            const endCharOffset = this._byteOffsetToCharOffset(startByte + lengthBytes);
             const rawText = sourceCode.substring(startCharOffset, endCharOffset);
             const line = offsetToLine(startCharOffset);
             const lineStart = lineStarts[line - 1];

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/node-utils.js
@@ -373,12 +373,59 @@ const NodeUtils = {
         return expression.toString() === textBlock.fields.TEXT.value;
     },
 
+    /**
+     * Build a byte-offset → char-offset mapping for the current source code.
+     * Prism WASM returns UTF-8 byte offsets, but JavaScript strings use
+     * UTF-16 char indices. This mapping must be built once after setting sourceCode.
+     */
+    _buildByteToCharMap () {
+        const sourceCode = this._context.sourceCode;
+        if (!sourceCode) {
+            this._context.byteToChar = new Int32Array(1);
+            return;
+        }
+        const sourceBytes = new TextEncoder().encode(sourceCode);
+        const byteToChar = new Int32Array(sourceBytes.length + 1);
+        let ci = 0;
+        let bi = 0;
+        while (ci < sourceCode.length) {
+            const cp = sourceCode.codePointAt(ci);
+            const charLen = cp > 0xFFFF ? 2 : 1; // surrogate pair in UTF-16
+            const byteLen = cp <= 0x7F ? 1 : cp <= 0x7FF ? 2 : cp <= 0xFFFF ? 3 : 4;
+            for (let b = 0; b < byteLen; b++) {
+                byteToChar[bi + b] = ci;
+            }
+            bi += byteLen;
+            ci += charLen;
+        }
+        byteToChar[bi] = ci; // end sentinel
+        this._context.byteToChar = byteToChar;
+    },
+
+    /**
+     * Convert a byte offset from Prism to a char offset for JavaScript strings.
+     * Lazily builds the mapping if not yet constructed.
+     * @param {number} byteOffset - UTF-8 byte offset from Prism
+     * @returns {number} UTF-16 char offset for JavaScript
+     */
+    _byteOffsetToCharOffset (byteOffset) {
+        if (!this._context.byteToChar) {
+            this._buildByteToCharMap();
+        }
+        const map = this._context.byteToChar;
+        if (!map || byteOffset < 0) return 0;
+        if (byteOffset >= map.length) return this._context.sourceCode ? this._context.sourceCode.length : 0;
+        return map[byteOffset];
+    },
+
     _getSource (node) {
         if (!node || !node.location) {
             return '';
         }
         const {startOffset, length} = node.location;
-        return this._context.sourceCode.slice(startOffset, startOffset + length);
+        const startChar = this._byteOffsetToCharOffset(startOffset);
+        const endChar = this._byteOffsetToCharOffset(startOffset + length);
+        return this._context.sourceCode.slice(startChar, endChar);
     },
 
     _truncateSource (src, maxLength = 40) {
@@ -457,14 +504,16 @@ const NodeUtils = {
                 column: node.location.startColumn || 0
             };
         }
-        const offset = node.location.startOffset;
-        if (typeof offset !== 'number' || !this._context.sourceCode) {
+        const byteOffset = node.location.startOffset;
+        if (typeof byteOffset !== 'number' || !this._context.sourceCode) {
             return {line: 1, column: 0};
         }
+        // Convert byte offset to char offset before walking the string
+        const charOffset = this._byteOffsetToCharOffset(byteOffset);
         const source = this._context.sourceCode;
         let line = 1;
         let column = 0;
-        for (let i = 0; i < offset && i < source.length; i++) {
+        for (let i = 0; i < charOffset && i < source.length; i++) {
             if (source[i] === '\n') {
                 line++;
                 column = 0;

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/looks.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/looks.test.js
@@ -211,8 +211,92 @@ describe('RubyGenerator/Looks', () => {
 
             const code = 'say("Hello!")\n';
             const result = RubyGenerator.scrub_(block, code);
-            
+
             expect(result).toEqual('# normal comment\nsay("Hello!")\n');
+        });
+
+        test('should filter @ruby: lines and keep user comment when mixed', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'looks_say',
+                inputs: {},
+                next: null
+            };
+            RubyGenerator.cache_.comments['block-id'] = {
+                text: 'user comment\n@ruby:syntax:+=\n@ruby:lvar:x:0'
+            };
+            RubyGenerator.getInputs = jest.fn().mockReturnValue({});
+            RubyGenerator.isConnectedValue = jest.fn().mockReturnValue(false);
+            RubyGenerator.getBlock = jest.fn().mockReturnValue(null);
+            RubyGenerator.blockToCode = jest.fn().mockReturnValue('');
+
+            const code = 'x += 10\n';
+            const result = RubyGenerator.scrub_(block, code);
+
+            expect(result).toEqual('# user comment\nx += 10\n');
+        });
+
+        test('should handle multi-line user comments mixed with metadata', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'looks_say',
+                inputs: {},
+                next: null
+            };
+            RubyGenerator.cache_.comments['block-id'] = {
+                text: 'first line\nsecond line\n@ruby:method:puts'
+            };
+            RubyGenerator.getInputs = jest.fn().mockReturnValue({});
+            RubyGenerator.isConnectedValue = jest.fn().mockReturnValue(false);
+            RubyGenerator.getBlock = jest.fn().mockReturnValue(null);
+            RubyGenerator.blockToCode = jest.fn().mockReturnValue('');
+
+            const code = 'puts("hello")\n';
+            const result = RubyGenerator.scrub_(block, code);
+
+            expect(result).toEqual('# first line\n# second line\nputs("hello")\n');
+        });
+
+        test('should output nothing when all lines are @ruby: metadata', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'looks_say',
+                inputs: {},
+                next: null
+            };
+            RubyGenerator.cache_.comments['block-id'] = {
+                text: '@ruby:syntax:+=\n@ruby:lvar:x:0'
+            };
+            RubyGenerator.getInputs = jest.fn().mockReturnValue({});
+            RubyGenerator.isConnectedValue = jest.fn().mockReturnValue(false);
+            RubyGenerator.getBlock = jest.fn().mockReturnValue(null);
+            RubyGenerator.blockToCode = jest.fn().mockReturnValue('');
+
+            const code = 'x += 10\n';
+            const result = RubyGenerator.scrub_(block, code);
+
+            expect(result).toEqual('x += 10\n');
+        });
+
+        test('should output inline comment on same line with @ruby:comment_position:inline marker', () => {
+            const block = {
+                id: 'block-id',
+                opcode: 'looks_say',
+                inputs: {},
+                next: null
+            };
+            RubyGenerator.cache_.comments['block-id'] = {
+                text: '@ruby:comment_position:inline\ninline comment\n@ruby:syntax:+='
+            };
+            RubyGenerator.getInputs = jest.fn().mockReturnValue({});
+            RubyGenerator.isConnectedValue = jest.fn().mockReturnValue(false);
+            RubyGenerator.getBlock = jest.fn().mockReturnValue(null);
+            RubyGenerator.blockToCode = jest.fn().mockReturnValue('');
+
+            const code = 'x += 10\n';
+            const result = RubyGenerator.scrub_(block, code);
+
+            expect(result).toEqual('x += 10 # inline comment\n');
         });
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/comment-round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/comment-round-trip.test.js
@@ -95,6 +95,46 @@ describe('Ruby Comment Round Trip', () => {
         expect(generatedRuby.trim()).toEqual('# just a comment');
     });
 
+    test('comments inside nested control structures are preserved', async () => {
+        const code = [
+            '# before loop',
+            'loop do',
+            '  # before if',
+            '  if distance("_mouse_") < 100',
+            '    # before point_towards',
+            '    point_towards("_mouse_")',
+            '    self.direction += 180',
+            '    move(10)',
+            '  else',
+            '    # before move in else',
+            '    move(2)',
+            '    bounce_if_on_edge',
+            '  end',
+            'end'
+        ].join('\n');
+        const result = await converter.targetCodeToBlocks(null, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(result).toBeTruthy();
+
+        const comments = converter._context.comments;
+        const commentValues = Object.values(comments);
+        const userComments = commentValues.filter(c => !c.text.startsWith('@ruby:') &&
+            c.text.split('\n').some(line => !line.startsWith('@ruby:')));
+
+        // All 4 user comments should be preserved
+        const userTexts = userComments.map(c =>
+            c.text.split('\n').filter(l => !l.startsWith('@ruby:')).join('\n')
+        );
+        expect(userTexts.some(t => t.includes('before loop'))).toBe(true);
+        expect(userTexts.some(t => t.includes('before if'))).toBe(true);
+        expect(userTexts.some(t => t.includes('before point_towards'))).toBe(true);
+        expect(userTexts.some(t => t.includes('before move in else'))).toBe(true);
+    });
+
+    test('Japanese comments with multibyte characters are preserved', async () => {
+        await expectRoundTrip('# ゴーストが動く\nmove(10)');
+    });
+
     test('code without comments still works (regression)', async () => {
         await expectRoundTrip('move(10)');
     });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/comment-round-trip.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/comment-round-trip.test.js
@@ -1,0 +1,117 @@
+import Blocks from '@smalruby/scratch-vm/src/engine/blocks';
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import RubyGenerator from '../../../../src/lib/ruby-generator';
+
+describe('Ruby Comment Round Trip', () => {
+    let converter;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null, {version: '2'});
+    });
+
+    const expectRoundTrip = async (code, expectedRuby = null) => {
+        const result = await converter.targetCodeToBlocks(null, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(result).toBeTruthy();
+
+        const blocks = new Blocks();
+        blocks.forceNoGlow = true;
+        Object.keys(converter.blocks).forEach(blockId => {
+            blocks.createBlock(converter.blocks[blockId]);
+        });
+
+        const variables = {};
+        [converter.variables, converter._context.localVariables].forEach(vars => {
+            Object.values(vars).forEach(v => {
+                variables[v.id] = v;
+            });
+        });
+
+        const lists = {};
+        Object.values(converter.lists).forEach(v => {
+            lists[v.id] = v;
+        });
+
+        const target = {
+            id: 'target-id',
+            blocks: blocks,
+            variables: variables,
+            lists: lists,
+            comments: converter._context.comments,
+            isStage: false,
+            lookupVariableById: id => variables[id],
+            lookupVariableByNameAndType: (name, type) => {
+                return Object.values(variables).find(v => v.name === name && v.type === type);
+            }
+        };
+
+        RubyGenerator.init({version: '2'});
+        RubyGenerator.currentTarget = target;
+
+        const generatedRuby = RubyGenerator.targetToCode(target, {version: '2'});
+        expect(generatedRuby.trim()).toEqual((expectedRuby || code).trim());
+    };
+
+    test('comment before a statement is preserved', async () => {
+        await expectRoundTrip('# move forward\nmove(10)');
+    });
+
+    test('multiple consecutive comments before a statement', async () => {
+        await expectRoundTrip('# first comment\n# second comment\nmove(10)');
+    });
+
+    test('inline comment is preserved', async () => {
+        await expectRoundTrip('move(10) # move forward');
+    });
+
+    test('comment-only code (target-level)', async () => {
+        // Comment-only code produces no blocks, but comments are preserved as target-level
+        const code = '# just a comment';
+        const result = await converter.targetCodeToBlocks(null, code);
+        expect(result).toBeTruthy();
+
+        const comments = converter._context.comments;
+        const commentValues = Object.values(comments);
+        const targetComments = commentValues.filter(c => c.blockId === null && !c.text.startsWith('@ruby:'));
+        expect(targetComments).toHaveLength(1);
+        expect(targetComments[0].text).toBe('just a comment');
+
+        // Generator should output target-level comments
+        const blocks = new Blocks();
+        blocks.forceNoGlow = true;
+        const target = {
+            id: 'target-id',
+            blocks: blocks,
+            variables: {},
+            lists: {},
+            comments: comments,
+            isStage: false,
+            lookupVariableById: () => null,
+            lookupVariableByNameAndType: () => null
+        };
+        RubyGenerator.init({version: '2'});
+        RubyGenerator.currentTarget = target;
+        const generatedRuby = RubyGenerator.targetToCode(target, {version: '2'});
+        expect(generatedRuby.trim()).toEqual('# just a comment');
+    });
+
+    test('code without comments still works (regression)', async () => {
+        await expectRoundTrip('move(10)');
+    });
+
+    test('comment before class definition is preserved', async () => {
+        const code = '# class description\nclass Sprite1\n  when_flag_clicked do\n    move(10)\n  end\nend';
+        const result = await converter.targetCodeToBlocks(null, code);
+        expect(converter.errors).toHaveLength(0);
+        expect(result).toBeTruthy();
+
+        // Verify comment is stored
+        const comments = converter._context.comments;
+        const commentValues = Object.values(comments);
+        const hasClassDescription = commentValues.some(c => c.text.includes('class description'));
+        expect(hasClassDescription).toBe(true);
+
+        // For full round-trip with class, a proper sprite target mock would be needed.
+        // Here we verify the comment is preserved through the converter.
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/comments.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/comments.test.js
@@ -103,4 +103,147 @@ describe('RubyToBlocksConverter comment extraction', () => {
             expect(comments[2].text).toBe(' two spaces');
         });
     });
+
+    describe('comment preservation through targetCodeToBlocks', () => {
+        beforeEach(() => {
+            converter = new RubyToBlocksConverter(null, {version: '2'});
+        });
+
+        test('should preserve target-level comment (no block following)', async () => {
+            // Comment-only code has no blocks, so comment is target-level
+            const code = '# file description';
+            await converter.targetCodeToBlocks(null, code);
+
+            const comments = converter._context.comments;
+            const commentValues = Object.values(comments);
+            const targetComments = commentValues.filter(c => c.blockId === null && !c.text.startsWith('@ruby:'));
+
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toBe('file description');
+        });
+
+        test('should preserve comment before a statement as block-attached comment', async () => {
+            const code = '# move forward\nmove(10)';
+            await converter.targetCodeToBlocks(null, code);
+
+            const comments = converter._context.comments;
+            const blocks = converter._context.blocks;
+
+            // Find the move block
+            const moveBlock = Object.values(blocks).find(b => b.opcode === 'motion_movesteps');
+            expect(moveBlock).toBeDefined();
+            expect(moveBlock.comment).toBeDefined();
+
+            const comment = comments[moveBlock.comment];
+            expect(comment.text).toContain('move forward');
+        });
+
+        test('should preserve trailing inline comment with position marker', async () => {
+            const code = 'move(10) # move forward';
+            await converter.targetCodeToBlocks(null, code);
+
+            const comments = converter._context.comments;
+            const blocks = converter._context.blocks;
+
+            const moveBlock = Object.values(blocks).find(b => b.opcode === 'motion_movesteps');
+            expect(moveBlock).toBeDefined();
+            expect(moveBlock.comment).toBeDefined();
+
+            const comment = comments[moveBlock.comment];
+            expect(comment.text).toContain('move forward');
+            expect(comment.text).toContain('@ruby:comment_position:inline');
+        });
+
+        test('should preserve multiple consecutive comments before a statement', async () => {
+            const code = '# first line\n# second line\nmove(10)';
+            await converter.targetCodeToBlocks(null, code);
+
+            const comments = converter._context.comments;
+            const blocks = converter._context.blocks;
+
+            const moveBlock = Object.values(blocks).find(b => b.opcode === 'motion_movesteps');
+            expect(moveBlock).toBeDefined();
+            expect(moveBlock.comment).toBeDefined();
+
+            const comment = comments[moveBlock.comment];
+            expect(comment.text).toContain('first line');
+            expect(comment.text).toContain('second line');
+        });
+
+        test('should merge user comment with existing metadata comment', async () => {
+            // self.x += 10 generates a @ruby:operator:+= metadata comment on the motion block
+            const code = '# change x position\nself.x += 10';
+            await converter.targetCodeToBlocks(null, code);
+
+            const comments = converter._context.comments;
+            const commentValues = Object.values(comments);
+            const blocks = converter._context.blocks;
+            const blockValues = Object.values(blocks);
+
+            // The user comment "change x position" is attached to the block that also has
+            // a @ruby:operator:+= metadata comment. Check that both are present.
+            // The motion changexby block has a metadata comment, and the user comment should be merged.
+            const hasChangeX = commentValues.some(c => c.text.includes('change x position'));
+            expect(hasChangeX).toBe(true);
+
+            // Check that the block also has metadata
+            const blockWithComment = blockValues.find(b => b.comment);
+            expect(blockWithComment).toBeDefined();
+            if (blockWithComment) {
+                const comment = comments[blockWithComment.comment];
+                // Comment should contain user text
+                expect(comment.text).toContain('change x position');
+            }
+        });
+
+        test('should preserve =begin...=end before a statement as block-attached', async () => {
+            const code = '=begin\nprogram description\n=end\nmove(10)';
+            await converter.targetCodeToBlocks(null, code);
+
+            const comments = converter._context.comments;
+            const blocks = converter._context.blocks;
+            const moveBlock = Object.values(blocks).find(b => b.opcode === 'motion_movesteps');
+            expect(moveBlock).toBeDefined();
+            expect(moveBlock.comment).toBeDefined();
+
+            const comment = comments[moveBlock.comment];
+            expect(comment.text).toContain('program description');
+        });
+
+        test('should preserve =begin...=end as target-level when no block follows', async () => {
+            const code = '=begin\nprogram description\n=end';
+            await converter.targetCodeToBlocks(null, code);
+
+            const comments = converter._context.comments;
+            const commentValues = Object.values(comments);
+            const targetComments = commentValues.filter(c => c.blockId === null && !c.text.startsWith('@ruby:'));
+
+            expect(targetComments).toHaveLength(1);
+            expect(targetComments[0].text).toBe('program description');
+        });
+
+        test('should not create user comments when there are none', async () => {
+            const code = 'move(10)';
+            await converter.targetCodeToBlocks(null, code);
+
+            const comments = converter._context.comments;
+            const commentValues = Object.values(comments);
+            const userComments = commentValues.filter(c => !c.text.startsWith('@ruby:'));
+
+            expect(userComments).toHaveLength(0);
+        });
+
+        test('should preserve comment before class definition', async () => {
+            const code = '# class description\nclass Sprite1\n  when_flag_clicked do\n    move(10)\n  end\nend';
+            const result = await converter.targetCodeToBlocks(null, code);
+            expect(result).toBe(true);
+
+            const comments = converter._context.comments;
+            const commentValues = Object.values(comments);
+
+            // The "class description" comment should be preserved as a target-level comment
+            const hasClassDescription = commentValues.some(c => c.text.includes('class description'));
+            expect(hasClassDescription).toBe(true);
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/comments.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/comments.test.js
@@ -1,0 +1,106 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {loadPrism} from '../../../../src/lib/prism-parser';
+
+describe('RubyToBlocksConverter comment extraction', () => {
+    let converter;
+    let prism;
+
+    beforeAll(async () => {
+        prism = await loadPrism();
+    });
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null);
+        converter.reset();
+    });
+
+    describe('_extractSourceComments', () => {
+        test('should extract inline comments with line numbers', () => {
+            const code = '# top comment\nmove(10)';
+            const parseResult = prism.parse(code);
+
+            const comments = converter._extractSourceComments(parseResult, code);
+
+            expect(comments).toHaveLength(1);
+            expect(comments[0]).toMatchObject({
+                type: 'inline',
+                text: 'top comment',
+                line: 1,
+                isTrailing: false
+            });
+        });
+
+        test('should extract multiple consecutive comments', () => {
+            const code = '# first\n# second\nmove(10)';
+            const parseResult = prism.parse(code);
+
+            const comments = converter._extractSourceComments(parseResult, code);
+
+            expect(comments).toHaveLength(2);
+            expect(comments[0]).toMatchObject({type: 'inline', text: 'first', line: 1});
+            expect(comments[1]).toMatchObject({type: 'inline', text: 'second', line: 2});
+        });
+
+        test('should detect trailing comments (inline after code)', () => {
+            const code = 'move(10) # inline comment';
+            const parseResult = prism.parse(code);
+
+            const comments = converter._extractSourceComments(parseResult, code);
+
+            expect(comments).toHaveLength(1);
+            expect(comments[0]).toMatchObject({
+                type: 'inline',
+                text: 'inline comment',
+                line: 1,
+                isTrailing: true
+            });
+        });
+
+        test('should extract =begin...=end block comments', () => {
+            const code = '=begin\nblock comment\nmore text\n=end\nmove(10)';
+            const parseResult = prism.parse(code);
+
+            const comments = converter._extractSourceComments(parseResult, code);
+
+            expect(comments).toHaveLength(1);
+            expect(comments[0]).toMatchObject({
+                type: 'embdoc',
+                text: 'block comment\nmore text',
+                line: 1,
+                isTrailing: false
+            });
+        });
+
+        test('should handle comments at various positions', () => {
+            const code = '# before class\nclass Foo\n  # inside class\n  move(10) # inline\nend';
+            const parseResult = prism.parse(code);
+
+            const comments = converter._extractSourceComments(parseResult, code);
+
+            expect(comments).toHaveLength(3);
+            expect(comments[0]).toMatchObject({text: 'before class', line: 1, isTrailing: false});
+            expect(comments[1]).toMatchObject({text: 'inside class', line: 3, isTrailing: false});
+            expect(comments[2]).toMatchObject({text: 'inline', line: 4, isTrailing: true});
+        });
+
+        test('should return empty array when no comments', () => {
+            const code = 'move(10)';
+            const parseResult = prism.parse(code);
+
+            const comments = converter._extractSourceComments(parseResult, code);
+
+            expect(comments).toHaveLength(0);
+        });
+
+        test('should strip leading space from comment text', () => {
+            const code = '#no space\n# one space\n#  two spaces';
+            const parseResult = prism.parse(code);
+
+            const comments = converter._extractSourceComments(parseResult, code);
+
+            expect(comments[0].text).toBe('no space');
+            expect(comments[1].text).toBe('one space');
+            expect(comments[2].text).toBe(' two spaces');
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/multibyte-offset.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/multibyte-offset.test.js
@@ -1,0 +1,65 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+
+describe('Multibyte character offset handling', () => {
+    let converter;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null, {version: '2'});
+    });
+
+    describe('error location with multibyte characters', () => {
+        test('error after Japanese comment reports correct line', async () => {
+            // go_to(0, 0) is a syntax error (should be go_to([0, 0]))
+            // '# ゴースト' has multibyte chars that shift byte offsets
+            const code = '# ゴースト\ngo_to(0, 0)';
+            await converter.targetCodeToBlocks(null, code);
+            expect(converter.errors.length).toBeGreaterThan(0);
+            // Error should be on line 2, not misplaced due to byte offset
+            expect(converter.errors[0].row).toBe(1); // 0-indexed, so line 2 = row 1
+        });
+
+        test('error on line with Japanese text reports correct column', async () => {
+            // 'ゴースト.abc(' has a syntax error at the unclosed paren
+            // 'ゴースト' is 4 chars but 12 bytes in UTF-8
+            const code = 'ゴースト.abc(';
+            await converter.targetCodeToBlocks(null, code);
+            expect(converter.errors.length).toBeGreaterThan(0);
+            // Column should be based on char offset (9), not byte offset (17)
+            // 'ゴースト.abc(' = 4 + 1 + 3 + 1 = 9 chars, column is 0-indexed
+            expect(converter.errors[0].column).toBeLessThanOrEqual(9);
+        });
+
+        test('multiple lines with Japanese text have correct error positions', async () => {
+            const code = '# 最初のコメント\n# 二番目のコメント\ngo_to(0, 0)';
+            await converter.targetCodeToBlocks(null, code);
+            expect(converter.errors.length).toBeGreaterThan(0);
+            // Error should be on line 3 (row 2 in 0-indexed)
+            expect(converter.errors[0].row).toBe(2);
+        });
+    });
+
+    describe('_getSource with multibyte characters', () => {
+        test('extracts correct source from node after Japanese text', async () => {
+            // 'say("こんにちは")' after Japanese comment
+            const code = '# 日本語コメント\nsay("こんにちは")';
+            await converter.targetCodeToBlocks(null, code);
+            // Even if conversion fails, _getSource should work correctly
+            // We can verify indirectly through error messages containing correct source
+            if (converter.errors.length > 0 && converter.errors[0].source) {
+                // Source in error should not be garbled
+                expect(converter.errors[0].source).not.toMatch(/[\x00-\x08]/);
+            }
+        });
+
+        test('error source text is not garbled with multibyte characters', async () => {
+            // This code has an intentional error after Japanese text
+            const code = '# ゴーストがずっと動くようにします\ngo_to(0, 0)';
+            await converter.targetCodeToBlocks(null, code);
+            expect(converter.errors.length).toBeGreaterThan(0);
+            // The error source should contain readable text, not garbled bytes
+            if (converter.errors[0].source) {
+                expect(converter.errors[0].source).toMatch(/go_to/);
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Ruby タブでユーザーが入力したコメントを、ブロック変換の round-trip で保持する。

Closes #299

## Implementation Steps

- [x] **Phase 1**: ジェネレーターの `scrub_()` 修正（行単位フィルタリング）
- [x] **Phase 2**: コメント抽出基盤（prism `parseResult.comments` → コンテキスト）
- [x] **Phase 3**: ターゲットレベルコメントの保持
- [x] **Phase 4**: ブロック付きコメント（文の前のコメント）の保持
- [x] **Phase 5**: インラインコメントの保持
- [x] **Phase 6**: `=begin...=end` ブロックコメントの保持
- [x] **Phase Final**: Integration Tests (round-trip tests)
- [x] **Phase DoD**: CI 完了待ち + ブラウザ確認

## Definition of Done

- [x] ユニットテスト pass (1175 tests)
- [x] Integration テスト pass (round-trip tests)
- [x] lint pass
- [x] CI green
- [x] ブラウザ確認（Playwright MCP）:
  - [x] Ruby タブで `# コメント付きコード` を入力 → ブロックタブに切替 → Ruby タブに戻る → コメントが保持されている
  - [x] class/module 前のコメントが保持される
  - [x] メソッド前のコメントが保持される
  - [x] 複数行の連続コメントが保持される
  - [x] コメントなしのコードが従来通り動作する（回帰確認）

## Test Plan

| Type | Timing | Target |
|------|--------|--------|
| Unit tests (TDD) | Before implementation (RED → GREEN) | コメント抽出、マッピング、マージ、出力ロジック |
| Integration tests | After implementation | round-trip でのコメント保持 |
| Browser verification | After CI green | Playwright MCP で DoD 確認 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
