### PR TITLE
feat: implement Stage backdrop image rendering

### DIFF
--- a/ruby/smalruby3/lib/smalruby3/render/renderer.rb
+++ b/ruby/smalruby3/lib/smalruby3/render/renderer.rb
@@ -89,8 +89,26 @@ module Smalruby3
         end
       end
 
-      def draw_stage(_stage)
-        # Stage background is white (already cleared to white in begin_frame)
+      def draw_stage(stage)
+        costume = stage.current_backdrop_obj
+        return unless costume
+
+        texture = get_texture(costume)
+        return unless texture
+
+        w = costume.display_width.to_i
+        h = costume.display_height.to_i
+
+        # Center the backdrop on stage
+        screen_x = ((@width - w) / 2).to_i
+        screen_y = ((@height - h) / 2).to_i
+
+        dst = SDL2::Rect.new(screen_x, screen_y, w, h)
+        @sdl_renderer.copy(texture, nil, dst)
+
+        if capturing? && @capture_surface
+          blit_to_capture(costume.surface, screen_x, screen_y, w, h)
+        end
       end
 
       def draw_sprite(sprite)

--- a/ruby/smalruby3/lib/smalruby3/stage.rb
+++ b/ruby/smalruby3/lib/smalruby3/stage.rb
@@ -33,6 +33,10 @@ module Smalruby3
       end
     end
 
+    def current_backdrop_obj
+      @backdrops[@current_backdrop]
+    end
+
     def backdrop_number
       @current_backdrop + 1
     end

--- a/ruby/smalruby3/test/stage_test.rb
+++ b/ruby/smalruby3/test/stage_test.rb
@@ -59,4 +59,18 @@ class StageTest < Minitest::Test
     stage = Smalruby3::Stage.new(@runtime)
     assert_equal "backdrop1", stage.backdrop_name
   end
+
+  def test_current_backdrop_obj
+    stage = Smalruby3::Stage.new(@runtime)
+    costume = stage.current_backdrop_obj
+    assert_instance_of Smalruby3::Costume, costume
+    assert_equal "backdrop1", costume.name
+  end
+
+  def test_current_backdrop_obj_after_switch
+    stage = Smalruby3::Stage.new(@runtime)
+    # Default stage has only one backdrop, so switch to same name
+    stage.switch_backdrop("backdrop1")
+    assert_equal "backdrop1", stage.current_backdrop_obj.name
+  end
 end


### PR DESCRIPTION
## Summary

Stage の背景画像（backdrop）を実際に描画するように実装。

- `draw_stage` で現在の backdrop コスチュームをテクスチャとして描画
- `Stage#current_backdrop_obj` アクセサを追加
- スクリーンショットキャプチャにも backdrop を反映

これまでは白背景のクリアのみだったが、背景画像が設定されている場合はそれを表示する。

## Changes

- `lib/smalruby3/stage.rb` — `current_backdrop_obj` メソッド追加
- `lib/smalruby3/render/renderer.rb` — `draw_stage` 実装（テクスチャ描画 + キャプチャ対応）
- `test/stage_test.rb` — `current_backdrop_obj` のテスト追加

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
