### PR TITLE
fix: use stable selector for Code tab in dncl-mode-validation test

### DIFF
--- a/packages/scratch-gui/test/integration/dncl-mode-validation.test.js
+++ b/packages/scratch-gui/test/integration/dncl-mode-validation.test.js
@@ -52,6 +52,12 @@ const waitForActiveState = (d, testId, expected) =>
     );
 
 /**
+ * Click the Code tab using a stable selector instead of XPath text matching.
+ * @param {import('selenium-webdriver').WebDriver} d - WebDriver instance.
+ */
+const clickCodeTab = d => d.executeScript(`document.querySelector('[role="tab"]').click()`);
+
+/**
  * Load the editor in Ruby mode (not DNCL), clearing any localStorage state.
  * @param {import('selenium-webdriver').WebDriver} d - WebDriver instance.
  */
@@ -145,7 +151,7 @@ describe('DNCL mode validation on switch', () => {
         await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', false);
 
         // Switch to Code tab
-        await clickText('コード', '*[@role="tab"]');
+        await clickCodeTab(driver);
 
         // Wait for the extension button to be visible and clickable (not disabled)
         await driver.wait(
@@ -179,7 +185,7 @@ describe('DNCL mode validation on switch', () => {
         await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', false);
 
         // Switch to Code tab
-        await clickText('コード', '*[@role="tab"]');
+        await clickCodeTab(driver);
 
         // Wait for extension button to be visible and not disabled
         await driver.wait(


### PR DESCRIPTION
## Summary

`dncl-mode-validation` integration test の2つのテストケースが CI で flaky に失敗する問題を修正。

- `clickText('コード', '*[@role="tab"]')` (XPath テキスト検索) を `document.querySelector('[role="tab"]').click()` に置換
- Code タブは常に最初の `role="tab"` 要素なので、テキスト描画のタイミングに依存せず安定して選択できる

## Changes Made

- `clickCodeTab()` ヘルパー関数を追加（`document.querySelector('[role="tab"]')` を使用）
- 2箇所の `clickText('コード', ...)` を `clickCodeTab(driver)` に置換

## Test Coverage

- 修正対象のテストファイル自体が CI で実行される
- lint パス確認済み

Fixes #434
