### PR TITLE
fix: コメント付き module/def/メソッド呼び出しの round-trip 不具合

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/code-finisher.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/code-finisher.js
@@ -24,14 +24,27 @@ export default function (Generator) {
 
         const comments = Generator.getTargetCommentTexts();
 
-        // Detect @ruby:class comments
+        // Detect @ruby:class and @ruby:module comments
         let classComment = null;
+        const moduleComments = {}; // moduleName -> user comment text
         const otherComments = [];
         for (const comment of comments) {
             if (comment === '@ruby:class' || comment.startsWith('@ruby:class:')) {
                 classComment = comment;
             } else {
-                otherComments.push(comment);
+                // Check for module comment: "user text\n@ruby:module:ModuleName"
+                const moduleMatch = comment.match(/@ruby:module:(\S+)/);
+                if (moduleMatch) {
+                    const moduleName = moduleMatch[1];
+                    const userText = comment.split('\n')
+                        .filter(line => !line.startsWith('@ruby:'))
+                        .join('\n');
+                    if (userText.trim().length > 0) {
+                        moduleComments[moduleName] = userText;
+                    }
+                } else {
+                    otherComments.push(comment);
+                }
             }
         }
 
@@ -56,6 +69,10 @@ export default function (Generator) {
                 const methods = this._moduleMethodCodes[moduleName];
                 if (methods && methods.length > 0) {
                     const methodsCode = methods.join('\n');
+                    // Prepend user comment if present
+                    if (moduleComments[moduleName]) {
+                        moduleCode += `${this.prefixLines(moduleComments[moduleName], '# ')}\n`;
+                    }
                     moduleCode += `module ${moduleName}\n`;
                     moduleCode += this.prefixLines(methodsCode, this.INDENT);
                     moduleCode += `end\n\n`;
@@ -127,8 +144,9 @@ export default function (Generator) {
         }
 
         // Deduplicate module definitions in multi-target output.
-        // Extract all module...end blocks, keep unique ones, place them before class definitions.
-        const moduleRegex = /^module (\w+)\n[\s\S]*?^end\n/gm;
+        // Extract all module...end blocks (with optional preceding comment lines),
+        // keep unique ones, place them before class definitions.
+        const moduleRegex = /^(?:#[^\n]*\n)*module (\w+)\n[\s\S]*?^end\n/gm;
         const seenModules = new Set();
         const uniqueModules = [];
         let match;

--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -8,12 +8,11 @@ export default function (Generator) {
         let variable = Generator.variableName(Generator.getFieldId(block, 'VARIABLE'));
         const comment = Generator.getCommentText(block);
 
-        // Check for local variable metadata
-        if (comment && comment.startsWith('@ruby:lvar:')) {
-            const parts = comment.split(':');
-            if (parts.length === 4) {
-                const originalName = parts[2];
-                return [originalName, Generator.ORDER_ATOMIC];
+        // Check for local variable metadata (may be mixed with user comments)
+        if (comment) {
+            const lvarMatch = comment.match(/@ruby:lvar:([^:,\s]+):\d+/);
+            if (lvarMatch && !comment.includes('@ruby:return:')) {
+                return [lvarMatch[1], Generator.ORDER_ATOMIC];
             }
         }
 

--- a/packages/scratch-gui/src/lib/ruby-generator/procedure.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/procedure.js
@@ -71,7 +71,7 @@ export default function (Generator) {
         // Check for @ruby:module_source:ModuleName comment
         // Extended format: @ruby:module_source:Mod:super_of:originalName
         const comment = Generator.getCommentText(block);
-        const moduleSourceMatch = comment && comment.match(/^@ruby:module_source:(.+)$/);
+        const moduleSourceMatch = comment && comment.match(/^@ruby:module_source:(.+)$/m);
 
         // Check for super_of: extract original method name for renamed module methods
         let superOfOriginalName = null;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -638,11 +638,13 @@ class RubyToBlocksConverter extends Visitor {
                 // Preceding comment: attach to block on the next code line
                 const nextCodeLine = group.endLine + 1;
 
-                // Check if next line is a class/module/def start
+                // Check if next line is a class/module start
                 // In that case, create a target-level comment (describes the definition, not a block)
+                // DefNode is excluded: comments before def are attached to the
+                // procedures_definition block so they appear inside the class.
                 const isBeforeContainer = this._context.containerNodeRanges.some(
                     r => r.startLine === nextCodeLine &&
-                        (r.type === 'ClassNode' || r.type === 'ModuleNode' || r.type === 'DefNode')
+                        (r.type === 'ClassNode' || r.type === 'ModuleNode')
                 );
                 if (isBeforeContainer) {
                     this._createComment(text, null);

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -418,12 +418,17 @@ class RubyToBlocksConverter extends Visitor {
                 node instanceof ModuleNode;
 
             if (isContainerNode) {
-                this._context.containerNodeRanges.push({
+                const rangeEntry = {
                     type: node.constructor.name,
                     startLine,
                     endLine,
                     depth
-                });
+                };
+                // Store module name for comment association
+                if (node instanceof ModuleNode) {
+                    rangeEntry.moduleName = node.name;
+                }
+                this._context.containerNodeRanges.push(rangeEntry);
             } else {
                 for (let line = startLine; line <= endLine; line++) {
                     const existingEntry = this._context.lineToNodeMap.get(line);
@@ -642,12 +647,20 @@ class RubyToBlocksConverter extends Visitor {
                 // In that case, create a target-level comment (describes the definition, not a block)
                 // DefNode is excluded: comments before def are attached to the
                 // procedures_definition block so they appear inside the class.
-                const isBeforeContainer = this._context.containerNodeRanges.some(
+                const containerRange = this._context.containerNodeRanges.find(
                     r => r.startLine === nextCodeLine &&
                         (r.type === 'ClassNode' || r.type === 'ModuleNode')
                 );
-                if (isBeforeContainer) {
-                    this._createComment(text, null);
+                if (containerRange) {
+                    // For modules, include @ruby:module:Name metadata so
+                    // the generator can place the comment before the module code
+                    if (containerRange.type === 'ModuleNode' && containerRange.moduleName) {
+                        this._createComment(
+                            `${text}\n@ruby:module:${containerRange.moduleName}`, null
+                        );
+                    } else {
+                        this._createComment(text, null);
+                    }
                 } else {
                     const blockId = findBlockForLine(nextCodeLine);
                     if (blockId) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -572,15 +572,29 @@ class RubyToBlocksConverter extends Visitor {
         // Unlike lineToNodeMap (which uses a range/shallowest strategy), this maps only
         // lines where a node actually STARTS, preferring the most specific (smallest range) node.
         // This ensures "# comment\nloop do" attaches to the loop block, not a parent block.
+        // Among blocks with equal range, prefer statement blocks over input (value) blocks,
+        // so that "# comment\ngreet(name)" attaches to the procedures_call, not data_variable.
+        const inputBlockIds = new Set();
+        for (const block of Object.values(this._context.blocks)) {
+            if (block.inputs) {
+                for (const input of Object.values(block.inputs)) {
+                    if (input.block) inputBlockIds.add(input.block);
+                }
+            }
+        }
+
         const lineStartBlockMap = new Map();
         for (const [node, blockId] of this._context.nodeToBlockMap.entries()) {
             const startLine = this._getNodeStartLine(node);
             if (startLine === null) continue;
             const endLine = this._getNodeEndLine(node) || startLine;
             const range = endLine - startLine;
+            const isInput = inputBlockIds.has(blockId);
             const existing = lineStartBlockMap.get(startLine);
-            if (!existing || range < existing.range) {
-                lineStartBlockMap.set(startLine, {blockId, range});
+            if (!existing ||
+                range < existing.range ||
+                (range === existing.range && !isInput && existing.isInput)) {
+                lineStartBlockMap.set(startLine, {blockId, range, isInput});
             }
         }
 

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip-comment-bugs.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip-comment-bugs.test.js
@@ -1,0 +1,215 @@
+import RubyToBlocksConverter from '../../../src/lib/ruby-to-blocks-converter';
+import RubyGenerator from '../../../src/lib/ruby-generator';
+import Variable from '@smalruby/scratch-vm/src/engine/variable';
+import Blocks from '@smalruby/scratch-vm/src/engine/blocks';
+
+// Import all block generators
+import MathBlocks from '../../../src/lib/ruby-generator/math.js';
+import TextBlocks from '../../../src/lib/ruby-generator/text.js';
+import ColourBlocks from '../../../src/lib/ruby-generator/colour.js';
+import MotionBlocks from '../../../src/lib/ruby-generator/motion.js';
+import LooksBlocks from '../../../src/lib/ruby-generator/looks.js';
+import SoundBlocks from '../../../src/lib/ruby-generator/sound.js';
+import EventBlocks from '../../../src/lib/ruby-generator/event.js';
+import ControlBlocks from '../../../src/lib/ruby-generator/control.js';
+import SensingBlocks from '../../../src/lib/ruby-generator/sensing.js';
+import OperatorsBlocks from '../../../src/lib/ruby-generator/operators.js';
+import DataBlocks from '../../../src/lib/ruby-generator/data.js';
+import ProcedureBlocks from '../../../src/lib/ruby-generator/procedure.js';
+import RubyBlocks from '../../../src/lib/ruby-generator/ruby.js';
+
+describe('Ruby Roundtrip/Comment Bugs (#336)', () => {
+    let converter;
+    let target;
+    let runtime;
+    let vm;
+
+    beforeEach(() => {
+        runtime = {
+            emitProjectChanged: () => {},
+            getTargetForStage: () => target
+        };
+        target = {
+            blocks: new Blocks(runtime),
+            variables: {},
+            lists: {},
+            broadcastMsgs: {},
+            comments: {},
+            isStage: false,
+            id: 'sprite1',
+            createVariable: function (id, name, type) {
+                this.variables[id] = new Variable(id, name, type);
+            },
+            lookupVariableByNameAndType: function (name, type) {
+                for (const varId in this.variables) {
+                    const currVar = this.variables[varId];
+                    if (currVar.name === name && currVar.type === type) {
+                        return currVar;
+                    }
+                }
+                return null;
+            },
+            createComment: function (id, blockId, text, x, y, width, height, minimized) {
+                this.comments[id] = {
+                    id,
+                    blockId,
+                    text,
+                    x,
+                    y,
+                    width,
+                    height,
+                    minimized
+                };
+            }
+        };
+        vm = {
+            runtime: runtime,
+            emitWorkspaceUpdate: () => {},
+            extensionManager: {
+                isExtensionLoaded: () => true,
+                loadExtensionURL: () => Promise.resolve()
+            }
+        };
+        converter = new RubyToBlocksConverter(vm, {version: '2'});
+        converter._context.target = target;
+
+        // Reset RubyGenerator state
+        RubyGenerator.cache_ = {
+            comments: {},
+            targetCommentTexts: []
+        };
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.functionNames_ = {};
+
+        // Register all block generators
+        MathBlocks(RubyGenerator);
+        TextBlocks(RubyGenerator);
+        ColourBlocks(RubyGenerator);
+        MotionBlocks(RubyGenerator);
+        LooksBlocks(RubyGenerator);
+        SoundBlocks(RubyGenerator);
+        EventBlocks(RubyGenerator);
+        ControlBlocks(RubyGenerator);
+        SensingBlocks(RubyGenerator);
+        OperatorsBlocks(RubyGenerator);
+        DataBlocks(RubyGenerator);
+        ProcedureBlocks(RubyGenerator);
+        RubyBlocks(RubyGenerator);
+    });
+
+    const rubyToBlocksToRuby = async (code) => {
+        const result = await converter.targetCodeToBlocks(target, code);
+
+        if (!result) {
+            throw new Error(`Failed to convert Ruby to blocks. Errors: ${JSON.stringify(converter.errors)}`);
+        }
+
+        await converter.applyTargetBlocks(target);
+
+        target.runtime = runtime;
+        runtime.targets = [
+            {isStage: true, sprite: {name: 'Stage'}},
+            target
+        ];
+        target.sprite = {name: 'Sprite1'};
+
+        RubyGenerator.currentTarget = target;
+        const generatedCode = RubyGenerator.targetToCode(target, {version: '2'});
+
+        return generatedCode;
+    };
+
+    describe('Bug 3: variable reference corrupted by comment before method call', () => {
+        test('comment before greet(name) preserves variable name', async () => {
+            const inputCode = [
+                'class Sprite1',
+                '  def greet(name)',
+                '    say(name)',
+                '  end',
+                '',
+                '  when_flag_clicked do',
+                '    ask("name?")',
+                '    name = answer',
+                '    # call greet',
+                '    greet(name)',
+                '  end',
+                'end',
+                ''
+            ].join('\n');
+
+            const outputCode = await rubyToBlocksToRuby(inputCode);
+
+            // Variable name should be preserved, not become @_name_1_
+            expect(outputCode).toContain('greet(name)');
+            expect(outputCode).not.toContain('@_name_1_');
+            expect(outputCode).toContain('# call greet');
+        });
+    });
+
+    describe('Bug 2: def comment position', () => {
+        test('comment before def inside class is placed before method definition', async () => {
+            const inputCode = [
+                'class Sprite1',
+                '  # method description',
+                '  def greet',
+                '    say("hello")',
+                '  end',
+                '',
+                '  when_flag_clicked do',
+                '    greet',
+                '  end',
+                'end',
+                ''
+            ].join('\n');
+
+            const outputCode = await rubyToBlocksToRuby(inputCode);
+
+            // Comment should be directly before def, not outside class
+            expect(outputCode).toContain('# method description');
+            expect(outputCode).toContain('def greet');
+
+            // Comment should be inside the class, before the def
+            const classStart = outputCode.indexOf('class Sprite1');
+            const commentPos = outputCode.indexOf('# method description');
+            const defPos = outputCode.indexOf('def greet');
+            expect(commentPos).toBeGreaterThan(classStart);
+            expect(commentPos).toBeLessThan(defPos);
+        });
+    });
+
+    describe('Bug 1: module comment position', () => {
+        test('comment before module is placed before module definition', async () => {
+            const inputCode = [
+                '# module description',
+                'module Greeter',
+                '  def greet(name)',
+                '    say(name)',
+                '  end',
+                'end',
+                '',
+                'class Sprite1',
+                '  include Greeter',
+                '',
+                '  when_flag_clicked do',
+                '    greet("hello")',
+                '  end',
+                'end',
+                ''
+            ].join('\n');
+
+            const outputCode = await rubyToBlocksToRuby(inputCode);
+
+            // Comment should be before module, not between module and class
+            expect(outputCode).toContain('# module description');
+            expect(outputCode).toContain('module Greeter');
+
+            const commentPos = outputCode.indexOf('# module description');
+            const modulePos = outputCode.indexOf('module Greeter');
+            const classPos = outputCode.indexOf('class Sprite1');
+
+            // Comment must appear before module, not after
+            expect(commentPos).toBeLessThan(modulePos);
+            expect(modulePos).toBeLessThan(classPos);
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip-comment-bugs.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip-comment-bugs.test.js
@@ -177,6 +177,71 @@ describe('Ruby Roundtrip/Comment Bugs (#336)', () => {
         });
     });
 
+    describe('Full round-trip: module + class + comments', () => {
+        test('complete example with module, class, comments, and method calls', async () => {
+            const inputCode = [
+                '# 挨拶の基本機能を持つモジュール',
+                'module Greeter',
+                '  def greet(name)',
+                '    say(("こんにちは、" + name) + "さん！")',
+                '  end',
+                'end',
+                '',
+                'class Sprite1',
+                '  include Greeter',
+                '',
+                '  # 挨拶メソッドを上書き（オーバーライド）',
+                '  def greet(name)',
+                '    super(name)',
+                '    if name =~ /^ス/',
+                '      say("スモウルビーマスターだね！", 2)',
+                '    else',
+                '      say("よろしくね！", 2)',
+                '    end',
+                '  end',
+                '',
+                '  when_flag_clicked do',
+                '    ask("お名前は？")',
+                '    name = answer',
+                '    # greetメソッドを実行',
+                '    greet(name)',
+                '  end',
+                'end',
+                ''
+            ].join('\n');
+
+            const outputCode = await rubyToBlocksToRuby(inputCode);
+
+            // Module comment before module
+            const moduleCommentPos = outputCode.indexOf('# 挨拶の基本機能を持つモジュール');
+            const modulePos = outputCode.indexOf('module Greeter');
+            expect(moduleCommentPos).not.toBe(-1);
+            expect(moduleCommentPos).toBeLessThan(modulePos);
+
+            // Def comment inside class, before method (find the class def, not module def)
+            const defCommentPos = outputCode.indexOf('# 挨拶メソッドを上書き（オーバーライド）');
+            const classPos = outputCode.indexOf('class Sprite1');
+            // Find def greet(name) after class Sprite1
+            const defPos = outputCode.indexOf('def greet(name)', classPos);
+            expect(defCommentPos).not.toBe(-1);
+            expect(defCommentPos).toBeGreaterThan(classPos);
+            expect(defCommentPos).toBeLessThan(defPos);
+
+            // Method call comment preserved
+            expect(outputCode).toContain('# greetメソッドを実行');
+
+            // Variable name preserved
+            expect(outputCode).toContain('greet(name)');
+            expect(outputCode).not.toContain('@_name_1_');
+
+            // Super call preserved
+            expect(outputCode).toContain('super(name)');
+
+            // Regex preserved
+            expect(outputCode).toContain('name =~ /^ス/');
+        });
+    });
+
     describe('Bug 1: module comment position', () => {
         test('comment before module is placed before module definition', async () => {
             const inputCode = [


### PR DESCRIPTION
## Summary

Ruby → Blocks → Ruby ラウンドトリップにおける3つのコメント関連不具合を修正。

- **Bug 3**: `findBlockForLine` が input ブロック（`data_variable`）を優先してしまい、ユーザーコメントが `@ruby:lvar:` メタデータを破壊 → `greet(name)` が `greet(@_name_1_)` に変化。statement ブロックを優先するよう修正
- **Bug 2**: `isBeforeContainer` に `DefNode` が含まれ、def 前のコメントが workspace コメントとしてクラス外に出力される → `DefNode` を除外し `procedures_definition` ブロックに関連付け
- **Bug 1**: モジュール前のコメントが `otherComments` として module コードの後に配置される → `@ruby:module:ModuleName` workspace コメントを導入し、コメントをモジュールの前に配置

## Changes Made

### `packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js`
- `lineStartBlockMap` 構築時に input ブロックより statement ブロックを優先（Bug 3）
- `isBeforeContainer` から `DefNode` を除外（Bug 2）
- `ModuleNode` の `containerNodeRanges` にモジュール名を保存（Bug 1）
- モジュール前コメントに `@ruby:module:ModuleName` メタデータを付加（Bug 1）

### `packages/scratch-gui/src/lib/ruby-generator/data.js`
- `@ruby:lvar:` メタデータ抽出を `startsWith` → `match()` に変更（防御的修正）

### `packages/scratch-gui/src/lib/ruby-generator/procedure.js`
- `@ruby:module_source:` マッチングに multiline フラグ追加

### `packages/scratch-gui/src/lib/ruby-generator/code-finisher.js`
- `@ruby:module:` workspace コメント検出・モジュールコード前にユーザーコメント出力
- `finishTargets` のモジュール抽出正規表現で preceding コメント行を含むよう修正

## Implementation Steps
- [x] Phase 1: Bug 3 — `findBlockForLine` のブロック優先度修正 + `@ruby:lvar:` ロバスト化
- [x] Phase 2: Bug 2 — def コメントのブロック関連付け
- [x] Phase 3: Bug 1 — モジュールの workspace コメント
- [x] Phase Final: 完全なラウンドトリップ統合テスト

## Test Coverage

- 4 unit tests added in `ruby-roundtrip-comment-bugs.test.js`
- Full round-trip test using exact reproduction case from issue
- All existing tests pass (comment-round-trip, super, my_blocks, module, data, variables)

## Related Issues

Fixes #336
