### PR TITLE
feat: update mesh-v2 examples for polling protocol and new API

### DIFF
--- a/infra/smalruby-mesh-v2/.gitignore
+++ b/infra/smalruby-mesh-v2/.gitignore
@@ -1,6 +1,7 @@
 *.js
 !jest.config.js
 !js/**/*.js
+!examples/**/*.js
 *.d.ts
 node_modules
 

--- a/infra/smalruby-mesh-v2/examples/javascript-client/README.md
+++ b/infra/smalruby-mesh-v2/examples/javascript-client/README.md
@@ -9,10 +9,11 @@ This prototype serves as a reference implementation for integrating Mesh v2 func
 - Domain-based group management (up to 256 characters)
 - Mandatory domain for all operations
 - Domain generation from source IP via `createDomain` mutation
+- **Dual protocol support**: WebSocket (real-time) and Polling (HTTPS-only fallback)
 - Real-time sensor data transmission with rate limiting
 - Event system with pub/sub capabilities
-- 10-minute session management
-- Pure JavaScript implementation (no TypeScript, no build tools)
+- Session management (up to 35 minutes, configurable per environment)
+- JavaScript with esbuild bundling (AWS Amplify for WebSocket subscriptions)
 
 **Related Issues:**
 - [smalruby/smalruby3-gui#453](https://github.com/smalruby/smalruby3-gui/issues/453) - Phase 3: Mesh v2 Frontend Extension
@@ -84,9 +85,14 @@ http://localhost:3000?mesh=custom-domain
 2. (Optional) Set custom domain
 3. Click "Connect to Mesh v2"
 4. Enter group name
-5. Click "Create Group"
+5. Select protocol: **WebSocket** (real-time) or **Polling** (HTTPS only)
+6. Click "Create Group"
 
 You automatically become the **host** of the created group.
+
+**Protocol Selection:**
+- **WebSocket (default)**: Uses AppSync Subscriptions for real-time event delivery. Requires `wss://` protocol support.
+- **Polling**: Uses `recordEventsByNode` + `getEventsSince` for HTTPS-only event delivery. Works behind strict firewalls that block WebSocket. Events are polled at the server-configured interval (stg: 1s, prod: 2s).
 
 #### List Groups
 - Click "Refresh Group List" to see all groups in your domain
@@ -101,7 +107,7 @@ You automatically become the **host** of the created group.
 - Click "Dissolve Group" to exit and dissolve the group (host only)
 - Only the group host can dissolve groups
 - Dissolving removes all members and deletes the group
-- **Group Dissolution Detection**: When a host dissolves a group, all member nodes automatically detect the dissolution via WebSocket subscription and are disconnected from the group
+- **Group Dissolution Detection**: When a host dissolves a group, all member nodes automatically detect the dissolution via WebSocket subscription (or polling) and are disconnected from the group
 
 ### 3. Sensor Data
 

--- a/infra/smalruby-mesh-v2/examples/javascript-client/app.js
+++ b/infra/smalruby-mesh-v2/examples/javascript-client/app.js
@@ -433,8 +433,8 @@ function displayGroupList(groups) {
          data-use-websocket="${group.useWebSocket}"
          data-polling-interval="${group.pollingIntervalSeconds || ''}">
       <strong>${group.name}</strong>
-      <span class="status ${group.useWebSocket ? 'connected' : 'member'}" style="float: right; font-size: 11px;">
-        ${group.useWebSocket ? 'WS' : 'Poll'}
+      <span class="status ${group.useWebSocket !== false ? 'connected' : 'member'}" style="float: right; font-size: 11px;">
+        ${group.useWebSocket !== false ? 'WS' : 'Poll'}
       </span><br>
       <small>ID: ${group.id} | Host: ${group.hostId}</small>
       ${group.expiresAt ? `<br><small style="color: #666;">Expires: ${new Date(group.expiresAt).toLocaleTimeString()}</small>` : ''}

--- a/infra/smalruby-mesh-v2/examples/javascript-client/app.js
+++ b/infra/smalruby-mesh-v2/examples/javascript-client/app.js
@@ -1,6 +1,7 @@
 /**
  * Mesh v2 Client Application Logic
  * Handles UI interactions and state management
+ * Supports both WebSocket and Polling protocols
  */
 
 import { MeshClient, RateLimiter, ChangeDetector } from './mesh-client.bundle.js';
@@ -15,8 +16,13 @@ const state = {
   sessionStartTime: null,
   sessionTimerId: null,
   heartbeatTimerId: null,
-  heartbeatIntervalSeconds: 60, // Default 60 seconds
+  heartbeatIntervalSeconds: 15, // Default fallback (stg value)
   messageSubscriptionId: null,
+  // Polling protocol state
+  pollingTimerId: null,
+  pollingIntervalSeconds: 2, // Default fallback
+  pollingSince: null, // Cursor for getEventsSince
+  sensorPollingTimerId: null, // Polling timer for sensor data updates
   sensorData: {
     temperature: 20,
     brightness: 50,
@@ -125,43 +131,29 @@ function setupEventListeners() {
  * Setup sensor input listeners
  */
 function setupSensorListeners() {
-  // Temperature
-  const tempSlider = document.getElementById('temperature');
-  const tempValue = document.getElementById('tempValue');
-  tempSlider.addEventListener('input', (e) => {
-    tempValue.textContent = e.target.value;
-    state.sensorData.temperature = parseInt(e.target.value);
-    handleSensorChange('temperature', state.sensorData.temperature);
-  });
+  const sensors = [
+    { id: 'temperature', valueId: 'tempValue', key: 'temperature' },
+    { id: 'brightness', valueId: 'brightnessValue', key: 'brightness' },
+    { id: 'distance', valueId: 'distanceValue', key: 'distance' }
+  ];
 
-  // Brightness
-  const brightnessSlider = document.getElementById('brightness');
-  const brightnessValue = document.getElementById('brightnessValue');
-  brightnessSlider.addEventListener('input', (e) => {
-    brightnessValue.textContent = e.target.value;
-    state.sensorData.brightness = parseInt(e.target.value);
-    handleSensorChange('brightness', state.sensorData.brightness);
-  });
-
-  // Distance
-  const distanceSlider = document.getElementById('distance');
-  const distanceValue = document.getElementById('distanceValue');
-  distanceSlider.addEventListener('input', (e) => {
-    distanceValue.textContent = e.target.value;
-    state.sensorData.distance = parseInt(e.target.value);
-    handleSensorChange('distance', state.sensorData.distance);
+  sensors.forEach(({ id, valueId, key }) => {
+    const slider = document.getElementById(id);
+    const display = document.getElementById(valueId);
+    slider.addEventListener('input', (e) => {
+      display.textContent = e.target.value;
+      state.sensorData[key] = parseInt(e.target.value);
+      handleSensorChange(key, state.sensorData[key]);
+    });
   });
 }
 
 /**
  * Check if the error indicates the group/node is no longer valid
- * @param {Error} error - The error to check
- * @returns {boolean} true if should disconnect
  */
 function shouldDisconnectOnError(error) {
   if (!error) return false;
 
-  // Check GraphQL errorType if available
   if (error.graphQLErrors && error.graphQLErrors.length > 0) {
     const errorType = error.graphQLErrors[0].errorType;
     if (['GroupNotFound', 'Unauthorized', 'NodeNotFound'].includes(errorType)) {
@@ -169,15 +161,21 @@ function shouldDisconnectOnError(error) {
     }
   }
 
-  // Fallback: check message string
   if (error.message) {
     const message = error.message.toLowerCase();
-    return message.includes('not found') || 
-           message.includes('expired') || 
+    return message.includes('not found') ||
+           message.includes('expired') ||
            message.includes('unauthorized');
   }
 
   return false;
+}
+
+/**
+ * Whether the current group uses WebSocket protocol
+ */
+function isWebSocketMode() {
+  return state.currentGroup && state.currentGroup.useWebSocket !== false;
 }
 
 /**
@@ -194,17 +192,14 @@ async function handleConnect() {
   }
 
   try {
-    // Save configuration
     saveConfiguration(endpoint, apiKey);
 
-    // Create client
     state.client = new MeshClient({
       endpoint,
       apiKey,
       domain: domain || null
     });
 
-    // Generate node ID
     state.currentNodeId = 'node-' + Math.random().toString(36).substr(2, 9);
 
     let actualDomain = domain;
@@ -214,20 +209,16 @@ async function handleConnect() {
       document.getElementById('domain').value = actualDomain;
     }
 
-    // Mark as connected
     state.connected = true;
     state.sessionStartTime = Date.now();
 
-    // Start session timer
     startSessionTimer();
 
-    // Update UI
     updateUI();
     document.getElementById('currentDomain').textContent = actualDomain;
     document.getElementById('currentNodeId').textContent = state.currentNodeId;
 
     showSuccess('configError', 'Connected to Mesh v2!');
-
     console.log('Connected:', { endpoint, domain: actualDomain, nodeId: state.currentNodeId });
   } catch (error) {
     showError('configError', 'Connection failed: ' + error.message);
@@ -241,6 +232,7 @@ async function handleConnect() {
 async function handleCreateGroup() {
   const groupName = document.getElementById('groupName').value.trim();
   const domain = document.getElementById('domain').value.trim();
+  const useWebSocket = document.getElementById('protocolWebSocket').checked;
 
   if (!groupName) {
     showError('groupError', 'Please enter a group name');
@@ -251,19 +243,21 @@ async function handleCreateGroup() {
     const group = await state.client.createGroup(
       groupName,
       state.currentNodeId,
-      domain || null
+      domain || null,
+      useWebSocket
     );
 
     console.log('Group created:', group);
 
-    // Join the created group automatically
     state.currentGroup = group;
     if (group.heartbeatIntervalSeconds) {
       state.heartbeatIntervalSeconds = group.heartbeatIntervalSeconds;
     }
+    if (group.pollingIntervalSeconds) {
+      state.pollingIntervalSeconds = group.pollingIntervalSeconds;
+    }
 
     // Initialize sensor data for this node
-    // This immediately shares current sensor state with other group members
     const initialData = [
       { key: 'temperature', value: state.sensorData.temperature.toString() },
       { key: 'brightness', value: state.sensorData.brightness.toString() },
@@ -277,29 +271,129 @@ async function handleCreateGroup() {
       initialData
     );
 
-    // Subscribe to all group messages via unified subscription
-    state.messageSubscriptionId = state.client.subscribeToMessageInGroup(
-      state.currentGroup.id,
-      state.currentGroup.domain,
-      {
-        onDataUpdate: displayOtherNodesData,
-        onBatchEvent: handleBatchEventReceived,
-        onGroupDissolve: handleGroupDissolved
-      }
-    );
+    // Start communication based on protocol
+    if (isWebSocketMode()) {
+      startWebSocketMode();
+    } else {
+      startPollingMode();
+    }
 
-    // Start heartbeat for host
     startHeartbeat();
 
-    showSuccess('groupSuccess', `Group created: ${group.fullId}`);
+    showSuccess('groupSuccess', `Group created: ${group.fullId} (${isWebSocketMode() ? 'WebSocket' : 'Polling'})`);
     updateCurrentGroupUI();
 
-    // Refresh group list
     await handleListGroups();
   } catch (error) {
     showError('groupError', 'Failed to create group: ' + error.message);
     console.error('Create group error:', error);
   }
+}
+
+/**
+ * Start WebSocket mode (subscription-based)
+ */
+function startWebSocketMode() {
+  state.messageSubscriptionId = state.client.subscribeToMessageInGroup(
+    state.currentGroup.id,
+    state.currentGroup.domain,
+    {
+      onDataUpdate: displayOtherNodesData,
+      onBatchEvent: handleBatchEventReceived,
+      onGroupDissolve: handleGroupDissolved
+    }
+  );
+  console.log('WebSocket mode started');
+}
+
+/**
+ * Start Polling mode (getEventsSince + listGroupStatuses polling)
+ */
+function startPollingMode() {
+  state.pollingSince = new Date().toISOString();
+
+  const intervalMs = state.pollingIntervalSeconds * 1000;
+
+  // Poll for events
+  state.pollingTimerId = setInterval(async () => {
+    if (!state.currentGroup || !state.connected) {
+      stopPolling();
+      return;
+    }
+
+    try {
+      const events = await state.client.getEventsSince(
+        state.currentGroup.id,
+        state.currentGroup.domain,
+        state.pollingSince
+      );
+
+      if (events && events.length > 0) {
+        const lastEvent = events[events.length - 1];
+        if (lastEvent.cursor) {
+          state.pollingSince = lastEvent.cursor;
+        }
+
+        events.forEach(event => addEventToHistory(event));
+
+        const nodeIds = [...new Set(events.map(e => e.firedByNodeId))];
+        showSuccess('eventSuccess', `Polled ${events.length} events from ${nodeIds.join(', ')}`);
+      }
+
+      document.getElementById('lastPollTime').textContent = new Date().toLocaleTimeString();
+    } catch (error) {
+      console.error('Polling error:', error);
+      if (shouldDisconnectOnError(error)) {
+        handleGroupDissolved({ message: 'Connection lost (polling)' });
+      }
+    }
+  }, intervalMs);
+
+  // Also poll for sensor data updates
+  state.sensorPollingTimerId = setInterval(async () => {
+    if (!state.currentGroup || !state.connected) return;
+
+    try {
+      const statuses = await state.client.listGroupStatuses(
+        state.currentGroup.id,
+        state.currentGroup.domain
+      );
+      displayOtherNodesData(statuses);
+    } catch (error) {
+      console.error('Sensor polling error:', error);
+      if (shouldDisconnectOnError(error)) {
+        handleGroupDissolved({ message: 'Connection lost (polling)' });
+      }
+    }
+  }, intervalMs);
+
+  console.log(`Polling mode started (interval: ${state.pollingIntervalSeconds}s)`);
+}
+
+/**
+ * Stop polling timers
+ */
+function stopPolling() {
+  if (state.pollingTimerId) {
+    clearInterval(state.pollingTimerId);
+    state.pollingTimerId = null;
+  }
+  if (state.sensorPollingTimerId) {
+    clearInterval(state.sensorPollingTimerId);
+    state.sensorPollingTimerId = null;
+  }
+  state.pollingSince = null;
+}
+
+/**
+ * Stop all communication (subscription + polling)
+ */
+function stopCommunication() {
+  if (state.messageSubscriptionId) {
+    state.client.unsubscribe(state.messageSubscriptionId);
+    state.messageSubscriptionId = null;
+  }
+  stopPolling();
 }
 
 /**
@@ -310,9 +404,7 @@ async function handleListGroups() {
 
   try {
     const groups = await state.client.listGroupsByDomain(domain || null);
-
     console.log('Groups:', groups);
-
     displayGroupList(groups);
   } catch (error) {
     showError('groupError', 'Failed to list groups: ' + error.message);
@@ -337,22 +429,29 @@ function displayGroupList(groups) {
          data-group-name="${group.name}"
          data-group-domain="${group.domain}"
          data-host-id="${group.hostId}"
-         data-expires-at="${group.expiresAt || ''}">
-      <strong>${group.name}</strong><br>
+         data-expires-at="${group.expiresAt || ''}"
+         data-use-websocket="${group.useWebSocket}"
+         data-polling-interval="${group.pollingIntervalSeconds || ''}">
+      <strong>${group.name}</strong>
+      <span class="status ${group.useWebSocket ? 'connected' : 'member'}" style="float: right; font-size: 11px;">
+        ${group.useWebSocket ? 'WS' : 'Poll'}
+      </span><br>
       <small>ID: ${group.id} | Host: ${group.hostId}</small>
       ${group.expiresAt ? `<br><small style="color: #666;">Expires: ${new Date(group.expiresAt).toLocaleTimeString()}</small>` : ''}
     </div>
   `).join('');
 
-  // Add click listeners to all group items
   groupList.querySelectorAll('.group-item').forEach(item => {
     item.addEventListener('click', () => {
-      const groupId = item.dataset.groupId;
-      const groupName = item.dataset.groupName;
-      const domain = item.dataset.groupDomain;
-      const hostId = item.dataset.hostId;
-      const expiresAt = item.dataset.expiresAt;
-      selectGroup(groupId, groupName, domain, hostId, expiresAt);
+      selectGroup(
+        item.dataset.groupId,
+        item.dataset.groupName,
+        item.dataset.groupDomain,
+        item.dataset.hostId,
+        item.dataset.expiresAt,
+        item.dataset.useWebsocket === 'true',
+        parseInt(item.dataset.pollingInterval) || null
+      );
     });
   });
 }
@@ -360,22 +459,15 @@ function displayGroupList(groups) {
 /**
  * Select a group from the list
  */
-function selectGroup(groupId, groupName, domain, hostId, expiresAt) {
+function selectGroup(groupId, groupName, domain, hostId, expiresAt, useWebSocket, pollingIntervalSeconds) {
   state.selectedGroupId = groupId;
-  state.selectedGroup = { id: groupId, name: groupName, domain, hostId, expiresAt };
+  state.selectedGroup = { id: groupId, name: groupName, domain, hostId, expiresAt, useWebSocket, pollingIntervalSeconds };
 
-  // Update UI - remove selected from all, add to clicked item
   document.querySelectorAll('.group-item').forEach(item => {
-    if (item.dataset.groupId === groupId) {
-      item.classList.add('selected');
-    } else {
-      item.classList.remove('selected');
-    }
+    item.classList.toggle('selected', item.dataset.groupId === groupId);
   });
 
   console.log('Selected group:', state.selectedGroup);
-
-  // Update button states
   updateUI();
 }
 
@@ -397,22 +489,25 @@ async function handleJoinGroup() {
 
     console.log('Joined group:', result);
 
-    // Use selected group info and join result (expiresAt) to set current group
     state.currentGroup = {
       id: state.selectedGroup.id,
       name: state.selectedGroup.name,
       domain: state.selectedGroup.domain,
       hostId: state.selectedGroup.hostId,
       fullId: `${state.selectedGroup.id}@${state.selectedGroup.domain}`,
-      expiresAt: result.expiresAt
+      expiresAt: result.expiresAt,
+      useWebSocket: result.useWebSocket !== undefined ? result.useWebSocket : state.selectedGroup.useWebSocket,
+      pollingIntervalSeconds: result.pollingIntervalSeconds || state.selectedGroup.pollingIntervalSeconds
     };
 
     if (result.heartbeatIntervalSeconds) {
       state.heartbeatIntervalSeconds = result.heartbeatIntervalSeconds;
     }
+    if (state.currentGroup.pollingIntervalSeconds) {
+      state.pollingIntervalSeconds = state.currentGroup.pollingIntervalSeconds;
+    }
 
-    // Initialize sensor data for this node
-    // This immediately shares current sensor state with other group members
+    // Initialize sensor data
     const initialData = [
       { key: 'temperature', value: state.sensorData.temperature.toString() },
       { key: 'brightness', value: state.sensorData.brightness.toString() },
@@ -426,22 +521,16 @@ async function handleJoinGroup() {
       initialData
     );
 
-    // Subscribe to all group messages via unified subscription
-    state.messageSubscriptionId = state.client.subscribeToMessageInGroup(
-      state.currentGroup.id,
-      state.currentGroup.domain,
-      {
-        onDataUpdate: displayOtherNodesData,
-        onBatchEvent: handleBatchEventReceived,
-        onGroupDissolve: handleGroupDissolved
-      }
-    );
+    if (isWebSocketMode()) {
+      startWebSocketMode();
+    } else {
+      startPollingMode();
+    }
 
-    // Stop heartbeat if it was running (e.g. from a previously created group)
     stopHeartbeat();
     startHeartbeat();
 
-    showSuccess('groupSuccess', `Joined group: ${state.selectedGroup.name}`);
+    showSuccess('groupSuccess', `Joined group: ${state.selectedGroup.name} (${isWebSocketMode() ? 'WebSocket' : 'Polling'})`);
     updateCurrentGroupUI();
   } catch (error) {
     showError('groupError', 'Failed to join group: ' + error.message);
@@ -459,32 +548,21 @@ async function handleLeaveGroup() {
   }
 
   try {
-    const result = await state.client.leaveGroup(
+    await state.client.leaveGroup(
       state.currentGroup.id,
       state.currentNodeId,
       state.currentGroup.domain
     );
 
-    console.log('Left group:', result);
-
-    // Unsubscribe from all group messages
-    if (state.messageSubscriptionId) {
-      state.client.unsubscribe(state.messageSubscriptionId);
-      state.messageSubscriptionId = null;
-    }
-
+    stopCommunication();
     stopHeartbeat();
 
     state.currentGroup = null;
     state.selectedGroupId = null;
-
-    // Clear other nodes display
     displayOtherNodesData(null);
 
     showSuccess('groupSuccess', 'Left group successfully');
     updateCurrentGroupUI();
-
-    // Refresh group list
     await handleListGroups();
   } catch (error) {
     showError('groupError', 'Failed to leave group: ' + error.message);
@@ -501,7 +579,6 @@ async function handleDissolveGroup() {
     return;
   }
 
-  // Check if current node is host
   const isHost = state.currentGroup.hostId === state.currentNodeId;
   if (!isHost) {
     showError('groupError', 'Only the host can dissolve the group');
@@ -519,26 +596,15 @@ async function handleDissolveGroup() {
       state.currentGroup.domain
     );
 
-    console.log('Group dissolved');
-
-    // Unsubscribe from all group messages
-    if (state.messageSubscriptionId) {
-      state.client.unsubscribe(state.messageSubscriptionId);
-      state.messageSubscriptionId = null;
-    }
-
+    stopCommunication();
     stopHeartbeat();
 
     state.currentGroup = null;
     state.selectedGroupId = null;
-
-    // Clear other nodes display
     displayOtherNodesData(null);
 
     showSuccess('groupSuccess', 'Group dissolved successfully');
     updateCurrentGroupUI();
-
-    // Refresh group list
     await handleListGroups();
   } catch (error) {
     showError('groupError', 'Failed to dissolve group: ' + error.message);
@@ -548,77 +614,45 @@ async function handleDissolveGroup() {
 
 /**
  * Handle disconnect
- * Disconnects from the mesh network and cleans up subscriptions
  */
 async function handleDisconnect() {
-  if (!state.connected) {
-    return;
-  }
+  if (!state.connected) return;
 
-  if (!confirm('Are you sure you want to disconnect? You will leave the current group.')) {
-    return;
-  }
+  if (!confirm('Are you sure you want to disconnect? You will leave the current group.')) return;
 
   try {
-    // Check if current node is host
     const isHost = state.currentGroup && state.currentGroup.hostId === state.currentNodeId;
 
     if (isHost) {
-      // Host: dissolve the group
-      await state.client.dissolveGroup(
-        state.currentGroup.id,
-        state.currentNodeId,
-        state.currentGroup.domain
-      );
-      console.log('Group dissolved by disconnect');
+      await state.client.dissolveGroup(state.currentGroup.id, state.currentNodeId, state.currentGroup.domain);
     } else if (state.currentGroup) {
-      // Member: leave the group
-      await state.client.leaveGroup(
-        state.currentGroup.id,
-        state.currentNodeId,
-        state.currentGroup.domain
-      );
-      console.log('Left group by disconnect');
+      await state.client.leaveGroup(state.currentGroup.id, state.currentNodeId, state.currentGroup.domain);
     }
 
-    // Unsubscribe from all group messages
-    if (state.messageSubscriptionId) {
-      state.client.unsubscribe(state.messageSubscriptionId);
-      state.messageSubscriptionId = null;
-    }
-
-    // Stop session timer
+    stopCommunication();
     if (state.sessionTimerId) {
       clearInterval(state.sessionTimerId);
       state.sessionTimerId = null;
     }
-
     stopHeartbeat();
 
-    // Clear state
     state.currentGroup = null;
     state.selectedGroupId = null;
     state.connected = false;
     state.currentNodeId = null;
-    state.currentDomain = null;
     state.sessionStartTime = null;
 
-    // Reset session timer display
     const timerEl = document.getElementById('sessionTimer');
     timerEl.textContent = 'Session: --:--';
     timerEl.classList.remove('warning');
 
-    // Clear other nodes display
     displayOtherNodesData(null);
-
-    // Clear group list
     document.getElementById('groupList').innerHTML =
       '<p style="color: #999; text-align: center;">No groups available</p>';
 
     showSuccess('groupSuccess', 'Disconnected successfully');
     updateCurrentGroupUI();
     updateUI();
-
   } catch (error) {
     showError('groupError', 'Failed to disconnect: ' + error.message);
     console.error('Disconnect error:', error);
@@ -633,18 +667,24 @@ function updateCurrentGroupUI() {
 
   if (!state.currentGroup) {
     currentGroupInfo.innerHTML = '<p><strong>Status:</strong> Not in a group</p>';
+    document.getElementById('pollingStatus').style.display = 'none';
     updateUI();
     return;
   }
 
   const isHost = state.currentGroup.hostId === state.currentNodeId;
+  const protocol = isWebSocketMode() ? 'WebSocket' : 'Polling';
 
   currentGroupInfo.innerHTML = `
     <p><strong>Group:</strong> ${state.currentGroup.name}</p>
     <p><strong>Full ID:</strong> ${state.currentGroup.fullId || state.currentGroup.id}</p>
     <p><strong>Role:</strong> <span class="status ${isHost ? 'host' : 'member'}">${isHost ? 'Host' : 'Member'}</span></p>
+    <p><strong>Protocol:</strong> <span class="status ${isWebSocketMode() ? 'connected' : 'member'}">${protocol}</span></p>
+    ${!isWebSocketMode() ? `<p><strong>Polling Interval:</strong> ${state.pollingIntervalSeconds}s</p>` : ''}
     ${state.currentGroup.expiresAt ? `<p><strong>Expires At:</strong> ${new Date(state.currentGroup.expiresAt).toLocaleString()}</p>` : ''}
   `;
+
+  document.getElementById('pollingStatus').style.display = isWebSocketMode() ? 'none' : 'block';
 
   updateUI();
 }
@@ -653,41 +693,24 @@ function updateCurrentGroupUI() {
  * Handle sensor change
  */
 async function handleSensorChange(sensorName, value) {
-  if (!state.connected || !state.currentGroup) {
-    return;
-  }
-
-  // Check if value actually changed
-  if (!sensorChangeDetector.hasChanged(sensorName, value)) {
-    return;
-  }
-
-  // Check rate limit
+  if (!state.connected || !state.currentGroup) return;
+  if (!sensorChangeDetector.hasChanged(sensorName, value)) return;
   if (!sensorRateLimiter.canMakeCall()) {
     console.warn('Sensor data rate limit exceeded');
     return;
   }
 
   try {
-    // Send sensor data
-    const data = [
-      { key: sensorName, value: value.toString() }
-    ];
-
     await state.client.reportDataByNode(
       state.currentNodeId,
       state.currentGroup.id,
       state.currentGroup.domain,
-      data
+      [{ key: sensorName, value: value.toString() }]
     );
-
     console.log('Sensor data sent:', { sensorName, value });
-
-    // Update rate status
     updateRateStatus();
   } catch (error) {
     showError('sensorError', 'Failed to send sensor data: ' + error.message);
-    console.error('Sensor data error:', error);
     if (shouldDisconnectOnError(error)) {
       handleGroupDissolved({ message: 'Connection lost' });
     }
@@ -711,7 +734,6 @@ async function handleSendEvent() {
     return;
   }
 
-  // Check rate limit
   if (!eventRateLimiter.canMakeCall()) {
     showError('eventError', 'Event rate limit exceeded (2 per second)');
     return;
@@ -722,46 +744,38 @@ async function handleSendEvent() {
   ];
 
   try {
-    const result = await state.client.fireEventsByNode(
-      state.currentNodeId,
-      state.currentGroup.id,
-      state.currentGroup.domain,
-      events
-    );
+    if (isWebSocketMode()) {
+      await state.client.fireEventsByNode(
+        state.currentNodeId, state.currentGroup.id, state.currentGroup.domain, events
+      );
+    } else {
+      const result = await state.client.recordEventsByNode(
+        state.currentNodeId, state.currentGroup.id, state.currentGroup.domain, events
+      );
+      if (result.nextSince) {
+        state.pollingSince = result.nextSince;
+      }
+    }
 
-    console.log('Event sent:', result);
-    showSuccess('eventSuccess', `Sent event: ${name}`);
-    
-    // Clear inputs
+    showSuccess('eventSuccess', `Sent event: ${name} (${isWebSocketMode() ? 'WS' : 'Poll'})`);
     document.getElementById('eventName').value = '';
     document.getElementById('eventPayload').value = '';
   } catch (error) {
-    console.error('Failed to send event:', error);
     showError('eventError', `Failed to send event: ${error.message}`);
-    
     if (shouldDisconnectOnError(error)) {
       handleGroupDissolved({ message: 'Connection lost' });
     }
   }
 }
 
-/**
- * Add event to history
- */
 function addEventToHistory(event) {
   state.eventHistory.unshift(event);
-
-  // Keep only last 20 events
   if (state.eventHistory.length > 20) {
     state.eventHistory = state.eventHistory.slice(0, 20);
   }
-
   displayEventHistory();
 }
 
-/**
- * Display event history
- */
 function displayEventHistory() {
   const eventHistory = document.getElementById('eventHistory');
 
@@ -780,58 +794,32 @@ function displayEventHistory() {
   `).join('');
 }
 
-/**
- * Handle clear events
- */
 function handleClearEvents() {
   state.eventHistory = [];
   displayEventHistory();
 }
 
-/**
- * Handle batch event received from subscription
- */
 function handleBatchEventReceived(batchEvent) {
-  console.log('Batch event received from subscription:', batchEvent);
-
   if (!batchEvent || !batchEvent.events) return;
-
-  // Add each event to history
-  batchEvent.events.forEach(event => {
-    addEventToHistory(event);
-  });
-
+  batchEvent.events.forEach(event => addEventToHistory(event));
   showSuccess('eventSuccess', `Received batch of ${batchEvent.events.length} events from ${batchEvent.firedByNodeId}`);
 }
 
-/**
- * Handle group dissolution notification
- */
 function handleGroupDissolved(dissolveData) {
   console.log('Group has been dissolved:', dissolveData);
 
-  // Unsubscribe from all group messages
-  if (state.messageSubscriptionId) {
-    state.client.unsubscribe(state.messageSubscriptionId);
-    state.messageSubscriptionId = null;
-  }
-
+  stopCommunication();
   stopHeartbeat();
-  
-      // Clear group state
-      state.currentGroup = null;
-      state.selectedGroupId = null;
-    // Clear UI
+
+  state.currentGroup = null;
+  state.selectedGroupId = null;
+
   displayOtherNodesData(null);
   updateCurrentGroupUI();
 
-  // Show notification
   showError('groupError', `Group has been dissolved: ${dissolveData.message}`);
 }
 
-/**
- * Display other nodes' sensor data
- */
 function displayOtherNodesData(statuses) {
   const otherNodesData = document.getElementById('otherNodesData');
 
@@ -840,7 +828,6 @@ function displayOtherNodesData(statuses) {
     return;
   }
 
-  // Filter out current node
   const otherNodes = statuses.filter(status => status.nodeId !== state.currentNodeId);
 
   if (otherNodes.length === 0) {
@@ -861,22 +848,13 @@ function displayOtherNodesData(statuses) {
   `).join('');
 }
 
-/**
- * Update rate limit status displays
- */
 function updateRateStatus() {
   document.getElementById('sensorRateStatus').textContent =
     `${sensorRateLimiter.getCallCount()}/4 per second`;
 }
 
-/**
- * Start heartbeat timer
- * Renews the group heartbeat periodically using server-provided interval
- */
 function startHeartbeat() {
-  if (state.heartbeatTimerId) {
-    clearInterval(state.heartbeatTimerId);
-  }
+  if (state.heartbeatTimerId) clearInterval(state.heartbeatTimerId);
 
   console.log(`Starting heartbeat timer (${state.heartbeatIntervalSeconds}s)...`);
   document.getElementById('heartbeatStatus').style.display = 'block';
@@ -890,35 +868,20 @@ function startHeartbeat() {
     const isHost = state.currentGroup.hostId === state.currentNodeId;
 
     try {
-      let result;
-      if (isHost) {
-        result = await state.client.renewHeartbeat(
-          state.currentGroup.id,
-          state.currentNodeId,
-          state.currentGroup.domain
-        );
-        console.log('Host heartbeat renewed, expires at:', result.expiresAt);
-      } else {
-        result = await state.client.sendMemberHeartbeat(
-          state.currentGroup.id,
-          state.currentNodeId,
-          state.currentGroup.domain
-        );
-        console.log('Member heartbeat sent, expires at:', result.expiresAt);
-      }
+      const result = isHost
+        ? await state.client.renewHeartbeat(state.currentGroup.id, state.currentNodeId, state.currentGroup.domain)
+        : await state.client.sendMemberHeartbeat(state.currentGroup.id, state.currentNodeId, state.currentGroup.domain);
 
       document.getElementById('lastHeartbeatTime').textContent = new Date().toLocaleTimeString();
 
-      // Update session timer with new expiration if possible
       if (result.expiresAt) {
         state.currentGroup.expiresAt = result.expiresAt;
       }
 
-      // Check if interval has changed
       if (result.heartbeatIntervalSeconds && result.heartbeatIntervalSeconds !== state.heartbeatIntervalSeconds) {
         console.log(`Heartbeat interval changed: ${state.heartbeatIntervalSeconds}s -> ${result.heartbeatIntervalSeconds}s`);
         state.heartbeatIntervalSeconds = result.heartbeatIntervalSeconds;
-        startHeartbeat(); // Restart with new interval
+        startHeartbeat();
       }
     } catch (error) {
       console.error('Heartbeat failed:', error);
@@ -929,40 +892,25 @@ function startHeartbeat() {
   }, state.heartbeatIntervalSeconds * 1000);
 }
 
-/**
- * Stop heartbeat timer
- */
 function stopHeartbeat() {
   if (state.heartbeatTimerId) {
-    console.log('Stopping heartbeat timer');
     clearInterval(state.heartbeatTimerId);
     state.heartbeatTimerId = null;
     document.getElementById('heartbeatStatus').style.display = 'none';
   }
 }
 
-/**
- * Start session timer
- * If in a group, uses expiresAt from the group.
- * Otherwise uses a default 10 minute limit from connection.
- */
 function startSessionTimer() {
-  // Prevent multiple timers
-  if (state.sessionTimerId) {
-    clearInterval(state.sessionTimerId);
-  }
+  if (state.sessionTimerId) clearInterval(state.sessionTimerId);
 
   state.sessionTimerId = setInterval(() => {
     let remaining;
 
     if (state.currentGroup && state.currentGroup.expiresAt) {
-      // Use expiration from group (ISO string)
-      const expiresAt = new Date(state.currentGroup.expiresAt).getTime();
-      remaining = expiresAt - Date.now();
+      remaining = new Date(state.currentGroup.expiresAt).getTime() - Date.now();
     } else if (state.sessionStartTime) {
-      // Fallback to connection-based timer
-      const elapsed = Date.now() - state.sessionStartTime;
-      remaining = (10 * 60 * 1000) - elapsed;
+      // Fallback: 35 minutes (matches prod MESH_MAX_CONNECTION_TIME_SECONDS=2100)
+      remaining = (35 * 60 * 1000) - (Date.now() - state.sessionStartTime);
     } else {
       return;
     }
@@ -977,118 +925,67 @@ function startSessionTimer() {
 
     const timerEl = document.getElementById('sessionTimer');
     timerEl.textContent = `Session: ${minutes}:${seconds.toString().padStart(2, '0')}`;
-
-    // Warning at 5 minutes remaining
-    if (remaining <= 5 * 60 * 1000) {
-      timerEl.classList.add('warning');
-    } else {
-      timerEl.classList.remove('warning');
-    }
+    timerEl.classList.toggle('warning', remaining <= 5 * 60 * 1000);
   }, 1000);
 }
 
-/**
- * Handle session timeout
- */
 function handleSessionTimeout() {
   alert('Session timeout. Please reconnect.');
 
-  // Dissolve group if host, otherwise just clear state
   if (state.currentGroup) {
     const isHost = state.currentGroup.hostId === state.currentNodeId;
     if (isHost) {
-      // Try to dissolve group before timeout
       handleDissolveGroup().catch(console.error);
     } else {
-      // Member: just clear local state
       state.currentGroup = null;
     }
   }
 
-  // Stop heartbeat
   stopHeartbeat();
+  stopCommunication();
 
-  // Disconnect
-  if (state.client) {
-    state.client.disconnect();
-  }
+  if (state.client) state.client.disconnect();
 
   state.connected = false;
   state.sessionStartTime = null;
-
   updateUI();
 }
 
-/**
- * Update UI based on state
- */
 function updateUI() {
   const connected = state.connected;
-  const inGroup = state.connected && state.currentGroup;
+  const inGroup = connected && state.currentGroup;
 
-  // Connection status
   const statusEl = document.getElementById('connectionStatus');
-  if (connected) {
-    statusEl.textContent = 'Connected';
-    statusEl.className = 'status connected';
-  } else {
-    statusEl.textContent = 'Disconnected';
-    statusEl.className = 'status disconnected';
-  }
+  statusEl.textContent = connected ? 'Connected' : 'Disconnected';
+  statusEl.className = `status ${connected ? 'connected' : 'disconnected'}`;
 
-  // Show/hide disconnect button
-  const disconnectBtn = document.getElementById('disconnectBtn');
-  if (connected) {
-    disconnectBtn.style.display = 'block';
-  } else {
-    disconnectBtn.style.display = 'none';
-  }
+  document.getElementById('disconnectBtn').style.display = connected ? 'block' : 'none';
 
-  // Enable/disable buttons
   document.getElementById('createGroupBtn').disabled = !connected;
   document.getElementById('listGroupsBtn').disabled = !connected;
   document.getElementById('joinGroupBtn').disabled = !connected || !state.selectedGroupId;
 
-  // Dissolve button only enabled when user is host
-  const isHost = inGroup && state.currentGroup && state.currentGroup.hostId === state.currentNodeId;
+  const isHost = inGroup && state.currentGroup.hostId === state.currentNodeId;
   document.getElementById('dissolveGroupBtn').disabled = !isHost;
 
-  // Leave button shown when in group and not host
   const leaveBtn = document.getElementById('leaveGroupBtn');
-  if (inGroup && !isHost) {
-    leaveBtn.style.display = 'inline-block';
-  } else {
-    leaveBtn.style.display = 'none';
-  }
+  leaveBtn.style.display = (inGroup && !isHost) ? 'inline-block' : 'none';
 
   document.getElementById('sendEventBtn').disabled = !inGroup;
 
-  // Update rate status
   updateRateStatus();
 }
 
-/**
- * Show error message
- */
 function showError(elementId, message) {
   const el = document.getElementById(elementId);
   el.textContent = message;
   el.style.display = 'block';
-
-  setTimeout(() => {
-    el.style.display = 'none';
-  }, 5000);
+  setTimeout(() => { el.style.display = 'none'; }, 5000);
 }
 
-/**
- * Show success message
- */
 function showSuccess(elementId, message) {
   const el = document.getElementById(elementId);
   el.textContent = message;
   el.style.display = 'block';
-
-  setTimeout(() => {
-    el.style.display = 'none';
-  }, 3000);
+  setTimeout(() => { el.style.display = 'none'; }, 3000);
 }

--- a/infra/smalruby-mesh-v2/examples/javascript-client/app.js
+++ b/infra/smalruby-mesh-v2/examples/javascript-client/app.js
@@ -1,0 +1,1094 @@
+/**
+ * Mesh v2 Client Application Logic
+ * Handles UI interactions and state management
+ */
+
+import { MeshClient, RateLimiter, ChangeDetector } from './mesh-client.bundle.js';
+
+// Application state
+const state = {
+  client: null,
+  connected: false,
+  currentGroup: null,
+  currentNodeId: null,
+  selectedGroupId: null,
+  sessionStartTime: null,
+  sessionTimerId: null,
+  heartbeatTimerId: null,
+  heartbeatIntervalSeconds: 60, // Default 60 seconds
+  messageSubscriptionId: null,
+  sensorData: {
+    temperature: 20,
+    brightness: 50,
+    distance: 100
+  },
+  eventHistory: []
+};
+
+// Rate limiters (initialized after DOM loads)
+let sensorRateLimiter;
+let eventRateLimiter;
+
+// Change detector for sensors (initialized after DOM loads)
+let sensorChangeDetector;
+
+/**
+ * Initialize application on page load
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('Mesh v2 Client initializing...');
+
+  // Initialize rate limiters and change detector
+  sensorRateLimiter = new RateLimiter(4, 1000); // 4 calls per second
+  eventRateLimiter = new RateLimiter(2, 1000); // 2 calls per second
+  sensorChangeDetector = new ChangeDetector();
+
+  // Load saved configuration from localStorage
+  loadConfiguration();
+
+  // Parse domain from URL parameter
+  parseDomainFromURL();
+
+  // Setup event listeners
+  setupEventListeners();
+
+  // Setup sensor change listeners
+  setupSensorListeners();
+
+  // Update UI
+  updateUI();
+
+  // Start rate status update interval
+  setInterval(updateRateStatus, 1000);
+
+  console.log('Application ready!');
+});
+
+/**
+ * Load configuration from localStorage
+ */
+function loadConfiguration() {
+  const savedEndpoint = localStorage.getItem('mesh_endpoint');
+  const savedApiKey = localStorage.getItem('mesh_apikey');
+
+  if (savedEndpoint) {
+    document.getElementById('appsyncEndpoint').value = savedEndpoint;
+  }
+
+  if (savedApiKey) {
+    document.getElementById('apiKey').value = savedApiKey;
+  }
+}
+
+/**
+ * Save configuration to localStorage
+ */
+function saveConfiguration(endpoint, apiKey) {
+  localStorage.setItem('mesh_endpoint', endpoint);
+  localStorage.setItem('mesh_apikey', apiKey);
+}
+
+/**
+ * Parse domain from URL parameter ?mesh=domain
+ */
+function parseDomainFromURL() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const meshParam = urlParams.get('mesh');
+
+  if (meshParam) {
+    document.getElementById('domain').value = meshParam;
+    console.log('Domain from URL:', meshParam);
+  }
+}
+
+/**
+ * Setup all event listeners
+ */
+function setupEventListeners() {
+  // Connect button
+  document.getElementById('connectBtn').addEventListener('click', handleConnect);
+
+  // Group management
+  document.getElementById('createGroupBtn').addEventListener('click', handleCreateGroup);
+  document.getElementById('listGroupsBtn').addEventListener('click', handleListGroups);
+  document.getElementById('joinGroupBtn').addEventListener('click', handleJoinGroup);
+  document.getElementById('leaveGroupBtn').addEventListener('click', handleLeaveGroup);
+  document.getElementById('dissolveGroupBtn').addEventListener('click', handleDissolveGroup);
+  document.getElementById('disconnectBtn').addEventListener('click', handleDisconnect);
+
+  // Events
+  document.getElementById('sendEventBtn').addEventListener('click', handleSendEvent);
+  document.getElementById('clearEventsBtn').addEventListener('click', handleClearEvents);
+}
+
+/**
+ * Setup sensor input listeners
+ */
+function setupSensorListeners() {
+  // Temperature
+  const tempSlider = document.getElementById('temperature');
+  const tempValue = document.getElementById('tempValue');
+  tempSlider.addEventListener('input', (e) => {
+    tempValue.textContent = e.target.value;
+    state.sensorData.temperature = parseInt(e.target.value);
+    handleSensorChange('temperature', state.sensorData.temperature);
+  });
+
+  // Brightness
+  const brightnessSlider = document.getElementById('brightness');
+  const brightnessValue = document.getElementById('brightnessValue');
+  brightnessSlider.addEventListener('input', (e) => {
+    brightnessValue.textContent = e.target.value;
+    state.sensorData.brightness = parseInt(e.target.value);
+    handleSensorChange('brightness', state.sensorData.brightness);
+  });
+
+  // Distance
+  const distanceSlider = document.getElementById('distance');
+  const distanceValue = document.getElementById('distanceValue');
+  distanceSlider.addEventListener('input', (e) => {
+    distanceValue.textContent = e.target.value;
+    state.sensorData.distance = parseInt(e.target.value);
+    handleSensorChange('distance', state.sensorData.distance);
+  });
+}
+
+/**
+ * Check if the error indicates the group/node is no longer valid
+ * @param {Error} error - The error to check
+ * @returns {boolean} true if should disconnect
+ */
+function shouldDisconnectOnError(error) {
+  if (!error) return false;
+
+  // Check GraphQL errorType if available
+  if (error.graphQLErrors && error.graphQLErrors.length > 0) {
+    const errorType = error.graphQLErrors[0].errorType;
+    if (['GroupNotFound', 'Unauthorized', 'NodeNotFound'].includes(errorType)) {
+      return true;
+    }
+  }
+
+  // Fallback: check message string
+  if (error.message) {
+    const message = error.message.toLowerCase();
+    return message.includes('not found') || 
+           message.includes('expired') || 
+           message.includes('unauthorized');
+  }
+
+  return false;
+}
+
+/**
+ * Handle connection to Mesh v2
+ */
+async function handleConnect() {
+  const endpoint = document.getElementById('appsyncEndpoint').value.trim();
+  const apiKey = document.getElementById('apiKey').value.trim();
+  const domain = document.getElementById('domain').value.trim();
+
+  if (!endpoint || !apiKey) {
+    showError('configError', 'Please enter both AppSync endpoint and API key');
+    return;
+  }
+
+  try {
+    // Save configuration
+    saveConfiguration(endpoint, apiKey);
+
+    // Create client
+    state.client = new MeshClient({
+      endpoint,
+      apiKey,
+      domain: domain || null
+    });
+
+    // Generate node ID
+    state.currentNodeId = 'node-' + Math.random().toString(36).substr(2, 9);
+
+    let actualDomain = domain;
+    if (!actualDomain) {
+      console.log('No domain specified, calling createDomain...');
+      actualDomain = await state.client.createDomain();
+      document.getElementById('domain').value = actualDomain;
+    }
+
+    // Mark as connected
+    state.connected = true;
+    state.sessionStartTime = Date.now();
+
+    // Start session timer
+    startSessionTimer();
+
+    // Update UI
+    updateUI();
+    document.getElementById('currentDomain').textContent = actualDomain;
+    document.getElementById('currentNodeId').textContent = state.currentNodeId;
+
+    showSuccess('configError', 'Connected to Mesh v2!');
+
+    console.log('Connected:', { endpoint, domain: actualDomain, nodeId: state.currentNodeId });
+  } catch (error) {
+    showError('configError', 'Connection failed: ' + error.message);
+    console.error('Connection error:', error);
+  }
+}
+
+/**
+ * Handle create group
+ */
+async function handleCreateGroup() {
+  const groupName = document.getElementById('groupName').value.trim();
+  const domain = document.getElementById('domain').value.trim();
+
+  if (!groupName) {
+    showError('groupError', 'Please enter a group name');
+    return;
+  }
+
+  try {
+    const group = await state.client.createGroup(
+      groupName,
+      state.currentNodeId,
+      domain || null
+    );
+
+    console.log('Group created:', group);
+
+    // Join the created group automatically
+    state.currentGroup = group;
+    if (group.heartbeatIntervalSeconds) {
+      state.heartbeatIntervalSeconds = group.heartbeatIntervalSeconds;
+    }
+
+    // Initialize sensor data for this node
+    // This immediately shares current sensor state with other group members
+    const initialData = [
+      { key: 'temperature', value: state.sensorData.temperature.toString() },
+      { key: 'brightness', value: state.sensorData.brightness.toString() },
+      { key: 'distance', value: state.sensorData.distance.toString() }
+    ];
+
+    await state.client.reportDataByNode(
+      state.currentNodeId,
+      state.currentGroup.id,
+      state.currentGroup.domain,
+      initialData
+    );
+
+    // Subscribe to all group messages via unified subscription
+    state.messageSubscriptionId = state.client.subscribeToMessageInGroup(
+      state.currentGroup.id,
+      state.currentGroup.domain,
+      {
+        onDataUpdate: displayOtherNodesData,
+        onBatchEvent: handleBatchEventReceived,
+        onGroupDissolve: handleGroupDissolved
+      }
+    );
+
+    // Start heartbeat for host
+    startHeartbeat();
+
+    showSuccess('groupSuccess', `Group created: ${group.fullId}`);
+    updateCurrentGroupUI();
+
+    // Refresh group list
+    await handleListGroups();
+  } catch (error) {
+    showError('groupError', 'Failed to create group: ' + error.message);
+    console.error('Create group error:', error);
+  }
+}
+
+/**
+ * Handle list groups
+ */
+async function handleListGroups() {
+  const domain = document.getElementById('domain').value.trim();
+
+  try {
+    const groups = await state.client.listGroupsByDomain(domain || null);
+
+    console.log('Groups:', groups);
+
+    displayGroupList(groups);
+  } catch (error) {
+    showError('groupError', 'Failed to list groups: ' + error.message);
+    console.error('List groups error:', error);
+  }
+}
+
+/**
+ * Display group list in UI
+ */
+function displayGroupList(groups) {
+  const groupList = document.getElementById('groupList');
+
+  if (!groups || groups.length === 0) {
+    groupList.innerHTML = '<p style="color: #999; text-align: center;">No groups available</p>';
+    return;
+  }
+
+  groupList.innerHTML = groups.map(group => `
+    <div class="group-item ${state.selectedGroupId === group.id ? 'selected' : ''}"
+         data-group-id="${group.id}"
+         data-group-name="${group.name}"
+         data-group-domain="${group.domain}"
+         data-host-id="${group.hostId}"
+         data-expires-at="${group.expiresAt || ''}">
+      <strong>${group.name}</strong><br>
+      <small>ID: ${group.id} | Host: ${group.hostId}</small>
+      ${group.expiresAt ? `<br><small style="color: #666;">Expires: ${new Date(group.expiresAt).toLocaleTimeString()}</small>` : ''}
+    </div>
+  `).join('');
+
+  // Add click listeners to all group items
+  groupList.querySelectorAll('.group-item').forEach(item => {
+    item.addEventListener('click', () => {
+      const groupId = item.dataset.groupId;
+      const groupName = item.dataset.groupName;
+      const domain = item.dataset.groupDomain;
+      const hostId = item.dataset.hostId;
+      const expiresAt = item.dataset.expiresAt;
+      selectGroup(groupId, groupName, domain, hostId, expiresAt);
+    });
+  });
+}
+
+/**
+ * Select a group from the list
+ */
+function selectGroup(groupId, groupName, domain, hostId, expiresAt) {
+  state.selectedGroupId = groupId;
+  state.selectedGroup = { id: groupId, name: groupName, domain, hostId, expiresAt };
+
+  // Update UI - remove selected from all, add to clicked item
+  document.querySelectorAll('.group-item').forEach(item => {
+    if (item.dataset.groupId === groupId) {
+      item.classList.add('selected');
+    } else {
+      item.classList.remove('selected');
+    }
+  });
+
+  console.log('Selected group:', state.selectedGroup);
+
+  // Update button states
+  updateUI();
+}
+
+/**
+ * Handle join group
+ */
+async function handleJoinGroup() {
+  if (!state.selectedGroup) {
+    showError('groupError', 'Please select a group to join');
+    return;
+  }
+
+  try {
+    const result = await state.client.joinGroup(
+      state.selectedGroup.id,
+      state.currentNodeId,
+      state.selectedGroup.domain
+    );
+
+    console.log('Joined group:', result);
+
+    // Use selected group info and join result (expiresAt) to set current group
+    state.currentGroup = {
+      id: state.selectedGroup.id,
+      name: state.selectedGroup.name,
+      domain: state.selectedGroup.domain,
+      hostId: state.selectedGroup.hostId,
+      fullId: `${state.selectedGroup.id}@${state.selectedGroup.domain}`,
+      expiresAt: result.expiresAt
+    };
+
+    if (result.heartbeatIntervalSeconds) {
+      state.heartbeatIntervalSeconds = result.heartbeatIntervalSeconds;
+    }
+
+    // Initialize sensor data for this node
+    // This immediately shares current sensor state with other group members
+    const initialData = [
+      { key: 'temperature', value: state.sensorData.temperature.toString() },
+      { key: 'brightness', value: state.sensorData.brightness.toString() },
+      { key: 'distance', value: state.sensorData.distance.toString() }
+    ];
+
+    await state.client.reportDataByNode(
+      state.currentNodeId,
+      state.currentGroup.id,
+      state.currentGroup.domain,
+      initialData
+    );
+
+    // Subscribe to all group messages via unified subscription
+    state.messageSubscriptionId = state.client.subscribeToMessageInGroup(
+      state.currentGroup.id,
+      state.currentGroup.domain,
+      {
+        onDataUpdate: displayOtherNodesData,
+        onBatchEvent: handleBatchEventReceived,
+        onGroupDissolve: handleGroupDissolved
+      }
+    );
+
+    // Stop heartbeat if it was running (e.g. from a previously created group)
+    stopHeartbeat();
+    startHeartbeat();
+
+    showSuccess('groupSuccess', `Joined group: ${state.selectedGroup.name}`);
+    updateCurrentGroupUI();
+  } catch (error) {
+    showError('groupError', 'Failed to join group: ' + error.message);
+    console.error('Join group error:', error);
+  }
+}
+
+/**
+ * Handle leave group
+ */
+async function handleLeaveGroup() {
+  if (!state.currentGroup) {
+    showError('groupError', 'Not in a group');
+    return;
+  }
+
+  try {
+    const result = await state.client.leaveGroup(
+      state.currentGroup.id,
+      state.currentNodeId,
+      state.currentGroup.domain
+    );
+
+    console.log('Left group:', result);
+
+    // Unsubscribe from all group messages
+    if (state.messageSubscriptionId) {
+      state.client.unsubscribe(state.messageSubscriptionId);
+      state.messageSubscriptionId = null;
+    }
+
+    stopHeartbeat();
+
+    state.currentGroup = null;
+    state.selectedGroupId = null;
+
+    // Clear other nodes display
+    displayOtherNodesData(null);
+
+    showSuccess('groupSuccess', 'Left group successfully');
+    updateCurrentGroupUI();
+
+    // Refresh group list
+    await handleListGroups();
+  } catch (error) {
+    showError('groupError', 'Failed to leave group: ' + error.message);
+    console.error('Leave group error:', error);
+  }
+}
+
+/**
+ * Handle dissolve group (host only)
+ */
+async function handleDissolveGroup() {
+  if (!state.currentGroup) {
+    showError('groupError', 'Not in a group');
+    return;
+  }
+
+  // Check if current node is host
+  const isHost = state.currentGroup.hostId === state.currentNodeId;
+  if (!isHost) {
+    showError('groupError', 'Only the host can dissolve the group');
+    return;
+  }
+
+  if (!confirm('Are you sure you want to dissolve this group? All members will be removed.')) {
+    return;
+  }
+
+  try {
+    await state.client.dissolveGroup(
+      state.currentGroup.id,
+      state.currentNodeId,
+      state.currentGroup.domain
+    );
+
+    console.log('Group dissolved');
+
+    // Unsubscribe from all group messages
+    if (state.messageSubscriptionId) {
+      state.client.unsubscribe(state.messageSubscriptionId);
+      state.messageSubscriptionId = null;
+    }
+
+    stopHeartbeat();
+
+    state.currentGroup = null;
+    state.selectedGroupId = null;
+
+    // Clear other nodes display
+    displayOtherNodesData(null);
+
+    showSuccess('groupSuccess', 'Group dissolved successfully');
+    updateCurrentGroupUI();
+
+    // Refresh group list
+    await handleListGroups();
+  } catch (error) {
+    showError('groupError', 'Failed to dissolve group: ' + error.message);
+    console.error('Dissolve group error:', error);
+  }
+}
+
+/**
+ * Handle disconnect
+ * Disconnects from the mesh network and cleans up subscriptions
+ */
+async function handleDisconnect() {
+  if (!state.connected) {
+    return;
+  }
+
+  if (!confirm('Are you sure you want to disconnect? You will leave the current group.')) {
+    return;
+  }
+
+  try {
+    // Check if current node is host
+    const isHost = state.currentGroup && state.currentGroup.hostId === state.currentNodeId;
+
+    if (isHost) {
+      // Host: dissolve the group
+      await state.client.dissolveGroup(
+        state.currentGroup.id,
+        state.currentNodeId,
+        state.currentGroup.domain
+      );
+      console.log('Group dissolved by disconnect');
+    } else if (state.currentGroup) {
+      // Member: leave the group
+      await state.client.leaveGroup(
+        state.currentGroup.id,
+        state.currentNodeId,
+        state.currentGroup.domain
+      );
+      console.log('Left group by disconnect');
+    }
+
+    // Unsubscribe from all group messages
+    if (state.messageSubscriptionId) {
+      state.client.unsubscribe(state.messageSubscriptionId);
+      state.messageSubscriptionId = null;
+    }
+
+    // Stop session timer
+    if (state.sessionTimerId) {
+      clearInterval(state.sessionTimerId);
+      state.sessionTimerId = null;
+    }
+
+    stopHeartbeat();
+
+    // Clear state
+    state.currentGroup = null;
+    state.selectedGroupId = null;
+    state.connected = false;
+    state.currentNodeId = null;
+    state.currentDomain = null;
+    state.sessionStartTime = null;
+
+    // Reset session timer display
+    const timerEl = document.getElementById('sessionTimer');
+    timerEl.textContent = 'Session: --:--';
+    timerEl.classList.remove('warning');
+
+    // Clear other nodes display
+    displayOtherNodesData(null);
+
+    // Clear group list
+    document.getElementById('groupList').innerHTML =
+      '<p style="color: #999; text-align: center;">No groups available</p>';
+
+    showSuccess('groupSuccess', 'Disconnected successfully');
+    updateCurrentGroupUI();
+    updateUI();
+
+  } catch (error) {
+    showError('groupError', 'Failed to disconnect: ' + error.message);
+    console.error('Disconnect error:', error);
+  }
+}
+
+/**
+ * Update current group UI
+ */
+function updateCurrentGroupUI() {
+  const currentGroupInfo = document.getElementById('currentGroupInfo');
+
+  if (!state.currentGroup) {
+    currentGroupInfo.innerHTML = '<p><strong>Status:</strong> Not in a group</p>';
+    updateUI();
+    return;
+  }
+
+  const isHost = state.currentGroup.hostId === state.currentNodeId;
+
+  currentGroupInfo.innerHTML = `
+    <p><strong>Group:</strong> ${state.currentGroup.name}</p>
+    <p><strong>Full ID:</strong> ${state.currentGroup.fullId || state.currentGroup.id}</p>
+    <p><strong>Role:</strong> <span class="status ${isHost ? 'host' : 'member'}">${isHost ? 'Host' : 'Member'}</span></p>
+    ${state.currentGroup.expiresAt ? `<p><strong>Expires At:</strong> ${new Date(state.currentGroup.expiresAt).toLocaleString()}</p>` : ''}
+  `;
+
+  updateUI();
+}
+
+/**
+ * Handle sensor change
+ */
+async function handleSensorChange(sensorName, value) {
+  if (!state.connected || !state.currentGroup) {
+    return;
+  }
+
+  // Check if value actually changed
+  if (!sensorChangeDetector.hasChanged(sensorName, value)) {
+    return;
+  }
+
+  // Check rate limit
+  if (!sensorRateLimiter.canMakeCall()) {
+    console.warn('Sensor data rate limit exceeded');
+    return;
+  }
+
+  try {
+    // Send sensor data
+    const data = [
+      { key: sensorName, value: value.toString() }
+    ];
+
+    await state.client.reportDataByNode(
+      state.currentNodeId,
+      state.currentGroup.id,
+      state.currentGroup.domain,
+      data
+    );
+
+    console.log('Sensor data sent:', { sensorName, value });
+
+    // Update rate status
+    updateRateStatus();
+  } catch (error) {
+    showError('sensorError', 'Failed to send sensor data: ' + error.message);
+    console.error('Sensor data error:', error);
+    if (shouldDisconnectOnError(error)) {
+      handleGroupDissolved({ message: 'Connection lost' });
+    }
+  }
+}
+
+/**
+ * Handle send single event
+ */
+async function handleSendEvent() {
+  if (!state.currentGroup) {
+    showError('eventError', 'Not in a group');
+    return;
+  }
+
+  const name = document.getElementById('eventName').value.trim();
+  const payload = document.getElementById('eventPayload').value.trim();
+
+  if (!name) {
+    showError('eventError', 'Please enter an event name');
+    return;
+  }
+
+  // Check rate limit
+  if (!eventRateLimiter.canMakeCall()) {
+    showError('eventError', 'Event rate limit exceeded (2 per second)');
+    return;
+  }
+
+  const events = [
+    { eventName: name, payload: payload || null, firedAt: new Date().toISOString() }
+  ];
+
+  try {
+    const result = await state.client.fireEventsByNode(
+      state.currentNodeId,
+      state.currentGroup.id,
+      state.currentGroup.domain,
+      events
+    );
+
+    console.log('Event sent:', result);
+    showSuccess('eventSuccess', `Sent event: ${name}`);
+    
+    // Clear inputs
+    document.getElementById('eventName').value = '';
+    document.getElementById('eventPayload').value = '';
+  } catch (error) {
+    console.error('Failed to send event:', error);
+    showError('eventError', `Failed to send event: ${error.message}`);
+    
+    if (shouldDisconnectOnError(error)) {
+      handleGroupDissolved({ message: 'Connection lost' });
+    }
+  }
+}
+
+/**
+ * Add event to history
+ */
+function addEventToHistory(event) {
+  state.eventHistory.unshift(event);
+
+  // Keep only last 20 events
+  if (state.eventHistory.length > 20) {
+    state.eventHistory = state.eventHistory.slice(0, 20);
+  }
+
+  displayEventHistory();
+}
+
+/**
+ * Display event history
+ */
+function displayEventHistory() {
+  const eventHistory = document.getElementById('eventHistory');
+
+  if (state.eventHistory.length === 0) {
+    eventHistory.innerHTML = '<p style="color: #999; text-align: center;">No events yet</p>';
+    return;
+  }
+
+  eventHistory.innerHTML = state.eventHistory.map(event => `
+    <div class="event-item">
+      <div class="event-name">${event.name}</div>
+      <div>From: ${event.firedByNodeId}</div>
+      ${event.payload ? `<div>Payload: ${event.payload}</div>` : ''}
+      <div class="event-time">${new Date(event.timestamp).toLocaleTimeString()}</div>
+    </div>
+  `).join('');
+}
+
+/**
+ * Handle clear events
+ */
+function handleClearEvents() {
+  state.eventHistory = [];
+  displayEventHistory();
+}
+
+/**
+ * Handle batch event received from subscription
+ */
+function handleBatchEventReceived(batchEvent) {
+  console.log('Batch event received from subscription:', batchEvent);
+
+  if (!batchEvent || !batchEvent.events) return;
+
+  // Add each event to history
+  batchEvent.events.forEach(event => {
+    addEventToHistory(event);
+  });
+
+  showSuccess('eventSuccess', `Received batch of ${batchEvent.events.length} events from ${batchEvent.firedByNodeId}`);
+}
+
+/**
+ * Handle group dissolution notification
+ */
+function handleGroupDissolved(dissolveData) {
+  console.log('Group has been dissolved:', dissolveData);
+
+  // Unsubscribe from all group messages
+  if (state.messageSubscriptionId) {
+    state.client.unsubscribe(state.messageSubscriptionId);
+    state.messageSubscriptionId = null;
+  }
+
+  stopHeartbeat();
+  
+      // Clear group state
+      state.currentGroup = null;
+      state.selectedGroupId = null;
+    // Clear UI
+  displayOtherNodesData(null);
+  updateCurrentGroupUI();
+
+  // Show notification
+  showError('groupError', `Group has been dissolved: ${dissolveData.message}`);
+}
+
+/**
+ * Display other nodes' sensor data
+ */
+function displayOtherNodesData(statuses) {
+  const otherNodesData = document.getElementById('otherNodesData');
+
+  if (!statuses || statuses.length === 0) {
+    otherNodesData.innerHTML = '<p style="color: #999; text-align: center;">No other nodes in group</p>';
+    return;
+  }
+
+  // Filter out current node
+  const otherNodes = statuses.filter(status => status.nodeId !== state.currentNodeId);
+
+  if (otherNodes.length === 0) {
+    otherNodesData.innerHTML = '<p style="color: #999; text-align: center;">No other nodes in group</p>';
+    return;
+  }
+
+  otherNodesData.innerHTML = otherNodes.map(status => `
+    <div class="node-data">
+      <h4>Node: ${status.nodeId}</h4>
+      ${status.data && status.data.length > 0 ? status.data.map(item => `
+        <div><strong>${item.key}:</strong> ${item.value}</div>
+      `).join('') : '<div>No data</div>'}
+      <div style="color: #999; font-size: 11px; margin-top: 5px;">
+        Updated: ${new Date(status.timestamp).toLocaleTimeString()}
+      </div>
+    </div>
+  `).join('');
+}
+
+/**
+ * Update rate limit status displays
+ */
+function updateRateStatus() {
+  document.getElementById('sensorRateStatus').textContent =
+    `${sensorRateLimiter.getCallCount()}/4 per second`;
+}
+
+/**
+ * Start heartbeat timer
+ * Renews the group heartbeat periodically using server-provided interval
+ */
+function startHeartbeat() {
+  if (state.heartbeatTimerId) {
+    clearInterval(state.heartbeatTimerId);
+  }
+
+  console.log(`Starting heartbeat timer (${state.heartbeatIntervalSeconds}s)...`);
+  document.getElementById('heartbeatStatus').style.display = 'block';
+
+  state.heartbeatTimerId = setInterval(async () => {
+    if (!state.currentGroup || !state.connected) {
+      stopHeartbeat();
+      return;
+    }
+
+    const isHost = state.currentGroup.hostId === state.currentNodeId;
+
+    try {
+      let result;
+      if (isHost) {
+        result = await state.client.renewHeartbeat(
+          state.currentGroup.id,
+          state.currentNodeId,
+          state.currentGroup.domain
+        );
+        console.log('Host heartbeat renewed, expires at:', result.expiresAt);
+      } else {
+        result = await state.client.sendMemberHeartbeat(
+          state.currentGroup.id,
+          state.currentNodeId,
+          state.currentGroup.domain
+        );
+        console.log('Member heartbeat sent, expires at:', result.expiresAt);
+      }
+
+      document.getElementById('lastHeartbeatTime').textContent = new Date().toLocaleTimeString();
+
+      // Update session timer with new expiration if possible
+      if (result.expiresAt) {
+        state.currentGroup.expiresAt = result.expiresAt;
+      }
+
+      // Check if interval has changed
+      if (result.heartbeatIntervalSeconds && result.heartbeatIntervalSeconds !== state.heartbeatIntervalSeconds) {
+        console.log(`Heartbeat interval changed: ${state.heartbeatIntervalSeconds}s -> ${result.heartbeatIntervalSeconds}s`);
+        state.heartbeatIntervalSeconds = result.heartbeatIntervalSeconds;
+        startHeartbeat(); // Restart with new interval
+      }
+    } catch (error) {
+      console.error('Heartbeat failed:', error);
+      if (shouldDisconnectOnError(error)) {
+        handleGroupDissolved({ message: 'Session expired or group lost' });
+      }
+    }
+  }, state.heartbeatIntervalSeconds * 1000);
+}
+
+/**
+ * Stop heartbeat timer
+ */
+function stopHeartbeat() {
+  if (state.heartbeatTimerId) {
+    console.log('Stopping heartbeat timer');
+    clearInterval(state.heartbeatTimerId);
+    state.heartbeatTimerId = null;
+    document.getElementById('heartbeatStatus').style.display = 'none';
+  }
+}
+
+/**
+ * Start session timer
+ * If in a group, uses expiresAt from the group.
+ * Otherwise uses a default 10 minute limit from connection.
+ */
+function startSessionTimer() {
+  // Prevent multiple timers
+  if (state.sessionTimerId) {
+    clearInterval(state.sessionTimerId);
+  }
+
+  state.sessionTimerId = setInterval(() => {
+    let remaining;
+
+    if (state.currentGroup && state.currentGroup.expiresAt) {
+      // Use expiration from group (ISO string)
+      const expiresAt = new Date(state.currentGroup.expiresAt).getTime();
+      remaining = expiresAt - Date.now();
+    } else if (state.sessionStartTime) {
+      // Fallback to connection-based timer
+      const elapsed = Date.now() - state.sessionStartTime;
+      remaining = (10 * 60 * 1000) - elapsed;
+    } else {
+      return;
+    }
+
+    if (remaining <= 0) {
+      handleSessionTimeout();
+      return;
+    }
+
+    const minutes = Math.floor(remaining / 60000);
+    const seconds = Math.floor((remaining % 60000) / 1000);
+
+    const timerEl = document.getElementById('sessionTimer');
+    timerEl.textContent = `Session: ${minutes}:${seconds.toString().padStart(2, '0')}`;
+
+    // Warning at 5 minutes remaining
+    if (remaining <= 5 * 60 * 1000) {
+      timerEl.classList.add('warning');
+    } else {
+      timerEl.classList.remove('warning');
+    }
+  }, 1000);
+}
+
+/**
+ * Handle session timeout
+ */
+function handleSessionTimeout() {
+  alert('Session timeout. Please reconnect.');
+
+  // Dissolve group if host, otherwise just clear state
+  if (state.currentGroup) {
+    const isHost = state.currentGroup.hostId === state.currentNodeId;
+    if (isHost) {
+      // Try to dissolve group before timeout
+      handleDissolveGroup().catch(console.error);
+    } else {
+      // Member: just clear local state
+      state.currentGroup = null;
+    }
+  }
+
+  // Stop heartbeat
+  stopHeartbeat();
+
+  // Disconnect
+  if (state.client) {
+    state.client.disconnect();
+  }
+
+  state.connected = false;
+  state.sessionStartTime = null;
+
+  updateUI();
+}
+
+/**
+ * Update UI based on state
+ */
+function updateUI() {
+  const connected = state.connected;
+  const inGroup = state.connected && state.currentGroup;
+
+  // Connection status
+  const statusEl = document.getElementById('connectionStatus');
+  if (connected) {
+    statusEl.textContent = 'Connected';
+    statusEl.className = 'status connected';
+  } else {
+    statusEl.textContent = 'Disconnected';
+    statusEl.className = 'status disconnected';
+  }
+
+  // Show/hide disconnect button
+  const disconnectBtn = document.getElementById('disconnectBtn');
+  if (connected) {
+    disconnectBtn.style.display = 'block';
+  } else {
+    disconnectBtn.style.display = 'none';
+  }
+
+  // Enable/disable buttons
+  document.getElementById('createGroupBtn').disabled = !connected;
+  document.getElementById('listGroupsBtn').disabled = !connected;
+  document.getElementById('joinGroupBtn').disabled = !connected || !state.selectedGroupId;
+
+  // Dissolve button only enabled when user is host
+  const isHost = inGroup && state.currentGroup && state.currentGroup.hostId === state.currentNodeId;
+  document.getElementById('dissolveGroupBtn').disabled = !isHost;
+
+  // Leave button shown when in group and not host
+  const leaveBtn = document.getElementById('leaveGroupBtn');
+  if (inGroup && !isHost) {
+    leaveBtn.style.display = 'inline-block';
+  } else {
+    leaveBtn.style.display = 'none';
+  }
+
+  document.getElementById('sendEventBtn').disabled = !inGroup;
+
+  // Update rate status
+  updateRateStatus();
+}
+
+/**
+ * Show error message
+ */
+function showError(elementId, message) {
+  const el = document.getElementById(elementId);
+  el.textContent = message;
+  el.style.display = 'block';
+
+  setTimeout(() => {
+    el.style.display = 'none';
+  }, 5000);
+}
+
+/**
+ * Show success message
+ */
+function showSuccess(elementId, message) {
+  const el = document.getElementById(elementId);
+  el.textContent = message;
+  el.style.display = 'block';
+
+  setTimeout(() => {
+    el.style.display = 'none';
+  }, 3000);
+}

--- a/infra/smalruby-mesh-v2/examples/javascript-client/index.html
+++ b/infra/smalruby-mesh-v2/examples/javascript-client/index.html
@@ -325,6 +325,20 @@
           <label for="groupName">Group Name</label>
           <input type="text" id="groupName" placeholder="Enter group name">
         </div>
+        <div class="form-group">
+          <label>Protocol</label>
+          <div style="display: flex; gap: 15px; margin-top: 5px;">
+            <label style="display: flex; align-items: center; gap: 5px; cursor: pointer;">
+              <input type="radio" name="protocol" id="protocolWebSocket" value="websocket" checked>
+              WebSocket (real-time)
+            </label>
+            <label style="display: flex; align-items: center; gap: 5px; cursor: pointer;">
+              <input type="radio" name="protocol" id="protocolPolling" value="polling">
+              Polling (HTTPS only)
+            </label>
+          </div>
+          <small style="color: #999;">Polling works behind strict firewalls that block WebSocket.</small>
+        </div>
         <button id="createGroupBtn" disabled>Create Group</button>
         <button id="listGroupsBtn" class="secondary" disabled>Refresh Group List</button>
 
@@ -345,6 +359,9 @@
         </div>
         <div id="heartbeatStatus" style="display: none; margin-top: 10px; font-size: 12px; color: #666;">
           <p><strong>Last Heartbeat:</strong> <span id="lastHeartbeatTime">-</span></p>
+        </div>
+        <div id="pollingStatus" style="display: none; margin-top: 10px; font-size: 12px; color: #666;">
+          <p><strong>Last Poll:</strong> <span id="lastPollTime">-</span></p>
         </div>
       </div>
 

--- a/infra/smalruby-mesh-v2/examples/javascript-client/mesh-client.js
+++ b/infra/smalruby-mesh-v2/examples/javascript-client/mesh-client.js
@@ -162,8 +162,6 @@ class MeshClient {
           hostId
           expiresAt
           heartbeatIntervalSeconds
-          useWebSocket
-          pollingIntervalSeconds
         }
       }
     `;
@@ -238,8 +236,6 @@ class MeshClient {
           domain
           expiresAt
           heartbeatIntervalSeconds
-          useWebSocket
-          pollingIntervalSeconds
         }
       }
     `;

--- a/infra/smalruby-mesh-v2/examples/javascript-client/mesh-client.js
+++ b/infra/smalruby-mesh-v2/examples/javascript-client/mesh-client.js
@@ -1,0 +1,708 @@
+/**
+ * Mesh v2 Client Library
+ * JavaScript GraphQL client for AWS AppSync with WebSocket subscriptions
+ * and polling protocol support
+ */
+
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/api';
+
+class MeshClient {
+  constructor(config) {
+    this.endpoint = config.endpoint;
+    this.apiKey = config.apiKey;
+    this.domain = config.domain || null;
+    this.connected = false;
+    this.subscriptions = new Map();
+    this.eventHandlers = new Map();
+
+    // Configure Amplify for AppSync
+    Amplify.configure({
+      API: {
+        GraphQL: {
+          endpoint: this.endpoint,
+          region: this.extractRegion(this.endpoint),
+          defaultAuthMode: 'apiKey',
+          apiKey: this.apiKey
+        }
+      }
+    });
+
+    // Create GraphQL client for subscriptions
+    this.graphqlClient = generateClient();
+  }
+
+  /**
+   * Extract AWS region from AppSync endpoint URL
+   */
+  extractRegion(endpoint) {
+    const match = endpoint.match(/https:\/\/\w+\.appsync-api\.([^.]+)\.amazonaws\.com/);
+    return match ? match[1] : 'ap-northeast-1';
+  }
+
+  /**
+   * Execute GraphQL query or mutation
+   */
+  async execute(query, variables = {}) {
+    try {
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiKey
+        },
+        body: JSON.stringify({ query, variables })
+      });
+
+      const result = await response.json();
+
+      if (result.errors) {
+        const error = new Error(result.errors[0].message);
+        error.graphQLErrors = result.errors;
+        throw error;
+      }
+
+      return result.data;
+    } catch (error) {
+      console.error('GraphQL execution error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Create a domain from source IP
+   */
+  async createDomain() {
+    const query = `
+      mutation CreateDomain {
+        createDomain
+      }
+    `;
+
+    const data = await this.execute(query);
+    this.domain = data.createDomain;
+    return data.createDomain;
+  }
+
+  /**
+   * Create a new group
+   * @param {string} name - Group name
+   * @param {string} hostId - Host node ID
+   * @param {string} domain - Domain
+   * @param {boolean} useWebSocket - Whether to use WebSocket protocol
+   * @param {number|null} maxConnectionTimeSeconds - Optional max connection time
+   */
+  async createGroup(name, hostId, domain, useWebSocket = true, maxConnectionTimeSeconds = null) {
+    const query = `
+      mutation CreateGroup($name: String!, $hostId: ID!, $domain: String!, $useWebSocket: Boolean!, $maxConnectionTimeSeconds: Int) {
+        createGroup(name: $name, hostId: $hostId, domain: $domain, useWebSocket: $useWebSocket, maxConnectionTimeSeconds: $maxConnectionTimeSeconds) {
+          id
+          domain
+          fullId
+          name
+          hostId
+          expiresAt
+          heartbeatIntervalSeconds
+          useWebSocket
+          pollingIntervalSeconds
+        }
+      }
+    `;
+
+    const variables = {
+      name,
+      hostId,
+      domain: domain || this.domain,
+      useWebSocket
+    };
+
+    if (maxConnectionTimeSeconds !== null) {
+      variables.maxConnectionTimeSeconds = maxConnectionTimeSeconds;
+    }
+
+    const data = await this.execute(query, variables);
+    return data.createGroup;
+  }
+
+  /**
+   * Renew heartbeat (host only)
+   */
+  async renewHeartbeat(groupId, hostId, domain) {
+    const query = `
+      mutation RenewHeartbeat($groupId: ID!, $hostId: ID!, $domain: String!) {
+        renewHeartbeat(groupId: $groupId, hostId: $hostId, domain: $domain) {
+          groupId
+          domain
+          expiresAt
+          heartbeatIntervalSeconds
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      groupId,
+      hostId,
+      domain: domain || this.domain
+    });
+
+    return data.renewHeartbeat;
+  }
+
+  /**
+   * List groups by domain
+   */
+  async listGroupsByDomain(domain) {
+    const query = `
+      query ListGroupsByDomain($domain: String!) {
+        listGroupsByDomain(domain: $domain) {
+          id
+          domain
+          fullId
+          name
+          hostId
+          expiresAt
+          heartbeatIntervalSeconds
+          useWebSocket
+          pollingIntervalSeconds
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      domain: domain || this.domain
+    });
+
+    return data.listGroupsByDomain;
+  }
+
+  /**
+   * List all node statuses in a group
+   */
+  async listGroupStatuses(groupId, domain) {
+    const query = `
+      query ListGroupStatuses($groupId: ID!, $domain: String!) {
+        listGroupStatuses(groupId: $groupId, domain: $domain) {
+          nodeId
+          groupId
+          domain
+          data {
+            key
+            value
+          }
+          timestamp
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      groupId,
+      domain: domain || this.domain
+    });
+
+    return data.listGroupStatuses;
+  }
+
+  /**
+   * Get node status by nodeId
+   */
+  async getNodeStatus(nodeId) {
+    const query = `
+      query GetNodeStatus($nodeId: ID!) {
+        getNodeStatus(nodeId: $nodeId) {
+          nodeId
+          groupId
+          domain
+          data {
+            key
+            value
+          }
+          timestamp
+        }
+      }
+    `;
+
+    const data = await this.execute(query, { nodeId });
+    return data.getNodeStatus;
+  }
+
+  /**
+   * List all nodes in a group
+   */
+  async listNodesInGroup(groupId, domain) {
+    const query = `
+      query ListNodesInGroup($groupId: ID!, $domain: String!) {
+        listNodesInGroup(groupId: $groupId, domain: $domain) {
+          id
+          name
+          groupId
+          domain
+          expiresAt
+          heartbeatIntervalSeconds
+          useWebSocket
+          pollingIntervalSeconds
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      groupId,
+      domain: domain || this.domain
+    });
+
+    return data.listNodesInGroup;
+  }
+
+  /**
+   * Search groups by name prefix (cross-domain)
+   * @param {string} namePrefix - hostId prefix (hex lowercase)
+   * @param {number|null} limit - Max results
+   */
+  async searchGroupsByNamePrefix(namePrefix, limit = null) {
+    const query = `
+      query SearchGroupsByNamePrefix($namePrefix: String!, $limit: Int) {
+        searchGroupsByNamePrefix(namePrefix: $namePrefix, limit: $limit) {
+          id
+          domain
+          fullId
+          name
+          hostId
+          expiresAt
+          useWebSocket
+          pollingIntervalSeconds
+        }
+      }
+    `;
+
+    const variables = { namePrefix };
+    if (limit !== null) {
+      variables.limit = limit;
+    }
+
+    const data = await this.execute(query, variables);
+    return data.searchGroupsByNamePrefix;
+  }
+
+  /**
+   * Get events since a cursor (for polling protocol)
+   * @param {string} groupId - Group ID
+   * @param {string} domain - Domain
+   * @param {string} since - Previous nextSince or event cursor
+   */
+  async getEventsSince(groupId, domain, since) {
+    const query = `
+      query GetEventsSince($groupId: ID!, $domain: String!, $since: String!) {
+        getEventsSince(groupId: $groupId, domain: $domain, since: $since) {
+          name
+          firedByNodeId
+          groupId
+          domain
+          payload
+          timestamp
+          cursor
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      groupId,
+      domain: domain || this.domain,
+      since
+    });
+
+    return data.getEventsSince;
+  }
+
+  /**
+   * Join a group
+   */
+  async joinGroup(groupId, nodeId, domain) {
+    const query = `
+      mutation JoinGroup($groupId: ID!, $nodeId: ID!, $domain: String!) {
+        joinGroup(groupId: $groupId, nodeId: $nodeId, domain: $domain) {
+          id
+          name
+          groupId
+          domain
+          expiresAt
+          heartbeatIntervalSeconds
+          useWebSocket
+          pollingIntervalSeconds
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      groupId,
+      nodeId,
+      domain: domain || this.domain
+    });
+
+    return data.joinGroup;
+  }
+
+  /**
+   * Send member heartbeat
+   */
+  async sendMemberHeartbeat(groupId, nodeId, domain) {
+    const query = `
+      mutation SendMemberHeartbeat($groupId: ID!, $nodeId: ID!, $domain: String!) {
+        sendMemberHeartbeat(groupId: $groupId, nodeId: $nodeId, domain: $domain) {
+          nodeId
+          groupId
+          domain
+          expiresAt
+          heartbeatIntervalSeconds
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      groupId,
+      nodeId,
+      domain: domain || this.domain
+    });
+
+    return data.sendMemberHeartbeat;
+  }
+
+  /**
+   * Leave a group
+   */
+  async leaveGroup(groupId, nodeId, domain) {
+    const query = `
+      mutation LeaveGroup($groupId: ID!, $nodeId: ID!, $domain: String!) {
+        leaveGroup(groupId: $groupId, nodeId: $nodeId, domain: $domain) {
+          peerId
+          groupId
+          domain
+          message
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      groupId,
+      nodeId,
+      domain: domain || this.domain
+    });
+
+    return data.leaveGroup;
+  }
+
+  /**
+   * Dissolve a group (host only)
+   */
+  async dissolveGroup(groupId, hostId, domain) {
+    const query = `
+      mutation DissolveGroup($groupId: ID!, $hostId: ID!, $domain: String!) {
+        dissolveGroup(groupId: $groupId, hostId: $hostId, domain: $domain) {
+          groupId
+          domain
+          groupDissolve {
+            groupId
+            domain
+            message
+          }
+        }
+      }
+    `;
+
+    const data = await this.execute(query, {
+      groupId,
+      hostId,
+      domain: domain || this.domain
+    });
+
+    return data.dissolveGroup;
+  }
+
+  /**
+   * Report sensor data
+   */
+  async reportDataByNode(nodeId, groupId, domain, data) {
+    const query = `
+      mutation ReportDataByNode($nodeId: ID!, $groupId: ID!, $domain: String!, $data: [SensorDataInput!]!) {
+        reportDataByNode(nodeId: $nodeId, groupId: $groupId, domain: $domain, data: $data) {
+          groupId
+          domain
+          nodeStatus {
+            nodeId
+            groupId
+            domain
+            data {
+              key
+              value
+            }
+            timestamp
+          }
+        }
+      }
+    `;
+
+    const result = await this.execute(query, {
+      nodeId,
+      groupId,
+      domain: domain || this.domain,
+      data
+    });
+
+    return result.reportDataByNode;
+  }
+
+  /**
+   * Fire multiple events in a batch (WebSocket protocol - triggers subscription)
+   */
+  async fireEventsByNode(nodeId, groupId, domain, events) {
+    const query = `
+      mutation FireEventsByNode($nodeId: ID!, $groupId: ID!, $domain: String!, $events: [EventInput!]!) {
+        fireEventsByNode(nodeId: $nodeId, groupId: $groupId, domain: $domain, events: $events) {
+          groupId
+          domain
+          batchEvent {
+            events {
+              name
+              firedByNodeId
+              groupId
+              domain
+              payload
+              timestamp
+            }
+            firedByNodeId
+            groupId
+            domain
+            timestamp
+          }
+        }
+      }
+    `;
+
+    const result = await this.execute(query, {
+      nodeId,
+      groupId,
+      domain: domain || this.domain,
+      events
+    });
+
+    return result.fireEventsByNode;
+  }
+
+  /**
+   * Record events for polling protocol (does NOT trigger subscription)
+   * @param {string} nodeId - Node ID
+   * @param {string} groupId - Group ID
+   * @param {string} domain - Domain
+   * @param {Array} events - Array of EventInput
+   * @returns {object} RecordEventsPayload with groupId, domain, recordedCount, nextSince
+   */
+  async recordEventsByNode(nodeId, groupId, domain, events) {
+    const query = `
+      mutation RecordEventsByNode($nodeId: ID!, $groupId: ID!, $domain: String!, $events: [EventInput!]!) {
+        recordEventsByNode(nodeId: $nodeId, groupId: $groupId, domain: $domain, events: $events) {
+          groupId
+          domain
+          recordedCount
+          nextSince
+        }
+      }
+    `;
+
+    const result = await this.execute(query, {
+      nodeId,
+      groupId,
+      domain: domain || this.domain,
+      events
+    });
+
+    return result.recordEventsByNode;
+  }
+
+  /**
+   * Subscribe to all group messages via unified subscription
+   * @param {string} groupId - Group ID
+   * @param {string} domain - Domain
+   * @param {object} callbacks - Callback functions for each message type
+   * @param {Function} callbacks.onDataUpdate - Called when nodeStatus is received
+   * @param {Function} callbacks.onBatchEvent - Called when batchEvent is received
+   * @param {Function} callbacks.onGroupDissolve - Called when groupDissolve is received
+   * @returns {string} Subscription ID
+   */
+  subscribeToMessageInGroup(groupId, domain, callbacks) {
+    console.log('Subscription: onMessageInGroup', { groupId, domain });
+
+    const subscriptionId = `message-${groupId}`;
+
+    // GraphQL subscription query - unified
+    const subscription = `
+      subscription OnMessageInGroup($groupId: ID!, $domain: String!) {
+        onMessageInGroup(groupId: $groupId, domain: $domain) {
+          groupId
+          domain
+          nodeStatus {
+            nodeId
+            groupId
+            domain
+            data {
+              key
+              value
+            }
+            timestamp
+          }
+          batchEvent {
+            events {
+              name
+              firedByNodeId
+              groupId
+              domain
+              payload
+              timestamp
+            }
+            firedByNodeId
+            groupId
+            domain
+            timestamp
+          }
+          groupDissolve {
+            groupId
+            domain
+            message
+          }
+        }
+      }
+    `;
+
+    // Subscribe using Amplify
+    const sub = this.graphqlClient.graphql({
+      query: subscription,
+      variables: { groupId, domain: domain || this.domain }
+    }).subscribe({
+      next: ({ data }) => {
+        console.log('Unified subscription data received:', data);
+
+        if (!data || !data.onMessageInGroup) return;
+
+        const message = data.onMessageInGroup;
+
+        // Route to appropriate callback based on which field is non-null
+        if (message.nodeStatus && callbacks.onDataUpdate) {
+          console.log('Received message type: nodeStatus');
+          // When nodeStatus is received, fetch all group statuses
+          this.listGroupStatuses(groupId, domain || this.domain)
+            .then(statuses => callbacks.onDataUpdate(statuses))
+            .catch(error => console.error('Error fetching group statuses:', error));
+        } else if (message.batchEvent && callbacks.onBatchEvent) {
+          console.log('Received message type: batchEvent');
+          callbacks.onBatchEvent(message.batchEvent);
+        } else if (message.groupDissolve && callbacks.onGroupDissolve) {
+          console.log('Received message type: groupDissolve');
+          callbacks.onGroupDissolve(message.groupDissolve);
+        }
+      },
+      error: (error) => {
+        console.error('Unified subscription error:', error);
+        if (error.errors && error.errors.length > 0) {
+          console.error('GraphQL errors:', error.errors);
+          error.errors.forEach(err => {
+            console.error('- Error:', err.message);
+            if (err.path) console.error('  Path:', err.path);
+            if (err.locations) console.error('  Locations:', err.locations);
+          });
+        }
+      }
+    });
+
+    this.subscriptions.set(subscriptionId, sub);
+
+    return subscriptionId;
+  }
+
+  /**
+   * Unsubscribe from a subscription
+   */
+  unsubscribe(subscriptionId) {
+    if (this.subscriptions.has(subscriptionId)) {
+      const subscription = this.subscriptions.get(subscriptionId);
+      // Amplify subscriptions have an unsubscribe method
+      if (subscription && typeof subscription.unsubscribe === 'function') {
+        subscription.unsubscribe();
+      }
+      this.subscriptions.delete(subscriptionId);
+    }
+    this.eventHandlers.delete(subscriptionId);
+  }
+
+  /**
+   * Disconnect and cleanup
+   */
+  disconnect() {
+    // Clear all subscriptions
+    for (const [id, subscription] of this.subscriptions.entries()) {
+      if (subscription && typeof subscription.unsubscribe === 'function') {
+        subscription.unsubscribe();
+      }
+    }
+    this.subscriptions.clear();
+    this.eventHandlers.clear();
+    this.connected = false;
+  }
+}
+
+/**
+ * Rate limiter utility
+ */
+class RateLimiter {
+  constructor(maxCalls, timeWindow) {
+    this.maxCalls = maxCalls;
+    this.timeWindow = timeWindow; // in milliseconds
+    this.calls = [];
+  }
+
+  canMakeCall() {
+    const now = Date.now();
+    // Remove old calls outside the time window
+    this.calls = this.calls.filter(time => now - time < this.timeWindow);
+
+    if (this.calls.length < this.maxCalls) {
+      this.calls.push(now);
+      return true;
+    }
+
+    return false;
+  }
+
+  getCallCount() {
+    const now = Date.now();
+    this.calls = this.calls.filter(time => now - time < this.timeWindow);
+    return this.calls.length;
+  }
+
+  reset() {
+    this.calls = [];
+  }
+}
+
+/**
+ * Change detector for sensor data
+ */
+class ChangeDetector {
+  constructor() {
+    this.previousValues = new Map();
+  }
+
+  hasChanged(key, value) {
+    const previous = this.previousValues.get(key);
+    const changed = previous !== value;
+
+    if (changed) {
+      this.previousValues.set(key, value);
+    }
+
+    return changed;
+  }
+
+  reset() {
+    this.previousValues.clear();
+  }
+}
+
+// Export classes for use in app.js
+export { MeshClient, RateLimiter, ChangeDetector };

--- a/infra/smalruby-mesh-v2/examples/javascript-client/server.js
+++ b/infra/smalruby-mesh-v2/examples/javascript-client/server.js
@@ -1,0 +1,52 @@
+/**
+ * Simple Express server for Mesh v2 JavaScript client prototype
+ * Serves static files for the prototype web application
+ */
+
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static files from current directory
+app.use(express.static(__dirname));
+
+// Default route serves index.html
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', message: 'Mesh v2 client server running' });
+});
+
+// Start server
+app.listen(PORT, () => {
+  console.log(`
+╔════════════════════════════════════════════════════════════╗
+║  Mesh v2 JavaScript Client Prototype                      ║
+╚════════════════════════════════════════════════════════════╝
+
+Server running at: http://localhost:${PORT}
+
+Usage:
+  - Open http://localhost:${PORT} in your browser
+  - Use ?mesh=domain parameter for custom domain
+  - Example: http://localhost:${PORT}?mesh=test-domain
+
+Press Ctrl+C to stop the server
+  `);
+});
+
+// Graceful shutdown
+process.on('SIGTERM', () => {
+  console.log('SIGTERM received, shutting down gracefully...');
+  process.exit(0);
+});
+
+process.on('SIGINT', () => {
+  console.log('\nSIGINT received, shutting down gracefully...');
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

- Update mesh-client.js for new API (`useWebSocket`, `maxConnectionTimeSeconds`, polling mutations/queries)
- Add full polling protocol support (UI + logic) alongside existing WebSocket mode
- Track example source files in git (previously untracked due to `*.js` gitignore)
- Update README for dual protocol documentation

## Changes

### mesh-client.js
- `createGroup`: add `useWebSocket: Boolean!` (required) and `maxConnectionTimeSeconds: Int` params
- Remove `createdAt` from all queries (not in schema)
- Add `useWebSocket`, `pollingIntervalSeconds` to Group/Node response fields
- New: `searchGroupsByNamePrefix`, `getEventsSince`, `recordEventsByNode`

### app.js
- Protocol-aware event sending: `fireEventsByNode` (WS) vs `recordEventsByNode` (Polling)
- Polling loop: `getEventsSince` + `listGroupStatuses` at server-configured interval
- Default heartbeat fallback: 60s -> 15s (stg value)
- Session timer fallback: 10min -> 35min (prod maxConnectionTime=2100)

### index.html
- Protocol selection radio buttons (WebSocket / Polling) in Group Management
- Polling status display (last poll time) in Current Group panel

### .gitignore
- Add `!examples/**/*.js` to track example source files

## Implementation Steps

- [x] Phase 1: mesh-client.js API update
- [x] Phase 2: app.js polling support + defaults update
- [x] Phase 3: index.html UI update
- [x] Phase 4: bundle rebuild + README update

## Definition of Done

- [ ] CI green
- [ ] `createGroup` に `useWebSocket: true` を渡してグループ作成が成功すること
- [ ] ポーリングモード（`useWebSocket: false`）でイベント送受信ができること
- [ ] WebSocket モードで従来通り動作すること
- [ ] bundle が正常にビルドされること（`npm run build` in examples dir）

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
