### PR TITLE
fix: mitigate flaky ChromeDriver session crash in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -200,7 +200,7 @@ jobs:
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
-      - uses: browser-actions/setup-chrome@facf10a55b9caf92e0cc749b4f45a9a17dbe063a # v1
+      - uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1
         id: setup-chrome
         with:
           chrome-version: stable

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -200,11 +200,16 @@ jobs:
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
+      - uses: browser-actions/setup-chrome@facf10a55b9caf92e0cc749b4f45a9a17dbe063a # v1
+        id: setup-chrome
+        with:
+          chrome-version: stable
       - name: Info
         run: |
           cat <<EOF
           Node version: $(node --version)
           NPM version: $(npm --version)
+          Chrome: ${{ steps.setup-chrome.outputs.chrome-path }} ($(${{ steps.setup-chrome.outputs.chrome-path }} --version))
           GitHub ref: ${{ github.ref }}
           GitHub head ref: ${{ github.head_ref }}
           EOF

--- a/packages/scratch-gui/test/helpers/selenium-helper.js
+++ b/packages/scratch-gui/test/helpers/selenium-helper.js
@@ -2,6 +2,10 @@
 // allow time for that so we get a more specific error message
 jest.setTimeout(95000);
 
+// Retry flaky tests once to mitigate transient CI failures
+// (e.g., ChromeDriver session crashes, resource contention)
+jest.retryTimes(1);
+
 import {promises as fs} from 'fs';
 import path from 'path';
 
@@ -172,10 +176,10 @@ class SeleniumHelper {
     }
 
     /**
-     * Instantiate a new Selenium driver.
-     * @returns {webdriver.ThenableWebDriver} The new driver.
+     * Build Chrome capabilities for the Selenium driver.
+     * @returns {webdriver.Capabilities} The Chrome capabilities.
      */
-    getDriver () {
+    _buildChromeCapabilities () {
         const chromeCapabilities = webdriver.Capabilities.chrome();
         const args = [];
         if (USE_HEADLESS) {
@@ -201,11 +205,42 @@ class SeleniumHelper {
         chromeCapabilities.setLoggingPrefs({
             performance: 'ALL'
         });
-        this.driver = new webdriver.Builder()
-            .forBrowser('chrome')
-            .withCapabilities(chromeCapabilities)
-            .build();
-        return this.driver;
+        return chromeCapabilities;
+    }
+
+    /**
+     * Instantiate a new Selenium driver with retry on session creation failure.
+     * ChromeDriver can intermittently fail to start in CI (version mismatch,
+     * resource contention), so we retry up to `retries` times.
+     * @param {number} [retries=2] Maximum number of retry attempts.
+     * @returns {Promise<webdriver.ThenableWebDriver>} The new driver.
+     */
+    async getDriver (retries = 2) {
+        const chromeCapabilities = this._buildChromeCapabilities();
+
+        for (let attempt = 0; attempt <= retries; attempt++) {
+            try {
+                this.driver = new webdriver.Builder()
+                    .forBrowser('chrome')
+                    .withCapabilities(chromeCapabilities)
+                    .build();
+                // Verify the session is actually alive
+                await this.driver.getSession();
+                return this.driver;
+            } catch (e) {
+                if (attempt < retries) {
+                    const delayMs = 1000 * (attempt + 1);
+                    console.warn(
+                        `getDriver: session creation failed (attempt ${attempt + 1}/${retries + 1}), ` +
+                        `retrying in ${delayMs}ms...`,
+                        e.message
+                    );
+                    await new Promise(resolve => setTimeout(resolve, delayMs));
+                } else {
+                    throw e;
+                }
+            }
+        }
     }
 
     /**

--- a/packages/scratch-gui/test/integration/backdrops.test.js
+++ b/packages/scratch-gui/test/integration/backdrops.test.js
@@ -17,8 +17,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Working with backdrops', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/backpack.test.js
+++ b/packages/scratch-gui/test/integration/backpack.test.js
@@ -16,8 +16,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Backpack with localStorage', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/block-display-modal.test.js
+++ b/packages/scratch-gui/test/integration/block-display-modal.test.js
@@ -21,8 +21,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Block Display Modal', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/block-palette.test.js
+++ b/packages/scratch-gui/test/integration/block-palette.test.js
@@ -24,8 +24,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Block palette', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/blocks-standalone.test.js
+++ b/packages/scratch-gui/test/integration/blocks-standalone.test.js
@@ -27,8 +27,8 @@ let driver;
 // standalone way of initialization is working
 // NOTE: Skipped in Smalruby as standalone.html is not built (not used in Smalruby)
 describe.skip('Working with the blocks', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/blocks.test.js
+++ b/packages/scratch-gui/test/integration/blocks.test.js
@@ -25,8 +25,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Working with the blocks', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/connection-modal.test.js
+++ b/packages/scratch-gui/test/integration/connection-modal.test.js
@@ -24,8 +24,8 @@ const websocketFakeoutJs = `var RealWebSocket = WebSocket;
     }`;
 
 describe('Hardware extension connection modal', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {
@@ -34,7 +34,7 @@ describe('Hardware extension connection modal', () => {
 
     test('Message saying Scratch Link is unavailable (BLE)', async () => {
         await driver.quit();
-        driver = getDriver();
+        driver = await getDriver();
 
         await loadUri(uri);
 

--- a/packages/scratch-gui/test/integration/costumes.test.js
+++ b/packages/scratch-gui/test/integration/costumes.test.js
@@ -23,8 +23,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Working with costumes', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/debug_defaults.test.js
+++ b/packages/scratch-gui/test/integration/debug_defaults.test.js
@@ -8,8 +8,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe.skip('Debug Smalruby 3 Defaults', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/dncl-mode-validation.test.js
+++ b/packages/scratch-gui/test/integration/dncl-mode-validation.test.js
@@ -70,8 +70,8 @@ const loadInRubyMode = async d => {
 let driver;
 
 describe('DNCL mode validation on switch', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/examples.test.js
+++ b/packages/scratch-gui/test/integration/examples.test.js
@@ -16,8 +16,8 @@ let driver;
 describe('player example', () => {
     const uri = path.resolve(__dirname, '../../build/player.html');
 
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {
@@ -46,8 +46,8 @@ describe('player example', () => {
 describe('blocks example', () => {
     const uri = path.resolve(__dirname, '../../build/blocks-only.html');
 
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/feedback-link.test.js
+++ b/packages/scratch-gui/test/integration/feedback-link.test.js
@@ -8,8 +8,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Feedback link', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/how-tos.test.js
+++ b/packages/scratch-gui/test/integration/how-tos.test.js
@@ -15,8 +15,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe.skip('Working with the how-to library', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/localization.test.js
+++ b/packages/scratch-gui/test/integration/localization.test.js
@@ -24,8 +24,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Localization', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/menu-bar.test.js
+++ b/packages/scratch-gui/test/integration/menu-bar.test.js
@@ -22,8 +22,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Menu bar settings', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/project-loading.test.js
+++ b/packages/scratch-gui/test/integration/project-loading.test.js
@@ -18,8 +18,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Loading scratch gui', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {
@@ -37,7 +37,7 @@ describe('Loading scratch gui', () => {
         // of loading projects that we are not actively using anymore
         test.skip('Load a project by ID directly through url', async () => {
             await driver.quit(); // Reset driver to test hitting # url directly
-            driver = getDriver();
+            driver = await getDriver();
 
             const projectId = '96708228';
             await loadUri(`${uri}#${projectId}`);
@@ -52,7 +52,7 @@ describe('Loading scratch gui', () => {
         // of loading projects that we are not actively using anymore
         test.skip('Load a project by ID (fullscreen)', async () => {
             await driver.quit(); // Reset driver to test hitting # url directly
-            driver = getDriver();
+            driver = await getDriver();
 
             const prevSize = driver.manage()
                 .window()

--- a/packages/scratch-gui/test/integration/project-state.test.js
+++ b/packages/scratch-gui/test/integration/project-state.test.js
@@ -16,8 +16,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Project state', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/ruby-editor-actions.test.js
+++ b/packages/scratch-gui/test/integration/ruby-editor-actions.test.js
@@ -20,8 +20,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Ruby editor actions', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/ruby-module.test.js
+++ b/packages/scratch-gui/test/integration/ruby-module.test.js
@@ -24,8 +24,8 @@ let driver;
 const stubConfirmToDecline = () => driver.executeScript('window.confirm = () => false;');
 
 describe('Ruby module/include round-trip', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/ruby-script-preview.test.js
+++ b/packages/scratch-gui/test/integration/ruby-script-preview.test.js
@@ -58,8 +58,8 @@ const waitForPreviewCode = async () => {
 };
 
 describe('Ruby script preview panel', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/ruby-super.test.js
+++ b/packages/scratch-gui/test/integration/ruby-super.test.js
@@ -16,8 +16,8 @@ const uri = `${path.resolve(__dirname, '../../build/index.html')}?ruby_version=2
 let driver;
 
 describe('Ruby super keyword round-trip', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/ruby-tab-completion-and-indent.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab-completion-and-indent.test.js
@@ -9,8 +9,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Ruby tab completion and indentation', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/ruby-tab-furigana-zoom.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab-furigana-zoom.test.js
@@ -57,8 +57,8 @@ const clickZoomReset = async () => {
 };
 
 describe('Ruby tab furigana zoom follow', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/ruby-tab.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab.test.js
@@ -28,8 +28,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('convert Code from Ruby', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/sb-file-uploader-hoc.test.js
+++ b/packages/scratch-gui/test/integration/sb-file-uploader-hoc.test.js
@@ -16,8 +16,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Loading scratch gui', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/smalrubot-firmware.test.js
+++ b/packages/scratch-gui/test/integration/smalrubot-firmware.test.js
@@ -28,8 +28,8 @@ const loadExtension = async (d, extensionName) => {
 };
 
 describe('SmalrubotS1 firmware flash', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/smalruby-tutorials.test.js
+++ b/packages/scratch-gui/test/integration/smalruby-tutorials.test.js
@@ -14,8 +14,8 @@ const uriWithTutorial = id => `${uri}?tutorial=${id}`;
 let driver;
 
 describe('Smalruby Tutorials', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/sounds.test.js
+++ b/packages/scratch-gui/test/integration/sounds.test.js
@@ -21,8 +21,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Working with sounds', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/sprites.test.js
+++ b/packages/scratch-gui/test/integration/sprites.test.js
@@ -21,8 +21,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Working with sprites', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/stage-size.test.js
+++ b/packages/scratch-gui/test/integration/stage-size.test.js
@@ -16,8 +16,8 @@ const uri = path.resolve(__dirname, '../../build/index.html');
 let driver;
 
 describe('Loading scratch gui', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/tutorials-shortcut.test.js
+++ b/packages/scratch-gui/test/integration/tutorials-shortcut.test.js
@@ -14,8 +14,8 @@ const uriPrefix = path.resolve(__dirname, '../../build/index.html?tutorial=');
 let driver;
 
 describe.skip('Working with shortcut to Tutorials library', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {

--- a/packages/scratch-gui/test/integration/v1-detection-prompt.test.js
+++ b/packages/scratch-gui/test/integration/v1-detection-prompt.test.js
@@ -34,8 +34,8 @@ const V2_CODE = 'self.when_flag_clicked do\\n  move(10)\\nend';
 let driver;
 
 describe('v1 code detection prompt', () => {
-    beforeAll(() => {
-        driver = getDriver();
+    beforeAll(async () => {
+        driver = await getDriver();
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## Summary

CI の integration test で ChromeDriver セッション作成が間欠的に失敗する flaky テストを修正。

- **A. Chrome バージョン固定**: CI に `browser-actions/setup-chrome` を追加し、Chrome/ChromeDriver のバージョン不一致を防止
- **B. getDriver() リトライ**: セッション作成失敗時に最大2回リトライ（1秒→2秒間隔）する機構を追加
- **D. jest.retryTimes(1)**: 全 integration test で transient failure 時に1回自動リトライ

対策 C（並列度を下げる）は適用していません。

## Changes Made

- `.github/workflows/ci-cd.yml`: `browser-actions/setup-chrome@v1` ステップ追加、Info に Chrome バージョン表示
- `test/helpers/selenium-helper.js`: `getDriver()` を async + retry 化、`jest.retryTimes(1)` 追加
- 32 integration test ファイル: `driver = getDriver()` → `driver = await getDriver()`、`beforeAll` を async 化

## Test Coverage

- 既存の integration test がそのまま動作することを確認（API 互換性維持）
- リトライ機構は `getSession()` で明示的にセッション生存を検証

Fixes #468
