### PR TITLE
fix: client-side file size limit for submissions (#450)

### DIFF
--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -639,9 +639,23 @@ const ClassroomModal = () => {
                 screenshotBlobs.length,
             );
 
-            // 3. Upload .sb3
+            // 3. Upload .sb3 (with size check)
             setSubmitProgress({ current: 0, total: 1, label: 'project' });
             const sb3Data = await vm.saveProjectSb3();
+            const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+            if (sb3Data.byteLength > MAX_FILE_SIZE) {
+                const sizeMB = (sb3Data.byteLength / (1024 * 1024)).toFixed(1);
+                throw new Error(
+                    intl.formatMessage(
+                        {
+                            defaultMessage: 'Project is too large ({size}MB). Maximum size is 10MB.',
+                            description: 'File too large error',
+                            id: 'gui.classroom.error.fileTooLarge',
+                        },
+                        { size: sizeMB },
+                    ),
+                );
+            }
             await classroomAPI.uploadToPresignedUrl(submissionData.uploadUrl, sb3Data, 'application/octet-stream');
 
             // 4. Upload thumbnail

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -91,6 +91,7 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'Open in Smalruby',
     'gui.classroom.teacherDetail.returnSubmission': 'Return',
     'gui.classroom.teacherDetail.returned': 'Returned',
+    'gui.classroom.error.fileTooLarge': 'Project is too large ({size}MB). Maximum size is 10MB.',
     'gui.classroom.teacherDetail.cancelDelete': 'Cancel',
     'gui.classroom.codeDisplay.title': 'Class Code',
     'gui.classroom.codeDisplay.copyLink': 'Copy invite link',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -88,6 +88,7 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'スモウルビーでひらく',
     'gui.classroom.teacherDetail.returnSubmission': 'へんきゃくする',
     'gui.classroom.teacherDetail.returned': 'へんきゃくずみ',
+    'gui.classroom.error.fileTooLarge': 'プロジェクトがおおきすぎます（{size}MB）。じょうげんは10MBです。',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
     'gui.classroom.codeDisplay.title': 'クラスコード',
     'gui.classroom.codeDisplay.copyLink': 'しょうたいリンクをコピー',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -87,6 +87,7 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'スモウルビーで開く',
     'gui.classroom.teacherDetail.returnSubmission': '返却する',
     'gui.classroom.teacherDetail.returned': '返却済み',
+    'gui.classroom.error.fileTooLarge': 'プロジェクトが大きすぎます（{size}MB）。上限は10MBです。',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
     'gui.classroom.codeDisplay.title': 'クラスコード',
     'gui.classroom.codeDisplay.copyLink': '招待リンクをコピー',


### PR DESCRIPTION
## Summary

- Validate .sb3 file size (max 10MB) before uploading
- Show localized error message with actual file size

## Related Issue

Closes #450

## Test plan

- [ ] Build succeeds
- [ ] Lint passes
- [ ] Submit a project < 10MB → succeeds
- [ ] (Manual) A project > 10MB would show error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)