### PR TITLE
feat: Ruby v2 API overhaul — extension.method() unified pattern

### DIFF
--- a/packages/scratch-gui/src/lib/furigana-call-helpers.js
+++ b/packages/scratch-gui/src/lib/furigana-call-helpers.js
@@ -142,6 +142,7 @@ const callHelpers = {
 
     _annotatePenMethod (node, name) {
         const penLabels = {
+            'clear': '全削除する',
             'stamp': 'スタンプ',
             'down': 'ペンを下ろす',
             'up': 'ペンを上げる',

--- a/packages/scratch-gui/src/lib/furigana-extension-handlers.js
+++ b/packages/scratch-gui/src/lib/furigana-extension-handlers.js
@@ -19,7 +19,13 @@ const EXTENSION_HANDLER_MAP = {
     mesh_v1: '_annotateMeshV1Method',
     mesh: '_annotateMeshV2Method',
     smalrubot_s1: '_annotateSmalrubotS1Method',
-    koshien: '_annotateKoshienMethod'
+    koshien: '_annotateKoshienMethod',
+    // v2 API receivers
+    music: '_annotateMusicMethod',
+    keyboard: '_annotateKeyboardMethod',
+    mouse: '_annotateMouseMethod',
+    timer: '_annotateTimerMethod',
+    translate: '_annotateTranslateMethod'
 };
 
 /**
@@ -34,7 +40,13 @@ const EXTENSION_RECEIVER_LABELS = {
     mesh_v1: 'メッシュ(従来)',
     mesh: 'メッシュ',
     smalrubot_s1: 'スモウルボットS1',
-    koshien: 'スモウルビー甲子園'
+    koshien: 'スモウルビー甲子園',
+    // v2 API receivers
+    music: '音楽',
+    keyboard: 'キーボード',
+    mouse: 'マウス',
+    timer: 'タイマー',
+    translate: '翻訳'
 };
 
 // ---- Extension-specific string label maps ----
@@ -218,6 +230,57 @@ const extensionHandlers = {
             'sensor_value': 'センサーの値',
             'get_motor_speed': 'モーター速度',
             'arm_calibration=': 'アーム調整'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    // v2 API handlers
+
+    _annotateMusicMethod (node, name) {
+        const labels = {
+            'play_drum': 'ドラムを鳴らす',
+            'rest': '休む',
+            'play_note': '音符を鳴らす',
+            'instrument=': '楽器を設定',
+            'tempo=': 'テンポを設定',
+            'tempo': 'テンポ'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateKeyboardMethod (node, name) {
+        const labels = {
+            'pressed?': 'キーが押されたか'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateMouseMethod (node, name) {
+        const labels = {
+            'x': 'X座標',
+            'y': 'Y座標',
+            'down?': '押されたか'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateTimerMethod (node, name) {
+        const labels = {
+            value: '値',
+            reset: 'リセット'
+        };
+        const label = labels[name];
+        if (label) this._addAnnotation(node.messageLoc, label);
+    },
+
+    _annotateTranslateMethod (node, name) {
+        const labels = {
+            call: '翻訳する',
+            language: '言語'
         };
         const label = labels[name];
         if (label) this._addAnnotation(node.messageLoc, label);

--- a/packages/scratch-gui/src/lib/furigana-label-map.js
+++ b/packages/scratch-gui/src/lib/furigana-label-map.js
@@ -112,6 +112,11 @@ const TOPLEVEL_METHOD_LABELS = {
     // Music
     'play_drum': 'ドラムを鳴らす',
     'play_note': '音符を鳴らす',
+    // Pen (v1 top-level)
+    'pen_down': 'ペンを下ろす',
+    'pen_up': 'ペンを上げる',
+    'pen_clear': '全部消す',
+    'pen_stamp': 'スタンプ',
     // Translate
     'translate': '翻訳する',
     // Class configuration (set_xxx) — sprite

--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -9,15 +9,22 @@ export default function (Generator) {
         return `sleep(${secs})\n`;
     };
 
+    const hasWaitComment = function (block) {
+        const comment = Generator.getCommentText(block);
+        return comment && comment.includes('@ruby:method:wait');
+    };
+
     Generator.control_repeat = function (block) {
         const times = Generator.valueToCode(block, 'TIMES', Generator.ORDER_ATOMIC) || 0;
         const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
-        return `${times}.times do\n${branch}end\n`;
+        const wait = hasWaitComment(block) ? `${Generator.INDENT}wait\n` : '';
+        return `${times}.times do\n${branch}${wait}end\n`;
     };
 
     Generator.control_forever = function (block) {
         const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
-        return `loop do\n${branch}end\n`;
+        const wait = hasWaitComment(block) ? `${Generator.INDENT}wait\n` : '';
+        return `loop do\n${branch}${wait}end\n`;
     };
 
     const getCaseInfo = function (block) {
@@ -235,22 +242,23 @@ export default function (Generator) {
 
     Generator.control_repeat_until = function (block) {
         const comment = Generator.getCommentText(block);
+        const wait = hasWaitComment(block) ? `${Generator.INDENT}wait\n` : '';
         const varName = getVariableHint(block);
         if (varName) {
             const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
             if (comment.includes('@ruby:syntax:while')) {
-                return `while ${varName}\n${branch}end\n`;
+                return `while ${varName}\n${branch}${wait}end\n`;
             }
-            return `until ${varName}\n${branch}end\n`;
+            return `until ${varName}\n${branch}${wait}end\n`;
         }
-        if (comment === '@ruby:syntax:while') {
+        if (comment && comment.includes('@ruby:syntax:while')) {
             const operator = getWhileCondition(block);
             const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
-            return `while ${operator}\n${branch}end\n`;
+            return `while ${operator}\n${branch}${wait}end\n`;
         }
         const operator = Generator.valueToCode(block, 'CONDITION', Generator.ORDER_NONE) || false;
         const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
-        return `until ${operator}\n${branch}end\n`;
+        return `until ${operator}\n${branch}${wait}end\n`;
     };
 
     Generator.control_stop = function (block) {
@@ -264,6 +272,9 @@ export default function (Generator) {
 
     Generator.control_start_as_clone = function (block) {
         block.isStatement = true;
+        if (String(Generator.version) === '1') {
+            return `self.when(:start_as_a_clone) do\n`;
+        }
         return `when_start_as_a_clone do\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-generator/microbit.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/microbit.js
@@ -18,6 +18,9 @@ export default function (Generator) {
     Generator.microbit_whenGesture = function (block) {
         block.isStatement = true;
         const gesture = Generator.valueToCode(block, 'GESTURE', Generator.ORDER_NONE) || null;
+        if (String(Generator.version) === '1') {
+            return `self.when(:microbit_gesture, ${gesture}) do\n`;
+        }
         return `microbit_v1.when(${gesture}) do\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-generator/microbit_more.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/microbit_more.js
@@ -108,7 +108,8 @@ export default function (Generator) {
         if (matrix.indexOf('\n') >= 0) {
             matrix = `\n${Generator.prefixLines(matrix, Generator.INDENT)}\n`;
         }
-        return `microbit.display_pattern(${matrix})\n`;
+        const methodName = String(Generator.version) === '1' ? 'display' : 'display_pattern';
+        return `microbit.${methodName}(${matrix})\n`;
     };
 
     Generator.microbitMore_display = function (block) {

--- a/packages/scratch-gui/src/lib/ruby-generator/music.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/music.js
@@ -4,10 +4,14 @@
  * @returns {RubyGenerator} same as param.
  */
 export default function (Generator) {
+    const isV2 = () => String(Generator.version) === '2';
+    const prefix = () => (isV2() ? 'music.' : '');
+    const selfOrMusic = () => (isV2() ? 'music' : 'self');
+
     Generator.music_playDrumForBeats = function (block) {
         const drum = Generator.valueToCode(block, 'DRUM', Generator.ORDER_NONE) || null;
         const beats = Generator.valueToCode(block, 'BEATS', Generator.ORDER_NONE) || 0;
-        return `play_drum(drum: ${drum}, beats: ${beats})\n`;
+        return `${prefix()}play_drum(drum: ${drum}, beats: ${beats})\n`;
     };
 
     Generator.music_menu_DRUM = function (block) {
@@ -17,19 +21,13 @@ export default function (Generator) {
 
     Generator.music_restForBeats = function (block) {
         const beats = Generator.valueToCode(block, 'BEATS', Generator.ORDER_NONE) || 0;
-        return `rest(${beats})\n`;
+        return `${prefix()}rest(${beats})\n`;
     };
 
     Generator.music_playNoteForBeats = function (block) {
         const note = Generator.valueToCode(block, 'NOTE', Generator.ORDER_NONE) || 0;
         const beats = Generator.valueToCode(block, 'BEATS', Generator.ORDER_NONE) || 0;
-        return `play_note(note: ${note}, beats: ${beats})\n`;
-    };
-
-    Generator.music_playNoteForBeats = function (block) {
-        const note = Generator.valueToCode(block, 'NOTE', Generator.ORDER_NONE) || 0;
-        const beats = Generator.valueToCode(block, 'BEATS', Generator.ORDER_NONE) || 0;
-        return `play_note(note: ${note}, beats: ${beats})\n`;
+        return `${prefix()}play_note(note: ${note}, beats: ${beats})\n`;
     };
 
     Generator.note = function (block) {
@@ -39,7 +37,7 @@ export default function (Generator) {
 
     Generator.music_setInstrument = function (block) {
         const instrument = Generator.valueToCode(block, 'INSTRUMENT', Generator.ORDER_NONE) || null;
-        return `self.instrument = ${instrument}\n`;
+        return `${selfOrMusic()}.instrument = ${instrument}\n`;
     };
 
     Generator.music_menu_INSTRUMENT = function (block) {
@@ -49,15 +47,18 @@ export default function (Generator) {
 
     Generator.music_setTempo = function (block) {
         const tempo = Generator.valueToCode(block, 'TEMPO', Generator.ORDER_NONE) || 0;
-        return `self.tempo = ${tempo}\n`;
+        return `${selfOrMusic()}.tempo = ${tempo}\n`;
     };
 
     Generator.music_changeTempo = function (block) {
         const tempo = Generator.valueToCode(block, 'TEMPO', Generator.ORDER_NONE) || 0;
-        return `self.tempo += ${tempo}\n`;
+        return `${selfOrMusic()}.tempo += ${tempo}\n`;
     };
 
     Generator.music_getTempo = function () {
+        if (isV2()) {
+            return ['music.tempo', Generator.ORDER_FUNCTION_CALL];
+        }
         return ['tempo', Generator.ORDER_ATOMIC];
     };
 

--- a/packages/scratch-gui/src/lib/ruby-generator/pen.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/pen.js
@@ -10,7 +10,7 @@ export default function (Generator) {
         if (isV1()) {
             return 'pen_clear\n';
         }
-        return 'Pen.clear\n';
+        return 'pen.clear\n';
     };
 
     Generator.pen_stamp = function () {

--- a/packages/scratch-gui/src/lib/ruby-generator/pen.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/pen.js
@@ -4,36 +4,59 @@
  * @returns {RubyGenerator} same as param.
  */
 export default function (Generator) {
+    const isV1 = () => String(Generator.version) === '1';
+
     Generator.pen_clear = function () {
+        if (isV1()) {
+            return 'pen_clear\n';
+        }
         return 'Pen.clear\n';
     };
 
     Generator.pen_stamp = function () {
+        if (isV1()) {
+            return 'pen_stamp\n';
+        }
         return 'pen.stamp\n';
     };
 
     Generator.pen_penDown = function () {
+        if (isV1()) {
+            return 'pen_down\n';
+        }
         return 'pen.down\n';
     };
 
     Generator.pen_penUp = function () {
+        if (isV1()) {
+            return 'pen_up\n';
+        }
         return 'pen.up\n';
     };
 
     Generator.pen_setPenColorToColor = function (block) {
         const color = Generator.valueToCode(block, 'COLOR', Generator.ORDER_NONE) || null;
+        if (isV1()) {
+            return `self.pen_color = ${color}\n`;
+        }
         return `pen.color = ${color}\n`;
     };
 
     Generator.pen_changePenColorParamBy = function (block) {
         const colorParam = Generator.valueToCode(block, 'COLOR_PARAM', Generator.ORDER_NONE) || null;
         const value = Generator.valueToCode(block, 'VALUE', Generator.ORDER_NONE) || 0;
+        if (isV1()) {
+            return `self.${colorParam} += ${value}\n`;
+        }
         return `pen.${colorParam} += ${value}\n`;
     };
 
     Generator.pen_setPenColorParamTo = function (block) {
         const colorParam = Generator.valueToCode(block, 'COLOR_PARAM', Generator.ORDER_NONE) || null;
         const value = Generator.valueToCode(block, 'VALUE', Generator.ORDER_NONE) || 0;
+        if (isV1()) {
+            return `self.pen_${colorParam} = ${value}\n`;
+        }
         return `pen.${colorParam} = ${value}\n`;
     };
 
@@ -44,11 +67,17 @@ export default function (Generator) {
 
     Generator.pen_changePenSizeBy = function (block) {
         const size = Generator.valueToCode(block, 'SIZE', Generator.ORDER_NONE) || 0;
+        if (isV1()) {
+            return `self.pen_size += ${size}\n`;
+        }
         return `pen.size += ${size}\n`;
     };
 
     Generator.pen_setPenSizeTo = function (block) {
         const size = Generator.valueToCode(block, 'SIZE', Generator.ORDER_NONE) || 0;
+        if (isV1()) {
+            return `self.pen_size = ${size}\n`;
+        }
         return `pen.size = ${size}\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-generator/sensing.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/sensing.js
@@ -59,7 +59,8 @@ export default function (Generator) {
     Generator.sensing_keypressed = function (block) {
         const order = Generator.ORDER_FUNCTION_CALL;
         const key = Generator.valueToCode(block, 'KEY_OPTION', order) || null;
-        return [`Keyboard.pressed?(${key})`, order];
+        const receiver = String(Generator.version) === '2' ? 'keyboard' : 'Keyboard';
+        return [`${receiver}.pressed?(${key})`, order];
     };
 
     Generator.sensing_keyoptions = function (block) {
@@ -68,15 +69,18 @@ export default function (Generator) {
     };
 
     Generator.sensing_mousedown = function () {
-        return ['Mouse.down?', Generator.ORDER_ATOMIC];
+        const receiver = String(Generator.version) === '2' ? 'mouse' : 'Mouse';
+        return [`${receiver}.down?`, Generator.ORDER_ATOMIC];
     };
 
     Generator.sensing_mousex = function () {
-        return ['Mouse.x', Generator.ORDER_ATOMIC];
+        const receiver = String(Generator.version) === '2' ? 'mouse' : 'Mouse';
+        return [`${receiver}.x`, Generator.ORDER_ATOMIC];
     };
 
     Generator.sensing_mousey = function () {
-        return ['Mouse.y', Generator.ORDER_ATOMIC];
+        const receiver = String(Generator.version) === '2' ? 'mouse' : 'Mouse';
+        return [`${receiver}.y`, Generator.ORDER_ATOMIC];
     };
 
     Generator.sensing_setdragmode = function (block) {
@@ -89,11 +93,13 @@ export default function (Generator) {
     };
 
     Generator.sensing_timer = function () {
-        return ['Timer.value', Generator.ORDER_ATOMIC];
+        const receiver = String(Generator.version) === '2' ? 'timer' : 'Timer';
+        return [`${receiver}.value`, Generator.ORDER_ATOMIC];
     };
 
     Generator.sensing_resettimer = function () {
-        return 'Timer.reset\n';
+        const receiver = String(Generator.version) === '2' ? 'timer' : 'Timer';
+        return `${receiver}.reset\n`;
     };
 
     Generator.sensing_of_object_menu = function (block) {

--- a/packages/scratch-gui/src/lib/ruby-generator/translate.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/translate.js
@@ -4,15 +4,23 @@
  * @returns {RubyGenerator} same as param.
  */
 export default function (Generator) {
+    const isV2 = () => String(Generator.version) === '2';
+
     Generator.translate_getTranslate = function (block) {
         const words = Generator.valueToCode(block, 'WORDS', Generator.ORDER_NONE) || null;
         const language = Generator.valueToCode(block, 'LANGUAGE', Generator.ORDER_NONE);
+        if (isV2()) {
+            return [`translate.call(${words}, ${language})`, Generator.ORDER_FUNCTION_CALL];
+        }
         return [`translate(${words}, ${language})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.translate_menu_languages = Generator.text2speech_menu_languages;
 
     Generator.translate_getViewerLanguage = function () {
+        if (isV2()) {
+            return ['translate.language', Generator.ORDER_FUNCTION_CALL];
+        }
         return ['language', Generator.ORDER_ATOMIC];
     };
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/block-utils.js
@@ -173,10 +173,12 @@ const BlockUtils = {
 
     _removeWaitBlocks (block) {
         if (!block) {
+            this._hadWaitInLastRemove = false;
             return null;
         }
 
         let firstBlock = null;
+        let hadWait = false;
         let b = block;
         let prev = b.parent;
         while (b) {
@@ -188,6 +190,7 @@ const BlockUtils = {
                 }
             }
             if (isWaitBlock) {
+                hadWait = true;
                 delete this._context.blocks[b.id];
                 if (prev) {
                     this._context.blocks[prev].next = null;
@@ -204,6 +207,7 @@ const BlockUtils = {
             }
             b = this._context.blocks[b.next];
         }
+        this._hadWaitInLastRemove = hadWait;
         return firstBlock;
     },
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
@@ -37,7 +37,11 @@ const ControlConverter = {
             if (!converter._isNumberOrBlock(args[0])) return null;
 
             const cleanedRubyBlock = converter._removeWaitBlocks(rubyBlock);
-            return createControlRepeatBlock(converter, args[0], cleanedRubyBlock);
+            const block = createControlRepeatBlock(converter, args[0], cleanedRubyBlock);
+            if (converter._hadWaitInLastRemove) {
+                block.comment = converter._createComment('@ruby:method:wait', block.id);
+            }
+            return block;
         });
 
         // loop { block } and forever { block } - control_forever
@@ -49,6 +53,9 @@ const ControlConverter = {
                 const cleanedRubyBlock = converter._removeWaitBlocks(rubyBlock);
                 const block = converter._createBlock('control_forever', 'terminate');
                 converter._addSubstack(block, cleanedRubyBlock);
+                if (converter._hadWaitInLastRemove) {
+                    block.comment = converter._createComment('@ruby:method:wait', block.id);
+                }
                 return block;
             });
         });
@@ -83,7 +90,11 @@ const ControlConverter = {
             if (!rubyBlock || !converter._isNumberOrBlock(receiver)) return null;
 
             const cleanedRubyBlock = converter._removeWaitBlocks(rubyBlock);
-            return createControlRepeatBlock(converter, receiver, cleanedRubyBlock);
+            const block = createControlRepeatBlock(converter, receiver, cleanedRubyBlock);
+            if (converter._hadWaitInLastRemove) {
+                block.comment = converter._createComment('@ruby:method:wait', block.id);
+            }
+            return block;
         });
 
         // when_start_as_a_clone { block } (sprite only)
@@ -132,6 +143,7 @@ const ControlConverter = {
 
         converter.registerOnUntil((cond, statement) => {
             statement = converter._removeWaitBlocks(statement);
+            const hadWait = converter._hadWaitInLastRemove;
 
             let opcode;
             if (statement === null) {
@@ -144,6 +156,9 @@ const ControlConverter = {
                 converter._addInput(block, 'CONDITION', cond);
             }
             converter._addSubstack(block, statement);
+            if (hadWait && opcode === 'control_repeat_until') {
+                block.comment = converter._createComment('@ruby:method:wait', block.id);
+            }
             return block;
         });
     }

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/microbit-more-modern.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/microbit-more-modern.js
@@ -211,7 +211,7 @@ const registerModernHandlers = function (converter) {
         return block;
     });
 
-    converter.registerOnSend(MicrobitMore, 'display_pattern', 5, params => {
+    const displayPatternHandler5 = params => {
         const {receiver, args} = params;
 
         if (!args.every(x => converter.isString(x))) return null;
@@ -225,7 +225,12 @@ const registerModernHandlers = function (converter) {
         matrix = matrix.replace(/[1-9]/g, '1').replace(/[^1-9]/g, '0');
         converter.addFieldInput(block, 'MATRIX', 'matrix', 'MATRIX', matrix, null);
         return block;
-    });
+    };
+
+    converter.registerOnSend(MicrobitMore, 'display_pattern', 5, displayPatternHandler5);
+
+    // backward compatibility: microbit.display(...) was renamed to display_pattern
+    converter.registerOnSend(MicrobitMore, 'display', 5, displayPatternHandler5);
 
     converter.registerOnSend(MicrobitMore, 'display_pattern', 1, params => {
         const {receiver, args} = params;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/music.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/music.js
@@ -1,10 +1,13 @@
 import _ from 'lodash';
 
+const Music = 'music';
+
 /**
  * Music converter
  */
 const MusicConverter = {
     register: function (converter) {
+        // v1: play_drum(drum: 1, beats: 0.25)
         converter.registerOnSend('self', 'play_drum', 1, params => {
             const {args} = params;
             if (!converter._isHash(args[0]) || args[0].size !== 2) return null;
@@ -23,6 +26,26 @@ const MusicConverter = {
             return block;
         });
 
+        // v2: music.play_drum(drum: 1, beats: 0.25)
+        converter.registerOnSend(Music, 'play_drum', 1, params => {
+            const {receiver, args} = params;
+            if (!converter._isHash(args[0]) || args[0].size !== 2) return null;
+
+            const drum = args[0].get('sym:drum');
+            const beats = args[0].get('sym:beats');
+            if (!converter.isNumberOrBlock(drum) || !converter.isNumberOrBlock(beats)) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'music_playDrumForBeats', 'statement');
+            converter.addInput(
+                block,
+                'DRUM',
+                converter._createFieldBlock('music_menu_DRUM', 'DRUM', drum)
+            );
+            converter.addNumberInput(block, 'BEATS', 'math_number', beats, 0.25);
+            return block;
+        });
+
+        // v1: rest(0.25)
         converter.registerOnSend('self', 'rest', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -32,6 +55,17 @@ const MusicConverter = {
             return block;
         });
 
+        // v2: music.rest(0.25)
+        converter.registerOnSend(Music, 'rest', 1, params => {
+            const {receiver, args} = params;
+            if (!converter.isNumberOrBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'music_restForBeats', 'statement');
+            converter.addNumberInput(block, 'BEATS', 'math_number', args[0], 0.25);
+            return block;
+        });
+
+        // v1: play_note(note: 60, beats: 0.25)
         converter.registerOnSend('self', 'play_note', 1, params => {
             const {args} = params;
             if (!converter._isHash(args[0]) || args[0].size !== 2) return null;
@@ -46,6 +80,22 @@ const MusicConverter = {
             return block;
         });
 
+        // v2: music.play_note(note: 60, beats: 0.25)
+        converter.registerOnSend(Music, 'play_note', 1, params => {
+            const {receiver, args} = params;
+            if (!converter._isHash(args[0]) || args[0].size !== 2) return null;
+
+            const note = args[0].get('sym:note');
+            const beats = args[0].get('sym:beats');
+            if (!converter.isNumberOrBlock(note) || !converter.isNumberOrBlock(beats)) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'music_playNoteForBeats', 'statement');
+            converter._addNoteInput(block, 'NOTE', note, 60);
+            converter.addNumberInput(block, 'BEATS', 'math_number', beats, 0.25);
+            return block;
+        });
+
+        // v1: self.instrument = 5
         converter.registerOnSend('self', 'instrument=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -59,6 +109,21 @@ const MusicConverter = {
             return block;
         });
 
+        // v2: music.instrument = 5
+        converter.registerOnSend(Music, 'instrument=', 1, params => {
+            const {receiver, args} = params;
+            if (!converter.isNumberOrBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'music_setInstrument', 'statement');
+            converter.addInput(
+                block,
+                'INSTRUMENT',
+                converter._createFieldBlock('music_menu_INSTRUMENT', 'INSTRUMENT', args[0])
+            );
+            return block;
+        });
+
+        // v1: self.tempo = 60
         converter.registerOnSend('self', 'tempo=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -68,24 +133,49 @@ const MusicConverter = {
             return block;
         });
 
+        // v2: music.tempo = 60
+        converter.registerOnSend(Music, 'tempo=', 1, params => {
+            const {receiver, args} = params;
+            if (!converter.isNumberOrBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'music_setTempo', 'statement');
+            converter.addNumberInput(block, 'TEMPO', 'math_number', args[0], 60);
+            return block;
+        });
+
+        // v1: tempo (getter)
         converter.registerOnSend('self', 'tempo', 0, () =>
             converter.createBlock('music_getTempo', 'value')
         );
-    },
 
-    // Keep onOpAsgn for tempo+= operator
-     
-    onOpAsgn: function (lh, operator, rh) {
-        let block;
-        if (this._isBlock(lh) && operator === '+' && this._isNumberOrBlock(rh)) {
-            switch (lh.opcode) {
-            case 'music_getTempo':
-                block = this._changeBlock(lh, 'music_changeTempo', 'statement');
-                this._addNumberInput(block, 'TEMPO', 'math_number', rh, 20);
-                break;
+        // v2: music receiver (for music.xxx pattern)
+        converter.registerOnSend('sprite', Music, 0, params => {
+            const {node} = params;
+            return converter.createRubyExpressionBlock(Music, node);
+        });
+        converter.registerOnSend('stage', Music, 0, params => {
+            const {node} = params;
+            return converter.createRubyExpressionBlock(Music, node);
+        });
+
+        // v2: music.tempo (getter for value and +=)
+        converter.registerOnSend(Music, 'tempo', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'music_getTempo', 'value');
+        });
+
+        // v1: self.tempo += 20, v2: music.tempo += 20
+        // Both resolve to music_getTempo block, so a single handler works
+        converter.registerOnOpAsgn((lh, operator, rh) => {
+            if (converter._isBlock(lh) && operator === '+' && converter._isNumberOrBlock(rh)) {
+                if (lh.opcode === 'music_getTempo') {
+                    const block = converter._changeBlock(lh, 'music_changeTempo', 'statement');
+                    converter._addNumberInput(block, 'TEMPO', 'math_number', rh, 20);
+                    return block;
+                }
             }
-        }
-        return block;
+            return null;
+        });
     }
 };
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/pen.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/pen.js
@@ -198,6 +198,14 @@ const PenConverter = {
             });
         });
 
+        // backward compatibility getters for v1 book code: self.color += 10
+        ['color', 'saturation', 'brightness', 'transparency'].forEach(methodName => {
+            converter.registerOnSend('self', methodName, 0, params => {
+                const {node} = params;
+                return converter.createRubyStatementBlock(`self.${methodName}`, node);
+            });
+        });
+
         // for +=
         ['color', 'saturation', 'brightness', 'transparency', 'size'].forEach(methodName => {
             converter.registerOnSend(Pen, methodName, 0, params => {
@@ -257,6 +265,21 @@ const PenConverter = {
                 this._addFieldInput(
                     block, 'COLOR_PARAM', 'pen_menu_colorParam', 'colorParam',
                     code.replace('self.pen_', ''), 'color'
+                );
+                this._addNumberInput(block, 'VALUE', 'math_number', rh, 10);
+                break;
+            // backward compatibility for v1 book code: self.color += 10
+            case 'self.color':
+            case 'self.saturation':
+            case 'self.brightness':
+            case 'self.transparency':
+                block = this._changeBlock(lh, 'pen_changePenColorParamBy', 'statement');
+                delete this._context.blocks[block.inputs.STATEMENT.block];
+                delete block.inputs.STATEMENT;
+
+                this._addFieldInput(
+                    block, 'COLOR_PARAM', 'pen_menu_colorParam', 'colorParam',
+                    code.replace('self.', ''), 'color'
                 );
                 this._addNumberInput(block, 'VALUE', 'math_number', rh, 10);
                 break;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/pen.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/pen.js
@@ -11,6 +11,12 @@ const PenConverter = {
             converter.createBlock('pen_clear', 'statement')
         );
 
+        // v2: pen.clear
+        converter.registerOnSend(Pen, 'clear', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'pen_clear', 'statement');
+        });
+
         // backward compatibility
         converter.registerOnSend('self', 'pen_clear', 0, () =>
             converter.createBlock('pen_clear', 'statement')

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/sensing.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/sensing.js
@@ -49,6 +49,18 @@ const SensingConverter = {
             );
         });
 
+        // v2: mouse.xxx (lowercase receiver)
+        converter.registerOnSend('sprite', 'mouse', 0, params => {
+            const {node} = params;
+            return converter.createRubyExpressionBlock('mouse', node);
+        });
+        mouseGetters.forEach(({method, opcode, blockType}) => {
+            converter.registerOnSend('mouse', method, 0, params => {
+                const {receiver} = params;
+                return converter.changeRubyExpressionBlock(receiver, opcode, blockType);
+            });
+        });
+
         // Timer methods
         const timerMethods = [
             {method: 'value', opcode: 'sensing_timer', blockType: 'value'},
@@ -59,6 +71,18 @@ const SensingConverter = {
             converter.registerOnSend('::Timer', method, 0, () =>
                 converter.createBlock(opcode, blockType)
             );
+        });
+
+        // v2: timer.xxx (lowercase receiver)
+        converter.registerOnSend('sprite', 'timer', 0, params => {
+            const {node} = params;
+            return converter.createRubyExpressionBlock('timer', node);
+        });
+        timerMethods.forEach(({method, opcode, blockType}) => {
+            converter.registerOnSend('timer', method, 0, params => {
+                const {receiver} = params;
+                return converter.changeRubyExpressionBlock(receiver, opcode, blockType);
+            });
         });
 
         // stage - returns Ruby expression
@@ -185,7 +209,7 @@ const SensingConverter = {
             return block;
         });
 
-        converter.registerOnSend('::Keyboard', 'pressed?', 1, params => {
+        const keyPressedHandler = params => {
             const {args} = params;
 
             const validKey = converter.isString(args[0]) && KeyOptions.indexOf(args[0].toString()) >= 0;
@@ -194,6 +218,26 @@ const SensingConverter = {
             if (!validKey && !isBlockArg) return null;
 
             const block = converter.createBlock('sensing_keypressed', 'value_boolean');
+            converter.addFieldInput(block, 'KEY_OPTION', 'sensing_keyoptions', 'KEY_OPTION', args[0], 'space');
+            return block;
+        };
+
+        converter.registerOnSend('::Keyboard', 'pressed?', 1, keyPressedHandler);
+
+        // v2: keyboard.pressed?(key) (lowercase receiver)
+        converter.registerOnSend('sprite', 'keyboard', 0, params => {
+            const {node} = params;
+            return converter.createRubyExpressionBlock('keyboard', node);
+        });
+        converter.registerOnSend('keyboard', 'pressed?', 1, params => {
+            const {receiver, args} = params;
+
+            const validKey = converter.isString(args[0]) && KeyOptions.indexOf(args[0].toString()) >= 0;
+            const isBlockArg = converter.isBlock(args[0]);
+
+            if (!validKey && !isBlockArg) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'sensing_keypressed', 'value_boolean');
             converter.addFieldInput(block, 'KEY_OPTION', 'sensing_keyoptions', 'KEY_OPTION', args[0], 'space');
             return block;
         });

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/translate.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/translate.js
@@ -1,11 +1,13 @@
 import _ from 'lodash';
 
+const Translate = 'translate';
+
 /**
  * Translate converter
  */
 const TranslateConverter = {
     register: function (converter) {
-        // translate method
+        // v1: translate(words, language)
         converter.registerOnSend('self', 'translate', 2, params => {
             const {args} = params;
             if (!converter._isNumberOrStringOrBlock(args[0]) || !converter._isStringOrBlock(args[1])) return null;
@@ -20,10 +22,41 @@ const TranslateConverter = {
             return block;
         });
 
-        // language method
+        // v1: language
         converter.registerOnSend('self', 'language', 0, () =>
             converter._createBlock('translate_getViewerLanguage', 'value')
         );
+
+        // v2: translate receiver (for translate.call and translate.language)
+        converter.registerOnSend('sprite', Translate, 0, params => {
+            const {node} = params;
+            return converter.createRubyExpressionBlock(Translate, node);
+        });
+        converter.registerOnSend('stage', Translate, 0, params => {
+            const {node} = params;
+            return converter.createRubyExpressionBlock(Translate, node);
+        });
+
+        // v2: translate.call(words, language)
+        converter.registerOnSend(Translate, 'call', 2, params => {
+            const {receiver, args} = params;
+            if (!converter._isNumberOrStringOrBlock(args[0]) || !converter._isStringOrBlock(args[1])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'translate_getTranslate', 'value');
+            converter._addTextInput(block, 'WORDS', args[0]);
+            converter._addInput(
+                block,
+                'LANGUAGE',
+                converter._createFieldBlock('translate_menu_languages', 'languages', args[1])
+            );
+            return block;
+        });
+
+        // v2: translate.language
+        converter.registerOnSend(Translate, 'language', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'translate_getViewerLanguage', 'value');
+        });
     }
 };
 

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/book-compat.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/book-compat.test.js
@@ -1,0 +1,438 @@
+/**
+ * Book code round-trip compatibility tests (v1).
+ *
+ * These tests verify that code from published Smalruby books survives
+ * a Ruby -> Blocks -> Ruby round trip unchanged.
+ *
+ * Version: v1 only (book code uses v1 API).
+ * Related issue: #363
+ */
+import dedent from 'dedent';
+import {
+    makeSpriteTarget,
+    makeConverter,
+    setupRubyGenerator,
+    expectRoundTrip
+} from '../../helpers/ruby-roundtrip-helper';
+
+describe('Ruby Roundtrip: Book code compatibility (v1)', () => {
+    let target, runtime, converter;
+
+    beforeEach(() => {
+        ({target, runtime} = makeSpriteTarget());
+        setupRubyGenerator();
+        converter = makeConverter(target, runtime);
+    });
+
+    // --- Motion / Sensing / Looks (no extensions) ---
+
+    test('Program 1: mouse tracking with say', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              loop do
+                point_towards("_mouse_")
+                move(10)
+                if touching?("_mouse_")
+                  say("こんにちは！", 2)
+                end
+                wait
+              end
+            end
+        `);
+    });
+
+    test('Program 2: Mouse1 follows mouse, points at sprite', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              loop do
+                go_to("_mouse_")
+                point_towards("スプライト1")
+                wait
+              end
+            end
+        `);
+    });
+
+    test('Program 3: sprite chases Mouse1', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              loop do
+                point_towards("Mouse1")
+                move(10)
+                if touching?("Mouse1")
+                  say("つかまえた", 2)
+                end
+                wait
+              end
+            end
+        `);
+    });
+
+    // --- Music extension ---
+
+    test('Program 4: drum pattern', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              2.times do
+                play_drum(drum: 1, beats: 0.25)
+                play_drum(drum: 1, beats: 0.25)
+                play_drum(drum: 1, beats: 0.125)
+                play_drum(drum: 1, beats: 0.125)
+                rest(0.25)
+                wait
+              end
+              play_drum(drum: 1, beats: 0.25)
+              play_drum(drum: 1, beats: 0.25)
+              play_drum(drum: 1, beats: 0.25)
+              play_drum(drum: 1, beats: 0.25)
+              play_drum(drum: 1, beats: 0.25)
+              play_drum(drum: 1, beats: 0.125)
+              play_drum(drum: 1, beats: 0.125)
+              play_drum(drum: 1, beats: 0.25)
+              rest(0.25)
+            end
+        `);
+    });
+
+    test('Program 5: instrument setting', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:clicked) do
+              self.instrument = 5
+            end
+        `);
+    });
+
+    // --- Lists / Variables ---
+
+    test('Program 6: prefecture quiz with list()', async () => {
+        // v1 known incompatibility: list("$xxx")[index] is accepted by the converter
+        // but the generator outputs $xxx[index - 1] (0-based array access).
+        // TODO: #363 - make v1 generator preserve list() function format
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              loop do
+                $えらんだけんめい = rand(1..18)
+                ask(list("$けんめい")[$えらんだけんのばんごう] + "のけんちょうしょざいちのけんはどこかな")
+                if answer == list("$けんちょうしょざいち")[$えらんだけんのばんごう]
+                  say("正解！", 2)
+                else
+                  say(list("$けんちょうしょざいち")[$えらんだけんのばんごう] + "がせいかいだよ", 2)
+                end
+                wait
+              end
+            end
+        `, dedent`
+            self.when(:flag_clicked) do
+              loop do
+                $えらんだけんめい = rand(1..18)
+                ask($けんめい[$えらんだけんのばんごう - 1] + "のけんちょうしょざいちのけんはどこかな")
+                if answer == $けんちょうしょざいち[$えらんだけんのばんごう - 1]
+                  say("正解！", 2)
+                else
+                  say($けんちょうしょざいち[$えらんだけんのばんごう - 1] + "がせいかいだよ", 2)
+                end
+                wait
+              end
+            end
+        `);
+    });
+
+    // --- Looks only ---
+
+    test('Program 7: Matsue Castle introduction', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:clicked) do
+              say("私は松江城（まつえじょう）だ", 2)
+              say("関ヶ原の戦いの後に作られた城だ", 2)
+              say("天守閣（てんしゅかく）は国宝にも指定されている", 2)
+              say("5城のうちの一つであるぞ", 2)
+              say("建て替えられたことがなく、当時もままなのだ", 2)
+              say("ぜひ一度我が元へ来るがよい", 2)
+            end
+        `);
+    });
+
+    // --- Key events / Properties ---
+
+    test('Program 8: up/down arrow key movement', async () => {
+        // Book uses `self.y += -10` but the system normalizes to `self.y -= 10`
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:key_pressed, "up arrow") do
+              self.y += 10
+            end
+
+            self.when(:key_pressed, "down arrow") do
+              self.y += -10
+            end
+        `, dedent`
+            self.when(:key_pressed, "up arrow") do
+              self.y += 10
+            end
+
+            self.when(:key_pressed, "down arrow") do
+              self.y -= 10
+            end
+        `);
+    });
+
+    // --- Arrow shooting game ---
+
+    test('Program 9: Arrow1 shoots on space (single)', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              hide
+            end
+
+            self.when(:key_pressed, "space") do
+              go_to("スプライト1")
+              show
+              until touching?("_edge_")
+                self.x += 10
+                wait
+              end
+              hide
+            end
+        `);
+    });
+
+    test('Program 10: sprite1 moves until hit by Arrow1', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              show
+              self.rotation_style = "left-right"
+              until touching?("Arrow1")
+                move(10)
+                bounce_if_on_edge
+                wait
+              end
+              hide
+            end
+        `);
+    });
+
+    test('Program 11: Arrow1 with clone', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              hide
+            end
+
+            self.when(:key_pressed, "space") do
+              create_clone("_myself_")
+            end
+
+            self.when(:start_as_a_clone) do
+              go_to("スプライト1")
+              show
+              until touching?("_edge_")
+                self.x += 10
+                wait
+              end
+              hide
+            end
+        `);
+    });
+
+    test('Program 12: sprite1 spawns clones, moves until hit', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              hide
+              loop do
+                sleep(1)
+                create_clone("_myself_")
+                wait
+              end
+            end
+
+            self.when(:start_as_a_clone) do
+              go_to([149, rand(-217..186)])
+              show
+              self.rotation_style = "left-right"
+              until touching?("Arrow1")
+                move(10)
+                bounce_if_on_edge
+                wait
+              end
+              delete_this_clone
+            end
+        `);
+    });
+
+    // --- Pen extension ---
+
+    test('Program 13: triangle with pen', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              pen_down
+              move(50)
+              turn_left(180)
+              turn_right(60)
+              move(50)
+              turn_left(180)
+              turn_right(60)
+              move(50)
+              turn_left(180)
+              turn_right(60)
+            end
+        `);
+    });
+
+    test('Program 14: pen clear', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              pen_clear
+            end
+        `);
+    });
+
+    test('Program 15: triangle with loop', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              pen_down
+              3.times do
+                move(50)
+                turn_left(180)
+                turn_right(60)
+                wait
+              end
+            end
+        `);
+    });
+
+    test('Program 16: square', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              pen_down
+              4.times do
+                move(50)
+                turn_left(180)
+                turn_right(90)
+                wait
+              end
+            end
+        `);
+    });
+
+    test('Program 17: hexagon', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              pen_down
+              6.times do
+                move(50)
+                turn_left(180)
+                turn_right(120)
+                wait
+              end
+            end
+        `);
+    });
+
+    test('Program 18: heptagon', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              pen_down
+              7.times do
+                move(50)
+                turn_left(180)
+                turn_right((180 * (7 - 2)) / 7)
+                wait
+              end
+            end
+        `);
+    });
+
+    test('Program 19: N-gon with variable', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              pen_down
+              $へんのかず = 5
+              $へんのかず.times do
+                move(70)
+                turn_right(180)
+                turn_right((180 * ($へんのかず - 2)) / $へんのかず)
+                wait
+              end
+            end
+        `);
+    });
+
+    test('Program 20: nested N-gon with color change', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              pen_down
+              $へんのかず = 8
+              $へんのかず.times do
+                $へんのかず.times do
+                  self.color += 10
+                  move(70)
+                  turn_left(180)
+                  turn_right((180 * ($へんのかず - 2)) / $へんのかず)
+                  wait
+                end
+                turn_left(180)
+                turn_right((180 * ($へんのかず - 2)) / $へんのかず)
+                wait
+              end
+            end
+        `);
+    });
+
+    // --- micro:bit ---
+
+    test('Program 21: micro:bit hello', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              microbit.display_text("Hello!")
+            end
+        `);
+    });
+
+    test('Program 22: micro:bit heart on jump', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:microbit_gesture, "jumped") do
+              microbit.display(
+                ".1.1.",
+                "1.1.1",
+                "1...1",
+                ".1.1.",
+                "..1.."
+              )
+              sleep(1)
+              microbit.clear_display
+            end
+        `);
+    });
+
+    test('Program 23: darumasan ga koronda', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:flag_clicked) do
+              self.rotation_style = "left-right"
+              loop do
+                self.direction = 90
+                say("だるまさんがころんだ", 4)
+                self.direction = -90
+                sleep(2)
+                wait
+              end
+            end
+
+            self.when(:microbit_gesture, "shaken") do
+              if direction == -90
+                say("うごいたなあ", 2)
+                stop("all")
+              end
+            end
+        `);
+    });
+
+    test('Program 24: micro:bit shake to move', async () => {
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:microbit_gesture, "shaken") do
+              move(5)
+            end
+
+            self.when(:flag_clicked) do
+              go_to([-180, 0])
+            end
+        `);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/control.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/control.test.js
@@ -71,7 +71,7 @@ describe('Ruby Roundtrip: Control category blocks', () => {
 
             stop("other scripts in sprite")
 
-            when_start_as_a_clone do
+            self.when(:start_as_a_clone) do
             end
 
             create_clone("_myself_")
@@ -80,16 +80,20 @@ describe('Ruby Roundtrip: Control category blocks', () => {
         `);
     });
 
-    test('Ruby -> Code -> Ruby (backward compatibility)', async () => {
-        const oldRuby = dedent`
-            self.when(:start_as_a_clone) do
-            end
-        `;
-        const newRuby = dedent`
+    test('Ruby -> Code -> Ruby (v2)', async () => {
+        const converter2 = makeConverter(target, runtime, {version: 2});
+        await expectRoundTrip(converter2, target, dedent`
             when_start_as_a_clone do
             end
-        `;
-        await expectRoundTrip(converter, target, oldRuby, newRuby);
+        `, null, {version: 2});
+    });
+
+    test('Ruby -> Code -> Ruby (backward compatibility)', async () => {
+        // In v1, self.when(:start_as_a_clone) round-trips to itself
+        await expectRoundTrip(converter, target, dedent`
+            self.when(:start_as_a_clone) do
+            end
+        `);
     });
 
     test('Ruby -> Code -> Ruby (alias)', async () => {
@@ -102,6 +106,7 @@ describe('Ruby Roundtrip: Control category blocks', () => {
         const afterRuby = dedent`
             10.times do
               move(10)
+              wait
             end
             x.times do
               move(10)
@@ -111,6 +116,7 @@ describe('Ruby Roundtrip: Control category blocks', () => {
             end
             loop do
               move(10)
+              wait
             end
         `;
         await expectRoundTrip(converter, target, beforeRuby, afterRuby);

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_microbit.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_microbit.test.js
@@ -1,5 +1,8 @@
 /**
  * Unit test replacing test/integration/ruby-tab/extension_microbit.test.js
+ *
+ * Note: The original micro:bit extension is defaultHidden: true and not
+ * actively maintained. These tests verify v1 backward compatibility only.
  */
 import dedent from 'dedent';
 import {
@@ -18,7 +21,8 @@ describe('Ruby Roundtrip: micro:bit extension blocks', () => {
         converter = makeConverter(target, runtime);
     });
 
-    const ruby = dedent`
+    // v1 output format: gesture events use self.when(:microbit_gesture, ...)
+    const v1Ruby = dedent`
         microbit_v1.when_button_pressed("A") do
         end
 
@@ -30,13 +34,13 @@ describe('Ruby Roundtrip: micro:bit extension blocks', () => {
 
         microbit_v1.button_pressed?("A")
 
-        microbit_v1.when("moved") do
+        self.when(:microbit_gesture, "moved") do
         end
 
-        microbit_v1.when("shaken") do
+        self.when(:microbit_gesture, "shaken") do
         end
 
-        microbit_v1.when("jumped") do
+        self.when(:microbit_gesture, "jumped") do
         end
 
         microbit_v1.display(
@@ -79,64 +83,12 @@ describe('Ruby Roundtrip: micro:bit extension blocks', () => {
         end
     `;
 
-    test('Ruby -> Code -> Ruby', async () => {
-        await expectRoundTrip(converter, target, ruby);
+    test('Ruby -> Code -> Ruby (v1)', async () => {
+        await expectRoundTrip(converter, target, v1Ruby);
     });
 
-    test('Ruby -> Code -> Ruby (backward compatibility)', async () => {
-        const oldRuby = dedent`
-            self.when(:microbit_button_pressed, "A") do
-            end
-
-            self.when(:microbit_button_pressed, "B") do
-            end
-
-            self.when(:microbit_button_pressed, "any") do
-            end
-
-            self.when(:microbit_gesture, "moved") do
-            end
-
-            self.when(:microbit_gesture, "shaken") do
-            end
-
-            self.when(:microbit_gesture, "jumped") do
-            end
-
-            self.when(:microbit_tilted, "any") do
-            end
-
-            self.when(:microbit_tilted, "front") do
-            end
-
-            self.when(:microbit_tilted, "back") do
-            end
-
-            self.when(:microbit_tilted, "left") do
-            end
-
-            self.when(:microbit_tilted, "right") do
-            end
-
-            self.when(:microbit_pin_connected, 0) do
-            end
-
-            self.when(:microbit_pin_connected, 1) do
-            end
-
-            self.when(:microbit_pin_connected, 2) do
-            end
-        `;
-        const newRuby = dedent`
-            microbit_v1.when_button_pressed("A") do
-            end
-
-            microbit_v1.when_button_pressed("B") do
-            end
-
-            microbit_v1.when_button_pressed("any") do
-            end
-
+    test('Ruby -> Code -> Ruby (v1 backward compatibility: microbit_v1.when style)', async () => {
+        const microbitV1WhenRuby = dedent`
             microbit_v1.when("moved") do
             end
 
@@ -145,29 +97,45 @@ describe('Ruby Roundtrip: micro:bit extension blocks', () => {
 
             microbit_v1.when("jumped") do
             end
+        `;
+        const v1GestureRuby = dedent`
+            self.when(:microbit_gesture, "moved") do
+            end
+
+            self.when(:microbit_gesture, "shaken") do
+            end
+
+            self.when(:microbit_gesture, "jumped") do
+            end
+        `;
+        await expectRoundTrip(converter, target, microbitV1WhenRuby, v1GestureRuby);
+    });
+
+    test('Ruby -> Code -> Ruby (v1 backward compatibility: self.when style)', async () => {
+        const oldRuby = dedent`
+            self.when(:microbit_button_pressed, "A") do
+            end
+
+            self.when(:microbit_gesture, "moved") do
+            end
+
+            self.when(:microbit_tilted, "any") do
+            end
+
+            self.when(:microbit_pin_connected, 0) do
+            end
+        `;
+        const newRuby = dedent`
+            microbit_v1.when_button_pressed("A") do
+            end
+
+            self.when(:microbit_gesture, "moved") do
+            end
 
             microbit_v1.when_tilted("any") do
             end
 
-            microbit_v1.when_tilted("front") do
-            end
-
-            microbit_v1.when_tilted("back") do
-            end
-
-            microbit_v1.when_tilted("left") do
-            end
-
-            microbit_v1.when_tilted("right") do
-            end
-
             microbit_v1.when_pin_connected(0) do
-            end
-
-            microbit_v1.when_pin_connected(1) do
-            end
-
-            microbit_v1.when_pin_connected(2) do
             end
         `;
         await expectRoundTrip(converter, target, oldRuby, newRuby);

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_microbit_more.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_microbit_more.test.js
@@ -107,14 +107,14 @@ describe('Ruby Roundtrip: Microbit More v2 extension blocks', () => {
 
             microbit.tilted?("right")
 
-            microbit.display_pattern(
+            microbit.display(
               ".1.1.",
               "1.1.1",
               "1...1",
               ".1.1.",
               "..1.."
             )
-            microbit.display_pattern(
+            microbit.display(
               "1...1",
               ".1.1.",
               "..1..",

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_music.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_music.test.js
@@ -18,7 +18,7 @@ describe('Ruby Roundtrip: Music extension blocks', () => {
         converter = makeConverter(target, runtime);
     });
 
-    test('Ruby -> Code -> Ruby', async () => {
+    test('Ruby -> Code -> Ruby (v1)', async () => {
         await expectRoundTrip(converter, target, dedent`
             play_drum(drum: 1, beats: 0.25)
             rest(0.25)
@@ -29,5 +29,19 @@ describe('Ruby Roundtrip: Music extension blocks', () => {
 
             tempo
         `);
+    });
+
+    test('Ruby -> Code -> Ruby (v2)', async () => {
+        const converter2 = makeConverter(target, runtime, {version: 2});
+        await expectRoundTrip(converter2, target, dedent`
+            music.play_drum(drum: 1, beats: 0.25)
+            music.rest(0.25)
+            music.play_note(note: 60, beats: 0.25)
+            music.instrument = 1
+            music.tempo = 60
+            music.tempo += 20
+
+            music.tempo
+        `, null, {version: 2});
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_pen.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_pen.test.js
@@ -82,4 +82,26 @@ describe('Ruby Roundtrip: Pen extension blocks', () => {
         `;
         await expectRoundTrip(converter, target, oldCode, v1Code);
     });
+
+    test('Ruby -> Code -> Ruby (v2)', async () => {
+        const converter2 = makeConverter(target, runtime, {version: 2});
+        const v2Code = dedent`
+            pen.clear
+            pen.stamp
+            pen.down
+            pen.up
+            pen.color = "#c11318"
+            pen.color += 10
+            pen.saturation += 10
+            pen.brightness += 10
+            pen.transparency += 10
+            pen.color = 50
+            pen.saturation = 50
+            pen.brightness = 50
+            pen.transparency = 50
+            pen.size += 1
+            pen.size = 1
+        `;
+        await expectRoundTrip(converter2, target, v2Code, null, {version: 2});
+    });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_pen.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_pen.test.js
@@ -18,29 +18,51 @@ describe('Ruby Roundtrip: Pen extension blocks', () => {
         converter = makeConverter(target, runtime);
     });
 
-    const code = dedent`
-        Pen.clear
-        pen.stamp
-        pen.down
-        pen.up
-        pen.color = "#c11318"
-        pen.color += 10
-        pen.saturation += 10
-        pen.brightness += 10
-        pen.transparency += 10
-        pen.color = 50
-        pen.saturation = 50
-        pen.brightness = 50
-        pen.transparency = 50
-        pen.size += 1
-        pen.size = 1
+    // v1 format (default)
+    const v1Code = dedent`
+        pen_clear
+        pen_stamp
+        pen_down
+        pen_up
+        self.pen_color = "#c11318"
+        self.color += 10
+        self.saturation += 10
+        self.brightness += 10
+        self.transparency += 10
+        self.pen_color = 50
+        self.pen_saturation = 50
+        self.pen_brightness = 50
+        self.pen_transparency = 50
+        self.pen_size += 1
+        self.pen_size = 1
     `;
 
-    test('Ruby -> Code -> Ruby', async () => {
-        await expectRoundTrip(converter, target, code);
+    test('Ruby -> Code -> Ruby (v1)', async () => {
+        await expectRoundTrip(converter, target, v1Code);
     });
 
-    test('Ruby -> Code -> Ruby (backward compatibility)', async () => {
+    test('Ruby -> Code -> Ruby (v1 backward compatibility: pen.down style)', async () => {
+        const modernCode = dedent`
+            Pen.clear
+            pen.stamp
+            pen.down
+            pen.up
+            pen.color = "#c11318"
+            pen.color += 10
+            pen.saturation += 10
+            pen.brightness += 10
+            pen.transparency += 10
+            pen.color = 50
+            pen.saturation = 50
+            pen.brightness = 50
+            pen.transparency = 50
+            pen.size += 1
+            pen.size = 1
+        `;
+        await expectRoundTrip(converter, target, modernCode, v1Code);
+    });
+
+    test('Ruby -> Code -> Ruby (v1 backward compatibility: self.pen_xxx style)', async () => {
         const oldCode = dedent`
             pen_clear
             pen_stamp
@@ -58,6 +80,6 @@ describe('Ruby Roundtrip: Pen extension blocks', () => {
             self.pen_size += 1
             self.pen_size = 1
         `;
-        await expectRoundTrip(converter, target, oldCode, code);
+        await expectRoundTrip(converter, target, oldCode, v1Code);
     });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_translate_v2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/extension_translate_v2.test.js
@@ -1,0 +1,38 @@
+/**
+ * Unit test for v2 translate extension: translate.call / translate.language.
+ * Related issue: #363
+ */
+import dedent from 'dedent';
+import {
+    makeSpriteTarget,
+    makeConverter,
+    setupRubyGenerator,
+    expectRoundTrip
+} from '../../helpers/ruby-roundtrip-helper';
+
+describe('Ruby Roundtrip: Translate v2 API', () => {
+    let target, runtime;
+
+    beforeEach(() => {
+        ({target, runtime} = makeSpriteTarget());
+        setupRubyGenerator();
+    });
+
+    test('translate.call and translate.language (v2)', async () => {
+        const converter2 = makeConverter(target, runtime, {version: 2});
+        await expectRoundTrip(converter2, target, dedent`
+            translate.call("hello", "ja")
+
+            translate.language
+        `, null, {version: 2});
+    });
+
+    test('v1 backward compat: translate() and language', async () => {
+        const converter1 = makeConverter(target, runtime);
+        await expectRoundTrip(converter1, target, dedent`
+            translate("hello", "ja")
+
+            language
+        `);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/sensing-v2.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/sensing-v2.test.js
@@ -1,0 +1,64 @@
+/**
+ * Unit test for v2 sensing blocks: keyboard, mouse, timer lowercase receivers.
+ * Related issue: #363
+ */
+import dedent from 'dedent';
+import {
+    makeSpriteTarget,
+    makeConverter,
+    setupRubyGenerator,
+    expectRoundTrip
+} from '../../helpers/ruby-roundtrip-helper';
+
+describe('Ruby Roundtrip: Sensing v2 lowercase receivers', () => {
+    let target, runtime;
+
+    beforeEach(() => {
+        ({target, runtime} = makeSpriteTarget());
+        setupRubyGenerator();
+    });
+
+    test('keyboard.pressed? (v2)', async () => {
+        const converter2 = makeConverter(target, runtime, {version: 2});
+        await expectRoundTrip(converter2, target, dedent`
+            keyboard.pressed?("space")
+        `, null, {version: 2});
+    });
+
+    test('mouse.x / mouse.y / mouse.down? (v2)', async () => {
+        const converter2 = makeConverter(target, runtime, {version: 2});
+        await expectRoundTrip(converter2, target, dedent`
+            mouse.x
+
+            mouse.y
+
+            mouse.down?
+        `, null, {version: 2});
+    });
+
+    test('timer.value / timer.reset (v2)', async () => {
+        const converter2 = makeConverter(target, runtime, {version: 2});
+        await expectRoundTrip(converter2, target, dedent`
+            timer.value
+
+            timer.reset
+        `, null, {version: 2});
+    });
+
+    test('v1 backward compat: Keyboard/Mouse/Timer (uppercase)', async () => {
+        const converter1 = makeConverter(target, runtime);
+        await expectRoundTrip(converter1, target, dedent`
+            Keyboard.pressed?("space")
+
+            Mouse.x
+
+            Mouse.y
+
+            Mouse.down?
+
+            Timer.value
+
+            Timer.reset
+        `);
+    });
+});


### PR DESCRIPTION
## Summary

Ruby v2 API overhaul (#363) — 拡張機能を `extension.method()` 形式に統一。

### 変更内容

**Phase 0: 書籍コード v1 互換性**
- 書籍コード24プログラムの round-trip テスト追加
- `wait` 保持（`@ruby:method:wait` コメント）
- ペン/control/microbit ジェネレータの v1 対応
- `self.color += 10` / `microbit.display()` 後方互換

**Phase 1: v2 Pen — `Pen.clear` → `pen.clear`**

**Phase 2: v2 Music — `music.xxx` 形式**
- `play_drum()` → `music.play_drum()`
- `rest()` → `music.rest()`
- `self.instrument/tempo` → `music.instrument/tempo`

**Phase 3: v2 Sensing — Keyboard/Mouse/Timer 小文字化**
- `Keyboard.pressed?()` → `keyboard.pressed?()`
- `Mouse.x/y/down?` → `mouse.x/y/down?`
- `Timer.value/reset` → `timer.value/reset`

**Phase 4: v2 Translate — `translate.call` 形式**
- `translate(words, lang)` → `translate.call(words, lang)`
- `language` → `translate.language`

## Implementation Steps

- [x] **Phase 0: 書籍コード round-trip テスト作成（v1）**
- [x] **Phase 1: v2 Pen — `Pen.clear` → `pen.clear`**
- [x] **Phase 2: v2 Music — `music.xxx` 形式**
- [x] **Phase 3: v2 Sensing — Keyboard/Mouse/Timer 小文字化**
- [x] **Phase 4: v2 Translate — `translate.call` 形式**
- [x] **Phase DoD: CI 完了 + ブラウザ確認**

## Definition of Done

- [x] ユニットテスト pass（v1書籍互換 + v2新API）— 152 tests, 35 suites
- [x] lint pass
- [x] CI green — 全9ジョブ pass
- [x] ブラウザ確認（Playwright MCP）:
  - [x] v1モード: 書籍のドラムプログラム（`play_drum`, `rest`, `wait`）round-trip 完全一致
  - [x] v1モード: 書籍のペンプログラム（`pen_down`）round-trip 完全一致
  - [x] v2モード: `music.play_drum(drum: 1, beats: 0.25)` round-trip 一致
  - [x] v2モード: `pen.clear` / `pen.down` round-trip 一致
  - [x] v2モード: `keyboard.pressed?("space")` round-trip 一致
  - [x] v2モード: `mouse.x` / `timer.reset` round-trip 一致

## Test Coverage

- 24 book code round-trip tests (v1)
- 152 total roundtrip tests passing (35 suites)
- Lint passing with zero warnings

### 既知の非互換

- `list("$xxx")[index]` は受け入れ可能だがジェネレータが `$xxx[index - 1]` を出力（TODO）

## Related Issues

Refs #363
