### PR TITLE
feat: switch screenshot to read_pixels for complete frame capture

### DIFF
--- a/ruby/smalruby3/lib/smalruby3/render/renderer.rb
+++ b/ruby/smalruby3/lib/smalruby3/render/renderer.rb
@@ -24,7 +24,6 @@ module Smalruby3
         @sdl_renderer = @window.create_renderer(-1, SDL2::Renderer::Flags::ACCELERATED)
         @textures = {}
         @pen_skin = nil
-        @capture_surface = nil
         @window.show
         @window.raise
       end
@@ -83,10 +82,6 @@ module Smalruby3
       def begin_frame
         @sdl_renderer.draw_color = [255, 255, 255, 255]
         @sdl_renderer.clear
-
-        if capturing?
-          init_capture_surface
-        end
       end
 
       def draw_stage(stage)
@@ -105,10 +100,6 @@ module Smalruby3
 
         dst = SDL2::Rect.new(screen_x, screen_y, w, h)
         @sdl_renderer.copy(texture, nil, dst)
-
-        if capturing? && @capture_surface
-          blit_to_capture(costume.surface, screen_x, screen_y, w, h)
-        end
       end
 
       def draw_sprite(sprite)
@@ -144,17 +135,12 @@ module Smalruby3
 
         texture.blend_mode = SDL2::BlendMode::BLEND
         @sdl_renderer.copy_ex(texture, nil, dst, angle, center, SDL2::Renderer::FLIP_NONE)
-
-        # Also blit to capture surface for screenshot
-        if capturing? && @capture_surface
-          blit_to_capture(costume.surface, screen_x, screen_y, w, h)
-        end
       end
 
       def end_frame
+        maybe_save_screenshot
         @sdl_renderer.present
         @frame_count += 1
-        maybe_save_screenshot
       end
 
       def destroy
@@ -166,7 +152,6 @@ module Smalruby3
           end
         }
         @textures.clear
-        @capture_surface&.destroy
         @window&.destroy
       end
 
@@ -180,49 +165,41 @@ module Smalruby3
         end
       end
 
-      # --- Screenshot capture ---
-
-      def capturing?
-        @screenshot_at_frame && @frame_count == @screenshot_at_frame - 1
-      end
+      # --- Screenshot capture (read_pixels based) ---
+      # Reads pixels directly from the SDL2 renderer, capturing
+      # everything drawn in the current frame including text bubbles,
+      # monitors, and other renderer-drawn elements.
 
       def maybe_save_screenshot
         return unless @screenshot_at_frame
         return unless @frame_count == @screenshot_at_frame
+        return unless @screenshot_path && !File.symlink?(@screenshot_path)
 
-        if @capture_surface && @screenshot_path && !File.symlink?(@screenshot_path)
-          save_surface_as_png(@capture_surface, @screenshot_path)
-          warn "[Smalruby3] Screenshot saved to #{@screenshot_path} (frame #{@frame_count})"
-          @capture_surface.destroy
-          @capture_surface = nil
-        end
+        require "smalruby3/smalruby3_imageutil"
+        # read_pixels returns ARGB8888 (little-endian: BGRA bytes)
+        argb_data = @sdl_renderer.read_pixels(nil, 0)
+        # Convert BGRA → RGBA for PNG encoding
+        rgba_data = convert_bgra_to_rgba(argb_data)
+        Smalruby3::ImageUtil.save_png(rgba_data, @width, @height, @screenshot_path)
+        warn "[Smalruby3] Screenshot saved to #{@screenshot_path} (frame #{@frame_count})"
+        @screenshot_at_frame = nil
+      rescue => e
+        warn "[Smalruby3] Screenshot failed: #{e.message}"
         @screenshot_at_frame = nil
       end
 
-      def init_capture_surface
-        @capture_surface&.destroy
-        # Create white surface using from_string
-        white_pixel = "\xFF\xFF\xFF\xFF".b
-        white_data = (white_pixel * @width * @height)
-        @capture_surface = SDL2::Surface.from_string(white_data, @width, @height, 32)
-      end
-
-      def blit_to_capture(src_surface, screen_x, screen_y, w, h)
-        return unless src_surface && @capture_surface
-        src_rect = SDL2::Rect.new(0, 0, src_surface.w, src_surface.h)
-        dst_rect = SDL2::Rect.new(screen_x, screen_y, w, h)
-        SDL2::Surface.blit(src_surface, src_rect, @capture_surface, dst_rect)
-      end
-
-      def save_surface_as_png(surface, path)
-        require "smalruby3/smalruby3_imageutil"
-        # Extract RGBA pixel data from the SDL2 surface
-        rgba_data = surface.pixels
-        Smalruby3::ImageUtil.save_png(rgba_data, surface.w, surface.h, path)
-      rescue => e
-        warn "[Smalruby3] PNG save failed (#{e.message}), falling back to BMP"
-        bmp_path = "#{path.delete_suffix(".png")}.bmp"
-        SDL2::Surface.save_bmp(surface, bmp_path)
+      def convert_bgra_to_rgba(bgra)
+        rgba = bgra.dup
+        i = 0
+        len = rgba.bytesize
+        while i < len
+          # Swap B and R (bytes 0 and 2)
+          b = rgba.getbyte(i)
+          rgba.setbyte(i, rgba.getbyte(i + 2))
+          rgba.setbyte(i + 2, b)
+          i += 4
+        end
+        rgba
       end
 
       # Validate screenshot path: must not be a symlink or point outside /tmp


### PR DESCRIPTION
## Summary

スクリーンショット機能を `SDL2::Renderer#read_pixels` ベースに切り替え。

これまでの Surface blit 方式では、SDL2 Renderer で直接描画される要素（吹き出し、モニター等）がキャプチャに含まれなかった。`read_pixels` により、レンダラーの出力全体をピクセルとして読み取れるようになる。

## Changes

- `end_frame`: `present` 前に `read_pixels` でキャプチャ
- ARGB8888（BGRA バイト順）→ RGBA 変換して PNG 保存
- 古い Surface blit コード削除（`capturing?`, `init_capture_surface`, `blit_to_capture`, `@capture_surface`）

## 依存

`ruby/ruby-sdl2` submodule の `smalruby/add-read-pixels` ブランチが必要（PR #398 でマージ済み）。

Refs #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
