### PR TITLE
feat: hide legacy mesh extension by default

### DIFF
--- a/packages/scratch-gui/src/lib/libraries/extensions/index.jsx
+++ b/packages/scratch-gui/src/lib/libraries/extensions/index.jsx
@@ -457,6 +457,7 @@ export default [
             />
         ),
         featured: true,
+        defaultHidden: true,
         bluetoothRequired: false,
         internetConnectionRequired: true,
         launchPeripheralConnectionFlow: true,


### PR DESCRIPTION
## Summary

従来のメッシュ拡張（`mesh`）をデフォルトで非表示にし、「すべての拡張機能を表示」チェックボックスを有効にした場合のみ表示するようにする。

- 拡張ライブラリのメッシュエントリに `defaultHidden: true` を追加（既存パターンの適用）

Fixes #351

## Implementation Steps

- [x] メッシュ拡張エントリに `defaultHidden: true` を追加

## Definition of Done

- [x] lint pass
- [x] CI green
- [x] ブラウザ確認（Playwright MCP）:
  - [x] 拡張機能ライブラリを開いて、従来のメッシュが表示されないこと
  - [x] 「すべての拡張機能を表示」にチェックを入れると表示されること
