### PR TITLE
fix: delete member on student leave to reset teacher grid (#455)

### DIFF
--- a/infra/smalruby-classroom/lambda/handler.ts
+++ b/infra/smalruby-classroom/lambda/handler.ts
@@ -957,11 +957,27 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
       result = await handleListMembers(teacherSub, classroomId);
 
     } else if (method === 'DELETE' && /^\/classrooms\/[^/]+\/members\/[^/]+$/.test(path)) {
-      const token = extractBearerToken(event.headers?.authorization);
-      const teacherSub = await verifyGoogleIdToken(token);
       const classroomId = event.pathParameters?.classroomId || '';
       const memberId = event.pathParameters?.memberId || '';
-      result = await handleDeleteMember(teacherSub, classroomId, memberId);
+
+      if (memberId === 'me') {
+        // Student self-removal via sessionToken
+        const token = extractBearerToken(event.headers?.authorization);
+        const session = await verifySessionToken(token);
+        if (session.classroomId !== classroomId) {
+          throw new AuthError('Session does not match this classroom');
+        }
+        await docClient.send(new DeleteCommand({
+          TableName: MEMBERSHIPS_TABLE,
+          Key: { classroomId, memberId: session.memberId },
+        }));
+        result = { statusCode: 204 };
+      } else {
+        // Teacher removal via Google ID token
+        const token = extractBearerToken(event.headers?.authorization);
+        const teacherSub = await verifyGoogleIdToken(token);
+        result = await handleDeleteMember(teacherSub, classroomId, memberId);
+      }
 
     } else if (method === 'POST' && /^\/classrooms\/[^/]+\/submissions$/.test(path)) {
       const token = extractBearerToken(event.headers?.authorization);

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -543,10 +543,18 @@ const ClassroomModal = () => {
 
     // --- Student: Leave classroom ---
 
-    const handleLeaveClassroom = useCallback(() => {
+    const handleLeaveClassroom = useCallback(async () => {
+        // Notify server to remove member record (best-effort)
+        if (classroomState.sessionToken && classroomState.classroomId) {
+            try {
+                await classroomAPI.leaveClassroom(classroomState.sessionToken, classroomState.classroomId);
+            } catch {
+                // Proceed even if server call fails
+            }
+        }
         dispatch(clearClassroomSession());
         setPhase('role-select');
-    }, [dispatch]);
+    }, [classroomState.sessionToken, classroomState.classroomId, dispatch]);
 
     // --- Student: Start submit flow ---
 

--- a/packages/scratch-gui/src/lib/classroom-api.js
+++ b/packages/scratch-gui/src/lib/classroom-api.js
@@ -122,6 +122,16 @@ class ClassroomAPI {
     }
 
     /**
+     * Leave a classroom (student self-removal).
+     * @param {string} sessionToken - Student session token
+     * @param {string} classroomId - Classroom ID
+     * @returns {Promise<void>}
+     */
+    async leaveClassroom(sessionToken, classroomId) {
+        return this._request('DELETE', `/classrooms/${classroomId}/members/me`, null, sessionToken);
+    }
+
+    /**
      * Create a submission (get presigned URLs for upload).
      * @param {string} sessionToken - Student session token
      * @param {string} classroomId - Classroom ID


### PR DESCRIPTION
## Summary

- Backend: `DELETE /members/me` with sessionToken auth for student self-removal
- Frontend: `handleLeaveClassroom` now calls server before clearing local session
- Teacher's seat grid shows empty (gray) seat on next refresh after student leaves

## Related Issue

Closes #455

## Test plan

- [ ] Build succeeds
- [ ] Lint passes
- [ ] CDK deploy for new route handler
- [ ] Student joins → teacher sees blue seat → student leaves → teacher refreshes → seat is gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)