### PR TITLE
fix: address medium security findings (M3, M5) + MAX_STUDENT_COUNT env var

### DIFF
--- a/infra/smalruby-classroom/lambda/handler.ts
+++ b/infra/smalruby-classroom/lambda/handler.ts
@@ -25,7 +25,7 @@ const DEV_BYPASS_TOKEN = process.env.DEV_BYPASS_TOKEN || '';
 const CORS_ALLOWED_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || '').split(',').map(o => o.trim());
 
 const MAX_CLASS_NAME_LENGTH = 50;
-const MAX_STUDENT_COUNT = 50;
+const MAX_STUDENT_COUNT = parseInt(process.env.MAX_STUDENT_COUNT || '50', 10);
 const MAX_NICKNAME_LENGTH = 20;
 // 6-digit alphanumeric, excluding confusing chars (I, O, 0, 1)
 const JOIN_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
@@ -1044,6 +1044,7 @@ async function handleImportGoogleClassroom(
   if (studentCount === 0) {
     studentCount = 35; // default class size
   }
+  studentCount = Math.min(studentCount, MAX_STUDENT_COUNT);
 
   // Generate unique join code
   let joinCode = '';
@@ -1127,6 +1128,16 @@ async function handlePostAssignment(
   const link = body.link;
   if (typeof link !== 'string' || !link.startsWith('http')) {
     throw new ValidationError('Assignment link is required');
+  }
+  try {
+    const linkUrl = new URL(link);
+    const allowedHosts = ['smalruby.app', 'smalruby.jp', 'localhost'];
+    if (!allowedHosts.some(h => linkUrl.hostname === h || linkUrl.hostname.endsWith(`.${h}`))) {
+      throw new ValidationError('Assignment link must be a Smalruby URL');
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) throw e;
+    throw new ValidationError('Assignment link is not a valid URL');
   }
   const description = typeof body.description === 'string' ? body.description.trim() : '';
 

--- a/infra/smalruby-classroom/lib/classroom-stack.ts
+++ b/infra/smalruby-classroom/lib/classroom-stack.ts
@@ -200,6 +200,7 @@ export class ClassroomStack extends cdk.Stack {
         DEV_BYPASS_TOKEN: devBypassToken,
         CORS_ALLOWED_ORIGINS: corsOriginsEnv,
         CLASSROOM_TTL_DAYS: String(classroomTtlDays),
+        MAX_STUDENT_COUNT: process.env.MAX_STUDENT_COUNT || '50',
         SESSION_ACTIVE_TTL_SECONDS: process.env.SESSION_ACTIVE_TTL_SECONDS || '3600',
         PRESIGNED_URL_UPLOAD_EXPIRY: process.env.PRESIGNED_URL_UPLOAD_EXPIRY || '900',
         PRESIGNED_URL_DOWNLOAD_EXPIRY: process.env.PRESIGNED_URL_DOWNLOAD_EXPIRY || '3600',


### PR DESCRIPTION
## Summary
Medium セキュリティ項目 M3, M5 の対応 + `MAX_STUDENT_COUNT` 環境変数化。

- **M3**: 課題配信リンクのホスト名を `smalruby.app`, `smalruby.jp`, `localhost` に限定
- **M5**: Google Classroom インポート時の生徒数を `MAX_STUDENT_COUNT` で上限キャップ
- **MAX_STUDENT_COUNT**: 環境変数化（stg: 50, prod: 100）

## Test plan
- [x] 結合テスト 34/34 パス（stg）
- [x] stg/prod デプロイ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
