### PR TITLE
chore: add auto-generated files to .gitignore in ruby/ directories

### DIFF
--- a/ruby/smalruby3/.gitignore
+++ b/ruby/smalruby3/.gitignore
@@ -14,5 +14,8 @@ ext/smalruby3_launcher/smalruby3_launcher.o
 ext/smalruby3_launcher/Makefile
 ext/smalruby3_launcher/mkmf.log
 
+# Bundle lock (gem library)
+Gemfile.lock
+
 # Docker marker
 .built


### PR DESCRIPTION
## Summary

- `ruby/ruby-sdl2/.gitignore` に `Gemfile.lock`, `.ruby-version` を追加（サブモジュール更新）
- `ruby/smalruby3/.gitignore` に `Gemfile.lock` を追加

これらのファイルはユーザーの個人グローバル gitignore でのみ無視されていたため、他の開発者のクローン環境では untracked として表示されていた。

## Test plan

- [ ] `ruby/ruby-sdl2/` 内で `git status` に `Gemfile.lock`, `.ruby-version`, `sdl2_ext.bundle.dSYM/` が表示されないこと
- [ ] `ruby/smalruby3/` で `Gemfile.lock` が `git status` に表示されないこと

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)
