### PR TITLE
feat: add Docker environment for smalruby3 gem

### DIFF
--- a/.claude/rules/ruby/development.md
+++ b/.claude/rules/ruby/development.md
@@ -22,9 +22,47 @@ smalruby3 は scratch-vm の Ruby 実装。smalruby3-editor で生成した Ruby
   - `loop do...end` は自動 `Fiber.yield`（Scratch 互換）
   - `N.times(screen_refresh: true) do...end` で自動 `Fiber.yield`
 
+## Execution Environment
+
+### macOS ネイティブ（基本）
+
+**プログラムの実行は macOS ネイティブで行う。** Docker 上では SDL2 の GUI 表示ができないため。
+
+```bash
+cd ruby/smalruby3
+rsdl -Ilib examples/01_move.rb
+```
+
+**CRITICAL**: `ruby` コマンドでは SDL2 が segfault する。必ず `rsdl` を使うこと。
+
+### Docker（テスト・CI用）
+
+Docker 環境はテスト実行と CI 用。GUI 表示はできない（ヘッドレス）。
+
+```bash
+# テスト実行
+docker compose run --rm smalruby3 bundle exec rake test
+
+# lint
+docker compose run --rm smalruby3 bundle exec standardrb
+
+# ヘッドレス実行（スクリーンショットで結果確認）
+docker compose run --rm -e SMALRUBY3_SCREENSHOT=3 smalruby3 \
+  bash -c "timeout 15 ruby -Ilib examples/03_clone.rb"
+```
+
+VNC 経由で GUI 確認も可能（macOS の画面共有.app で接続）:
+
+```bash
+docker compose run --rm smalruby3-gui ruby -Ilib examples/01_move.rb
+# → open vnc://localhost:15900  (password: smalruby)
+```
+
 ## Commands
 
 ### Run Tests
+
+macOS ネイティブ:
 
 ```bash
 cd ruby/smalruby3
@@ -37,16 +75,18 @@ ruby -Ilib -Itest -e 'Dir["test/**/*_test.rb"].each { |f| require_relative f }'
 ruby -Ilib -Itest test/sprite_test.rb
 ```
 
-### Run Examples
+Docker:
 
-macOS では `rsdl` コマンド経由で実行する（GC/SDL2 メインスレッド問題の回避）:
+```bash
+docker compose run --rm smalruby3 bundle exec rake test
+```
+
+### Run Examples
 
 ```bash
 cd ruby/smalruby3
 rsdl -Ilib examples/01_move.rb
 ```
-
-**CRITICAL**: `ruby` コマンドでは SDL2 が segfault する。必ず `rsdl` を使うこと。
 
 ### Lint (Standard Ruby)
 
@@ -201,76 +241,43 @@ ruby/smalruby3/
 
 ### Dependencies
 
-- 依存 gem は最小限に保つ（ruby-sdl2 + rsvg2）
-- ネイティブ拡張（SDL2）はシステムライブラリに依存 — バージョン互換性に注意
+- 依存 gem は最小限に保つ（ruby-sdl2 + rb_sys）
+- ネイティブ拡張: SDL2（システムライブラリ）+ smalruby3_imageutil（Rust、resvg によるSVG→PNG変換 + PNG保存）
 
 ## Debugging with Screenshots
 
 ### SDL2 スクリーンショットキャプチャ
 
-rsdl で起動した SDL2 ウィンドウの描画結果を BMP ファイルとしてキャプチャできる。
+SDL2 ウィンドウの描画結果を PNG ファイルとしてキャプチャできる。
 **デバッグ時は必ずこの機能を使って画面の状態を確認すること。**
 
 ```bash
 # N フレーム目のスクリーンショットを保存
 SMALRUBY3_SCREENSHOT=3 rsdl -Ilib examples/01_move.rb
-# → /tmp/smalruby3_screenshot.bmp
+# → /tmp/smalruby3_screenshot.png
 
 # 保存先を指定
-SMALRUBY3_SCREENSHOT=5 SMALRUBY3_SCREENSHOT_PATH=/tmp/debug.bmp rsdl -Ilib examples/01_move.rb
+SMALRUBY3_SCREENSHOT=5 SMALRUBY3_SCREENSHOT_PATH=/tmp/debug.png rsdl -Ilib examples/01_move.rb
+
+# Docker でのヘッドレスキャプチャ
+docker compose run --rm -e SMALRUBY3_SCREENSHOT=3 smalruby3 \
+  bash -c "timeout 15 ruby -Ilib examples/01_move.rb"
 ```
 
-### BMP → PNG 変換（Claude Code で確認するため）
-
-Claude Code の Read ツールは BMP を直接表示できないため、PNG に変換する。
-
-```bash
-ruby -e '
-require "zlib"
-bmp = File.binread("/tmp/smalruby3_screenshot.bmp")
-offset = bmp[10..13].unpack1("V")
-width = bmp[18..21].unpack1("V")
-height = bmp[22..25].unpack1("V")
-bpp = bmp[28..29].unpack1("v")
-row_size = ((bpp * width + 31) / 32) * 4
-raw = String.new(encoding: "ASCII-8BIT")
-(height - 1).downto(0) do |y|
-  raw << "\x00".b
-  width.times do |x|
-    pos = offset + y * row_size + x * (bpp / 8)
-    b = bmp.getbyte(pos); g = bmp.getbyte(pos + 1); r = bmp.getbyte(pos + 2)
-    a = bpp == 32 ? bmp.getbyte(pos + 3) : 255
-    raw << [r, g, b, a].pack("C4")
-  end
-end
-def png_chunk(type, data)
-  [data.length].pack("N") + type.b + data + [Zlib.crc32(type.b + data)].pack("N")
-end
-ihdr = [width, height, 8, 6, 0, 0, 0].pack("NNCCCCC")
-idat = Zlib::Deflate.deflate(raw)
-png = "\x89PNG\r\n\x1A\n".b
-png << png_chunk("IHDR", ihdr)
-png << png_chunk("IDAT", idat)
-png << png_chunk("IEND", "".b)
-File.binwrite("/tmp/smalruby3_screenshot.png", png)
-'
-```
-
-その後 Read ツールで `/tmp/smalruby3_screenshot.png` を開いて確認する。
+Read ツールで `/tmp/smalruby3_screenshot.png` を開いて確認する。
 
 ### 実装の注意点
 
 - `Surface.pixels` は**毎回コピーを返す**ため、書き込みに使えない
 - Surface への描画は `Surface.blit(src, srcrect, dst, dstrect)` を使う
 - 白い Surface の生成は `Surface.from_string(white_data, w, h, 32)` を使う
-- `Surface.save_bmp(surface, path)` はクラスメソッド
+- PNG 保存は Rust 拡張 `Smalruby3::ImageUtil.save_png` を使用（BMP フォールバックあり）
 
 ### デバッグ手順
 
-1. `SMALRUBY3_SCREENSHOT=N` でスクリーンショットを取得
-2. BMP → PNG 変換
-3. Read ツールで PNG を確認
-4. 問題があればコードを修正して再度スクリーンショット
+1. `SMALRUBY3_SCREENSHOT=N` でスクリーンショットを取得（PNG 直接保存）
+2. Read ツールで PNG を確認
+3. 問題があればコードを修正して再度スクリーンショット
 
 ## Architecture Notes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,33 @@ services:
         max-size: "100m"
         max-file: "3"
 
+  smalruby3:
+    build:
+      context: ruby/smalruby3
+      dockerfile: Dockerfile
+    working_dir: /app/ruby/smalruby3
+    volumes:
+      - type: bind
+        source: .
+        target: /app
+      - type: volume
+        source: smalruby3-editor_smalruby3_bundle
+        target: /usr/local/bundle
+      - type: volume
+        source: smalruby3-editor_smalruby3_cargo
+        target: /root/.cargo/registry
+      - type: volume
+        source: smalruby3-editor_smalruby3_target
+        target: /app/ruby/smalruby3/target
+    environment:
+      - SMALRUBY3_SCREENSHOT=${SMALRUBY3_SCREENSHOT:-}
+      - SMALRUBY3_SCREENSHOT_PATH=${SMALRUBY3_SCREENSHOT_PATH:-/tmp/smalruby3_screenshot.png}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   infra:
     build:
       context: .
@@ -88,4 +115,7 @@ volumes:
   smalruby3-editor_root_cache:
   smalruby3-editor_node_modules:
   smalruby3-editor_infra_mesh_v2_node_modules:
+  smalruby3-editor_smalruby3_bundle:
+  smalruby3-editor_smalruby3_cargo:
+  smalruby3-editor_smalruby3_target:
   smalruby3-editor_infra_bundle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
         max-file: "3"
 
   smalruby3:
+    image: smalruby3-editor-smalruby3
     build:
       context: ruby/smalruby3
       dockerfile: Dockerfile
@@ -71,16 +72,35 @@ services:
         max-file: "3"
 
   # GUI display via VNC (Xvfb + x11vnc)
-  # Connect with: open vnc://localhost:5900
+  # Usage: docker compose run --rm smalruby3-gui ruby -Ilib examples/01_move.rb
+  # Connect with: open vnc://localhost:15900
   smalruby3-gui:
-    extends:
-      service: smalruby3
+    image: smalruby3-editor-smalruby3
+    working_dir: /app/ruby/smalruby3
+    volumes:
+      - type: bind
+        source: .
+        target: /app
+      - type: volume
+        source: smalruby3-editor_smalruby3_bundle
+        target: /usr/local/bundle
+      - type: volume
+        source: smalruby3-editor_smalruby3_cargo
+        target: /root/.cargo/registry
+      - type: volume
+        source: smalruby3-editor_smalruby3_target
+        target: /app/ruby/smalruby3/target
     environment:
       - VNC_ENABLED=1
       - SMALRUBY3_SCREENSHOT=${SMALRUBY3_SCREENSHOT:-}
       - SMALRUBY3_SCREENSHOT_PATH=${SMALRUBY3_SCREENSHOT_PATH:-/tmp/smalruby3_screenshot.png}
     ports:
       - 0.0.0.0:15900:5900
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   infra:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,18 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # GUI display via VNC (Xvfb + x11vnc)
+  # Connect with: open vnc://localhost:5900
+  smalruby3-gui:
+    extends:
+      service: smalruby3
+    environment:
+      - VNC_ENABLED=1
+      - SMALRUBY3_SCREENSHOT=${SMALRUBY3_SCREENSHOT:-}
+      - SMALRUBY3_SCREENSHOT_PATH=${SMALRUBY3_SCREENSHOT_PATH:-/tmp/smalruby3_screenshot.png}
+    ports:
+      - 0.0.0.0:15900:5900
+
   infra:
     build:
       context: .

--- a/ruby/smalruby3/.gitignore
+++ b/ruby/smalruby3/.gitignore
@@ -6,3 +6,6 @@ tmp/
 lib/smalruby3/smalruby3_imageutil.bundle
 lib/smalruby3/smalruby3_imageutil.so
 *.gem
+
+# Docker marker
+.built

--- a/ruby/smalruby3/Dockerfile
+++ b/ruby/smalruby3/Dockerfile
@@ -1,0 +1,36 @@
+FROM ruby:3.3-slim-bookworm
+
+LABEL maintainer="Kouji Takao"
+
+ENV LANG=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+
+# SDL2 development libraries + Xvfb for headless rendering + build tools
+RUN set -eux \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    curl \
+    less \
+    vim \
+    libsdl2-dev \
+    libsdl2-image-dev \
+    libsdl2-mixer-dev \
+    libsdl2-ttf-dev \
+    libclang-dev \
+    xvfb \
+    fonts-ipafont-gothic \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Rust toolchain (needed for smalruby3_imageutil native extension)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /app/ruby/smalruby3
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/ruby/smalruby3/Dockerfile
+++ b/ruby/smalruby3/Dockerfile
@@ -20,6 +20,10 @@ RUN set -eux \
     libsdl2-ttf-dev \
     libclang-dev \
     xvfb \
+    libgl1-mesa-dri \
+    libgl1-mesa-glx \
+    libegl-mesa0 \
+    x11vnc \
     fonts-ipafont-gothic \
   && rm -rf /var/lib/apt/lists/*
 

--- a/ruby/smalruby3/entrypoint.sh
+++ b/ruby/smalruby3/entrypoint.sh
@@ -19,8 +19,11 @@ if [ -z "$DISPLAY" ]; then
 
   # Start x11vnc if VNC_ENABLED is set (for GUI viewing via VNC client)
   if [ "$VNC_ENABLED" = "1" ]; then
-    x11vnc -display :99 -forever -nopw -shared -rfbport 5900 &
-    echo "[smalruby3] VNC server started on port 5900"
+    VNC_PASSWORD="${VNC_PASSWORD:-smalruby}"
+    mkdir -p /tmp/.vnc
+    x11vnc -storepasswd "$VNC_PASSWORD" /tmp/.vnc/passwd
+    x11vnc -display :99 -forever -shared -rfbport 5900 -rfbauth /tmp/.vnc/passwd &
+    echo "[smalruby3] VNC server started on port 5900 (password: $VNC_PASSWORD)"
     echo "[smalruby3] Connect with: open vnc://localhost:15900"
   fi
 fi

--- a/ruby/smalruby3/entrypoint.sh
+++ b/ruby/smalruby3/entrypoint.sh
@@ -11,11 +11,18 @@ if [ ! -e /app/ruby/smalruby3/.built ]; then
   )
 fi
 
-# Start Xvfb for headless SDL2 rendering
+# Start Xvfb for headless SDL2 rendering (skipped if DISPLAY is already set)
 if [ -z "$DISPLAY" ]; then
   export DISPLAY=:99
   Xvfb :99 -screen 0 640x480x24 -nolisten tcp &
   sleep 1
+
+  # Start x11vnc if VNC_ENABLED is set (for GUI viewing via VNC client)
+  if [ "$VNC_ENABLED" = "1" ]; then
+    x11vnc -display :99 -forever -nopw -shared -rfbport 5900 &
+    echo "[smalruby3] VNC server started on port 5900"
+    echo "[smalruby3] Connect with: open vnc://localhost:15900"
+  fi
 fi
 
 exec "$@"

--- a/ruby/smalruby3/entrypoint.sh
+++ b/ruby/smalruby3/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# Install gems and compile native extension on first run
+if [ ! -e /app/ruby/smalruby3/.built ]; then
+  (
+    cd /app/ruby/smalruby3
+    bundle install
+    bundle exec rake compile
+    touch /app/ruby/smalruby3/.built
+  )
+fi
+
+# Start Xvfb for headless SDL2 rendering
+if [ -z "$DISPLAY" ]; then
+  export DISPLAY=:99
+  Xvfb :99 -screen 0 640x480x24 -nolisten tcp &
+  sleep 1
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

smalruby3 gem の開発・テスト・実行を Docker 環境で行えるようにする。

- `ruby/smalruby3/Dockerfile`: Ruby 3.3 + SDL2 + Rust toolchain + Xvfb + x11vnc
- `ruby/smalruby3/entrypoint.sh`: 初回自動 bundle install / rake compile、Xvfb 自動起動、VNCオプション
- `docker-compose.yml`: `smalruby3`（ヘッドレス）+ `smalruby3-gui`（VNC付き）サービス追加

## Usage

```bash
# テスト実行
docker compose run --rm smalruby3 bundle exec rake test

# lint
docker compose run --rm smalruby3 bundle exec standardrb

# GUI付きでexample実行（VNC経由で画面表示）
docker compose run --rm -p 15900:5900 smalruby3-gui ruby -Ilib examples/01_move.rb
# → macOSで接続: open vnc://localhost:15900

# ヘッドレスでexample実行（スクリーンショット付き）
docker compose run --rm -e SMALRUBY3_SCREENSHOT=3 smalruby3 \
  bash -c "timeout 15 ruby -Ilib examples/03_clone.rb"

# bash
docker compose run --rm smalruby3 bash
```

## Design Decisions

- **VNC方式を採用**: XQuartz X11転送はDocker on macOSでGLX非互換のため不可。Xvfb + x11vnc によるVNC方式を採用
- **2サービス構成**: `smalruby3`（ヘッドレス、テスト・CI用）と `smalruby3-gui`（VNC付き、GUI確認用）
- **ポート15900**: macOSのScreen Sharing（5900）と競合しないよう旧プロジェクトと同じポートを使用

## Test plan

- [x] `docker compose build smalruby3` 成功
- [x] `docker compose run --rm smalruby3 bundle exec rake test` — 177 tests, 0 failures
- [x] ヘッドレスでのスクリーンショット PNG 生成確認
- [x] VNCポート接続確認（port 15900）
- [x] VNC経由でSDL2ウィンドウ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
