### PR TITLE
fix: stub window.confirm in ruby-module tests to prevent CI failure

### DIFF
--- a/packages/scratch-gui/test/integration/ruby-module.test.js
+++ b/packages/scratch-gui/test/integration/ruby-module.test.js
@@ -21,6 +21,14 @@ const uri = `${path.resolve(__dirname, '../../build/index.html')}?ruby_version=2
 
 let driver;
 
+/**
+ * Stub window.confirm to return false, preventing the v1 detection
+ * prompt from blocking Selenium. The test code uses v1 syntax
+ * (self.when(:flag_clicked)) which triggers a native confirm dialog
+ * in v2 mode; declining it allows conversion to proceed in v2 mode.
+ */
+const stubConfirmToDecline = () => driver.executeScript('window.confirm = () => false;');
+
 describe('Ruby module/include round-trip', () => {
     beforeAll(() => {
         driver = getDriver();
@@ -32,6 +40,7 @@ describe('Ruby module/include round-trip', () => {
 
     test('module with single method', async () => {
         await loadUri(uri);
+        await stubConfirmToDecline();
         await expectInterconvertBetweenCodeAndRuby(
             'module Utils\n' +
             '  def add(a, b)\n' +
@@ -65,6 +74,7 @@ describe('Ruby module/include round-trip', () => {
 
     test('module with multiple methods', async () => {
         await loadUri(uri);
+        await stubConfirmToDecline();
         await expectInterconvertBetweenCodeAndRuby(
             'module Utils\n' +
             '  def add(a, b)\n' +
@@ -105,6 +115,7 @@ describe('Ruby module/include round-trip', () => {
 
     test('multiple modules with include', async () => {
         await loadUri(uri);
+        await stubConfirmToDecline();
         await expectInterconvertBetweenCodeAndRuby(
             'module Utils\n' +
             '  def add(a, b)\n' +
@@ -151,6 +162,7 @@ describe('Ruby module/include round-trip', () => {
 
     test('module method with no arguments', async () => {
         await loadUri(uri);
+        await stubConfirmToDecline();
         await expectInterconvertBetweenCodeAndRuby(
             'module Utils\n' +
             '  def greet\n' +
@@ -166,6 +178,7 @@ describe('Ruby module/include round-trip', () => {
 
     test('module sync: adding sprite with same module gets synced definition', async () => {
         await loadUri(uri);
+        await stubConfirmToDecline();
 
         // Set module code on Sprite1 and convert
         await clickText('Ruby', '*[@role="tab"]');


### PR DESCRIPTION
## Summary

`ruby-module.test.js` の全 5 テストが CI 環境でのみ `UnexpectedAlertOpenError` で失敗する問題を修正。

## 原因

テストコードが v1 構文（`self.when(:flag_clicked)`）を `?ruby_version=2` で使用している。CI 環境では localStorage が空のため `v1PromptDismissed` が常に `false` となり、`window.confirm()` によるネイティブダイアログが表示される。Selenium がこの予期しないアラートを処理できず全テストが失敗していた。

ローカルでは過去の実行で localStorage に値が残っているため再現しなかった。

## 変更内容

- `ruby-module.test.js` に `stubConfirmToDecline()` ヘルパーを追加
- 各テストの `loadUri(uri)` 直後に `window.confirm` を `() => false` でスタブ化
- v1 切替プロンプトを自動的に「いいえ」で応答し、v2 モードでの変換を継続

## Test plan

- [ ] CI で `ruby-module.test.js` の全 5 テストが pass すること
- [ ] `v1-detection-prompt.test.js` が影響を受けないこと（別の driver インスタンスを使用）

Fixes #380
