### PR TITLE
docs: add DoD and browser verification to design skill

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -53,6 +53,27 @@ Produce a structured design and **present it to the user for approval** before c
 - After each push (except the first): update the PR body to check off the completed phase's checkbox
 - This allows fine-grained progress tracking via PR checkboxes
 
+### Risks & Open Questions → User Interview
+
+Risks & Open Questions を洗い出した後、**各項目についてユーザーにインタビュー**する：
+
+1. リスクや未確定事項をリストアップする
+2. 各項目について、以下のいずれかをユーザーに確認する：
+   - **今すぐ調査する**: コードベースや外部ドキュメントを調べて解決する
+   - **設計判断を仰ぐ**: ユーザーの意見・方針を聞いて決定する
+   - **後回しにする**: 実装フェーズで判明次第対応する（Issue に記載）
+3. インタビュー結果を設計に反映し、解決済みの項目は Risks から除外する
+
+### Definition of Done (DoD)
+
+設計には必ず **DoD（完了の定義）** を含める。DoD は Playwright MCP を積極的に活用した**ブラウザ上での動作確認**を含む：
+
+1. **ユニットテスト**: 全関連テストが pass
+2. **Integration テスト**: round-trip や UI 動作の回帰テストが pass
+3. **CI 通過**: PR の CI が全て green
+4. **ブラウザ確認（Playwright MCP）**: CI 完了後、PR コメントのプレビュー URL を使って Playwright MCP でブラウザ上の動作を確認する。具体的な確認項目を DoD に定義する
+5. **コードレビュー対応**: レビュー指摘があれば対応
+
 ### Design Template
 
 ```markdown
@@ -83,18 +104,56 @@ One-paragraph description of what the feature does and why.
 - lint + affected tests pass (full suite runs on CI)
 - **[COMMIT & PUSH]** `test: add integration tests for <feature>`
 
+**Phase DoD: CI 完了待ち + ブラウザ確認**
+
+- CI の完了を待つ（`gh run watch` または PR checks を確認）
+- CI が green になったら、PR コメントに記載されたプレビュー URL を取得
+- Playwright MCP を使ってブラウザ上で DoD の各確認項目を実施
+- 全項目 OK なら PR の DoD チェックボックスを更新
+
+### Definition of Done
+- [ ] ユニットテスト pass
+- [ ] Integration テスト pass
+- [ ] lint pass
+- [ ] CI green
+- [ ] ブラウザ確認（Playwright MCP）:
+  - [ ] <具体的な確認項目1>
+  - [ ] <具体的な確認項目2>
+  - [ ] ...
+
 ### Test Plan
 
 | Type | Timing | Target |
 |------|--------|--------|
 | Unit tests (TDD) | Before implementation (RED → GREEN) | core logic |
 | Integration tests | After implementation | round-trip, UI behavior |
+| Browser verification | After CI green | Playwright MCP で DoD 確認 |
 
 ### Risks & Open Questions
-- ...
+- ... (インタビュー後、未解決のもののみ残す)
 ```
 
-Wait for explicit user approval ("looks good", "OK", "yes", etc.) before proceeding to Phase 4.
+### Phase 3a: Risks & Open Questions インタビュー
+
+設計案を提示した後、**DoD が明確に定まるまでユーザーインタビューを繰り返す**：
+
+1. Risks & Open Questions を提示し、各項目について：
+   - 「今すぐ調査しますか？」
+   - 「設計判断をお願いできますか？」
+   - 「実装時に判断で良いですか？」
+   を確認する
+
+2. ユーザーの回答に基づき設計を更新する
+
+3. **DoD のブラウザ確認項目**を具体化し、ユーザーに提示する：
+   - 「この確認項目で十分ですか？」
+   - 「他に確認したい動作はありますか？」
+
+4. DoD が明確になり、ユーザーが承認するまでこのループを繰り返す
+
+**Issue 作成時点で DoD は完全に確定していること。** 曖昧な DoD のまま Issue を作成しない。
+
+Wait for explicit user approval ("looks good", "OK", "yes", etc.) on the **complete design including DoD** before proceeding to Phase 4.
 
 ## Phase 4: GitHub Issue Creation
 
@@ -111,6 +170,9 @@ After user approves the design, create the GitHub Issue using the Write tool and
 
    ## Implementation Steps
    <checkbox list using `- [ ]` markdown syntax>
+
+   ## Definition of Done
+   <checkbox list — ブラウザ確認項目を含む>
 
    ## Test Plan
    <list>
@@ -132,7 +194,7 @@ After user approves the design, create the GitHub Issue using the Write tool and
 
 Issue title must follow Conventional Commits style (`feat:`, `fix:`, `refactor:`, etc.).
 
-## Final Report (Japanese)
+## Phase 5: Final Report (Japanese)
 
 Report the result to the user in Japanese:
 - Show the created issue URL
@@ -142,3 +204,28 @@ Report the result to the user in Japanese:
 ---
 
 **Important**: Do NOT start implementation. This skill only investigates, designs, and creates the Issue.
+
+## Implementation 完了後のフロー（実装時に参照）
+
+実装スキルから参照される最終フェーズの手順：
+
+### CI 完了待ち + DoD ブラウザ確認
+
+1. **CI 完了を待つ**:
+   ```bash
+   gh pr checks <PR番号> --repo smalruby/smalruby3-editor --watch
+   ```
+   または `gh run watch` で CI の完了を監視する
+
+2. **プレビュー URL を取得**:
+   - PR のコメントからデプロイプレビュー URL を取得する
+   - URL が無い場合はローカルの `http://localhost:8601` を使用（`docker compose up app` が必要）
+
+3. **Playwright MCP でブラウザ確認**:
+   - DoD に定義された各確認項目を Playwright MCP で実施
+   - `?no_beforeunload=1` パラメータを必ず付与
+   - スクリーンショットを撮って確認結果を記録
+   - 問題があれば修正コミットを追加
+
+4. **PR の DoD チェックボックスを更新**:
+   - 確認完了した項目をチェック済みに更新


### PR DESCRIPTION
## Summary
- design スキルに DoD（完了の定義）テンプレートを追加
- Playwright MCP によるブラウザ検証フェーズを追加
- Risks & Open Questions のユーザーインタビュープロセスを追加

## Changes Made
- `.claude/skills/design/SKILL.md` にDoD、ブラウザ確認、リスクインタビューのセクションを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
