### PR TITLE
feat: macOS での SmalrubotS1 ファームウェア書き込み対応

### DIFF
--- a/packages/scratch-gui/src/components/smalrubot-firmware-modal/smalrubot-firmware-modal.css
+++ b/packages/scratch-gui/src/components/smalrubot-firmware-modal/smalrubot-firmware-modal.css
@@ -118,6 +118,16 @@
     font-size: 0.875rem;
 }
 
+.app-store-link {
+    color: $motion-primary;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.app-store-link:hover {
+    text-decoration: underline;
+}
+
 .error-details {
     width: 100%;
     margin-top: 0.5rem;

--- a/packages/scratch-gui/src/components/smalrubot-firmware-modal/smalrubot-firmware-modal.jsx
+++ b/packages/scratch-gui/src/components/smalrubot-firmware-modal/smalrubot-firmware-modal.jsx
@@ -16,10 +16,20 @@ const messages = defineMessages({
 });
 
 /**
- * @typedef {'ready'|'flashing'|'success'|'error'} FlashPhase
+ * @typedef {'macSetup'|'ready'|'flashing'|'success'|'error'} FlashPhase
  */
 
-const SmalrubotFirmwareModal = ({ phase, progressPercent, statusMessage, errorMessage, onFlash, onClose }) => {
+const MAC_APP_STORE_URL = 'https://apps.apple.com/jp/app/pl2303-serial/id1624835354?mt=12';
+
+const SmalrubotFirmwareModal = ({
+    phase,
+    progressPercent,
+    statusMessage,
+    errorMessage,
+    onFlash,
+    onClose,
+    onProceedToReady,
+}) => {
     const intl = useIntl();
     return (
         <Modal
@@ -29,6 +39,54 @@ const SmalrubotFirmwareModal = ({ phase, progressPercent, statusMessage, errorMe
             onRequestClose={onClose}
         >
             <Box className={styles.body}>
+                {phase === 'macSetup' && (
+                    <React.Fragment>
+                        <div className={styles.description}>
+                            <FormattedMessage
+                                defaultMessage="To flash firmware on macOS, you need to install the PL2303 Serial Driver app from the Mac App Store."
+                                description="Description for macOS setup step in firmware flash modal"
+                                id="gui.smalrubotFirmware.macSetupDescription"
+                            />
+                        </div>
+                        <div className={styles.description}>
+                            <a
+                                className={styles.appStoreLink}
+                                href={MAC_APP_STORE_URL}
+                                rel="noopener noreferrer"
+                                target="_blank"
+                            >
+                                <FormattedMessage
+                                    defaultMessage="Open in Mac App Store"
+                                    description="Link to PL2303 Serial app on Mac App Store"
+                                    id="gui.smalrubotFirmware.macSetupLink"
+                                />
+                            </a>
+                        </div>
+                        <div className={styles.description}>
+                            <FormattedMessage
+                                defaultMessage="Install and set up the app following the instructions on the app page."
+                                description="Instruction for macOS setup step"
+                                id="gui.smalrubotFirmware.macSetupInstruction"
+                            />
+                        </div>
+                        <div className={styles.buttonRow}>
+                            <button className={styles.flashButton} onClick={onProceedToReady}>
+                                <FormattedMessage
+                                    defaultMessage="Setup Complete, Proceed to Flash"
+                                    description="Button to proceed from macOS setup to firmware flash"
+                                    id="gui.smalrubotFirmware.macSetupProceed"
+                                />
+                            </button>
+                            <button className={styles.closeButton} onClick={onClose}>
+                                <FormattedMessage
+                                    defaultMessage="Cancel"
+                                    description="Button to cancel firmware flash"
+                                    id="gui.smalrubotFirmware.cancelButton"
+                                />
+                            </button>
+                        </div>
+                    </React.Fragment>
+                )}
                 {phase === 'ready' && (
                     <React.Fragment>
                         <div className={styles.description}>
@@ -150,13 +208,15 @@ SmalrubotFirmwareModal.propTypes = {
     errorMessage: PropTypes.string,
     onClose: PropTypes.func.isRequired,
     onFlash: PropTypes.func.isRequired,
-    phase: PropTypes.oneOf(['ready', 'flashing', 'success', 'error']).isRequired,
+    onProceedToReady: PropTypes.func,
+    phase: PropTypes.oneOf(['macSetup', 'ready', 'flashing', 'success', 'error']).isRequired,
     progressPercent: PropTypes.number,
     statusMessage: PropTypes.string,
 };
 
 SmalrubotFirmwareModal.defaultProps = {
     errorMessage: null,
+    onProceedToReady: null,
     progressPercent: 0,
     statusMessage: null,
 };

--- a/packages/scratch-gui/src/containers/smalrubot-firmware-modal.jsx
+++ b/packages/scratch-gui/src/containers/smalrubot-firmware-modal.jsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import SmalrubotFirmwareModalComponent from '../components/smalrubot-firmware-modal/smalrubot-firmware-modal.jsx';
-import { FirmwareFlasher } from '../lib/smalrubot-firmware-flasher';
+import { FirmwareFlasher, isMacOS } from '../lib/smalrubot-firmware-flasher';
 import { closeSmalrubotFirmwareModal } from '../reducers/smalrubot-firmware';
 
 const SmalrubotFirmwareModal = () => {
     const dispatch = useDispatch();
-    const [phase, setPhase] = useState('ready');
+    const [phase, setPhase] = useState(isMacOS() ? 'macSetup' : 'ready');
     const [progressPercent, setProgressPercent] = useState(0);
     const [statusMessage, setStatusMessage] = useState(null);
     const [errorMessage, setErrorMessage] = useState(null);
@@ -38,12 +38,16 @@ const SmalrubotFirmwareModal = () => {
     }, []);
 
     const handleClose = useCallback(() => {
-        setPhase('ready');
+        setPhase(isMacOS() ? 'macSetup' : 'ready');
         setProgressPercent(0);
         setStatusMessage(null);
         setErrorMessage(null);
         dispatch(closeSmalrubotFirmwareModal());
     }, [dispatch]);
+
+    const handleProceedToReady = useCallback(() => {
+        setPhase('ready');
+    }, []);
 
     return (
         <SmalrubotFirmwareModalComponent
@@ -53,6 +57,7 @@ const SmalrubotFirmwareModal = () => {
             statusMessage={statusMessage}
             onClose={handleClose}
             onFlash={handleFlash}
+            onProceedToReady={handleProceedToReady}
         />
     );
 };

--- a/packages/scratch-gui/src/lib/smalrubot-firmware-flasher.js
+++ b/packages/scratch-gui/src/lib/smalrubot-firmware-flasher.js
@@ -2,8 +2,8 @@
  * SmalrubotS1 Firmware Flasher — WebSerial STK500v1 Implementation
  *
  * Flashes firmware to Studuino (ATmega168) boards via WebSerial API.
- * Supported on Windows and ChromeOS Chrome browsers.
- * macOS is NOT supported due to PL2303 USB-Serial chip limitations.
+ * Supported on Windows, ChromeOS, and macOS Chrome browsers.
+ * macOS requires the PL2303 Serial Driver app from the Mac App Store.
  *
  * Protocol: STK500v1 (Optiboot bootloader)
  * Reference: notes/issues/52/smalruby-integration/firmware-flasher.js
@@ -82,13 +82,12 @@ const isMacOS = () => {
 
 /**
  * Check if firmware flashing is supported on this platform.
- * Requires WebSerial API and a non-macOS platform.
+ * Requires WebSerial API.
  * @returns {boolean} True if firmware flashing is supported.
  */
 const isFirmwareFlashSupported = () => {
     if (typeof navigator === 'undefined') return false;
     if (!navigator.serial) return false;
-    if (isMacOS()) return false;
     return true;
 };
 

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -31,6 +31,13 @@ export default {
     'gui.smalrubotFirmware.retryButton': 'Try Again',
     'gui.smalrubotFirmware.closeButton': 'Close',
     'gui.smalrubotFirmware.closeAfterErrorButton': 'Close',
+    'gui.smalrubotFirmware.macSetupTitle': 'macOS Setup Required',
+    'gui.smalrubotFirmware.macSetupDescription':
+        'To flash firmware on macOS, you need to install the PL2303 Serial Driver app from the Mac App Store.',
+    'gui.smalrubotFirmware.macSetupLink': 'Open in Mac App Store',
+    'gui.smalrubotFirmware.macSetupInstruction':
+        'Install and set up the app following the instructions on the app page.',
+    'gui.smalrubotFirmware.macSetupProceed': 'Setup Complete, Proceed to Flash',
     'gui.connection.error.flashFirmwareButton': 'Write Firmware',
     'gui.classroom.title': 'Classroom',
     'gui.menuBar.classroom': 'Classroom',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -27,6 +27,13 @@ export default {
     'gui.smalrubotFirmware.retryButton': 'もういちどためす',
     'gui.smalrubotFirmware.closeButton': 'とじる',
     'gui.smalrubotFirmware.closeAfterErrorButton': 'とじる',
+    'gui.smalrubotFirmware.macSetupTitle': 'macOSセットアップがひつようです',
+    'gui.smalrubotFirmware.macSetupDescription':
+        'macOSでファームウェアをかきこむには、Mac App StoreからPL2303 Serial Driverアプリのインストールがひつようです。',
+    'gui.smalrubotFirmware.macSetupLink': 'Mac App Storeでひらく',
+    'gui.smalrubotFirmware.macSetupInstruction':
+        'アプリのせつめいにしたがってインストール・セットアップをおこなってください。',
+    'gui.smalrubotFirmware.macSetupProceed': 'セットアップかんりょう、かきこみにすすむ',
     'gui.connection.error.flashFirmwareButton': 'ファームウェアかきこみ',
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -27,6 +27,12 @@ export default {
     'gui.smalrubotFirmware.retryButton': 'もう一度試す',
     'gui.smalrubotFirmware.closeButton': '閉じる',
     'gui.smalrubotFirmware.closeAfterErrorButton': '閉じる',
+    'gui.smalrubotFirmware.macSetupTitle': 'macOSセットアップが必要です',
+    'gui.smalrubotFirmware.macSetupDescription':
+        'macOSでファームウェアを書き込むには、Mac App StoreからPL2303 Serial Driverアプリのインストールが必要です。',
+    'gui.smalrubotFirmware.macSetupLink': 'Mac App Storeで開く',
+    'gui.smalrubotFirmware.macSetupInstruction': 'アプリの説明に従ってインストール・セットアップを行ってください。',
+    'gui.smalrubotFirmware.macSetupProceed': 'セットアップ完了、書き込みに進む',
     'gui.connection.error.flashFirmwareButton': 'ファームウェア書き込み',
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',

--- a/packages/scratch-gui/test/unit/lib/smalrubot-firmware-flasher.test.js
+++ b/packages/scratch-gui/test/unit/lib/smalrubot-firmware-flasher.test.js
@@ -135,7 +135,7 @@ describe('smalrubot-firmware-flasher', () => {
             expect(isFirmwareFlashSupported()).toBe(false);
         });
 
-        test('should return false on macOS even with WebSerial', () => {
+        test('should return true on macOS with WebSerial', () => {
             Object.defineProperty(global, 'navigator', {
                 value: {
                     serial: { requestPort: jest.fn() },
@@ -144,7 +144,7 @@ describe('smalrubot-firmware-flasher', () => {
                 writable: true,
                 configurable: true,
             });
-            expect(isFirmwareFlashSupported()).toBe(false);
+            expect(isFirmwareFlashSupported()).toBe(true);
         });
 
         test('should return true on Windows with WebSerial', () => {


### PR DESCRIPTION
## Summary

- macOS でも SmalrubotS1 ファームウェア書き込みを可能にする
- [PL2303 Serial](https://apps.apple.com/jp/app/pl2303-serial/id1624835354?mt=12) アプリのインストール案内を macOS ユーザーに表示する

## Changes Made

### Phase 1: flasher ロジック変更
- `isFirmwareFlashSupported()` から macOS 除外ガードを削除
- macOS + WebSerial で `true` を返すようにテストを更新

### Phase 2: macSetup フェーズ UI
- ファームウェアモーダルに `macSetup` フェーズを追加
- macOS ではモーダル表示時にまず App Store リンク付きセットアップ案内を表示
- 「セットアップ完了、書き込みに進む」ボタンで通常の書き込みフローへ遷移
- en / ja / ja-Hira の3ロケールにメッセージ追加

## Test Coverage

- `smalrubot-firmware-flasher.test.js` 全17テスト pass
- lint zero errors / zero warnings

## Related Issues

Closes #458
