### PR TITLE
fix: allow not operator on variable in ruby-to-blocks converter

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators.js
@@ -392,7 +392,8 @@ const OperatorsConverter = {
 
         converter.registerOnSend(['variable', 'boolean', 'block'], '!', 0, params => {
             const {receiver} = params;
-            if (!converter._isFalseOrBooleanBlock(receiver)) return null;
+            if (!converter._isFalseOrBooleanBlock(receiver) &&
+                !(converter._isBlock(receiver) && receiver.opcode === 'data_variable')) return null;
 
             const block = converter._createBlock('operator_not', 'value_boolean');
             converter._addInput(

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control4.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control4.test.js
@@ -202,6 +202,46 @@ describe('RubyToBlocksConverter/Control/unless', () => {
             await convertAndExpectToEqualBlocks(converter, target, code, expected);
         });
 
+        test('if !@ivar; A; end => control_if(not(variable), branch=A)', async () => {
+            const code = `
+                if !@ivar
+                  move(10)
+                end
+            `;
+            const moveBlock = (await rubyToExpected(converter, target, 'move(10)'))[0];
+            const expected = [
+                {
+                    opcode: 'control_if',
+                    inputs: [
+                        {
+                            name: 'CONDITION',
+                            block: {
+                                opcode: 'operator_not',
+                                inputs: [
+                                    {
+                                        name: 'OPERAND',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: '@ivar'
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    branches: [
+                        moveBlock
+                    ]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
         test('if !local_var; A; end => control_if(not(variable), branch=A)', async () => {
             const code = `
                 bool = true

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control4.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/control/control4.test.js
@@ -160,4 +160,91 @@ describe('RubyToBlocksConverter/Control/unless', () => {
             await convertAndExpectToEqualBlocks(converter, target, code, expected);
         });
     });
+
+    describe('if !variable (not operator on variable)', () => {
+        test('if !$global; A; end => control_if(not(variable), branch=A)', async () => {
+            const code = `
+                if !$global
+                  move(10)
+                end
+            `;
+            const moveBlock = (await rubyToExpected(converter, target, 'move(10)'))[0];
+            const expected = [
+                {
+                    opcode: 'control_if',
+                    inputs: [
+                        {
+                            name: 'CONDITION',
+                            block: {
+                                opcode: 'operator_not',
+                                inputs: [
+                                    {
+                                        name: 'OPERAND',
+                                        block: {
+                                            opcode: 'data_variable',
+                                            fields: [
+                                                {
+                                                    name: 'VARIABLE',
+                                                    variable: '$global'
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    branches: [
+                        moveBlock
+                    ]
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('if !local_var; A; end => control_if(not(variable), branch=A)', async () => {
+            const code = `
+                bool = true
+                if !bool
+                  say("ok")
+                end
+            `;
+            const assignBlock = (await rubyToExpected(converter, target, 'bool = true'))[0];
+            const sayBlock = (await rubyToExpected(converter, target, 'say("ok")'))[0];
+            const expected = [
+                {
+                    ...assignBlock,
+                    next: {
+                        opcode: 'control_if',
+                        inputs: [
+                            {
+                                name: 'CONDITION',
+                                block: {
+                                    opcode: 'operator_not',
+                                    inputs: [
+                                        {
+                                            name: 'OPERAND',
+                                            block: {
+                                                opcode: 'data_variable',
+                                                fields: [
+                                                    {
+                                                        name: 'VARIABLE',
+                                                        variable: '_bool_1_'
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        branches: [
+                            sayBlock
+                        ]
+                    }
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/logical.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/logical.test.js
@@ -244,6 +244,20 @@ describe('RubyToBlocksConverter/Operators', () => {
         ];
         await convertAndExpectToEqualBlocks(converter, target, code, expected);
 
+        code = '!@ivar';
+        expected = [
+            {
+                opcode: 'operator_not',
+                inputs: [
+                    {
+                        name: 'OPERAND',
+                        block: (await rubyToExpected(converter, target, '@ivar'))[0]
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
         code = '!false';
         expected = [
             {

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/logical.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/operators/logical.test.js
@@ -230,6 +230,20 @@ describe('RubyToBlocksConverter/Operators', () => {
         ];
         await convertAndExpectToEqualBlocks(converter, target, code, expected);
 
+        code = '!$global';
+        expected = [
+            {
+                opcode: 'operator_not',
+                inputs: [
+                    {
+                        name: 'OPERAND',
+                        block: (await rubyToExpected(converter, target, '$global'))[0]
+                    }
+                ]
+            }
+        ];
+        await convertAndExpectToEqualBlocks(converter, target, code, expected);
+
         code = '!false';
         expected = [
             {


### PR DESCRIPTION
## Summary

- `!variable` の Ruby→Blocks 変換でエラーになる問題を修正
- `operators.js` の `!` ハンドラで `data_variable` ブロックも受け入れるよう条件を緩和
- ユニットテスト追加（`!$global`, `!@ivar` → `operator_not(data_variable)`)
- `if !variable` の制御フローテスト追加（グローバル変数・インスタンス変数・ローカル変数）

## Implementation Steps

- [x] **Phase 1**: `!variable` 変換の修正 (TDD: RED → GREEN → PASS)
- [x] **Phase 2**: Integration tests
- [x] **Phase DoD**: CI green + ブラウザ確認

## Definition of Done

- [x] ユニットテスト pass
- [x] Integration テスト pass
- [x] lint pass
- [x] CI green
- [x] ブラウザ確認（Playwright MCP）:
  - [x] `bool = true; if !bool; say("ok"); end` を Ruby タブに入力し、ブロック変換でエラーが出ないこと
  - [x] コンバーターが `operator_not(data_variable)`, `control_if`, `looks_say` を含む 13 ブロックを正しく生成すること（ブラウザ内 API で確認）
  - [x] `bool = true; if bool; say("ok"); end` が引き続き正常動作すること
  - ⚠️ Blockly 上でブロック表示が切断される既知問題あり（`Bubble.positionBubble_` のコメント位置計算エラー。今回の修正とは別の既存問題）

Closes #353
