### PR TITLE
feat: submission v2 — block screenshots, carousel, comment/return

### DIFF
--- a/infra/smalruby-classroom/lambda/handler.ts
+++ b/infra/smalruby-classroom/lambda/handler.ts
@@ -44,6 +44,8 @@ const MAX_PROJECT_NAME_LENGTH = 100;
 const PRESIGNED_URL_UPLOAD_EXPIRY = 15 * 60; // 15 minutes
 const PRESIGNED_URL_DOWNLOAD_EXPIRY = 60 * 60; // 1 hour
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_SCREENSHOT_COUNT = 20;
+const MAX_TEACHER_COMMENT_LENGTH = 500;
 
 // --- DynamoDB Client ---
 
@@ -638,10 +640,32 @@ export function validateProjectName(name: unknown): string {
   return trimmed;
 }
 
+export function validateScreenshotCount(count: unknown): number {
+  const n = typeof count === 'number' ? count : parseInt(String(count), 10);
+  if (isNaN(n) || n < 0) return 0;
+  if (n > MAX_SCREENSHOT_COUNT) {
+    throw new ValidationError(`Screenshot count must be ${MAX_SCREENSHOT_COUNT} or less`);
+  }
+  return n;
+}
+
+export function validateTeacherComment(comment: unknown): string {
+  if (comment === undefined || comment === null) return '';
+  if (typeof comment !== 'string') {
+    throw new ValidationError('Comment must be a string');
+  }
+  const trimmed = comment.trim();
+  if (trimmed.length > MAX_TEACHER_COMMENT_LENGTH) {
+    throw new ValidationError(`Comment must be ${MAX_TEACHER_COMMENT_LENGTH} characters or less`);
+  }
+  return trimmed;
+}
+
 async function handleCreateSubmission(
   classroomId: string, memberId: string, body: Record<string, unknown>
 ): Promise<APIGatewayProxyStructuredResultV2> {
   const projectName = validateProjectName(body.projectName);
+  const screenshotCount = validateScreenshotCount(body.screenshotCount);
   const submissionId = crypto.randomUUID();
   const now = new Date().toISOString();
 
@@ -655,8 +679,7 @@ async function handleCreateSubmission(
       Bucket: SUBMISSIONS_BUCKET,
       Key: s3KeyProject,
       ContentType: 'application/octet-stream',
-      ContentLengthRange: { Minimum: 1, Maximum: MAX_FILE_SIZE },
-    } as any),
+    }),
     { expiresIn: PRESIGNED_URL_UPLOAD_EXPIRY },
   );
 
@@ -670,6 +693,21 @@ async function handleCreateSubmission(
     { expiresIn: PRESIGNED_URL_UPLOAD_EXPIRY },
   );
 
+  // Generate presigned URLs for screenshots
+  const screenshotUploadUrls: string[] = [];
+  for (let i = 0; i < screenshotCount; i++) {
+    const ssUrl = await getSignedUrl(
+      s3Client,
+      new PutObjectCommand({
+        Bucket: SUBMISSIONS_BUCKET,
+        Key: `${classroomId}/${submissionId}/screenshot-${i}.png`,
+        ContentType: 'image/png',
+      }),
+      { expiresIn: PRESIGNED_URL_UPLOAD_EXPIRY },
+    );
+    screenshotUploadUrls.push(ssUrl);
+  }
+
   // Save submission record
   await docClient.send(new PutCommand({
     TableName: SUBMISSIONS_TABLE,
@@ -680,6 +718,7 @@ async function handleCreateSubmission(
       projectName,
       s3Key: s3KeyProject,
       thumbnailS3Key: s3KeyThumbnail,
+      screenshotCount,
       status: 'submitted',
       submittedAt: now,
       updatedAt: now,
@@ -693,6 +732,7 @@ async function handleCreateSubmission(
       submissionId,
       uploadUrl,
       thumbnailUploadUrl,
+      screenshotUploadUrls,
       projectName,
       submittedAt: now,
     }),
@@ -741,14 +781,31 @@ async function handleListSubmissions(
           { expiresIn: PRESIGNED_URL_DOWNLOAD_EXPIRY },
         );
       }
+      // Generate presigned URLs for screenshots
+      const ssCount = typeof item.screenshotCount === 'number' ? item.screenshotCount : 0;
+      const screenshotUrls: string[] = [];
+      for (let i = 0; i < ssCount; i++) {
+        const ssUrl = await getSignedUrl(
+          s3Client,
+          new GetObjectCommand({
+            Bucket: SUBMISSIONS_BUCKET,
+            Key: `${item.classroomId}/${item.submissionId}/screenshot-${i}.png`,
+          }),
+          { expiresIn: PRESIGNED_URL_DOWNLOAD_EXPIRY },
+        );
+        screenshotUrls.push(ssUrl);
+      }
+
       return {
         submissionId: item.submissionId,
         memberId: item.memberId,
         projectName: item.projectName,
         status: item.status,
         submittedAt: item.submittedAt,
+        teacherComment: item.teacherComment || null,
         thumbnailUrl,
         projectUrl,
+        screenshotUrls,
       };
     })
   );
@@ -756,6 +813,75 @@ async function handleListSubmissions(
   return {
     statusCode: 200,
     body: JSON.stringify({ submissions }),
+  };
+}
+
+async function handleUpdateSubmission(
+  teacherSub: string, classroomId: string, submissionId: string, body: Record<string, unknown>
+): Promise<APIGatewayProxyStructuredResultV2> {
+  // Verify ownership
+  const classroom = await docClient.send(new GetCommand({
+    TableName: CLASSROOMS_TABLE,
+    Key: { classroomId },
+  }));
+  if (!classroom.Item || classroom.Item.teacherSub !== teacherSub) {
+    throw new AuthError('Not authorized to update submissions');
+  }
+
+  // Verify submission exists
+  const submission = await docClient.send(new GetCommand({
+    TableName: SUBMISSIONS_TABLE,
+    Key: { classroomId, submissionId },
+  }));
+  if (!submission.Item) {
+    throw new ValidationError('Submission not found');
+  }
+
+  const updates: Record<string, unknown> = { updatedAt: new Date().toISOString() };
+  const exprParts: string[] = [];
+  const exprNames: Record<string, string> = {};
+  const exprValues: Record<string, unknown> = {};
+
+  if (body.teacherComment !== undefined) {
+    const comment = validateTeacherComment(body.teacherComment);
+    updates.teacherComment = comment;
+    exprParts.push('#tc = :tc');
+    exprNames['#tc'] = 'teacherComment';
+    exprValues[':tc'] = comment;
+  }
+
+  if (body.status !== undefined) {
+    if (body.status !== 'returned') {
+      throw new ValidationError('Status can only be set to "returned"');
+    }
+    updates.status = 'returned';
+    exprParts.push('#st = :st');
+    exprNames['#st'] = 'status';
+    exprValues[':st'] = 'returned';
+  }
+
+  if (exprParts.length === 0) {
+    throw new ValidationError('No fields to update');
+  }
+
+  exprParts.push('#ua = :ua');
+  exprNames['#ua'] = 'updatedAt';
+  exprValues[':ua'] = updates.updatedAt;
+
+  await docClient.send(new UpdateCommand({
+    TableName: SUBMISSIONS_TABLE,
+    Key: { classroomId, submissionId },
+    UpdateExpression: `SET ${exprParts.join(', ')}`,
+    ExpressionAttributeNames: exprNames,
+    ExpressionAttributeValues: exprValues,
+  }));
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      submissionId,
+      ...updates,
+    }),
   };
 }
 
@@ -851,6 +977,13 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
       const teacherSub = await verifyGoogleIdToken(token);
       const classroomId = event.pathParameters?.classroomId || '';
       result = await handleListSubmissions(teacherSub, classroomId);
+
+    } else if (method === 'PATCH' && /^\/classrooms\/[^/]+\/submissions\/[^/]+$/.test(path)) {
+      const token = extractBearerToken(event.headers?.authorization);
+      const teacherSub = await verifyGoogleIdToken(token);
+      const classroomId = event.pathParameters?.classroomId || '';
+      const submissionId = event.pathParameters?.submissionId || '';
+      result = await handleUpdateSubmission(teacherSub, classroomId, submissionId, body);
 
     } else {
       result = { statusCode: 404, body: JSON.stringify({ error: 'Not found' }) };

--- a/infra/smalruby-classroom/lambda/tests/handler.test.ts
+++ b/infra/smalruby-classroom/lambda/tests/handler.test.ts
@@ -7,6 +7,8 @@ import {
   validateNickname,
   validateJoinCode,
   validateProjectName,
+  validateTeacherComment,
+  validateScreenshotCount,
   getCorsHeaders,
 } from '../handler';
 
@@ -234,5 +236,65 @@ describe('validateProjectName', () => {
   test('should accept name at max length', () => {
     const maxName = 'a'.repeat(100);
     expect(validateProjectName(maxName)).toBe(maxName);
+  });
+});
+
+describe('validateTeacherComment', () => {
+  test('should accept valid comment', () => {
+    expect(validateTeacherComment('Good work!')).toBe('Good work!');
+  });
+
+  test('should trim whitespace', () => {
+    expect(validateTeacherComment('  nice  ')).toBe('nice');
+  });
+
+  test('should accept empty string', () => {
+    expect(validateTeacherComment('')).toBe('');
+  });
+
+  test('should return empty for null/undefined', () => {
+    expect(validateTeacherComment(null)).toBe('');
+    expect(validateTeacherComment(undefined)).toBe('');
+  });
+
+  test('should reject non-string', () => {
+    expect(() => validateTeacherComment(123)).toThrow('Comment must be a string');
+  });
+
+  test('should reject too-long comment', () => {
+    const long = 'a'.repeat(501);
+    expect(() => validateTeacherComment(long)).toThrow('500 characters or less');
+  });
+
+  test('should accept comment at max length', () => {
+    const maxComment = 'a'.repeat(500);
+    expect(validateTeacherComment(maxComment)).toBe(maxComment);
+  });
+});
+
+describe('validateScreenshotCount', () => {
+  test('should accept valid count', () => {
+    expect(validateScreenshotCount(5)).toBe(5);
+  });
+
+  test('should return 0 for undefined/null', () => {
+    expect(validateScreenshotCount(undefined)).toBe(0);
+    expect(validateScreenshotCount(null)).toBe(0);
+  });
+
+  test('should return 0 for negative', () => {
+    expect(validateScreenshotCount(-1)).toBe(0);
+  });
+
+  test('should parse string number', () => {
+    expect(validateScreenshotCount('3')).toBe(3);
+  });
+
+  test('should reject count over max', () => {
+    expect(() => validateScreenshotCount(21)).toThrow('20 or less');
+  });
+
+  test('should accept max count', () => {
+    expect(validateScreenshotCount(20)).toBe(20);
   });
 });

--- a/infra/smalruby-classroom/lib/classroom-stack.ts
+++ b/infra/smalruby-classroom/lib/classroom-stack.ts
@@ -315,6 +315,12 @@ export class ClassroomStack extends cdk.Stack {
       integration,
     });
 
+    this.api.addRoutes({
+      path: '/classrooms/{classroomId}/submissions/{submissionId}',
+      methods: [apigatewayv2.HttpMethod.PATCH],
+      integration,
+    });
+
     // Throttling
     const defaultStage = this.api.defaultStage?.node.defaultChild as apigatewayv2.CfnStage;
     if (defaultStage) {

--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
@@ -396,6 +396,11 @@
     color: white;
 }
 
+.member-cell-returned {
+    background-color: #ff8c1a;
+    color: white;
+}
+
 .member-cell-empty {
     background-color: #e8e8e8;
     color: #999;
@@ -434,6 +439,92 @@
     color: #0fbd8c;
     font-size: 0.75rem;
     margin-left: 0.5rem;
+}
+
+.returned-badge {
+    color: #ff8c1a;
+    font-size: 0.75rem;
+    margin-left: 0.5rem;
+}
+
+.image-carousel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.carousel-nav {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    color: #575e75;
+}
+
+.carousel-button {
+    background: none;
+    border: 1px solid #d9d9d9;
+    border-radius: 4px;
+    padding: 0.15rem 0.5rem;
+    cursor: pointer;
+    font-size: 0.8rem;
+    color: #575e75;
+}
+
+.carousel-button:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
+.carousel-button:hover:not(:disabled) {
+    background-color: #f0f0f0;
+}
+
+.comment-section {
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid #e0e0e0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.comment-input {
+    width: 100%;
+    min-height: 60px;
+    border: 1px solid #d9d9d9;
+    border-radius: 4px;
+    padding: 0.4rem;
+    font-size: 0.8rem;
+    resize: vertical;
+    font-family: inherit;
+    box-sizing: border-box;
+}
+
+.comment-input:focus {
+    outline: none;
+    border-color: #4c97ff;
+}
+
+.return-button {
+    background-color: #ff8c1a;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 0.4rem 0.8rem;
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
+.return-button:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.return-button:hover:not(:disabled) {
+    background-color: #e67e16;
 }
 
 .submission-detail {

--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.jsx
@@ -1,6 +1,6 @@
 import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 import Modal from '../../containers/modal.jsx';
@@ -45,9 +45,11 @@ const ClassroomModal = ({
     onLeaveClassroom,
     onOpenSubmission,
     onRefreshDetail,
+    onReturnSubmission,
     onStartSubmit,
     onConfirmSubmit,
     onCancelSubmit,
+    submitProgress,
     thumbnailDataUrl,
     onTeacherLogout,
     classroomState,
@@ -341,6 +343,7 @@ const ClassroomModal = ({
                         onDeleteMember={handleDeleteMember}
                         onOpenSubmission={onOpenSubmission}
                         onRefresh={onRefreshDetail}
+                        onReturnSubmission={onReturnSubmission}
                         onSelectMember={onSelectMember}
                         onShowCodeDisplay={onShowCodeDisplay}
                         onToggleCodeFullscreen={onToggleCodeFullscreen}
@@ -644,7 +647,9 @@ const ClassroomModal = ({
                                 disabled={isLoading}
                                 onClick={onConfirmSubmit}
                             >
-                                {isLoading ? (
+                                {isLoading && submitProgress ? (
+                                    `${submitProgress.label} (${submitProgress.current}/${submitProgress.total})`
+                                ) : isLoading ? (
                                     <FormattedMessage
                                         defaultMessage="Submitting..."
                                         description="Submitting progress"
@@ -911,6 +916,7 @@ const TeacherClassDetail = ({
     onDeleteClassroom,
     onOpenSubmission,
     onRefresh,
+    onReturnSubmission,
     onShowCodeDisplay,
     onCloseCodeDisplay,
     onCopyInviteLink,
@@ -920,6 +926,21 @@ const TeacherClassDetail = ({
 }) => {
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [showCodeDisplay, setShowCodeDisplay] = useState(false);
+    const [currentImageIndex, setCurrentImageIndex] = useState(0);
+    const [commentText, setCommentText] = useState('');
+
+    // Reset image index and comment when selected member changes
+    useEffect(() => {
+        setCurrentImageIndex(0);
+        if (selectedMember) {
+            const memberMap2 = {};
+            for (const m of members) memberMap2[m.memberId] = m;
+            const member = memberMap2[selectedMember];
+            setCommentText(member?.teacherComment || '');
+        } else {
+            setCommentText('');
+        }
+    }, [selectedMember, members]);
 
     const memberMap = React.useMemo(() => {
         const map = {};
@@ -959,6 +980,28 @@ const TeacherClassDetail = ({
         [onOpenSubmission],
     );
 
+    const handleReturnClick = useCallback(() => {
+        if (!selectedMember || !memberMap[selectedMember]?.submissionId) return;
+        onReturnSubmission(memberMap[selectedMember].submissionId, commentText);
+    }, [selectedMember, memberMap, commentText, onReturnSubmission]);
+
+    const handleCommentChange = useCallback(e => {
+        setCommentText(e.target.value);
+    }, []);
+
+    const handlePrevImage = useCallback(() => {
+        setCurrentImageIndex(prev => Math.max(0, prev - 1));
+    }, []);
+
+    const handleNextImage = useCallback(() => {
+        setCurrentImageIndex(prev => {
+            const member = memberMap[selectedMember];
+            if (!member) return prev;
+            const allImages = [member.thumbnailUrl, ...(member.screenshotUrls || [])].filter(Boolean);
+            return Math.min(allImages.length - 1, prev + 1);
+        });
+    }, [memberMap, selectedMember]);
+
     const handleShowCode = useCallback(() => {
         setShowCodeDisplay(true);
         onShowCodeDisplay(selectedClassroom.classroomId);
@@ -971,6 +1014,17 @@ const TeacherClassDetail = ({
 
     const joinedCount = members.length;
     const totalCount = selectedClassroom.studentCount;
+
+    // Pre-compute selected member's derived data for the right pane
+    const selectedMemberData = React.useMemo(() => {
+        if (!selectedMember || !memberMap[selectedMember]) return null;
+        const member = memberMap[selectedMember];
+        return {
+            ...member,
+            allImages: [member.thumbnailUrl, ...(member.screenshotUrls || [])].filter(Boolean),
+            isReturned: member.submissionStatus === 'returned',
+        };
+    }, [selectedMember, memberMap]);
 
     return (
         <div className={styles.detailLayout} data-testid="classroom-phase-teacher-detail">
@@ -1087,13 +1141,21 @@ const TeacherClassDetail = ({
                                         const member = memberMap[memberId];
                                         const isSelected = selectedMember === memberId;
                                         const hasSubmission = member && member.hasSubmission;
+                                        const isReturned = member && member.submissionStatus === 'returned';
                                         let cellColorClass = styles.memberCellEmpty;
                                         if (member) {
-                                            cellColorClass = hasSubmission
-                                                ? styles.memberCellSubmitted
-                                                : styles.memberCellJoined;
+                                            if (isReturned) {
+                                                cellColorClass = styles.memberCellReturned;
+                                            } else if (hasSubmission) {
+                                                cellColorClass = styles.memberCellSubmitted;
+                                            } else {
+                                                cellColorClass = styles.memberCellJoined;
+                                            }
                                         }
                                         const cellClass = `${styles.memberCell} ${cellColorClass} ${isSelected ? styles.memberCellSelected : ''}`;
+                                        let cellLabel = seatNum;
+                                        if (isReturned) cellLabel = `↩${seatNum}`;
+                                        else if (hasSubmission) cellLabel = `✓${seatNum}`;
                                         return (
                                             <button
                                                 className={cellClass}
@@ -1102,7 +1164,7 @@ const TeacherClassDetail = ({
                                                 key={memberId}
                                                 onClick={member ? handleCellClick : null}
                                             >
-                                                {hasSubmission ? `✓${seatNum}` : seatNum}
+                                                {cellLabel}
                                             </button>
                                         );
                                     })}
@@ -1164,7 +1226,7 @@ const TeacherClassDetail = ({
 
                         {/* Right pane - member detail */}
                         <div className={styles.detailRightPane}>
-                            {selectedMember && memberMap[selectedMember] ? (
+                            {selectedMemberData ? (
                                 <div
                                     className={styles.memberDetailPanel}
                                     data-testid="classroom-member-detail"
@@ -1182,15 +1244,15 @@ const TeacherClassDetail = ({
                                             />
                                         </span>
                                         <span data-testid="classroom-member-detail-name">
-                                            {memberMap[selectedMember].displayName || '-'}
+                                            {selectedMemberData.displayName || '-'}
                                         </span>
-                                        {memberMap[selectedMember].hasSubmission && (
+                                        {selectedMemberData.hasSubmission && (
                                             <span
-                                                className={styles.submissionBadge}
+                                                className={selectedMemberData.isReturned ? styles.returnedBadge : styles.submissionBadge}
                                                 data-testid="classroom-member-detail-submitted"
                                             >
-                                                {'✓ '}
-                                                {new Date(memberMap[selectedMember].submittedAt).toLocaleTimeString()}
+                                                {selectedMemberData.isReturned ? '↩ ' : '✓ '}
+                                                {new Date(selectedMemberData.submittedAt).toLocaleTimeString()}
                                             </span>
                                         )}
                                         <button
@@ -1206,28 +1268,54 @@ const TeacherClassDetail = ({
                                             />
                                         </button>
                                     </div>
-                                    {memberMap[selectedMember].hasSubmission && (
+                                    {selectedMemberData.hasSubmission && (
                                         <div className={styles.memberDetailBody}>
-                                            {memberMap[selectedMember].thumbnailUrl && (
-                                                <img
-                                                    alt="Submission thumbnail"
-                                                    className={styles.memberDetailThumbnailLarge}
-                                                    data-testid="classroom-member-detail-thumbnail"
-                                                    src={memberMap[selectedMember].thumbnailUrl}
-                                                />
+                                            {/* Image carousel */}
+                                            {selectedMemberData.allImages.length > 0 && (
+                                                <div className={styles.imageCarousel}>
+                                                    {selectedMemberData.allImages.length > 1 && (
+                                                        <div className={styles.carouselNav}>
+                                                            <button
+                                                                className={styles.carouselButton}
+                                                                data-testid="classroom-member-detail-prev"
+                                                                disabled={currentImageIndex === 0}
+                                                                onClick={handlePrevImage}
+                                                            >
+                                                                {'<'}
+                                                            </button>
+                                                            <span data-testid="classroom-member-detail-image-index">
+                                                                {`${currentImageIndex + 1} / ${selectedMemberData.allImages.length}`}
+                                                            </span>
+                                                            <button
+                                                                className={styles.carouselButton}
+                                                                data-testid="classroom-member-detail-next"
+                                                                disabled={currentImageIndex >= selectedMemberData.allImages.length - 1}
+                                                                onClick={handleNextImage}
+                                                            >
+                                                                {'>'}
+                                                            </button>
+                                                        </div>
+                                                    )}
+                                                    <img
+                                                        alt="Submission image"
+                                                        className={styles.memberDetailThumbnailLarge}
+                                                        data-testid="classroom-member-detail-thumbnail"
+                                                        src={selectedMemberData.allImages[currentImageIndex] || selectedMemberData.allImages[0]}
+                                                    />
+                                                </div>
                                             )}
-                                            {memberMap[selectedMember].projectName && (
+                                            {selectedMemberData.projectName && (
                                                 <span
                                                     className={styles.submissionProjectName}
                                                     data-testid="classroom-member-detail-project-name"
                                                 >
-                                                    {memberMap[selectedMember].projectName}
+                                                    {selectedMemberData.projectName}
                                                 </span>
                                             )}
-                                            {memberMap[selectedMember].projectUrl && (
+                                            {selectedMemberData.projectUrl && (
                                                 <button
                                                     className={styles.primaryButton}
-                                                    data-project-url={memberMap[selectedMember].projectUrl}
+                                                    data-project-url={selectedMemberData.projectUrl}
                                                     data-testid="classroom-member-detail-open"
                                                     disabled={isLoading}
                                                     onClick={handleOpenClick}
@@ -1239,6 +1327,37 @@ const TeacherClassDetail = ({
                                                     />
                                                 </button>
                                             )}
+                                            {/* Comment + Return */}
+                                            <div className={styles.commentSection}>
+                                                <textarea
+                                                    className={styles.commentInput}
+                                                    data-testid="classroom-member-detail-comment"
+                                                    maxLength={500}
+                                                    placeholder={selectedMemberData.isReturned ? '' : '...'}
+                                                    value={commentText}
+                                                    onChange={handleCommentChange}
+                                                />
+                                                <button
+                                                    className={styles.returnButton}
+                                                    data-testid="classroom-member-detail-return"
+                                                    disabled={isLoading || selectedMemberData.isReturned}
+                                                    onClick={handleReturnClick}
+                                                >
+                                                    {selectedMemberData.isReturned ? (
+                                                        <FormattedMessage
+                                                            defaultMessage="Returned"
+                                                            description="Returned status label"
+                                                            id="gui.classroom.teacherDetail.returned"
+                                                        />
+                                                    ) : (
+                                                        <FormattedMessage
+                                                            defaultMessage="Return"
+                                                            description="Return submission button"
+                                                            id="gui.classroom.teacherDetail.returnSubmission"
+                                                        />
+                                                    )}
+                                                </button>
+                                            </div>
                                         </div>
                                     )}
                                 </div>
@@ -1273,6 +1392,7 @@ TeacherClassDetail.propTypes = {
     onDeleteMember: PropTypes.func.isRequired,
     onOpenSubmission: PropTypes.func.isRequired,
     onRefresh: PropTypes.func.isRequired,
+    onReturnSubmission: PropTypes.func.isRequired,
     onSelectMember: PropTypes.func.isRequired,
     onShowCodeDisplay: PropTypes.func.isRequired,
     onToggleCodeFullscreen: PropTypes.func.isRequired,
@@ -1497,6 +1617,7 @@ ClassroomModal.propTypes = {
     onLeaveClassroom: PropTypes.func.isRequired,
     onOpenSubmission: PropTypes.func.isRequired,
     onRefreshDetail: PropTypes.func.isRequired,
+    onReturnSubmission: PropTypes.func.isRequired,
     onSelectClassroom: PropTypes.func.isRequired,
     onSelectMember: PropTypes.func.isRequired,
     onSelectSeat: PropTypes.func.isRequired,
@@ -1514,6 +1635,11 @@ ClassroomModal.propTypes = {
     selectedMember: PropTypes.string,
     selectedSeat: PropTypes.number,
     takenSeats: PropTypes.arrayOf(PropTypes.number),
+    submitProgress: PropTypes.shape({
+        current: PropTypes.number,
+        total: PropTypes.number,
+        label: PropTypes.string,
+    }),
     thumbnailDataUrl: PropTypes.string,
 };
 

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -806,7 +806,8 @@ class Blocks extends React.Component {
         const target = this.props.vm.editingTarget;
         const spriteName = target ? target.sprite.name : 'sprite';
         const projectTitle = this.props.projectTitle || 'project';
-        downloadBlocksAsImage(this.workspace, projectTitle, spriteName);
+        const costumeDataUri = target?.sprite?.costumes?.[target.currentCostume]?.asset?.encodeDataURI();
+        downloadBlocksAsImage(this.workspace, projectTitle, spriteName, costumeDataUri);
     }
     render () {
         const {

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -2,13 +2,7 @@ import React, { useCallback, useState, useEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import ClassroomModalComponent from '../components/classroom-modal/classroom-modal.jsx';
-import {
-    getBlocksBoundingBox,
-    mergeWithBubbleBBox,
-    calculateCanvasDimensions,
-    buildExportSVG,
-    renderSVGToCanvas,
-} from '../lib/blocks-screenshot.js';
+import { renderBlocksToCanvas } from '../lib/blocks-screenshot.js';
 import classroomAPI from '../lib/classroom-api.js';
 import { loadGoogleIdentity } from '../lib/google-script-loader.js';
 import { getProjectThumbnail } from '../lib/store-project-thumbnail.js';
@@ -606,41 +600,9 @@ const ClassroomModal = () => {
             });
 
             try {
-                const blockBbox = getBlocksBoundingBox(workspace);
-                if (!blockBbox) continue;
-
-                const bbox = mergeWithBubbleBBox(workspace, blockBbox);
-                const scale = workspace.scale;
-                const { width, height } = calculateCanvasDimensions(bbox, scale);
-                const svgStr = await buildExportSVG(workspace, bbox, scale, width, height);
-                const canvas = await renderSVGToCanvas(svgStr, width, height);
-
-                // Overlay sprite costume in top-right corner
-                const ctx = canvas.getContext('2d');
-                const costumeAsset = target.sprite.costumes[target.currentCostume]?.asset;
-                if (costumeAsset) {
-                    const costumeDataUri = costumeAsset.encodeDataURI();
-                    const spriteImg = await new Promise((resolve, reject) => {
-                        const img = new Image();
-                        img.onload = () => resolve(img);
-                        img.onerror = reject;
-                        img.src = costumeDataUri;
-                    });
-                    const spriteSize = 48;
-                    const margin = 8;
-                    // Draw white circle background
-                    ctx.fillStyle = '#ffffff';
-                    ctx.beginPath();
-                    ctx.arc(
-                        canvas.width - margin - spriteSize / 2,
-                        margin + spriteSize / 2,
-                        spriteSize / 2 + 4,
-                        0,
-                        Math.PI * 2,
-                    );
-                    ctx.fill();
-                    ctx.drawImage(spriteImg, canvas.width - spriteSize - margin, margin, spriteSize, spriteSize);
-                }
+                const costumeDataUri = target.sprite.costumes[target.currentCostume]?.asset?.encodeDataURI();
+                const canvas = await renderBlocksToCanvas(workspace, costumeDataUri);
+                if (!canvas) continue;
 
                 const blob = await new Promise(resolve => {
                     canvas.toBlob(resolve, 'image/png');

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -2,6 +2,13 @@ import React, { useCallback, useState, useEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import ClassroomModalComponent from '../components/classroom-modal/classroom-modal.jsx';
+import {
+    getBlocksBoundingBox,
+    mergeWithBubbleBBox,
+    calculateCanvasDimensions,
+    buildExportSVG,
+    renderSVGToCanvas,
+} from '../lib/blocks-screenshot.js';
 import classroomAPI from '../lib/classroom-api.js';
 import { loadGoogleIdentity } from '../lib/google-script-loader.js';
 import { getProjectThumbnail } from '../lib/store-project-thumbnail.js';
@@ -73,6 +80,7 @@ const ClassroomModal = () => {
     const intl = useIntl();
     const classroomState = useSelector(state => state.scratchGui.classroom);
     const vm = useSelector(state => state.scratchGui.vm);
+    const scratchBlocks = useSelector(state => state.scratchGui.blockDisplay?.scratchBlocks);
 
     // Determine initial phase based on persisted session
     const getInitialPhase = () => {
@@ -107,6 +115,7 @@ const ClassroomModal = () => {
 
     // Submission state
     const [thumbnailDataUrl, setThumbnailDataUrl] = useState(null);
+    const [submitProgress, setSubmitProgress] = useState(null); // { current, total, label }
 
     // Code display state
     const [codeDisplayClassroom, setCodeDisplayClassroom] = useState(null);
@@ -299,9 +308,13 @@ const ClassroomModal = () => {
                     if (sub) {
                         return {
                             ...m,
+                            submissionId: sub.submissionId,
+                            submissionStatus: sub.status || 'submitted',
                             thumbnailUrl: sub.thumbnailUrl || null,
                             projectUrl: sub.projectUrl || null,
                             projectName: sub.projectName || null,
+                            screenshotUrls: sub.screenshotUrls || [],
+                            teacherComment: sub.teacherComment || '',
                         };
                     }
                     return m;
@@ -557,6 +570,95 @@ const ClassroomModal = () => {
 
     // --- Student: Confirm submit ---
 
+    /**
+     * Capture block screenshots for all targets that have blocks.
+     * Switches editing target for each, takes screenshot, overlays sprite icon.
+     * @returns {Promise<Blob[]>} Array of PNG blobs
+     */
+    const captureBlockScreenshots = useCallback(async () => {
+        if (!vm || !scratchBlocks) return [];
+
+        const workspace = scratchBlocks.getMainWorkspace();
+        if (!workspace) return [];
+
+        const originalTargetId = vm.editingTarget?.id;
+        const allTargets = vm.runtime.targets.filter(t => !t.isOriginal === false || t.isOriginal);
+        // Filter targets that have blocks (including stage)
+        const targetsWithBlocks = allTargets.filter(t => {
+            const blocks = t.blocks._blocks;
+            return blocks && Object.keys(blocks).length > 0;
+        });
+
+        const blobs = [];
+        for (let i = 0; i < targetsWithBlocks.length; i++) {
+            const target = targetsWithBlocks[i];
+            setSubmitProgress({
+                current: i + 1,
+                total: targetsWithBlocks.length,
+                label: target.sprite.name,
+            });
+
+            // Switch editing target and wait for workspace update
+            vm.setEditingTarget(target.id);
+            await new Promise(resolve => {
+                // Wait for workspace to fully update after target switch
+                setTimeout(() => requestAnimationFrame(resolve), 100);
+            });
+
+            try {
+                const blockBbox = getBlocksBoundingBox(workspace);
+                if (!blockBbox) continue;
+
+                const bbox = mergeWithBubbleBBox(workspace, blockBbox);
+                const scale = workspace.scale;
+                const { width, height } = calculateCanvasDimensions(bbox, scale);
+                const svgStr = await buildExportSVG(workspace, bbox, scale, width, height);
+                const canvas = await renderSVGToCanvas(svgStr, width, height);
+
+                // Overlay sprite costume in top-right corner
+                const ctx = canvas.getContext('2d');
+                const costumeAsset = target.sprite.costumes[target.currentCostume]?.asset;
+                if (costumeAsset) {
+                    const costumeDataUri = costumeAsset.encodeDataURI();
+                    const spriteImg = await new Promise((resolve, reject) => {
+                        const img = new Image();
+                        img.onload = () => resolve(img);
+                        img.onerror = reject;
+                        img.src = costumeDataUri;
+                    });
+                    const spriteSize = 48;
+                    const margin = 8;
+                    // Draw white circle background
+                    ctx.fillStyle = '#ffffff';
+                    ctx.beginPath();
+                    ctx.arc(
+                        canvas.width - margin - spriteSize / 2,
+                        margin + spriteSize / 2,
+                        spriteSize / 2 + 4,
+                        0,
+                        Math.PI * 2,
+                    );
+                    ctx.fill();
+                    ctx.drawImage(spriteImg, canvas.width - spriteSize - margin, margin, spriteSize, spriteSize);
+                }
+
+                const blob = await new Promise(resolve => {
+                    canvas.toBlob(resolve, 'image/png');
+                });
+                if (blob) blobs.push(blob);
+            } catch {
+                // Skip sprites that fail to capture
+            }
+        }
+
+        // Restore original editing target
+        if (originalTargetId) {
+            vm.setEditingTarget(originalTargetId);
+        }
+        setSubmitProgress(null);
+        return blobs;
+    }, [vm, scratchBlocks]);
+
     const handleConfirmSubmit = useCallback(async () => {
         if (!classroomState.sessionToken || !classroomState.classroomId) return;
         clearError();
@@ -564,18 +666,23 @@ const ClassroomModal = () => {
         try {
             const projectTitle = vm.runtime.projectName || 'Untitled';
 
-            // 1. Get presigned URLs
+            // 1. Capture block screenshots
+            const screenshotBlobs = await captureBlockScreenshots();
+
+            // 2. Get presigned URLs (including screenshot URLs)
             const submissionData = await classroomAPI.createSubmission(
                 classroomState.sessionToken,
                 classroomState.classroomId,
                 projectTitle,
+                screenshotBlobs.length,
             );
 
-            // 2. Upload .sb3
+            // 3. Upload .sb3
+            setSubmitProgress({ current: 0, total: 1, label: 'project' });
             const sb3Data = await vm.saveProjectSb3();
             await classroomAPI.uploadToPresignedUrl(submissionData.uploadUrl, sb3Data, 'application/octet-stream');
 
-            // 3. Upload thumbnail
+            // 4. Upload thumbnail
             if (thumbnailDataUrl) {
                 const thumbnailBlob = await fetch(thumbnailDataUrl).then(r => r.blob());
                 await classroomAPI.uploadToPresignedUrl(
@@ -585,12 +692,23 @@ const ClassroomModal = () => {
                 );
             }
 
-            // 4. Update Redux state
+            // 5. Upload screenshots (parallel)
+            if (screenshotBlobs.length > 0 && submissionData.screenshotUploadUrls) {
+                await Promise.all(
+                    screenshotBlobs.map((blob, i) =>
+                        classroomAPI.uploadToPresignedUrl(submissionData.screenshotUploadUrls[i], blob, 'image/png'),
+                    ),
+                );
+            }
+
+            setSubmitProgress(null);
+
+            // 6. Update Redux state
             dispatch(setSubmissionStatus('submitted', submissionData.submittedAt));
             setPhase('student-status');
         } catch (err) {
+            setSubmitProgress(null);
             if (err.status === 401) {
-                // Session expired during submit
                 dispatch(clearClassroomSession());
                 const title = intl.formatMessage({
                     defaultMessage: 'An error occurred',
@@ -605,11 +723,34 @@ const ClassroomModal = () => {
         } finally {
             setIsLoading(false);
         }
-    }, [classroomState, vm, thumbnailDataUrl, dispatch, clearError, showError, intl]);
+    }, [classroomState, vm, thumbnailDataUrl, captureBlockScreenshots, dispatch, clearError, showError, intl]);
 
     const handleCancelSubmit = useCallback(() => {
         setPhase('student-status');
     }, []);
+
+    // --- Teacher: Return submission ---
+
+    const handleReturnSubmission = useCallback(
+        async (submissionId, teacherComment) => {
+            if (!idToken || !selectedClassroom) return;
+            clearError();
+            setIsLoading(true);
+            try {
+                await classroomAPI.updateSubmission(idToken, selectedClassroom.classroomId, submissionId, {
+                    status: 'returned',
+                    teacherComment,
+                });
+                // Refresh to show updated status
+                await loadClassroomDetail(selectedClassroom.classroomId);
+            } catch (err) {
+                showError(translateError(intl, err));
+            } finally {
+                setIsLoading(false);
+            }
+        },
+        [idToken, selectedClassroom, clearError, showError, intl, loadClassroomDetail],
+    );
 
     // --- Classcode URL parameter auto-join ---
     useEffect(() => {
@@ -667,8 +808,10 @@ const ClassroomModal = () => {
             onDeleteMember={handleDeleteMember}
             onJoinWithCode={handleJoinWithCode}
             onLeaveClassroom={handleLeaveClassroom}
+            submitProgress={submitProgress}
             onOpenSubmission={handleOpenSubmission}
             onRefreshDetail={handleRefreshDetail}
+            onReturnSubmission={handleReturnSubmission}
             onStartSubmit={handleStartSubmit}
             onConfirmSubmit={handleConfirmSubmit}
             onCancelSubmit={handleCancelSubmit}

--- a/packages/scratch-gui/src/lib/blocks-screenshot.js
+++ b/packages/scratch-gui/src/lib/blocks-screenshot.js
@@ -253,6 +253,7 @@ export {
     calculateCanvasDimensions,
     buildFilename,
     buildExportSVG,
+    renderSVGToCanvas,
     inlineImageHrefs,
     downloadBlocksAsImage,
     EXPORT_PADDING,

--- a/packages/scratch-gui/src/lib/blocks-screenshot.js
+++ b/packages/scratch-gui/src/lib/blocks-screenshot.js
@@ -222,22 +222,98 @@ const renderSVGToCanvas = function (svgStr, width, height) {
 };
 
 /**
+ * Size of the sprite costume image drawn at the top-left of screenshots.
+ */
+const SPRITE_IMAGE_SIZE = 48;
+const SPRITE_IMAGE_GAP = 8;
+
+/**
+ * Loads an image from a data URI and returns an HTMLImageElement.
+ * @param {string} dataUri - data URI string
+ * @returns {Promise<HTMLImageElement>} Loaded image element
+ */
+const loadImage = function (dataUri) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = reject;
+        img.src = dataUri;
+    });
+};
+
+/**
+ * Renders workspace blocks to a canvas, optionally with a sprite costume
+ * image drawn above the blocks at the top-left.
+ * @param {object} workspace - Scratch Blocks workspace
+ * @param {string} [costumeDataUri] - Sprite costume data URI (omit to skip)
+ * @returns {Promise<HTMLCanvasElement|null>} Canvas or null if workspace is empty
+ */
+const renderBlocksToCanvas = async function (workspace, costumeDataUri) {
+    const blockBbox = getBlocksBoundingBox(workspace);
+    if (!blockBbox) return null;
+
+    const bbox = mergeWithBubbleBBox(workspace, blockBbox);
+    const scale = workspace.scale;
+    const { width: blocksWidth, height: blocksHeight } = calculateCanvasDimensions(bbox, scale);
+
+    // Calculate sprite header height
+    let spriteHeaderHeight = 0;
+    let spriteImg = null;
+    if (costumeDataUri) {
+        spriteImg = await loadImage(costumeDataUri);
+        spriteHeaderHeight = SPRITE_IMAGE_SIZE + SPRITE_IMAGE_GAP;
+    }
+
+    const totalWidth = blocksWidth;
+    const totalHeight = blocksHeight + spriteHeaderHeight;
+
+    const svgStr = await buildExportSVG(workspace, bbox, scale, blocksWidth, blocksHeight);
+
+    // Render blocks SVG to a temporary canvas
+    const blocksCanvas = await renderSVGToCanvas(svgStr, blocksWidth, blocksHeight);
+
+    // Compose final canvas: sprite image on top, blocks below
+    const canvas = document.createElement('canvas');
+    canvas.width = totalWidth;
+    canvas.height = totalHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, totalWidth, totalHeight);
+
+    if (spriteImg) {
+        // Draw sprite at top-left, preserving aspect ratio within SPRITE_IMAGE_SIZE box
+        const aspectRatio = spriteImg.width / spriteImg.height;
+        let drawW = SPRITE_IMAGE_SIZE;
+        let drawH = SPRITE_IMAGE_SIZE;
+        if (aspectRatio > 1) {
+            drawH = SPRITE_IMAGE_SIZE / aspectRatio;
+        } else {
+            drawW = SPRITE_IMAGE_SIZE * aspectRatio;
+        }
+        const drawX = EXPORT_PADDING;
+        const drawY = (SPRITE_IMAGE_SIZE - drawH) / 2;
+        ctx.drawImage(spriteImg, drawX, drawY, drawW, drawH);
+    }
+
+    // Draw blocks below sprite header
+    ctx.drawImage(blocksCanvas, 0, spriteHeaderHeight);
+
+    return canvas;
+};
+
+/**
  * Downloads all blocks in the given workspace as a PNG image.
+ * If costumeDataUri is provided, the sprite image is drawn above the blocks.
  * Does nothing if the workspace contains no blocks.
  * @param {object} workspace - Scratch Blocks workspace
  * @param {string} projectTitle - Project name (used in filename)
  * @param {string} spriteName - Sprite / stage name (used in filename)
+ * @param {string} [costumeDataUri] - Sprite costume data URI
  * @returns {Promise<void>}
  */
-const downloadBlocksAsImage = async function (workspace, projectTitle, spriteName) {
-    const blockBbox = getBlocksBoundingBox(workspace);
-    if (!blockBbox) return;
-
-    const bbox = mergeWithBubbleBBox(workspace, blockBbox);
-    const scale = workspace.scale;
-    const { width, height } = calculateCanvasDimensions(bbox, scale);
-    const svgStr = await buildExportSVG(workspace, bbox, scale, width, height);
-    const canvas = await renderSVGToCanvas(svgStr, width, height);
+const downloadBlocksAsImage = async function (workspace, projectTitle, spriteName, costumeDataUri) {
+    const canvas = await renderBlocksToCanvas(workspace, costumeDataUri);
+    if (!canvas) return;
 
     return new Promise(resolve => {
         canvas.toBlob(blob => {
@@ -254,6 +330,7 @@ export {
     buildFilename,
     buildExportSVG,
     renderSVGToCanvas,
+    renderBlocksToCanvas,
     inlineImageHrefs,
     downloadBlocksAsImage,
     EXPORT_PADDING,

--- a/packages/scratch-gui/src/lib/classroom-api.js
+++ b/packages/scratch-gui/src/lib/classroom-api.js
@@ -126,10 +126,16 @@ class ClassroomAPI {
      * @param {string} sessionToken - Student session token
      * @param {string} classroomId - Classroom ID
      * @param {string} projectName - Project name
+     * @param {number} [screenshotCount] - Number of block screenshots
      * @returns {Promise<object>} Submission data with upload URLs
      */
-    async createSubmission(sessionToken, classroomId, projectName) {
-        return this._request('POST', `/classrooms/${classroomId}/submissions`, { projectName }, sessionToken);
+    async createSubmission(sessionToken, classroomId, projectName, screenshotCount = 0) {
+        return this._request(
+            'POST',
+            `/classrooms/${classroomId}/submissions`,
+            { projectName, screenshotCount },
+            sessionToken,
+        );
     }
 
     /**
@@ -140,6 +146,18 @@ class ClassroomAPI {
      */
     async listSubmissions(idToken, classroomId) {
         return this._request('GET', `/classrooms/${classroomId}/submissions`, null, idToken);
+    }
+
+    /**
+     * Update a submission (teacher comment / return).
+     * @param {string} idToken - Google ID token
+     * @param {string} classroomId - Classroom ID
+     * @param {string} submissionId - Submission ID
+     * @param {object} updates - Fields to update (teacherComment, status)
+     * @returns {Promise<object>} Updated submission data
+     */
+    async updateSubmission(idToken, classroomId, submissionId, updates) {
+        return this._request('PATCH', `/classrooms/${classroomId}/submissions/${submissionId}`, updates, idToken);
     }
 
     /**

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -89,6 +89,8 @@ export default {
     'gui.classroom.error.classroomInactive': 'This classroom is no longer active.',
     'gui.classroom.error.generic': 'An unexpected error occurred. Please try again.',
     'gui.classroom.teacherDetail.openSubmission': 'Open in Smalruby',
+    'gui.classroom.teacherDetail.returnSubmission': 'Return',
+    'gui.classroom.teacherDetail.returned': 'Returned',
     'gui.classroom.teacherDetail.cancelDelete': 'Cancel',
     'gui.classroom.codeDisplay.title': 'Class Code',
     'gui.classroom.codeDisplay.copyLink': 'Copy invite link',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -86,6 +86,8 @@ export default {
     'gui.classroom.error.classroomInactive': 'このクラスはげんざいりようできません。',
     'gui.classroom.error.generic': 'よきしないエラーがはっせいしました。もういちどおためしください。',
     'gui.classroom.teacherDetail.openSubmission': 'スモウルビーでひらく',
+    'gui.classroom.teacherDetail.returnSubmission': 'へんきゃくする',
+    'gui.classroom.teacherDetail.returned': 'へんきゃくずみ',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
     'gui.classroom.codeDisplay.title': 'クラスコード',
     'gui.classroom.codeDisplay.copyLink': 'しょうたいリンクをコピー',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -85,6 +85,8 @@ export default {
     'gui.classroom.error.classroomInactive': 'このクラスは現在利用できません。',
     'gui.classroom.error.generic': '予期しないエラーが発生しました。もう一度お試しください。',
     'gui.classroom.teacherDetail.openSubmission': 'スモウルビーで開く',
+    'gui.classroom.teacherDetail.returnSubmission': '返却する',
+    'gui.classroom.teacherDetail.returned': '返却済み',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
     'gui.classroom.codeDisplay.title': 'クラスコード',
     'gui.classroom.codeDisplay.copyLink': '招待リンクをコピー',

--- a/packages/scratch-gui/test/unit/reducers/classroom-reducer.test.js
+++ b/packages/scratch-gui/test/unit/reducers/classroom-reducer.test.js
@@ -75,10 +75,7 @@ describe('classroom reducer', () => {
     });
 
     test('should set submission status to submitted', () => {
-        const state = reducer(
-            classroomInitialState,
-            setSubmissionStatus('submitted', '2026-04-04T10:00:00Z'),
-        );
+        const state = reducer(classroomInitialState, setSubmissionStatus('submitted', '2026-04-04T10:00:00Z'));
         expect(state.submissionStatus).toBe('submitted');
         expect(state.lastSubmittedAt).toBe('2026-04-04T10:00:00Z');
     });

--- a/packages/scratch-gui/test/unit/reducers/classroom-reducer.test.js
+++ b/packages/scratch-gui/test/unit/reducers/classroom-reducer.test.js
@@ -4,6 +4,7 @@ import reducer, {
     closeClassroomModal,
     setClassroomSession,
     clearClassroomSession,
+    setSubmissionStatus,
 } from '../../../src/reducers/classroom';
 
 describe('classroom reducer', () => {
@@ -71,5 +72,38 @@ describe('classroom reducer', () => {
         );
         expect(state.modalVisible).toBe(true);
         expect(state.role).toBe('student');
+    });
+
+    test('should set submission status to submitted', () => {
+        const state = reducer(
+            classroomInitialState,
+            setSubmissionStatus('submitted', '2026-04-04T10:00:00Z'),
+        );
+        expect(state.submissionStatus).toBe('submitted');
+        expect(state.lastSubmittedAt).toBe('2026-04-04T10:00:00Z');
+    });
+
+    test('should set submission status to returned while preserving lastSubmittedAt', () => {
+        const withSubmission = {
+            ...classroomInitialState,
+            submissionStatus: 'submitted',
+            lastSubmittedAt: '2026-04-04T10:00:00Z',
+        };
+        const state = reducer(withSubmission, setSubmissionStatus('returned'));
+        expect(state.submissionStatus).toBe('returned');
+        expect(state.lastSubmittedAt).toBe('2026-04-04T10:00:00Z');
+    });
+
+    test('should clear submission status when clearing session', () => {
+        const withSubmission = {
+            ...classroomInitialState,
+            role: 'student',
+            sessionToken: 'token',
+            submissionStatus: 'submitted',
+            lastSubmittedAt: '2026-04-04T10:00:00Z',
+        };
+        const state = reducer(withSubmission, clearClassroomSession());
+        expect(state.submissionStatus).toBeNull();
+        expect(state.lastSubmittedAt).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

- Block screenshots: capture code for all sprites with blocks on submission, overlay sprite costume icon on top-right
- Image carousel: teacher can browse stage thumbnail + block screenshots with prev/next buttons
- Comment + Return: teacher can add comments and return submissions (orange grid color + ↩ mark)
- PATCH /submissions/{id} API endpoint for teacher comment and return status
- Multiple screenshot upload via presigned URLs (screenshotCount param)
- Reducer unit tests for submission status actions

## Related Issue

Closes #442 (remaining items except ZIP download and file size enforcement)

## Test plan

- [ ] Backend unit tests pass (validateTeacherComment, validateScreenshotCount)
- [ ] Frontend reducer tests pass (9 tests including 3 new submission tests)
- [ ] `npm run lint` passes
- [ ] Build succeeds
- [ ] CDK deploy (stg + prod) for PATCH route + screenshot support
- [ ] Playwright: student submits with blocks → teacher sees carousel with multiple images
- [ ] Playwright: teacher adds comment + clicks return → grid shows orange ↩

🤖 Generated with [Claude Code](https://claude.com/claude-code)
