### PR TITLE
fix: replace submission count limit with single-submission upsert model

### DIFF
--- a/infra/smalruby-classroom/lambda/handler.ts
+++ b/infra/smalruby-classroom/lambda/handler.ts
@@ -9,7 +9,7 @@ import {
   UpdateCommand,
   BatchWriteCommand,
 } from '@aws-sdk/lib-dynamodb';
-import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { OAuth2Client } from 'google-auth-library';
 import * as crypto from 'crypto';
@@ -49,7 +49,6 @@ const PRESIGNED_URL_DOWNLOAD_EXPIRY = parseInt(process.env.PRESIGNED_URL_DOWNLOA
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const MAX_SCREENSHOT_COUNT = 20;
 const MAX_TEACHER_COMMENT_LENGTH = 500;
-const MAX_SUBMISSIONS_PER_MEMBER = 10;
 
 // --- DynamoDB Client ---
 
@@ -730,16 +729,32 @@ async function handleCreateSubmission(
   const projectName = validateProjectName(body.projectName);
   const screenshotCount = validateScreenshotCount(body.screenshotCount);
 
-  // Limit submissions per member to prevent storage abuse
-  const existingSubmissions = await docClient.send(new QueryCommand({
+  // Single-submission model: find and clean up previous submission
+  const prevResult = await docClient.send(new QueryCommand({
     TableName: SUBMISSIONS_TABLE,
-    KeyConditionExpression: 'classroomId = :cid',
-    FilterExpression: 'memberId = :mid',
+    IndexName: 'classroomId-memberId-index',
+    KeyConditionExpression: 'classroomId = :cid AND memberId = :mid',
     ExpressionAttributeValues: { ':cid': classroomId, ':mid': memberId },
-    Select: 'COUNT',
+    Limit: 1,
   }));
-  if ((existingSubmissions.Count || 0) >= MAX_SUBMISSIONS_PER_MEMBER) {
-    throw new ValidationError(`Maximum ${MAX_SUBMISSIONS_PER_MEMBER} submissions allowed`);
+  if (prevResult.Items && prevResult.Items.length > 0) {
+    const prev = prevResult.Items[0];
+    const prevId = prev.submissionId as string;
+    const prevScreenshots = (prev.screenshotCount as number) || 0;
+    // Delete old S3 objects (best-effort)
+    const deleteKeys = [
+      `${classroomId}/${prevId}/project.sb3`,
+      `${classroomId}/${prevId}/thumbnail.png`,
+      ...Array.from({ length: prevScreenshots }, (_, i) => `${classroomId}/${prevId}/screenshot-${i}.png`),
+    ];
+    await Promise.allSettled(
+      deleteKeys.map(key => s3Client.send(new DeleteObjectCommand({ Bucket: SUBMISSIONS_BUCKET, Key: key }))),
+    );
+    // Delete old DynamoDB record
+    await docClient.send(new DeleteCommand({
+      TableName: SUBMISSIONS_TABLE,
+      Key: { classroomId, submissionId: prevId },
+    }));
   }
 
   const submissionId = crypto.randomUUID();


### PR DESCRIPTION
## Summary
提出モデルを「最大10件制限」から「最新1件のみ保持」に変更。

再提出時に:
1. 既存の提出のS3ファイル（project.sb3, thumbnail.png, screenshots）を削除
2. DynamoDBレコードを削除
3. 新しい提出を作成

ストレージ濫用を防ぎつつ、提出回数制限やリセット機能が不要になるシンプルなモデル。

## Test plan
- [x] 結合テスト 34/34 パス（stg）
- [x] stg/prod デプロイ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
