### PR TITLE
fix: dncl mode switch race condition and normalize ならば keyword

### DIFF
--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -184,6 +184,7 @@ const RubyTab = props => {
     const furiganaDebounceTimerRef = useRef(null);
     const furiganaLastMsRef = useRef(0);
     const isAutoCorrectUpdateRef = useRef(false);
+    const isModeSwitchRef = useRef(false);
 
     // Lazy initialization of heavy objects
     if (!quickFixProviderRef.current) quickFixProviderRef.current = new QuickFixProvider();
@@ -367,6 +368,10 @@ const RubyTab = props => {
 
     const handleEditorChange = useCallback(
         value => {
+            // Skip change events triggered by mode switch (Ruby↔DNCL) to
+            // prevent a Redux dispatch that causes a re-render race where
+            // the dnclMode state hasn't committed yet.
+            if (isModeSwitchRef.current) return;
             if (isAutoCorrectUpdateRef.current) {
                 isAutoCorrectUpdateRef.current = false;
                 dispatchCode(value);
@@ -554,31 +559,43 @@ const RubyTab = props => {
 
     // === Smalruby: Start of DNCL mode toggle ===
     const handleToggleDnclMode = useCallback(() => {
-        setDnclMode(prev => {
-            const enabled = !prev;
-            if (typeof window !== 'undefined' && window.localStorage) {
-                window.localStorage.setItem(DNCL_MODE_KEY, enabled);
+        // Suppress handleEditorChange during mode switch to prevent a
+        // re-render race: model.setValue triggers onChange synchronously,
+        // which dispatches to Redux, causing a re-render where dnclMode
+        // state hasn't committed yet — overwriting the editor content.
+        isModeSwitchRef.current = true;
+
+        const enabled = !dnclModeRef.current;
+        dnclModeRef.current = enabled;
+
+        if (typeof window !== 'undefined' && window.localStorage) {
+            window.localStorage.setItem(DNCL_MODE_KEY, enabled);
+        }
+
+        if (editorRef.current && monacoRef.current) {
+            const model = editorRef.current.getModel();
+            if (enabled) {
+                // Switching to DNCL: convert Ruby → DNCL
+                const currentRuby = model.getValue();
+                const result = rubyToDncl(currentRuby);
+                dnclSourceMapRef.current = new DnclSourceMap(result.dncl, currentRuby);
+                monacoRef.current.editor.setModelLanguage(model, 'dncl');
+                model.setValue(result.dncl);
+                setDnclDisplayCode(result.dncl);
+            } else {
+                // Switching to Ruby: convert DNCL → Ruby
+                const currentDncl = model.getValue();
+                const result = dnclToRuby(currentDncl);
+                dnclSourceMapRef.current = null;
+                monacoRef.current.editor.setModelLanguage(model, 'smalruby');
+                model.setValue(result.ruby);
+                setDnclDisplayCode('');
+                onChangeRef.current(result.ruby);
             }
-            if (editorRef.current && monacoRef.current) {
-                const model = editorRef.current.getModel();
-                if (enabled) {
-                    // Switching to DNCL: convert Ruby → DNCL
-                    const currentRuby = model.getValue();
-                    const result = rubyToDncl(currentRuby);
-                    setDnclDisplayCode(result.dncl);
-                    monacoRef.current.editor.setModelLanguage(model, 'dncl');
-                    model.setValue(result.dncl);
-                } else {
-                    // Switching to Ruby: convert DNCL → Ruby
-                    const currentDncl = model.getValue();
-                    const result = dnclToRuby(currentDncl);
-                    setDnclDisplayCode('');
-                    monacoRef.current.editor.setModelLanguage(model, 'smalruby');
-                    model.setValue(result.ruby);
-                }
-            }
-            return enabled;
-        });
+        }
+
+        isModeSwitchRef.current = false;
+        setDnclMode(enabled);
     }, []);
     // === Smalruby: End of DNCL mode toggle ===
 

--- a/packages/scratch-gui/src/containers/ruby-tab/dncl-snippets.js
+++ b/packages/scratch-gui/src/containers/ruby-tab/dncl-snippets.js
@@ -11,14 +11,14 @@
 /* eslint-disable no-template-curly-in-string */
 const DNCL_SNIPPETS = [
   {
-    label: 'もし...なら',
-    insertText: 'もし ${1:条件} なら\n  ${2}\nを実行する',
+    label: 'もし...ならば',
+    insertText: 'もし ${1:条件} ならば\n  ${2}\nを実行する',
     documentation: '条件分岐（if）',
   },
   {
     label: 'もし...そうでなければ',
     insertText:
-      'もし ${1:条件} なら\n  ${2}\nそうでなければ\n  ${3}\nを実行する',
+      'もし ${1:条件} ならば\n  ${2}\nそうでなければ\n  ${3}\nを実行する',
     documentation: '条件分岐（if-else）',
   },
   {

--- a/packages/scratch-gui/src/lib/dncl/ruby-to-dncl.js
+++ b/packages/scratch-gui/src/lib/dncl/ruby-to-dncl.js
@@ -170,19 +170,19 @@ const convertLine = (line) => {
     return null // sentinel: combine with next line
   }
 
-  // if condition → もし condition なら
+  // if condition → もし condition ならば
   const ifMatch = trimmed.match(/^if\s+(.+)$/)
   if (ifMatch) {
     blockStack.push('if')
     const condition = processSegments(ifMatch[1])
-    return `${indent}もし ${condition} なら`
+    return `${indent}もし ${condition} ならば`
   }
 
-  // elsif condition → そうでなくもし condition なら
+  // elsif condition → そうでなくもし condition ならば
   const elsifMatch = trimmed.match(/^elsif\s+(.+)$/)
   if (elsifMatch) {
     const condition = processSegments(elsifMatch[1])
-    return `${indent}そうでなくもし ${condition} なら`
+    return `${indent}そうでなくもし ${condition} ならば`
   }
 
   // else → そうでなければ

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/prism-error-translator.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/prism-error-translator.js
@@ -94,6 +94,10 @@ const messages = {
     expectedCloseParams: {
         defaultMessage: '`)` is missing.\nAdd `)` to close the parameters.',
         id: 'gui.smalruby3.prismError.expectedCloseParams'
+    },
+    unexpectedLocalVariableOrMethod: {
+        defaultMessage: 'Unexpected variable or method found where the code should have ended.\nCheck for missing `end` or extra statements.',
+        id: 'gui.smalruby3.prismError.unexpectedLocalVariableOrMethod'
     }
 };
 
@@ -176,6 +180,10 @@ const rules = [
     {
         pattern: /expected a `\)` to close the parameters$/,
         key: 'expectedCloseParams'
+    },
+    {
+        pattern: /^unexpected local variable or method, expecting end-of-input$/,
+        key: 'unexpectedLocalVariableOrMethod'
     }
 ];
 

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -229,6 +229,8 @@ export default {
         '`|` がたりません。\n`|` をついかしてブロックのひきすうをとじてください。',
     'gui.smalruby3.prismError.expectedCloseParams':
         '`)` がたりません。\n`)` をついかしてひきすうのていぎをとじてください。',
+    'gui.smalruby3.prismError.unexpectedLocalVariableOrMethod':
+        'コードがおわるべきばしょに、へんすうやメソッドがあります。\n`end` のふそくや、よぶんなめいれいがないかかくにんしてください。',
     'gui.smalruby3.telemetryOptIn.buttonTextYes': 'はい、スモウルビーのかいぜんにきょうりょくします。',
     'gui.smalruby3.extension.mesh.name': 'じゅうらいのメッシュ',
     'gui.smalruby3.extension.mesh.description': 'ネットワークじょうでユーザーかんのやりとりを おこなう。',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -220,6 +220,8 @@ export default {
     'gui.smalruby3.prismError.expectedBlockParamPipe':
         '`|` が足りません。\n`|` を追加してブロックの引数を閉じてください。',
     'gui.smalruby3.prismError.expectedCloseParams': '`)` が足りません。\n`)` を追加して引数の定義を閉じてください。',
+    'gui.smalruby3.prismError.unexpectedLocalVariableOrMethod':
+        'コードが終わるべき場所に、変数やメソッドがあります。\n`end` の不足や、余分な命令がないか確認してください。',
     'gui.smalruby3.telemetryOptIn.buttonTextYes': 'はい、スモウルビーの改善に協力します。',
     'gui.smalruby3.extension.mesh.name': '従来のメッシュ',
     'gui.smalruby3.extension.mesh.description': 'ネットワーク上でユーザー間のやりとりを行う。',

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-roundtrip.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-roundtrip.test.js
@@ -50,14 +50,20 @@ describe('DNCL round-trip (DNCL → Ruby → DNCL)', () => {
 
   describe('control flow', () => {
     test('simple if', () => {
-      const dncl = 'もし a > 0 なら\n  a = 1\nを実行する'
+      const dncl = 'もし a > 0 ならば\n  a = 1\nを実行する'
       expect(roundtrip(dncl)).toBe(dncl)
     })
 
     test('if-else', () => {
       const dncl =
-        'もし a > 0 なら\n  a = 1\nそうでなければ\n  a = 2\nを実行する'
+        'もし a > 0 ならば\n  a = 1\nそうでなければ\n  a = 2\nを実行する'
       expect(roundtrip(dncl)).toBe(dncl)
+    })
+
+    test('if with なら normalizes to ならば', () => {
+      const input = 'もし a > 0 なら\n  a = 1\nを実行する'
+      const expected = 'もし a > 0 ならば\n  a = 1\nを実行する'
+      expect(roundtrip(input)).toBe(expected)
     })
 
     test('while loop', () => {

--- a/packages/scratch-gui/test/unit/lib/dncl/ruby-to-dncl.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/ruby-to-dncl.test.js
@@ -94,14 +94,14 @@ describe('rubyToDncl', () => {
   describe('control flow: if', () => {
     test('simple if', () => {
       expect(convert('if @a > 0\n  @a = 1\nend')).toBe(
-        'もし a > 0 なら\n  a = 1\nを実行する',
+        'もし a > 0 ならば\n  a = 1\nを実行する',
       )
     })
 
     test('if-else', () => {
       expect(
         convert('if @a > 0\n  @a = 1\nelse\n  @a = 2\nend'),
-      ).toBe('もし a > 0 なら\n  a = 1\nそうでなければ\n  a = 2\nを実行する')
+      ).toBe('もし a > 0 ならば\n  a = 1\nそうでなければ\n  a = 2\nを実行する')
     })
 
     test('if-elsif-else', () => {
@@ -110,7 +110,7 @@ describe('rubyToDncl', () => {
           'if @a > 0\n  @a = 1\nelsif @a > 5\n  @a = 2\nelse\n  @a = 3\nend',
         ),
       ).toBe(
-        'もし a > 0 なら\n  a = 1\nそうでなくもし a > 5 なら\n  a = 2\nそうでなければ\n  a = 3\nを実行する',
+        'もし a > 0 ならば\n  a = 1\nそうでなくもし a > 5 ならば\n  a = 2\nそうでなければ\n  a = 3\nを実行する',
       )
     })
   })


### PR DESCRIPTION
## Summary

- DNCLモードの「もし」補完・変換で「なら」を「ならば」に統一
- Ruby↔DNCLモード切り替え時に `handleEditorChange` が同期的に発火し、React状態が未コミットのまま Redux にDNCLテキストがRubyとして保存されるレースコンディションを修正
- `unexpected local variable or method, expecting end-of-input` エラーメッセージの日本語・ひらがな翻訳を追加

## Changes Made

### モード切り替えバグ修正 (`ruby-tab.jsx`)
- `handleToggleDnclMode` を `setDnclMode` の関数アップデータの外に移動
- `isModeSwitchRef` フラグで切り替え中の `handleEditorChange` を抑制し、Redux dispatch によるリレンダーレースを防止
- `dnclModeRef.current` を `model.setValue()` の前に更新

### ならば統一
- `dncl-snippets.js`: 補完の「なら」→「ならば」
- `ruby-to-dncl.js`: `if`/`elsif` 変換出力の「なら」→「ならば」
- `dncl-to-ruby.js`: 入力は「なら」「ならば」両方引き続きサポート

### エラー翻訳
- `prism-error-translator.js`: `unexpectedLocalVariableOrMethod` ルール追加
- `ja.js` / `ja-Hira.js`: 日本語・ひらがな翻訳

## Test Coverage
- DNCL テスト 141件 全パス（roundtrip、ruby-to-dncl、dncl-to-ruby、source-map、block-filter、prism-error-translator）
- Playwright で Ruby→DNCL切り替え後の実行エラーが解消されたことを確認

## Related Issues
DNCLモードでの「もし」構文エラーおよびモード切り替え時の実行エラー
