### PR TITLE
feat: v2モードでv1書籍コード検出時にバージョン切り替えを提案する

### DIFF
--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -20,9 +20,7 @@ import {BLOCKS_TAB_INDEX, RUBY_TAB_INDEX} from '../reducers/editor-tab';
 
 import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
 import {targetCodeToBlocks} from '../lib/ruby-to-blocks-converter';
-// === Smalruby: Start of v1 code detection prompt ===
 import {containsV1Code} from '../lib/ruby-to-blocks-converter/v1-detection';
-// === Smalruby: End of v1 code detection prompt ===
 // === Smalruby: Start of module editor update ===
 import RubyGenerator from '../lib/ruby-generator';
 // === Smalruby: End of module editor update ===
@@ -103,10 +101,8 @@ const RubyTab = props => {
         onSetAiSaveStatus, onClearAiSaveStatus,
         onFontSizeChange, onMarkRubyTabUsed,
         onOpenRubyteeModal, onRegisterRubyteeApply,
-        // === Smalruby: Start of v1 code detection prompt ===
         v1PromptDismissed,
         onDismissV1Prompt
-        // === Smalruby: End of v1 code detection prompt ===
     } = props;
 
     // --- State ---
@@ -852,15 +848,13 @@ const RubyTab = props => {
             const changedTarget = vm.editingTarget && rubyCode.target &&
                 vm.editingTarget.id !== targetId;
             if (changedTarget || blocksTabVisible) {
-                // === Smalruby: Start of v1 code detection prompt ===
                 if (String(rubyVersion) === '2' &&
                     !v1PromptDismissed &&
                     containsV1Code(rubyCode.code)) {
-                    const message =
-                        'Rubyのバージョンを「v1」に変えますか？\n\n' +
-                        '入力されたコードは、書籍（教科書）で使われている' +
-                        '「v1」の書き方です。「v1」に変えると、書籍と同じ' +
-                        '書き方でプログラミングできます。';
+                    const message = intlRef.current.formatMessage({
+                        id: 'gui.rubyTab.v1CodeDetected',
+                        defaultMessage: 'Switch Ruby version to "v1"?\n\nThe code you entered uses the "v1" syntax found in textbooks. Switching to "v1" lets you program with the same syntax as the textbook.'
+                    });
                     // eslint-disable-next-line no-alert
                     if (window.confirm(message)) {
                         onRevertRubyVersion('1');
@@ -868,7 +862,6 @@ const RubyTab = props => {
                     }
                     onDismissV1Prompt();
                 }
-                // === Smalruby: End of v1 code detection prompt ===
                 targetCodeToBlocksHOC(intl).then(converter => {
                     if (converter.result) {
                         converter.apply().then(async () => {
@@ -1083,10 +1076,8 @@ RubyTab.propTypes = {
     activeTabIndex: PropTypes.number,
     onOpenRubyteeModal: PropTypes.func,
     onRegisterRubyteeApply: PropTypes.func,
-    // === Smalruby: Start of v1 code detection prompt ===
     v1PromptDismissed: PropTypes.bool,
     onDismissV1Prompt: PropTypes.func
-    // === Smalruby: End of v1 code detection prompt ===
 };
 
 const mapStateToProps = state => ({
@@ -1098,9 +1089,7 @@ const mapStateToProps = state => ({
     projectTitle: state.scratchGui.projectTitle,
     locale: state.locales.locale,
     activeTabIndex: state.scratchGui.editorTab.activeTabIndex,
-    // === Smalruby: Start of v1 code detection prompt ===
     v1PromptDismissed: state.scratchGui.settings.v1PromptDismissed
-    // === Smalruby: End of v1 code detection prompt ===
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -1118,9 +1107,7 @@ const mapDispatchToProps = dispatch => ({
     onClearAiSaveStatus: () => dispatch(clearAiSaveStatus()),
     onFontSizeChange: fontSize => dispatch(updateRubyFontSize(fontSize)),
     onMarkRubyTabUsed: () => dispatch(markRubyTabUsed()),
-    // === Smalruby: Start of v1 code detection prompt ===
     onDismissV1Prompt: () => dispatch(dismissV1Prompt())
-    // === Smalruby: End of v1 code detection prompt ===
 });
 
 const ConnectedRubyTab = RubyteeModalHOC(RubyToBlocksConverterHOC(injectIntl(connect(

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -11,7 +11,7 @@ import {
     updateRubyCodeTarget,
     updateRubyFontSize
 } from '../reducers/ruby-code';
-import {setRubyVersion} from '../reducers/settings';
+import {setRubyVersion, dismissV1Prompt} from '../reducers/settings';
 import {setProjectChanged} from '../reducers/project-changed';
 import {showAlertWithTimeout, closeAlertWithId} from '../reducers/alerts';
 import {markRubyTabUsed} from '../reducers/tutorial-onboarding';
@@ -20,6 +20,9 @@ import {BLOCKS_TAB_INDEX, RUBY_TAB_INDEX} from '../reducers/editor-tab';
 
 import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
 import {targetCodeToBlocks} from '../lib/ruby-to-blocks-converter';
+// === Smalruby: Start of v1 code detection prompt ===
+import {containsV1Code} from '../lib/ruby-to-blocks-converter/v1-detection';
+// === Smalruby: End of v1 code detection prompt ===
 // === Smalruby: Start of module editor update ===
 import RubyGenerator from '../lib/ruby-generator';
 // === Smalruby: End of module editor update ===
@@ -99,7 +102,11 @@ const RubyTab = props => {
         onRequestCloseFile, onProjectTelemetryEvent,
         onSetAiSaveStatus, onClearAiSaveStatus,
         onFontSizeChange, onMarkRubyTabUsed,
-        onOpenRubyteeModal, onRegisterRubyteeApply
+        onOpenRubyteeModal, onRegisterRubyteeApply,
+        // === Smalruby: Start of v1 code detection prompt ===
+        v1PromptDismissed,
+        onDismissV1Prompt
+        // === Smalruby: End of v1 code detection prompt ===
     } = props;
 
     // --- State ---
@@ -845,6 +852,23 @@ const RubyTab = props => {
             const changedTarget = vm.editingTarget && rubyCode.target &&
                 vm.editingTarget.id !== targetId;
             if (changedTarget || blocksTabVisible) {
+                // === Smalruby: Start of v1 code detection prompt ===
+                if (String(rubyVersion) === '2' &&
+                    !v1PromptDismissed &&
+                    containsV1Code(rubyCode.code)) {
+                    const message =
+                        'Rubyのバージョンを「v1」に変えますか？\n\n' +
+                        '入力されたコードは、書籍（教科書）で使われている' +
+                        '「v1」の書き方です。「v1」に変えると、書籍と同じ' +
+                        '書き方でプログラミングできます。';
+                    // eslint-disable-next-line no-alert
+                    if (window.confirm(message)) {
+                        onRevertRubyVersion('1');
+                        return;
+                    }
+                    onDismissV1Prompt();
+                }
+                // === Smalruby: End of v1 code detection prompt ===
                 targetCodeToBlocksHOC(intl).then(converter => {
                     if (converter.result) {
                         converter.apply().then(async () => {
@@ -1058,7 +1082,11 @@ RubyTab.propTypes = {
     locale: PropTypes.string,
     activeTabIndex: PropTypes.number,
     onOpenRubyteeModal: PropTypes.func,
-    onRegisterRubyteeApply: PropTypes.func
+    onRegisterRubyteeApply: PropTypes.func,
+    // === Smalruby: Start of v1 code detection prompt ===
+    v1PromptDismissed: PropTypes.bool,
+    onDismissV1Prompt: PropTypes.func
+    // === Smalruby: End of v1 code detection prompt ===
 };
 
 const mapStateToProps = state => ({
@@ -1069,7 +1097,10 @@ const mapStateToProps = state => ({
     vm: state.scratchGui.vm,
     projectTitle: state.scratchGui.projectTitle,
     locale: state.locales.locale,
-    activeTabIndex: state.scratchGui.editorTab.activeTabIndex
+    activeTabIndex: state.scratchGui.editorTab.activeTabIndex,
+    // === Smalruby: Start of v1 code detection prompt ===
+    v1PromptDismissed: state.scratchGui.settings.v1PromptDismissed
+    // === Smalruby: End of v1 code detection prompt ===
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -1086,7 +1117,10 @@ const mapDispatchToProps = dispatch => ({
     onSetAiSaveStatus: status => dispatch(setAiSaveStatus(status)),
     onClearAiSaveStatus: () => dispatch(clearAiSaveStatus()),
     onFontSizeChange: fontSize => dispatch(updateRubyFontSize(fontSize)),
-    onMarkRubyTabUsed: () => dispatch(markRubyTabUsed())
+    onMarkRubyTabUsed: () => dispatch(markRubyTabUsed()),
+    // === Smalruby: Start of v1 code detection prompt ===
+    onDismissV1Prompt: () => dispatch(dismissV1Prompt())
+    // === Smalruby: End of v1 code detection prompt ===
 });
 
 const ConnectedRubyTab = RubyteeModalHOC(RubyToBlocksConverterHOC(injectIntl(connect(

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -853,6 +853,7 @@ const RubyTab = props => {
                     containsV1Code(rubyCode.code)) {
                     const message = intlRef.current.formatMessage({
                         id: 'gui.rubyTab.v1CodeDetected',
+                        // eslint-disable-next-line max-len
                         defaultMessage: 'Switch Ruby version to "v1"?\n\nThe code you entered uses the "v1" syntax found in textbooks. Switching to "v1" lets you program with the same syntax as the textbook.'
                     });
                     // eslint-disable-next-line no-alert

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/v1-detection.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/v1-detection.js
@@ -1,0 +1,20 @@
+// === Smalruby: This file is Smalruby-specific (v1 book code detection) ===
+
+/**
+ * Regular expression to detect v1-specific Ruby code patterns from published books.
+ * These patterns are valid in v2 mode but produce different code after round-trip.
+ */
+// eslint-disable-next-line max-len
+const V1_CODE_PATTERN = /self\.when\(\s*:|(?<!\.)(?:play_drum|rest)\(|self\.instrument\b|(?<!\.)pen_(?:down|clear)\b|self\.color\s*[+-]?=/;
+
+/**
+ * Detect whether Ruby code contains v1-specific patterns from published books.
+ * @param {string} code - Ruby source code to check.
+ * @returns {boolean} True if v1 patterns are found.
+ */
+const containsV1Code = code => {
+    if (!code || typeof code !== 'string') return false;
+    return V1_CODE_PATTERN.test(code);
+};
+
+export {containsV1Code, V1_CODE_PATTERN};

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -5,6 +5,7 @@ export default {
     'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.rubyVersion': 'ルビー',
     'gui.rubyTab.paste': 'はりつけ',
+    'gui.rubyTab.v1CodeDetected': 'Rubyのバージョンを「v1」にかえますか？\n\nにゅうりょくされたコードは、しょせき（きょうかしょ）でつかわれている「v1」のかきかたです。「v1」にかえると、しょせきとおなじかきかたでプログラミングできます。',
     'gui.rubyVersion.v1': 'バージョン1',
     'gui.rubyVersion.v2': 'バージョン2 (しょきせってい)',
     'gui.menuBar.meshV2': 'メッシュ',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -5,7 +5,11 @@ export default {
     'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.rubyVersion': 'ルビー',
     'gui.rubyTab.paste': 'はりつけ',
-    'gui.rubyTab.v1CodeDetected': 'Rubyのバージョンを「v1」にかえますか？\n\nにゅうりょくされたコードは、しょせき（きょうかしょ）でつかわれている「v1」のかきかたです。「v1」にかえると、しょせきとおなじかきかたでプログラミングできます。',
+    'gui.rubyTab.v1CodeDetected':
+        'Rubyのバージョンを「v1」にかえますか？\n\n' +
+        'にゅうりょくされたコードは、しょせき（きょうかしょ）で' +
+        'つかわれている「v1」のかきかたです。「v1」にかえると、' +
+        'しょせきとおなじかきかたでプログラミングできます。',
     'gui.rubyVersion.v1': 'バージョン1',
     'gui.rubyVersion.v2': 'バージョン2 (しょきせってい)',
     'gui.menuBar.meshV2': 'メッシュ',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -5,7 +5,11 @@ export default {
     'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.rubyVersion': 'ルビー',
     'gui.rubyTab.paste': '貼り付け',
-    'gui.rubyTab.v1CodeDetected': 'Rubyのバージョンを「v1」に変えますか？\n\n入力されたコードは、書籍（教科書）で使われている「v1」の書き方です。「v1」に変えると、書籍と同じ書き方でプログラミングできます。',
+    'gui.rubyTab.v1CodeDetected':
+        'Rubyのバージョンを「v1」に変えますか？\n\n' +
+        '入力されたコードは、書籍（教科書）で使われている' +
+        '「v1」の書き方です。「v1」に変えると、' +
+        '書籍と同じ書き方でプログラミングできます。',
     'gui.rubyVersion.v1': 'バージョン1',
     'gui.rubyVersion.v2': 'バージョン2 (初期設定)',
     'gui.menuBar.meshV2': 'メッシュ',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -5,6 +5,7 @@ export default {
     'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.rubyVersion': 'ルビー',
     'gui.rubyTab.paste': '貼り付け',
+    'gui.rubyTab.v1CodeDetected': 'Rubyのバージョンを「v1」に変えますか？\n\n入力されたコードは、書籍（教科書）で使われている「v1」の書き方です。「v1」に変えると、書籍と同じ書き方でプログラミングできます。',
     'gui.rubyVersion.v1': 'バージョン1',
     'gui.rubyVersion.v2': 'バージョン2 (初期設定)',
     'gui.menuBar.meshV2': 'メッシュ',

--- a/packages/scratch-gui/src/reducers/settings.js
+++ b/packages/scratch-gui/src/reducers/settings.js
@@ -8,6 +8,9 @@ import {getUrlParams} from '../lib/url-params';
 const SET_COLOR_MODE = 'scratch-gui/settings/SET_COLOR_MODE';
 const SET_THEME = 'scratch-gui/settings/SET_THEME';
 const SET_RUBY_VERSION = 'scratch-gui/settings/SET_RUBY_VERSION';
+// === Smalruby: Start of v1 code detection prompt ===
+const DISMISS_V1_PROMPT = 'scratch-gui/settings/DISMISS_V1_PROMPT';
+// === Smalruby: End of v1 code detection prompt ===
 
 // === Smalruby: Start of ruby_version URL param ===
 const detectInitialRubyVersion = () => {
@@ -19,7 +22,10 @@ const detectInitialRubyVersion = () => {
 const initialState = {
     colorMode: detectColorMode(),
     theme: detectTheme(),
-    rubyVersion: detectInitialRubyVersion()
+    rubyVersion: detectInitialRubyVersion(),
+    // === Smalruby: Start of v1 code detection prompt ===
+    v1PromptDismissed: false
+    // === Smalruby: End of v1 code detection prompt ===
 };
 // === Smalruby: End of ruby_version URL param ===
 
@@ -31,6 +37,10 @@ const reducer = (state = initialState, action) => {
         return {...state, theme: action.theme};
     case SET_RUBY_VERSION:
         return {...state, rubyVersion: action.rubyVersion};
+    // === Smalruby: Start of v1 code detection prompt ===
+    case DISMISS_V1_PROMPT:
+        return {...state, v1PromptDismissed: true};
+    // === Smalruby: End of v1 code detection prompt ===
     default:
         return state;
     }
@@ -51,10 +61,17 @@ const setRubyVersion = rubyVersion => ({
     rubyVersion
 });
 
+// === Smalruby: Start of v1 code detection prompt ===
+const dismissV1Prompt = () => ({
+    type: DISMISS_V1_PROMPT
+});
+// === Smalruby: End of v1 code detection prompt ===
+
 export {
     reducer as default,
     initialState as settingsInitialState,
     setColorMode,
     setTheme,
-    setRubyVersion
+    setRubyVersion,
+    dismissV1Prompt
 };

--- a/packages/scratch-gui/test/integration/v1-detection-prompt.test.js
+++ b/packages/scratch-gui/test/integration/v1-detection-prompt.test.js
@@ -1,0 +1,124 @@
+import path from 'path';
+import webdriver from 'selenium-webdriver';
+import SeleniumHelper from '../helpers/selenium-helper';
+import RubyHelper from '../helpers/ruby-helper';
+
+const {until} = webdriver;
+
+const seleniumHelper = new SeleniumHelper();
+const {
+    /* eslint-disable no-unused-vars */
+    clickText,
+    clickButton,
+    clickXpath,
+    findByText,
+    findByXpath,
+    getDriver,
+    getLogs,
+    loadUri,
+    waitForLoadingFinished,
+    notExistsByXpath,
+    rightClickText,
+    scope
+    /* eslint-enable no-unused-vars */
+} = seleniumHelper;
+const rubyHelper = new RubyHelper(seleniumHelper);
+const {fillInRubyProgram, currentRubyProgram} = rubyHelper;
+
+const v2Uri = `${path.resolve(__dirname, '../../build/index.html')}?ruby_version=2`;
+const v1Uri = `${path.resolve(__dirname, '../../build/index.html')}?ruby_version=1`;
+
+const V1_CODE = 'self.when(:flag_clicked) do\\n  move(10)\\nend';
+const V2_CODE = 'self.when_flag_clicked do\\n  move(10)\\nend';
+
+let driver;
+
+describe('v1 code detection prompt', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('v2 mode + v1 code shows confirm dialog', async () => {
+        await loadUri(v2Uri);
+        await clickText('Ruby', '*[@role="tab"]');
+        await fillInRubyProgram(V1_CODE);
+
+        await clickText('Code', '*[@role="tab"]');
+
+        // The confirm dialog should appear
+        await driver.wait(until.alertIsPresent(), 5000);
+        const alert = await driver.switchTo().alert();
+        const text = await alert.getText();
+        expect(text).toContain('v1');
+        await alert.accept();
+    });
+
+    test('v1 mode + v1 code does NOT show confirm dialog', async () => {
+        await loadUri(v1Uri);
+        await clickText('Ruby', '*[@role="tab"]');
+        await fillInRubyProgram(V1_CODE);
+
+        await clickText('Code', '*[@role="tab"]');
+
+        // No confirm dialog should appear; the code tab should become active
+        await driver.sleep(1000);
+        let alertPresent = false;
+        try {
+            await driver.switchTo().alert();
+            alertPresent = true;
+        } catch (_e) {
+            // Expected: no alert
+        }
+        expect(alertPresent).toBe(false);
+    });
+
+    test('v2 mode + v2 code does NOT show confirm dialog', async () => {
+        await loadUri(v2Uri);
+        await clickText('Ruby', '*[@role="tab"]');
+        await fillInRubyProgram(V2_CODE);
+
+        await clickText('Code', '*[@role="tab"]');
+
+        // No confirm dialog should appear
+        await driver.sleep(1000);
+        let alertPresent = false;
+        try {
+            await driver.switchTo().alert();
+            alertPresent = true;
+        } catch (_e) {
+            // Expected: no alert
+        }
+        expect(alertPresent).toBe(false);
+    });
+
+    test('after dismiss, confirm is NOT shown again', async () => {
+        await loadUri(v2Uri);
+        await clickText('Ruby', '*[@role="tab"]');
+        await fillInRubyProgram(V1_CODE);
+
+        // First: click Code tab to trigger confirm, then dismiss it
+        await clickText('Code', '*[@role="tab"]');
+        await driver.wait(until.alertIsPresent(), 5000);
+        const alert = await driver.switchTo().alert();
+        await alert.dismiss();
+
+        // Now enter v1 code again and switch to Code
+        await fillInRubyProgram(V1_CODE);
+        await clickText('Code', '*[@role="tab"]');
+
+        // No confirm should appear this time (dismissed flag is on)
+        await driver.sleep(1000);
+        let alertPresent = false;
+        try {
+            await driver.switchTo().alert();
+            alertPresent = true;
+        } catch (_e) {
+            // Expected: no alert
+        }
+        expect(alertPresent).toBe(false);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1-detection.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1-detection.test.js
@@ -1,0 +1,127 @@
+import {containsV1Code} from '../../../../src/lib/ruby-to-blocks-converter/v1-detection';
+
+describe('containsV1Code', () => {
+    describe('v1 patterns that should be detected', () => {
+        test('should detect self.when(:flag_clicked)', () => {
+            expect(containsV1Code('self.when(:flag_clicked) do\nend')).toBe(true);
+        });
+
+        test('should detect self.when(:clicked)', () => {
+            expect(containsV1Code('self.when(:clicked) do\nend')).toBe(true);
+        });
+
+        test('should detect self.when(:key_pressed, "space")', () => {
+            expect(containsV1Code('self.when(:key_pressed, "space") do\nend')).toBe(true);
+        });
+
+        test('should detect self.when(:start_as_a_clone)', () => {
+            expect(containsV1Code('self.when(:start_as_a_clone) do\nend')).toBe(true);
+        });
+
+        test('should detect self.when(:microbit_gesture, "jumped")', () => {
+            expect(containsV1Code('self.when(:microbit_gesture, "jumped") do\nend')).toBe(true);
+        });
+
+        test('should detect self.when( :flag_clicked) with space', () => {
+            expect(containsV1Code('self.when( :flag_clicked) do\nend')).toBe(true);
+        });
+
+        test('should detect bare play_drum()', () => {
+            expect(containsV1Code('play_drum(drum: 1, beats: 0.25)')).toBe(true);
+        });
+
+        test('should detect bare rest()', () => {
+            expect(containsV1Code('rest(0.25)')).toBe(true);
+        });
+
+        test('should detect self.instrument', () => {
+            expect(containsV1Code('self.instrument = 5')).toBe(true);
+        });
+
+        test('should detect pen_down', () => {
+            expect(containsV1Code('pen_down')).toBe(true);
+        });
+
+        test('should detect pen_clear', () => {
+            expect(containsV1Code('pen_clear')).toBe(true);
+        });
+
+        test('should detect self.color +=', () => {
+            expect(containsV1Code('self.color += 10')).toBe(true);
+        });
+
+        test('should detect self.color =', () => {
+            expect(containsV1Code('self.color = 0')).toBe(true);
+        });
+
+        test('should detect self.color -=', () => {
+            expect(containsV1Code('self.color -= 5')).toBe(true);
+        });
+    });
+
+    describe('v2 patterns that should NOT be detected', () => {
+        test('should not detect self.when_flag_clicked', () => {
+            expect(containsV1Code('self.when_flag_clicked do\nend')).toBe(false);
+        });
+
+        test('should not detect music.play_drum()', () => {
+            expect(containsV1Code('music.play_drum(drum: 1, beats: 0.25)')).toBe(false);
+        });
+
+        test('should not detect music.rest()', () => {
+            expect(containsV1Code('music.rest(0.25)')).toBe(false);
+        });
+
+        test('should not detect music.instrument', () => {
+            expect(containsV1Code('music.instrument = 5')).toBe(false);
+        });
+
+        test('should not detect pen.down', () => {
+            expect(containsV1Code('pen.down')).toBe(false);
+        });
+
+        test('should not detect pen.clear', () => {
+            expect(containsV1Code('pen.clear')).toBe(false);
+        });
+
+        test('should not detect pen.color +=', () => {
+            expect(containsV1Code('pen.color += 10')).toBe(false);
+        });
+    });
+
+    describe('normal Ruby code that should NOT be detected', () => {
+        test('should not detect simple assignment', () => {
+            expect(containsV1Code('x = 1')).toBe(false);
+        });
+
+        test('should not detect method definition', () => {
+            expect(containsV1Code('def foo\nend')).toBe(false);
+        });
+
+        test('should not detect puts', () => {
+            expect(containsV1Code('puts "hello"')).toBe(false);
+        });
+
+        test('should not detect v2 event handlers', () => {
+            expect(containsV1Code('self.when_clicked do\nend')).toBe(false);
+        });
+    });
+
+    describe('edge cases', () => {
+        test('should return false for empty string', () => {
+            expect(containsV1Code('')).toBe(false);
+        });
+
+        test('should return false for null', () => {
+            expect(containsV1Code(null)).toBe(false);
+        });
+
+        test('should return false for undefined', () => {
+            expect(containsV1Code(undefined)).toBe(false);
+        });
+
+        test('should return false for non-string', () => {
+            expect(containsV1Code(42)).toBe(false);
+        });
+    });
+});

--- a/packages/scratch-gui/test/unit/reducers/settings.test.js
+++ b/packages/scratch-gui/test/unit/reducers/settings.test.js
@@ -1,0 +1,29 @@
+import reducer, {
+    settingsInitialState,
+    dismissV1Prompt
+} from '../../../src/reducers/settings';
+
+describe('settings reducer', () => {
+    describe('v1PromptDismissed', () => {
+        test('should have v1PromptDismissed as false in initial state', () => {
+            expect(settingsInitialState.v1PromptDismissed).toBe(false);
+        });
+
+        test('should set v1PromptDismissed to true on DISMISS_V1_PROMPT', () => {
+            const state = reducer(settingsInitialState, dismissV1Prompt());
+            expect(state.v1PromptDismissed).toBe(true);
+        });
+
+        test('should not affect other state properties', () => {
+            const state = reducer(settingsInitialState, dismissV1Prompt());
+            expect(state.colorMode).toBe(settingsInitialState.colorMode);
+            expect(state.theme).toBe(settingsInitialState.theme);
+            expect(state.rubyVersion).toBe(settingsInitialState.rubyVersion);
+        });
+
+        test('should handle unknown action', () => {
+            const state = reducer(settingsInitialState, {type: 'UNKNOWN'});
+            expect(state.v1PromptDismissed).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

v2モードで書籍（教科書）のv1コードを入力した際に、ブロック変換前にconfirmダイアログでv1への切り替えを提案する機能を追加します。

Closes #367

## Implementation Steps

- [x] **Phase 1: v1パターン検出関数** — `containsV1Code()` + 29 unit tests
- [x] **Phase 2: Reduxステート追加** — `v1PromptDismissed` フラグ + 4 unit tests
- [x] **Phase 3: ruby-tab.jsx にconfirmロジック統合**
- [x] **Phase 4: Integration Tests** — 4 tests

## Changes Made

- `packages/scratch-gui/src/lib/ruby-to-blocks-converter/v1-detection.js` — v1パターン検出関数（新規）
- `packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/v1-detection.test.js` — ユニットテスト（新規）
- `packages/scratch-gui/src/reducers/settings.js` — `DISMISS_V1_PROMPT` アクション追加
- `packages/scratch-gui/test/unit/reducers/settings.test.js` — reducerテスト（新規）
- `packages/scratch-gui/src/containers/ruby-tab.jsx` — confirm表示ロジック追加
- `packages/scratch-gui/test/integration/v1-detection-prompt.test.js` — Integration test（新規）

## Test plan

- [x] v1パターン検出のユニットテスト（29テスト）
- [x] settings reducerのユニットテスト（4テスト）
- [x] Integration test（v2モードでv1コード → confirm表示 等 4テスト）
- [x] lint pass（変更ファイルのみ）
- [ ] CI green
