### PR TITLE
docs: split infra rules into per-project files and add gemini-relay docs

### DIFF
--- a/.claude/rules/infra/development.md
+++ b/.claude/rules/infra/development.md
@@ -2,13 +2,23 @@
 paths:
   - "infra/"
   - "infra/*"
-  - "infra/**"
-  - "infra/**/*"
+  - "infra/Dockerfile"
 ---
 
 # Infrastructure Development (infra/)
 
 AWS CDK infrastructure projects live in `infra/`. Each project is independent from npm workspaces.
+
+## Projects
+
+| Project | Path | Description |
+|---------|------|-------------|
+| smalruby-mesh-v2 | `infra/smalruby-mesh-v2/` | Mesh v2 networking service (AppSync + DynamoDB) |
+| smalruby-gemini-relay | `infra/smalruby-gemini-relay/` | Smalruby Teacher AI relay (API Gateway + Lambda + DynamoDB) |
+
+See project-specific rules for details:
+- `.claude/rules/infra/smalruby-mesh-v2.md`
+- `.claude/rules/infra/smalruby-gemini-relay.md`
 
 ## Docker Service
 
@@ -17,6 +27,12 @@ Use the `infra` service for all CDK operations:
 - Service name: `infra`
 - Default working directory: `/app/infra/smalruby-mesh-v2`
 - Includes: Node.js 24 + AWS CLI v2
+
+For projects other than mesh-v2, override the working directory with `-w`:
+
+```bash
+docker compose run --rm -w /app/infra/<project-name> infra <command>
+```
 
 ## AWS Credentials
 
@@ -30,49 +46,21 @@ export AWS_DEFAULT_REGION=ap-northeast-1
 export AWS_PROFILE=your-profile
 ```
 
-## smalruby-mesh-v2
+## Stage Switching via `.env` Symlink
 
-CDK project for the Mesh v2 networking service (AppSync + DynamoDB).
-
-### Commands
+Both projects use the same pattern: per-stage `.env` files (`.env.stg`, `.env.stg2`, `.env.prod`) with a `.env` symlink pointing to the active stage.
 
 ```bash
-# Install dependencies
-docker compose run --rm infra npm install
+cd infra/<project-name>
 
-# Synthesize CloudFormation template
-docker compose run --rm infra npx cdk synth
+# Switch to staging
+rm .env && ln -s .env.stg .env
 
-# Show diff against deployed stack
-docker compose run --rm infra npx cdk diff --context stage=stg
+# Switch to production
+rm .env && ln -s .env.prod .env
 
-# Deploy to staging
-docker compose run --rm infra npx cdk deploy --context stage=stg
-
-# Deploy to production
-docker compose run --rm infra npx cdk deploy --context stage=prod
+# Verify current stage
+ls -la .env
 ```
 
-### Root-level shortcuts
-
-```bash
-docker compose run --rm infra npm run -w /app infra:mesh-v2:synth
-docker compose run --rm infra npm run -w /app infra:mesh-v2:diff
-docker compose run --rm infra npm run -w /app infra:mesh-v2:deploy
-```
-
-### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `STAGE` | Deployment stage (`stg` or `prod`) |
-| `MESH_SECRET_KEY` | Secret key for domain validation |
-| `MESH_HOST_HEARTBEAT_INTERVAL_SECONDS` | Host heartbeat interval |
-| `MESH_HOST_HEARTBEAT_TTL_SECONDS` | Host group TTL |
-| `MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS` | Member heartbeat interval |
-| `MESH_MEMBER_HEARTBEAT_TTL_SECONDS` | Member node TTL |
-| `MESH_MAX_CONNECTION_TIME_SECONDS` | Max connection time per group |
-
-Copy `.env.example` to `.env` inside `infra/smalruby-mesh-v2/` for local values.
-
-See `infra/smalruby-mesh-v2/CLAUDE.md` for detailed TDD workflow, architecture, and troubleshooting.
+The `STAGE` value in the linked `.env` file determines the deployment target. It can also be overridden with `--context stage=...`.

--- a/.claude/rules/infra/smalruby-gemini-relay.md
+++ b/.claude/rules/infra/smalruby-gemini-relay.md
@@ -1,0 +1,60 @@
+---
+paths:
+  - "infra/smalruby-gemini-relay/"
+  - "infra/smalruby-gemini-relay/**"
+  - "infra/smalruby-gemini-relay/**/*"
+---
+
+# smalruby-gemini-relay
+
+CDK project for the Smalruby Teacher AI relay service (API Gateway + Lambda + DynamoDB).
+Proxies requests from the Ruby tab's AI chat to the Gemini API with rate limiting and input validation.
+
+## Architecture
+
+- **API Gateway HTTP API**: POST `/generate` endpoint
+- **Lambda (Node.js 20)**: Request validation, rate limiting, Gemini API relay
+- **DynamoDB**: IP-based rate limiting with TTL
+
+## Commands
+
+Since the `infra` Docker service defaults to `smalruby-mesh-v2`, use `-w` to override the working directory:
+
+```bash
+# Install dependencies
+docker compose run --rm -w /app/infra/smalruby-gemini-relay infra npm install
+
+# Synthesize CloudFormation template
+docker compose run --rm -w /app/infra/smalruby-gemini-relay infra npx cdk synth
+
+# Show diff against deployed stack
+docker compose run --rm -w /app/infra/smalruby-gemini-relay infra npx cdk diff
+
+# Deploy (uses STAGE from .env symlink)
+docker compose run --rm -w /app/infra/smalruby-gemini-relay infra npx cdk deploy
+
+# Deploy with explicit stage override
+docker compose run --rm -w /app/infra/smalruby-gemini-relay infra npx cdk deploy --context stage=stg
+```
+
+**Note**: There is no dedicated Docker volume for `smalruby-gemini-relay/node_modules`, so `npm install` runs inside the bind-mounted directory. This is fine because gemini-relay has fewer dependencies than mesh-v2.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `STAGE` | Deployment stage (`stg`, `stg2`, or `prod`) |
+| `GEMINI_API_KEY` | Gemini API key |
+| `RATE_LIMIT_WINDOW_MINUTES` | Rate limit window in minutes (default: 35) |
+| `RATE_LIMIT_MAX_REQUESTS` | Max requests per window (default: 40) |
+| `MAX_USER_MESSAGE_LENGTH` | Max user message length (default: 250) |
+| `MIN_USER_MESSAGE_LENGTH` | Min user message length (default: 10) |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated allowed origins |
+
+## Typical Deployment Flow
+
+1. **Switch to target stage**: `cd infra/smalruby-gemini-relay && rm .env && ln -s .env.stg .env`
+2. **Check diff**: `docker compose run --rm -w /app/infra/smalruby-gemini-relay infra npx cdk diff`
+3. **Deploy**: `docker compose run --rm -w /app/infra/smalruby-gemini-relay infra npx cdk deploy`
+4. **Verify**: Test the deployed endpoint
+5. **Repeat for prod**: `rm .env && ln -s .env.prod .env` → diff → deploy

--- a/.claude/rules/infra/smalruby-mesh-v2.md
+++ b/.claude/rules/infra/smalruby-mesh-v2.md
@@ -1,0 +1,55 @@
+---
+paths:
+  - "infra/smalruby-mesh-v2/"
+  - "infra/smalruby-mesh-v2/**"
+  - "infra/smalruby-mesh-v2/**/*"
+---
+
+# smalruby-mesh-v2
+
+CDK project for the Mesh v2 networking service (AppSync + DynamoDB).
+
+## Commands
+
+The `infra` Docker service defaults to this project's working directory, so no `-w` override is needed:
+
+```bash
+# Install dependencies
+docker compose run --rm infra npm install
+
+# Synthesize CloudFormation template
+docker compose run --rm infra npx cdk synth
+
+# Show diff against deployed stack
+docker compose run --rm infra npx cdk diff
+
+# Deploy (uses STAGE from .env symlink)
+docker compose run --rm infra npx cdk deploy
+
+# Deploy with explicit stage override
+docker compose run --rm infra npx cdk deploy --context stage=stg
+```
+
+### Root-level shortcuts
+
+```bash
+docker compose run --rm infra npm run -w /app infra:mesh-v2:synth
+docker compose run --rm infra npm run -w /app infra:mesh-v2:diff
+docker compose run --rm infra npm run -w /app infra:mesh-v2:deploy
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `STAGE` | Deployment stage (`stg`, `stg2`, or `prod`) |
+| `MESH_SECRET_KEY` | Secret key for domain validation |
+| `MESH_HOST_HEARTBEAT_INTERVAL_SECONDS` | Host heartbeat interval |
+| `MESH_HOST_HEARTBEAT_TTL_SECONDS` | Host group TTL |
+| `MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS` | Member heartbeat interval |
+| `MESH_MEMBER_HEARTBEAT_TTL_SECONDS` | Member node TTL |
+| `MESH_MAX_CONNECTION_TIME_SECONDS` | Max connection time per group |
+
+Copy `.env.example` to `.env` inside `infra/smalruby-mesh-v2/` for local values.
+
+See `infra/smalruby-mesh-v2/CLAUDE.md` for detailed TDD workflow, architecture, and troubleshooting.


### PR DESCRIPTION
## Summary
- `.claude/rules/infra/development.md` を共通部分のみに整理（Docker サービス、AWS 認証、`.env` シンボリックリンクによるステージ切り替えパターン）
- `smalruby-mesh-v2.md` を新規作成: mesh-v2 固有のコマンド・環境変数・ショートカット
- `smalruby-gemini-relay.md` を新規作成: gemini-relay のアーキテクチャ・コマンド（`-w` 指定）・環境変数・デプロイフロー
- 各ファイルの frontmatter `paths` をプロジェクトディレクトリにスコープ

## Test plan
- [ ] ドキュメントのみの変更のため、動作確認不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)
