### PR TITLE
fix: match tm2scratch collaborator credit with Stretch3

### DIFF
--- a/packages/scratch-gui/src/lib/libraries/extensions/tm2scratch/index.jsx
+++ b/packages/scratch-gui/src/lib/libraries/extensions/tm2scratch/index.jsx
@@ -35,7 +35,7 @@ const entry = {
     launchPeripheralConnectionFlow: false,
     useAutoScan: false,
     helpLink: 'https://github.com/champierre/tm2scratch',
-    collaborator: 'Junya Ishihara, Koji Yokokawa',
+    collaborator: 'Tsukurusha, YengawaLab and Google',
     setFormatMessage: (formatter) => {
         formatMessage = formatter;
     },


### PR DESCRIPTION
## Summary

tm2scratch 拡張機能の「協力」欄を Stretch3 の表記に合わせる。

- 変更前: `Junya Ishihara, Koji Yokokawa`（個人名）
- 変更後: `Tsukurusha, YengawaLab and Google`（Stretch3 準拠）

tm2scratch の作者からの指摘に基づく修正。開発時に Google から支援を受けており、Stretch3 での表記に合わせる必要がある。

## Test plan

- [ ] CI green
- [ ] ブラウザ確認: 拡張機能ライブラリで「協力 Tsukurusha, YengawaLab and Google」と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
