### PR TITLE
fix: resolve gem build verify step failures

### DIFF
--- a/.github/workflows/gem-build-check.yml
+++ b/.github/workflows/gem-build-check.yml
@@ -50,6 +50,8 @@ jobs:
         run: bundle exec rake test
 
       - name: Verify smalruby3 loads
+        env:
+          SMALRUBY3_TESTING: '1'
         run: bundle exec ruby -e 'require "smalruby3"; puts "smalruby3 v#{Smalruby3::VERSION} loaded OK"'
 
       - name: Upload gem artifact
@@ -104,6 +106,9 @@ jobs:
         run: bundle exec rake test
 
       - name: Verify smalruby3 loads
+        shell: bash
+        env:
+          SMALRUBY3_TESTING: '1'
         run: bundle exec ruby -e 'require "smalruby3"; puts "smalruby3 v#{Smalruby3::VERSION} loaded OK"'
 
       - name: Upload gem artifact


### PR DESCRIPTION
- `SMALRUBY3_TESTING=1` で `at_exit` の `Smalruby3.start` をスキップ（SDL2 イベントループで永遠に終わらない問題）
- Windows: `shell: bash` でクォートのエスケープ問題を修正