### PR TITLE
chore: update MCP and Serena configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -26,7 +26,7 @@
         "git+https://github.com/oraios/serena",
         "serena-mcp-server",
         "--context",
-        "ide-assistant",
+        "claude-code",
         "--project",
         "smalruby3-editor"
       ]

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -119,3 +119,12 @@ symbol_info_budget:
 # Note: the backend is fixed at startup. If a project with a different backend
 # is activated post-init, an error will be returned.
 language_backend:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []


### PR DESCRIPTION
## Summary
- `.mcp.json`: `ide-assistant` → `claude-code` にリネーム
- `.serena/project.yml`: `line_ending` と `read_only_memory_patterns` 設定を追加

## Test Coverage
設定ファイルのみの変更のため、テスト不要。
