### PR TITLE
fix: DNCLモード切替後にcode tabのブロック一覧と拡張機能ボタンが復元されない

### DIFF
--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -28,6 +28,7 @@ import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
 import { containsV1Code } from '../lib/ruby-to-blocks-converter/v1-detection';
 import { getUrlParams } from '../lib/url-params';
 import { showAlertWithTimeout, closeAlertWithId } from '../reducers/alerts';
+import { setDnclMode as setDnclModeAction } from '../reducers/dncl-mode';
 import { BLOCKS_TAB_INDEX, RUBY_TAB_INDEX } from '../reducers/editor-tab';
 import { setAiSaveStatus, clearAiSaveStatus } from '../reducers/koshien-file';
 import { closeFileMenu } from '../reducers/menus.js';
@@ -119,6 +120,7 @@ const RubyTab = props => {
         onRegisterRubyteeApply,
         v1PromptDismissed,
         onDismissV1Prompt,
+        onSetDnclMode,
     } = props;
 
     // --- State ---
@@ -632,7 +634,8 @@ const RubyTab = props => {
 
         isModeSwitchRef.current = false;
         setDnclMode(enabling);
-    }, [vm, rubyCode.target, intl, rubyVersion, dnclValidationErrorMessage]);
+        onSetDnclMode(enabling);
+    }, [vm, rubyCode.target, intl, rubyVersion, dnclValidationErrorMessage, onSetDnclMode]);
 
     const handleToggleFurigana = useCallback(() => {
         setFuriganaEnabled(prev => {
@@ -1077,6 +1080,7 @@ const RubyTab = props => {
                 if (wasDncl) {
                     dnclModeRef.current = false;
                     setDnclMode(false);
+                    onSetDnclMode(false);
                     setFuriganaEnabled(true);
                     if (typeof window !== 'undefined' && window.localStorage) {
                         window.localStorage.setItem(DNCL_MODE_KEY, 'false');
@@ -1240,6 +1244,7 @@ RubyTab.propTypes = {
     onRegisterRubyteeApply: PropTypes.func,
     v1PromptDismissed: PropTypes.bool,
     onDismissV1Prompt: PropTypes.func,
+    onSetDnclMode: PropTypes.func,
 };
 
 const mapStateToProps = state => ({
@@ -1270,6 +1275,7 @@ const mapDispatchToProps = dispatch => ({
     onFontSizeChange: fontSize => dispatch(updateRubyFontSize(fontSize)),
     onMarkRubyTabUsed: () => dispatch(markRubyTabUsed()),
     onDismissV1Prompt: () => dispatch(dismissV1Prompt()),
+    onSetDnclMode: dnclMode => dispatch(setDnclModeAction(dnclMode)),
 });
 
 const ConnectedRubyTab = RubyteeModalHOC(

--- a/packages/scratch-gui/test/integration/dncl-mode-validation.test.js
+++ b/packages/scratch-gui/test/integration/dncl-mode-validation.test.js
@@ -133,4 +133,71 @@ describe('DNCL mode validation on switch', () => {
         await clickByTestId(driver, 'ruby-toolbar-mode-ruby');
         await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', false);
     });
+
+    test('DNCL to Ruby switch restores block palette and extension button on Code tab', async () => {
+        // Start in DNCL mode
+        await loadUri(`${uri}?rubyMode=dncl`);
+        await clickText('Ruby', '*[@role="tab"]');
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', true);
+
+        // Switch back to Ruby mode
+        await clickByTestId(driver, 'ruby-toolbar-mode-ruby');
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', false);
+
+        // Switch to Code tab
+        await clickText('コード', '*[@role="tab"]');
+
+        // Wait for the extension button to be visible and clickable (not disabled)
+        await driver.wait(
+            () =>
+                driver.executeScript(
+                    `const btn = document.querySelector('[class*="extension-button_extension-button-container"]');` +
+                        `return btn && btn.style.display !== 'none' && !btn.className.includes('Disabled');`,
+                ),
+            10000,
+            'Extension button did not become visible and enabled after leaving DNCL mode',
+        );
+
+        // Verify block palette (toolbox) is visible and has multiple categories
+        const categoryCount = await driver.executeScript(
+            `const toolbox = document.querySelector('.blocklyToolboxDiv');` +
+                `if (!toolbox || toolbox.style.display === 'none') return 0;` +
+                `return toolbox.querySelectorAll('.scratchCategoryMenuItem').length;`,
+        );
+        // Non-DNCL mode should have more categories than DNCL mode (which filters heavily)
+        expect(categoryCount).toBeGreaterThan(3);
+    });
+
+    test('DNCL to furigana switch restores block palette on Code tab', async () => {
+        // Start in DNCL mode
+        await loadUri(`${uri}?rubyMode=dncl`);
+        await clickText('Ruby', '*[@role="tab"]');
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', true);
+
+        // Switch to furigana mode
+        await clickByTestId(driver, 'ruby-toolbar-mode-furigana');
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', false);
+
+        // Switch to Code tab
+        await clickText('コード', '*[@role="tab"]');
+
+        // Wait for extension button to be visible and not disabled
+        await driver.wait(
+            () =>
+                driver.executeScript(
+                    `const btn = document.querySelector('[class*="extension-button_extension-button-container"]');` +
+                        `return btn && btn.style.display !== 'none' && !btn.className.includes('Disabled');`,
+                ),
+            10000,
+            'Extension button did not become visible and enabled after leaving DNCL mode',
+        );
+
+        // Verify block palette has full categories
+        const categoryCount = await driver.executeScript(
+            `const toolbox = document.querySelector('.blocklyToolboxDiv');` +
+                `if (!toolbox || toolbox.style.display === 'none') return 0;` +
+                `return toolbox.querySelectorAll('.scratchCategoryMenuItem').length;`,
+        );
+        expect(categoryCount).toBeGreaterThan(3);
+    });
 });


### PR DESCRIPTION
## Summary

Ruby tabでDNCLモードに切り替えた後、Ruby/ふりがなモードに戻してもCode tabのブロック一覧がフィルタされたまま、拡張機能ボタンも押せない状態が続くバグを修正。

**原因**: `ruby-tab.jsx`のDNCLモード状態がローカルuseStateのみで管理され、`blocks.jsx`と`gui.jsx`が参照するRedux storeにdispatchされていなかった。

**修正**: `setDnclMode`呼び出し時にRedux actionもdispatchするようにした。

## Implementation Steps

- [x] Phase 1: Redux dispatch の追加
- [x] Phase 2: Integration Tests
- [x] Phase DoD: CI完了待ち + ブラウザ確認

## Definition of Done

- [x] ユニットテスト pass
- [x] Integration テスト pass
- [x] lint pass
- [x] CI green
- [x] ブラウザ確認（Playwright MCP）:
  - [x] DNCLモードON → Code tab切替 → ブロック一覧がDNCLフィルタされている（7カテゴリ、拡張機能ボタンdisabled）
  - [x] DNCLモードON → Rubyモードに切替 → Code tab切替 → ブロック一覧が全カテゴリ表示される（9カテゴリ）
  - [x] DNCLモードON → Rubyモードに切替 → Code tab切替 → 拡張機能ボタンがクリック可能（拡張機能ライブラリが開く）
  - [x] DNCLモードON → ふりがなモードに切替 → Code tab切替 → ブロック一覧が全カテゴリ表示される（9カテゴリ）

Fixes #430
