### PR TITLE
feat: student return notification with teacher comment (#451)

### DIFF
--- a/infra/smalruby-classroom/lambda/handler.ts
+++ b/infra/smalruby-classroom/lambda/handler.ts
@@ -887,8 +887,34 @@ async function handleUpdateSubmission(
 
 async function handleVerifySession(sessionToken: string): Promise<APIGatewayProxyStructuredResultV2> {
   // verifySessionToken will throw AuthError if invalid
-  await verifySessionToken(sessionToken);
-  return { statusCode: 200, body: JSON.stringify({ valid: true }) };
+  const session = await verifySessionToken(sessionToken);
+
+  // Look up latest submission for this member
+  let submission: Record<string, unknown> | null = null;
+  const subResult = await docClient.send(new QueryCommand({
+    TableName: SUBMISSIONS_TABLE,
+    IndexName: 'classroomId-memberId-index',
+    KeyConditionExpression: 'classroomId = :cid AND memberId = :mid',
+    ExpressionAttributeValues: {
+      ':cid': session.classroomId,
+      ':mid': session.memberId,
+    },
+    ScanIndexForward: false,
+    Limit: 1,
+  }));
+  if (subResult.Items && subResult.Items.length > 0) {
+    const item = subResult.Items[0];
+    submission = {
+      status: item.status,
+      submittedAt: item.submittedAt,
+      teacherComment: item.teacherComment || null,
+    };
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ valid: true, submission }),
+  };
 }
 
 // --- Main handler ---

--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
@@ -527,6 +527,44 @@
     background-color: #e67e16;
 }
 
+.refresh-button {
+    background: none;
+    border: 1px solid #d9d9d9;
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+    color: #575e75;
+    margin-left: auto;
+}
+
+.refresh-button:hover:not(:disabled) {
+    background-color: #f0f0f0;
+}
+
+.refresh-button:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
+.teacher-comment-box {
+    background-color: #fff8e1;
+    border: 1px solid #ffcc02;
+    border-radius: 4px;
+    padding: 0.5rem;
+    margin-top: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.teacher-comment-text {
+    font-size: 0.85rem;
+    color: #575e75;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 .submission-detail {
     display: flex;
     gap: 0.5rem;

--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.jsx
@@ -50,6 +50,8 @@ const ClassroomModal = ({
     onConfirmSubmit,
     onCancelSubmit,
     submitProgress,
+    teacherComment,
+    onRefreshStudentStatus,
     thumbnailDataUrl,
     onTeacherLogout,
     classroomState,
@@ -531,7 +533,19 @@ const ClassroomModal = ({
                                     className={styles.statusValue}
                                     data-testid="classroom-submit-status"
                                 >
-                                    {classroomState.submissionStatus === 'submitted' ? (
+                                    {classroomState.submissionStatus === 'returned' ? (
+                                        <React.Fragment>
+                                            {'↩ '}
+                                            <FormattedMessage
+                                                defaultMessage="Returned"
+                                                description="Returned status"
+                                                id="gui.classroom.studentStatus.returned"
+                                            />
+                                            {classroomState.lastSubmittedAt && (
+                                                <span>{` (${new Date(classroomState.lastSubmittedAt).toLocaleTimeString()})`}</span>
+                                            )}
+                                        </React.Fragment>
+                                    ) : classroomState.submissionStatus === 'submitted' ? (
                                         <React.Fragment>
                                             {'✓ '}
                                             <FormattedMessage
@@ -551,7 +565,32 @@ const ClassroomModal = ({
                                         />
                                     )}
                                 </span>
+                                <button
+                                    className={styles.refreshButton}
+                                    data-testid="classroom-student-refresh"
+                                    disabled={isLoading}
+                                    onClick={onRefreshStudentStatus}
+                                >
+                                    {'↻'}
+                                </button>
                             </div>
+                            {classroomState.submissionStatus === 'returned' && teacherComment && (
+                                <div
+                                    className={styles.teacherCommentBox}
+                                    data-testid="classroom-status-teacher-comment"
+                                >
+                                    <span className={styles.statusLabel}>
+                                        <FormattedMessage
+                                            defaultMessage="Comment"
+                                            description="Teacher comment label"
+                                            id="gui.classroom.studentStatus.comment"
+                                        />
+                                    </span>
+                                    <span className={styles.teacherCommentText}>
+                                        {teacherComment}
+                                    </span>
+                                </div>
+                            )}
                         </div>
                         <div className={styles.buttonRow}>
                             <button
@@ -560,7 +599,7 @@ const ClassroomModal = ({
                                 disabled={isLoading}
                                 onClick={onStartSubmit}
                             >
-                                {classroomState.submissionStatus === 'submitted' ? (
+                                {classroomState.submissionStatus ? (
                                     <FormattedMessage
                                         defaultMessage="Resubmit"
                                         description="Resubmit button"
@@ -1617,6 +1656,7 @@ ClassroomModal.propTypes = {
     onLeaveClassroom: PropTypes.func.isRequired,
     onOpenSubmission: PropTypes.func.isRequired,
     onRefreshDetail: PropTypes.func.isRequired,
+    onRefreshStudentStatus: PropTypes.func.isRequired,
     onReturnSubmission: PropTypes.func.isRequired,
     onSelectClassroom: PropTypes.func.isRequired,
     onSelectMember: PropTypes.func.isRequired,
@@ -1640,6 +1680,7 @@ ClassroomModal.propTypes = {
         total: PropTypes.number,
         label: PropTypes.string,
     }),
+    teacherComment: PropTypes.string,
     thumbnailDataUrl: PropTypes.string,
 };
 

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -523,23 +523,39 @@ const ClassroomModal = () => {
         }
     }, [dispatch, pendingJoinCode, selectedSeat, clearError, showError, intl]);
 
-    // --- Student: Verify session on status screen ---
+    // --- Student: Verify session + fetch submission status ---
 
+    const [studentTeacherComment, setStudentTeacherComment] = useState(null);
+
+    const refreshStudentStatus = useCallback(async () => {
+        if (!classroomState.sessionToken) return;
+        setIsLoading(true);
+        try {
+            const result = await classroomAPI.verifySession(classroomState.sessionToken);
+            if (result.submission) {
+                dispatch(setSubmissionStatus(result.submission.status, result.submission.submittedAt));
+                setStudentTeacherComment(result.submission.teacherComment || null);
+            }
+        } catch {
+            dispatch(clearClassroomSession());
+            const title = intl.formatMessage({
+                defaultMessage: 'An error occurred',
+                description: 'Error dialog title',
+                id: 'gui.classroom.error.title',
+            });
+            showError(translateError(intl, { status: 401 }, 'session'), title);
+            setPhase('role-select');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [classroomState.sessionToken, dispatch, showError, intl]);
+
+    // Fetch on student-status phase display
     useEffect(() => {
         if (phase === 'student-status' && classroomState.sessionToken) {
-            classroomAPI.verifySession(classroomState.sessionToken).catch(() => {
-                // Session is invalid — clear and redirect
-                dispatch(clearClassroomSession());
-                const title = intl.formatMessage({
-                    defaultMessage: 'An error occurred',
-                    description: 'Error dialog title',
-                    id: 'gui.classroom.error.title',
-                });
-                showError(translateError(intl, { status: 401 }, 'session'), title);
-                setPhase('role-select');
-            });
+            refreshStudentStatus();
         }
-    }, [phase, classroomState.sessionToken, dispatch, showError, intl]);
+    }, [phase]); // Only on phase change, not on every render
 
     // --- Student: Leave classroom ---
 
@@ -774,6 +790,8 @@ const ClassroomModal = () => {
             onOpenSubmission={handleOpenSubmission}
             onRefreshDetail={handleRefreshDetail}
             onReturnSubmission={handleReturnSubmission}
+            teacherComment={studentTeacherComment}
+            onRefreshStudentStatus={refreshStudentStatus}
             onStartSubmit={handleStartSubmit}
             onConfirmSubmit={handleConfirmSubmit}
             onCancelSubmit={handleCancelSubmit}

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -91,6 +91,8 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'Open in Smalruby',
     'gui.classroom.teacherDetail.returnSubmission': 'Return',
     'gui.classroom.teacherDetail.returned': 'Returned',
+    'gui.classroom.studentStatus.returned': 'Returned',
+    'gui.classroom.studentStatus.comment': 'Comment',
     'gui.classroom.teacherDetail.cancelDelete': 'Cancel',
     'gui.classroom.codeDisplay.title': 'Class Code',
     'gui.classroom.codeDisplay.copyLink': 'Copy invite link',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -88,6 +88,8 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'スモウルビーでひらく',
     'gui.classroom.teacherDetail.returnSubmission': 'へんきゃくする',
     'gui.classroom.teacherDetail.returned': 'へんきゃくずみ',
+    'gui.classroom.studentStatus.returned': 'へんきゃくずみ',
+    'gui.classroom.studentStatus.comment': 'コメント',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
     'gui.classroom.codeDisplay.title': 'クラスコード',
     'gui.classroom.codeDisplay.copyLink': 'しょうたいリンクをコピー',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -87,6 +87,8 @@ export default {
     'gui.classroom.teacherDetail.openSubmission': 'スモウルビーで開く',
     'gui.classroom.teacherDetail.returnSubmission': '返却する',
     'gui.classroom.teacherDetail.returned': '返却済み',
+    'gui.classroom.studentStatus.returned': '返却済み',
+    'gui.classroom.studentStatus.comment': 'コメント',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
     'gui.classroom.codeDisplay.title': 'クラスコード',
     'gui.classroom.codeDisplay.copyLink': '招待リンクをコピー',


### PR DESCRIPTION
## Summary

- Backend: `verify-session` returns latest submission status + teacher comment
- Student status screen shows returned (↩) status with yellow comment box
- Refresh button (↻) for manual status reload (no polling to save costs)

## Related Issue

Closes #451

## Test plan

- [ ] Build succeeds
- [ ] Lint passes
- [ ] CDK deploy (stg + prod) for verify-session change
- [ ] Teacher returns submission with comment → student opens modal → sees ↩ returned + comment
- [ ] Student clicks ↻ refresh → status updates from server

🤖 Generated with [Claude Code](https://claude.com/claude-code)