### PR TITLE
fix: resolve cross-platform gem build CI failures

### DIFF
--- a/.github/workflows/gem-build-check.yml
+++ b/.github/workflows/gem-build-check.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Build gem
         run: gem build smalruby3.gemspec
 
-      - name: Install gem locally
-        run: gem install --local smalruby3-*.gem --no-document
-
       - name: Compile native extension
         run: bundle exec rake compile
 
@@ -81,6 +78,7 @@ jobs:
             mingw-w64-ucrt-x86_64-SDL2_image
             mingw-w64-ucrt-x86_64-SDL2_mixer
             mingw-w64-ucrt-x86_64-SDL2_ttf
+            mingw-w64-ucrt-x86_64-clang
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -104,6 +102,8 @@ jobs:
           CPATH: C:/msys64/ucrt64/include
           LIBRARY_PATH: C:/msys64/ucrt64/lib
           PKG_CONFIG_PATH: C:/msys64/ucrt64/lib/pkgconfig
+          LIBCLANG_PATH: C:/msys64/ucrt64/bin
+          BINDGEN_EXTRA_CLANG_ARGS: --sysroot=C:/msys64/ucrt64
         run: bundle exec rake compile
 
       - name: Run tests


### PR DESCRIPTION
## Summary

Cross-platform gem build check (#416 follow-up) の CI 修正。

- **Linux**: `gem install --local` を削除（`--local` では依存 gem `rb_sys` を取得できない）
- **Windows**: MSYS2 clang パッケージ追加 + `BINDGEN_EXTRA_CLANG_ARGS` で sysroot を指定（`rb-sys` の bindgen が `strings.h` を見つけられない問題を修正）

## Test Coverage

CI で検証: https://github.com/smalruby/smalruby3-editor/actions/runs/23710731208
