### PR TITLE
fix: stabilize flaky costumes integration test (#447)

### DIFF
--- a/packages/scratch-gui/test/integration/costumes.test.js
+++ b/packages/scratch-gui/test/integration/costumes.test.js
@@ -16,7 +16,7 @@ const {
 } = new SeleniumHelper();
 
 // The costumes library is slow to load. Increase the timeout for these tests.
-jest.setTimeout(60_000);
+jest.setTimeout(90_000);
 
 const uri = path.resolve(__dirname, '../../build/index.html');
 
@@ -35,6 +35,7 @@ describe('Working with costumes', () => {
         await loadUri(uri);
         await clickText('Costumes');
         await clickXpath('//button[@aria-label="Choose a Costume"]');
+        await waitForLoadingFinished();
         const el = await findByXpath("//input[@placeholder='Search']");
         await el.sendKeys('abb');
         await clickText('Abby-a'); // Should close the modal, then click the costumes in the selector
@@ -194,6 +195,7 @@ describe('Working with costumes', () => {
             .setSize(1244, 768); // Letters filter not visible at 1024 width
         await clickText('Costumes');
         await clickXpath('//button[@aria-label="Choose a Costume"]');
+        await waitForLoadingFinished();
         await clickText('Letters');
         await clickText('Block-a', scope.modal); // Closes modal
         await rightClickText('Block-a', scope.costumesTab); // Make sure it is there


### PR DESCRIPTION
## Summary

- Increase `jest.setTimeout` from 60s to 90s for costume integration tests to handle CI resource contention
- Add `waitForLoadingFinished()` after opening the costume library modal in two tests that interact with library contents

## Changes Made

1. **`jest.setTimeout(90_000)`** — gives more headroom on slow CI runners
2. **"Adding a costume through the library"** — added `waitForLoadingFinished()` between opening modal and searching
3. **"Adding a letter costume through the Letters filter"** — added `waitForLoadingFinished()` between opening modal and clicking filter

## Test Coverage

- No new tests needed — this fixes flaky behavior in existing tests
- The fix is safe: `waitForLoadingFinished()` is a no-op if loading is already complete

Fixes #447
