### PR TITLE
fix: スマホ表示時にリーガルリンクが見切れる問題を修正

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -106,7 +106,7 @@
 }
 
 .feedback-link {
-    padding: 0 3.75rem 0.25rem 0.5rem;
+    padding: 0 0.5rem 0.25rem 0.5rem;
     font-size: 0.65rem;
     color: $text-primary-transparent;
     text-decoration: none;
@@ -117,6 +117,13 @@
 .feedback-link:hover {
     color: $text-primary;
     text-decoration: underline;
+}
+
+@media (max-width: 767px) {
+    .feedback-link,
+    .link-separator {
+        display: none;
+    }
 }
 
 .tab {


### PR DESCRIPTION
## Summary

- `.feedback-link` の `padding-right: 3.75rem`（旧保存ボタン用、現在は不要）を `0.5rem` に変更し、リンクの右端を blocklyWorkspace の右端に揃えた
- `@media (max-width: 767px)` でフィードバックリンクとセパレータを非表示にし、プライバシーポリシーのみ表示するようにした

## Implementation Steps

- [x] Phase 1: CSS 修正（`padding-right` 変更 + メディアクエリ追加）
- [x] Phase DoD: CI + ブラウザ確認

## Definition of Done

- [x] lint pass
- [x] CI green
- [x] ブラウザ確認（Playwright MCP）:
  - [x] デスクトップ幅 (1200px): プライバシーポリシー・フィードバック両方表示、右端が blocklyWorkspace に揃っている
  - [x] スマホ幅 (375px): プライバシーポリシーのみ表示、フィードバックは非表示

Closes #306
