### PR TITLE
feat: bulk ZIP download for classroom submissions (#449)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "packages/scratch-vm",
         "packages/scratch-gui"
       ],
+      "dependencies": {
+        "jszip": "^3.10.1"
+      },
       "devDependencies": {
         "@commitlint/cli": "17.8.1",
         "@commitlint/config-conventional": "17.8.1",
@@ -26375,6 +26378,8 @@
     },
     "node_modules/jszip": {
       "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "npm": "10.9.5",
     "serialport": "^13.0.0",
     "ts-node": "10.9.2"
+  },
+  "dependencies": {
+    "jszip": "^3.10.1"
   }
 }

--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
@@ -638,6 +638,12 @@
     border-top: 1px solid #e0e0e0;
 }
 
+.detail-footer-buttons {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
 .delete-confirm-box {
     background-color: #fff0f3;
     border: 1px solid #ff6680;

--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.jsx
@@ -46,6 +46,8 @@ const ClassroomModal = ({
     onOpenSubmission,
     onRefreshDetail,
     onReturnSubmission,
+    onDownloadAll,
+    downloadProgress,
     onStartSubmit,
     onConfirmSubmit,
     onCancelSubmit,
@@ -344,6 +346,8 @@ const ClassroomModal = ({
                         onOpenSubmission={onOpenSubmission}
                         onRefresh={onRefreshDetail}
                         onReturnSubmission={onReturnSubmission}
+                        onDownloadAll={onDownloadAll}
+                        downloadProgress={downloadProgress}
                         onSelectMember={onSelectMember}
                         onShowCodeDisplay={onShowCodeDisplay}
                         onToggleCodeFullscreen={onToggleCodeFullscreen}
@@ -917,6 +921,8 @@ const TeacherClassDetail = ({
     onOpenSubmission,
     onRefresh,
     onReturnSubmission,
+    onDownloadAll,
+    downloadProgress,
     onShowCodeDisplay,
     onCloseCodeDisplay,
     onCopyInviteLink,
@@ -1208,18 +1214,36 @@ const TeacherClassDetail = ({
                                         </div>
                                     </div>
                                 ) : (
-                                    <button
-                                        className={styles.dangerButton}
-                                        data-testid="classroom-delete-classroom"
-                                        disabled={isLoading}
-                                        onClick={handleDeleteClick}
-                                    >
-                                        <FormattedMessage
-                                            defaultMessage="Delete Classroom"
-                                            description="Delete classroom button"
-                                            id="gui.classroom.teacherDetail.deleteClassroom"
-                                        />
-                                    </button>
+                                    <div className={styles.detailFooterButtons}>
+                                        <button
+                                            className={styles.dangerButton}
+                                            data-testid="classroom-delete-classroom"
+                                            disabled={isLoading}
+                                            onClick={handleDeleteClick}
+                                        >
+                                            <FormattedMessage
+                                                defaultMessage="Delete Classroom"
+                                                description="Delete classroom button"
+                                                id="gui.classroom.teacherDetail.deleteClassroom"
+                                            />
+                                        </button>
+                                        <button
+                                            className={styles.secondaryButton}
+                                            data-testid="classroom-download-all"
+                                            disabled={isLoading || !!downloadProgress}
+                                            onClick={onDownloadAll}
+                                        >
+                                            {downloadProgress ? (
+                                                `${downloadProgress.current}/${downloadProgress.total}`
+                                            ) : (
+                                                <FormattedMessage
+                                                    defaultMessage="Download All"
+                                                    description="Download all submissions button"
+                                                    id="gui.classroom.teacherDetail.downloadAll"
+                                                />
+                                            )}
+                                        </button>
+                                    </div>
                                 )}
                             </div>
                         </div>
@@ -1390,6 +1414,11 @@ TeacherClassDetail.propTypes = {
     onCopyInviteLink: PropTypes.func.isRequired,
     onDeleteClassroom: PropTypes.func.isRequired,
     onDeleteMember: PropTypes.func.isRequired,
+    onDownloadAll: PropTypes.func.isRequired,
+    downloadProgress: PropTypes.shape({
+        current: PropTypes.number,
+        total: PropTypes.number,
+    }),
     onOpenSubmission: PropTypes.func.isRequired,
     onRefresh: PropTypes.func.isRequired,
     onReturnSubmission: PropTypes.func.isRequired,
@@ -1613,6 +1642,11 @@ ClassroomModal.propTypes = {
     onCreateClassroom: PropTypes.func.isRequired,
     onDeleteClassroom: PropTypes.func.isRequired,
     onDeleteMember: PropTypes.func.isRequired,
+    onDownloadAll: PropTypes.func.isRequired,
+    downloadProgress: PropTypes.shape({
+        current: PropTypes.number,
+        total: PropTypes.number,
+    }),
     onJoinWithCode: PropTypes.func.isRequired,
     onLeaveClassroom: PropTypes.func.isRequired,
     onOpenSubmission: PropTypes.func.isRequired,

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -1,3 +1,4 @@
+import JSZip from 'jszip';
 import React, { useCallback, useState, useEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
@@ -114,6 +115,7 @@ const ClassroomModal = () => {
     // Code display state
     const [codeDisplayClassroom, setCodeDisplayClassroom] = useState(null);
     const [codeDisplayFullscreen, setCodeDisplayFullscreen] = useState(false);
+    const [downloadProgress, setDownloadProgress] = useState(null); // { current, total }
 
     // Refresh timer for teacher detail
     const refreshTimerRef = useRef(null);
@@ -714,6 +716,76 @@ const ClassroomModal = () => {
         [idToken, selectedClassroom, clearError, showError, intl, loadClassroomDetail],
     );
 
+    // --- Teacher: Download all submissions as ZIP ---
+
+    const handleDownloadAll = useCallback(async () => {
+        if (!selectedClassroom || !members || members.length === 0) return;
+        clearError();
+
+        const submittedMembers = members.filter(m => m.hasSubmission && m.projectUrl);
+        if (submittedMembers.length === 0) return;
+
+        setDownloadProgress({ current: 0, total: submittedMembers.length });
+
+        try {
+            const zip = new JSZip();
+            const className = selectedClassroom.className || 'class';
+
+            for (let i = 0; i < submittedMembers.length; i++) {
+                const m = submittedMembers[i];
+                setDownloadProgress({ current: i + 1, total: submittedMembers.length });
+
+                const seatLabel = m.memberId.replace('seat-', '');
+                const name = m.displayName || '';
+                const folderName = name ? `${seatLabel}_${name}` : seatLabel;
+                const folder = zip.folder(folderName);
+
+                // Download project .sb3
+                try {
+                    const res = await fetch(m.projectUrl);
+                    if (res.ok) folder.file(`${m.projectName || 'project'}.sb3`, await res.blob());
+                } catch {
+                    // Skip failed downloads
+                }
+
+                // Download thumbnail
+                if (m.thumbnailUrl) {
+                    try {
+                        const res = await fetch(m.thumbnailUrl);
+                        if (res.ok) folder.file('thumbnail.png', await res.blob());
+                    } catch {
+                        // Skip
+                    }
+                }
+
+                // Download screenshots
+                for (let si = 0; si < (m.screenshotUrls || []).length; si++) {
+                    try {
+                        const res = await fetch(m.screenshotUrls[si]);
+                        if (res.ok) folder.file(`screenshot-${si}.png`, await res.blob());
+                    } catch {
+                        // Skip
+                    }
+                }
+            }
+
+            // Generate and download ZIP
+            const blob = await zip.generateAsync({ type: 'blob' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `${className}.zip`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        } catch (err) {
+            showError(translateError(intl, err));
+        } finally {
+            setDownloadProgress(null);
+        }
+    }, [selectedClassroom, members, clearError, showError, intl]);
+
     // --- Classcode URL parameter auto-join ---
     useEffect(() => {
         const urlParams = getUrlParams();
@@ -768,6 +840,8 @@ const ClassroomModal = () => {
             onCreateClassroom={handleCreateClassroom}
             onDeleteClassroom={handleDeleteClassroom}
             onDeleteMember={handleDeleteMember}
+            onDownloadAll={handleDownloadAll}
+            downloadProgress={downloadProgress}
             onJoinWithCode={handleJoinWithCode}
             onLeaveClassroom={handleLeaveClassroom}
             submitProgress={submitProgress}

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -91,6 +91,7 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'Open in Smalruby',
     'gui.classroom.teacherDetail.returnSubmission': 'Return',
     'gui.classroom.teacherDetail.returned': 'Returned',
+    'gui.classroom.teacherDetail.downloadAll': 'Download All',
     'gui.classroom.teacherDetail.cancelDelete': 'Cancel',
     'gui.classroom.codeDisplay.title': 'Class Code',
     'gui.classroom.codeDisplay.copyLink': 'Copy invite link',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -88,6 +88,7 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'スモウルビーでひらく',
     'gui.classroom.teacherDetail.returnSubmission': 'へんきゃくする',
     'gui.classroom.teacherDetail.returned': 'へんきゃくずみ',
+    'gui.classroom.teacherDetail.downloadAll': 'ぜんさくひんダウンロード',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
     'gui.classroom.codeDisplay.title': 'クラスコード',
     'gui.classroom.codeDisplay.copyLink': 'しょうたいリンクをコピー',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -87,6 +87,7 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'スモウルビーで開く',
     'gui.classroom.teacherDetail.returnSubmission': '返却する',
     'gui.classroom.teacherDetail.returned': '返却済み',
+    'gui.classroom.teacherDetail.downloadAll': '全作品ダウンロード',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
     'gui.classroom.codeDisplay.title': 'クラスコード',
     'gui.classroom.codeDisplay.copyLink': '招待リンクをコピー',


### PR DESCRIPTION
## Summary

- Add "Download All" button to teacher class detail footer
- Client-side ZIP generation using JSZip (no Lambda changes needed)
- Downloads all submitted projects (.sb3, thumbnails, screenshots) organized by seat number
- Progress indicator shows download count during operation

## Related Issue

Closes #449

## Test plan

- [ ] `npm run build:dev` succeeds
- [ ] `npm run lint` passes
- [ ] Teacher class detail shows "全作品ダウンロード" button next to "クラスを削除"
- [ ] Clicking downloads a ZIP with folders per student containing their files
- [ ] Progress shows during download (e.g., "2/3")
- [ ] Button is disabled during download

🤖 Generated with [Claude Code](https://claude.com/claude-code)
