### PR TITLE
feat: add regex support to operator_contains

### DIFF
--- a/.claude/rules/scratch-vm/development.md
+++ b/.claude/rules/scratch-vm/development.md
@@ -226,11 +226,13 @@ upstream merge 時にコンフリクトを解決しやすくするための仕�
 | ファイル | 機能名 | 説明 |
 |----------|--------|------|
 | `src/extension-support/extension-manager.js` | extension registration | Smalruby 拡張機能の登録 |
+| `src/blocks/scratch3_operators.js` | regex support | operator_contains で正規表現マッチングをサポート |
 
 ### 関連ファイル
 
 マーカーで囲まれたコードが参照するファイル:
 - `src/extension-support/smalruby-extensions.js` — extension-manager.js のマーカーから参照
+- `test/unit/blocks_operators_regex.js` — scratch3_operators.js の regex support のテスト
 
 ## Development Notes
 

--- a/packages/scratch-vm/src/blocks/scratch3_operators.js
+++ b/packages/scratch-vm/src/blocks/scratch3_operators.js
@@ -112,6 +112,18 @@ class Scratch3OperatorsBlocks {
         const format = function (string) {
             return Cast.toString(string).toLowerCase();
         };
+        // === Smalruby: Start of regex support ===
+        const str2 = Cast.toString(args.STRING2);
+        const regexMatch = /^\/(.+)\/([gimsuy]*)$/.exec(str2);
+        if (regexMatch) {
+            try {
+                const regex = new RegExp(regexMatch[1], regexMatch[2]);
+                return regex.test(Cast.toString(args.STRING1));
+            } catch (e) {
+                return false;
+            }
+        }
+        // === Smalruby: End of regex support ===
         return format(args.STRING1).includes(format(args.STRING2));
     }
 

--- a/packages/scratch-vm/test/unit/blocks_operators_regex.js
+++ b/packages/scratch-vm/test/unit/blocks_operators_regex.js
@@ -1,0 +1,51 @@
+// === Smalruby: This file is Smalruby-specific (regex support for operator_contains) ===
+const test = require('tap').test;
+const Operators = require('../../src/blocks/scratch3_operators');
+
+const blocks = new Operators(null);
+
+test('contains with regex: basic matching', t => {
+    t.equal(blocks.contains({STRING1: 'hello world', STRING2: '/hello/'}), true);
+    t.equal(blocks.contains({STRING1: 'foo bar', STRING2: '/hello/'}), false);
+    t.end();
+});
+
+test('contains with regex: anchors', t => {
+    t.equal(blocks.contains({STRING1: 'hello world', STRING2: '/^hello/'}), true);
+    t.equal(blocks.contains({STRING1: 'say hello', STRING2: '/^hello/'}), false);
+    t.equal(blocks.contains({STRING1: 'hello world', STRING2: '/world$/'}), true);
+    t.equal(blocks.contains({STRING1: 'world hello', STRING2: '/world$/'}), false);
+    t.end();
+});
+
+test('contains with regex: meta characters', t => {
+    t.equal(blocks.contains({STRING1: 'abc123', STRING2: '/\\d+/'}), true);
+    t.equal(blocks.contains({STRING1: 'abcdef', STRING2: '/\\d+/'}), false);
+    t.end();
+});
+
+test('contains with regex: case sensitivity', t => {
+    t.equal(blocks.contains({STRING1: 'hello', STRING2: '/Hello/'}), false, 'regex is case-sensitive by default');
+    t.end();
+});
+
+test('contains with regex: flags', t => {
+    t.equal(blocks.contains({STRING1: 'hello', STRING2: '/Hello/i'}), true, 'i flag ignores case');
+    t.equal(blocks.contains({STRING1: 'foo', STRING2: '/o/g'}), true, 'g flag works');
+    t.end();
+});
+
+test('contains with regex: non-regex strings preserve existing behavior', t => {
+    t.equal(blocks.contains({STRING1: 'hello world', STRING2: 'hello'}), true, 'plain string works');
+    t.equal(blocks.contains({STRING1: 'HeLLo world', STRING2: 'hello'}), true, 'plain string is case-insensitive');
+    t.equal(blocks.contains({STRING1: '/hello', STRING2: '/hello'}), true, 'leading slash only is plain search');
+    t.equal(blocks.contains({STRING1: 'hello/', STRING2: 'hello/'}), true, 'trailing slash only is plain search');
+    t.equal(blocks.contains({STRING1: 'anything', STRING2: '//'}), false, 'empty regex pattern is plain search');
+    t.end();
+});
+
+test('contains with regex: invalid regex returns false', t => {
+    t.equal(blocks.contains({STRING1: 'hello', STRING2: '/[/'}), false, 'invalid regex returns false');
+    t.equal(blocks.contains({STRING1: 'hello', STRING2: '/hello/xyz'}), false, 'invalid flags returns false');
+    t.end();
+});


### PR DESCRIPTION
## Summary

`operator_contains` ブロックの STRING2 に `/pattern/flags` 形式を指定すると、正規表現マッチングを行うようにする拡張。

- `/pattern/` または `/pattern/flags` 形式を検出し、`RegExp` でマッチング
- フラグ `g`, `i`, `m`, `s`, `u`, `y` をサポート
- 不正な正規表現・不正なフラグは `false` を返す（エラーにならない）
- 既存の部分文字列検索（スラッシュなし）は完全に維持

## Implementation Steps

- [x] **[RED]** ユニットテスト追加（失敗確認）
- [x] **[GREEN]** `contains` メソッドに正規表現ロジック実装
- [x] **[PASS]** lint + テスト pass
- [x] **[COMMIT & PUSH]**
- [x] **[MAKE PR]**
- [x] CI green 確認
- [x] ブラウザ確認（Playwright MCP）

## Definition of Done

- [x] ユニットテスト pass
- [x] lint pass
- [x] CI green
- [x] ブラウザ確認（Playwright MCP）:
  - [x] `operator_contains` ブロックの STRING2 に `/\d+/` を入力し、STRING1 に `"abc123"` を入力して `true` になる
  - [x] `/hello/i` で大文字小文字無視マッチが動作する
  - [x] 通常の文字列検索（`apple` contains `a`）が引き続き動作する
  - [x] 不正な正規表現（`/[/`）でエラーにならない

## Risks

- `/文字列/` で部分文字列検索するケースが正規表現として解釈される → 稀なケースのため許容
- ReDoS でフリーズする可能性 → ユーザー責任として許容

Closes #329
