### PR TITLE
feat: add student count increase UI to teacher detail view

### DIFF
--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
@@ -1097,3 +1097,89 @@
     color: #575e75;
     line-height: 1.5;
 }
+
+.student-count-button {
+    background: none;
+    border: 1px solid #4c97ff;
+    border-radius: 4px;
+    color: #4c97ff;
+    font-size: inherit;
+    font-weight: bold;
+    padding: 0 0.3rem;
+    cursor: pointer;
+    min-width: 2rem;
+    text-align: center;
+}
+
+.student-count-button:hover {
+    background-color: #4c97ff;
+    color: white;
+}
+
+.student-count-dialog {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+    border-radius: 0 0 8px 8px;
+}
+
+.student-count-dialog-content {
+    background: white;
+    border-radius: 8px;
+    padding: 1.5rem;
+    min-width: 280px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.student-count-dialog-title {
+    font-size: 1rem;
+    font-weight: bold;
+    margin-bottom: 1rem;
+    color: #575e75;
+}
+
+.student-count-dialog-body {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.8rem;
+}
+
+.student-count-value {
+    font-size: 1.5rem;
+    font-weight: bold;
+    min-width: 3rem;
+    text-align: center;
+}
+
+.student-count-increment {
+    background: #4c97ff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    width: 2rem;
+    height: 2rem;
+    font-size: 1.2rem;
+    font-weight: bold;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.student-count-increment:hover {
+    background: #3373cc;
+}
+
+.student-count-dialog-hint {
+    font-size: 0.8rem;
+    color: #999;
+    margin-bottom: 1rem;
+}

--- a/packages/scratch-gui/src/components/classroom-modal/teacher-class-detail.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/teacher-class-detail.jsx
@@ -34,11 +34,14 @@ const TeacherClassDetail = ({
     onToggleCodeFullscreen,
     onShowPostAssignment,
     onUpdateAssignmentName,
+    onUpdateStudentCount,
     codeDisplayClassroom,
     codeDisplayFullscreen,
 }) => {
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [showCodeDisplay, setShowCodeDisplay] = useState(false);
+    const [showStudentCountDialog, setShowStudentCountDialog] = useState(false);
+    const [editStudentCount, setEditStudentCount] = useState(0);
     const [editAssignmentName, setEditAssignmentName] = useState(
         selectedClassroom.assignmentName || '',
     );
@@ -84,6 +87,26 @@ const TeacherClassDetail = ({
             onUpdateAssignmentName(trimmed);
         }
     }, [editAssignmentName, selectedClassroom, onUpdateAssignmentName]);
+
+    const handleOpenStudentCountDialog = useCallback(() => {
+        setEditStudentCount(selectedClassroom.studentCount);
+        setShowStudentCountDialog(true);
+    }, [selectedClassroom]);
+
+    const handleIncrementStudentCount = useCallback(() => {
+        setEditStudentCount((prev) => prev + 1);
+    }, []);
+
+    const handleConfirmStudentCount = useCallback(() => {
+        setShowStudentCountDialog(false);
+        if (editStudentCount > selectedClassroom.studentCount && onUpdateStudentCount) {
+            onUpdateStudentCount(editStudentCount);
+        }
+    }, [editStudentCount, selectedClassroom, onUpdateStudentCount]);
+
+    const handleCancelStudentCount = useCallback(() => {
+        setShowStudentCountDialog(false);
+    }, []);
 
     const handleShowCode = useCallback(() => {
         setShowCodeDisplay(true);
@@ -250,7 +273,14 @@ const TeacherClassDetail = ({
                                         className={styles.membersCount}
                                         data-testid="classroom-members-count"
                                     >
-                                        {joinedCount} / {totalCount}
+                                        {joinedCount} /{' '}
+                                        <button
+                                            className={styles.studentCountButton}
+                                            data-testid="classroom-student-count-btn"
+                                            onClick={handleOpenStudentCountDialog}
+                                        >
+                                            {totalCount}
+                                        </button>
                                     </span>
                                     <button
                                         className={styles.refreshButton}
@@ -427,6 +457,60 @@ const TeacherClassDetail = ({
                             </div>
                         </div>
 
+                        {showStudentCountDialog && (
+                            <div className={styles.studentCountDialog} data-testid="classroom-student-count-dialog">
+                                <div className={styles.studentCountDialogContent}>
+                                    <div className={styles.studentCountDialogTitle}>
+                                        <FormattedMessage
+                                            defaultMessage="Change Student Count"
+                                            description="Student count dialog title"
+                                            id="gui.classroom.teacherDetail.studentCountTitle"
+                                        />
+                                    </div>
+                                    <div className={styles.studentCountDialogBody}>
+                                        <span className={styles.studentCountValue} data-testid="classroom-student-count-value">
+                                            {editStudentCount}
+                                        </span>
+                                        <button
+                                            className={styles.studentCountIncrement}
+                                            data-testid="classroom-student-count-increment"
+                                            onClick={handleIncrementStudentCount}
+                                        >
+                                            {'+'}
+                                        </button>
+                                    </div>
+                                    <div className={styles.studentCountDialogHint}>
+                                        <FormattedMessage
+                                            defaultMessage="You can increase the number of seats. Decreasing is not allowed."
+                                            description="Student count dialog hint"
+                                            id="gui.classroom.teacherDetail.studentCountHint"
+                                        />
+                                    </div>
+                                    <div className={styles.buttonRow}>
+                                        <button
+                                            className={styles.secondaryButton}
+                                            data-testid="classroom-student-count-cancel"
+                                            onClick={handleCancelStudentCount}
+                                        >
+                                            <FormattedMessage
+                                                defaultMessage="Cancel"
+                                                description="Cancel button"
+                                                id="gui.classroom.teacherDetail.cancelStudentCount"
+                                            />
+                                        </button>
+                                        <button
+                                            className={styles.primaryButton}
+                                            data-testid="classroom-student-count-ok"
+                                            disabled={editStudentCount <= selectedClassroom.studentCount}
+                                            onClick={handleConfirmStudentCount}
+                                        >
+                                            {'OK'}
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
                         {/* Right pane - member detail */}
                         <div className={styles.detailRightPane}>
                             <TeacherMemberDetail
@@ -474,6 +558,7 @@ TeacherClassDetail.propTypes = {
     onShowPostAssignment: PropTypes.func,
     onToggleCodeFullscreen: PropTypes.func.isRequired,
     onUpdateAssignmentName: PropTypes.func,
+    onUpdateStudentCount: PropTypes.func,
     selectedClassroom: PropTypes.object.isRequired,
     selectedMember: PropTypes.string,
 };

--- a/packages/scratch-gui/src/components/classroom-teacher-modal/classroom-teacher-modal.jsx
+++ b/packages/scratch-gui/src/components/classroom-teacher-modal/classroom-teacher-modal.jsx
@@ -162,6 +162,7 @@ const ClassroomTeacherModal = ({ containerProps, onClose }) => {
         onSelectGoogleCourse,
         onConfirmGoogleImport,
         onUpdateAssignmentName,
+        onUpdateStudentCount,
     } = containerProps;
 
     const dispatch = useDispatch();
@@ -374,6 +375,7 @@ const ClassroomTeacherModal = ({ containerProps, onClose }) => {
                         onShowPostAssignment={onShowPostAssignment}
                         onToggleCodeFullscreen={onToggleCodeFullscreen}
                         onUpdateAssignmentName={onUpdateAssignmentName}
+                        onUpdateStudentCount={onUpdateStudentCount}
                     />
                 </div>
             );

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -490,6 +490,7 @@ const ClassroomModal = ({ mode = 'student' }) => {
         onSelectGoogleCourse: teacher.handleSelectGoogleCourse,
         onConfirmGoogleImport: teacher.handleConfirmGoogleImport,
         onUpdateAssignmentName: teacher.handleUpdateAssignmentName,
+        onUpdateStudentCount: teacher.handleUpdateStudentCount,
     };
 
     if (mode === 'teacher') {

--- a/packages/scratch-gui/src/containers/use-teacher-classroom.js
+++ b/packages/scratch-gui/src/containers/use-teacher-classroom.js
@@ -610,6 +610,25 @@ const useTeacherClassroom = ({
         [idToken, selectedClassroom, clearError, showError, intl],
     );
 
+    const handleUpdateStudentCount = useCallback(
+        async studentCount => {
+            if (!idToken || !selectedClassroom) return;
+            clearError();
+            try {
+                await classroomAPI.updateClassroom(idToken, selectedClassroom.classroomId, { studentCount });
+                setSelectedClassroom(prev => ({ ...prev, studentCount }));
+                // Refresh members to reflect new seat grid
+                const detail = await classroomAPI.getClassroom(idToken, selectedClassroom.classroomId);
+                const memberList = await classroomAPI.listMembers(idToken, selectedClassroom.classroomId);
+                setSelectedClassroom(detail);
+                setMembers(memberList.members || []);
+            } catch (err) {
+                showError(translateError(intl, err));
+            }
+        },
+        [idToken, selectedClassroom, clearError, showError, intl],
+    );
+
     // --- Teacher: Select member ---
 
     const handleSelectMember = useCallback(memberId => {
@@ -659,6 +678,7 @@ const useTeacherClassroom = ({
         handleShowPostAssignment,
         handlePostAssignment,
         handleUpdateAssignmentName,
+        handleUpdateStudentCount,
         handleSelectMember,
     };
 };

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -96,6 +96,10 @@ export default {
     'gui.classroom.teacherDetail.deleteClassroom': 'Delete Classroom',
     'gui.classroom.teacherDetail.deleteConfirm':
         'Are you sure you want to delete this classroom? All members will be removed.',
+    'gui.classroom.teacherDetail.studentCountTitle': 'Change Student Count',
+    'gui.classroom.teacherDetail.studentCountHint':
+        'You can increase the number of seats. Decreasing is not allowed.',
+    'gui.classroom.teacherDetail.cancelStudentCount': 'Cancel',
     'gui.classroom.error.title': 'An error occurred',
     'gui.classroom.error.invalidJoinCode': 'Could not join the classroom. Please check the join code and try again.',
     'gui.classroom.error.seatTaken': 'This seat is already taken. Please choose a different seat.',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -92,6 +92,9 @@ export default {
     'gui.classroom.teacherDetail.deleteClassroom': 'クラスをさくじょ',
     'gui.classroom.teacherDetail.deleteConfirm':
         'ほんとうにこのクラスをさくじょしますか？すべてのメンバーがさくじょされます。',
+    'gui.classroom.teacherDetail.studentCountTitle': 'にんずうをへんこう',
+    'gui.classroom.teacherDetail.studentCountHint': 'にんずうをふやすことができます。へらすことはできません。',
+    'gui.classroom.teacherDetail.cancelStudentCount': 'キャンセル',
     'gui.classroom.error.title': 'エラーがはっせいしました',
     'gui.classroom.error.invalidJoinCode':
         'クラスにさんかできませんでした。さんかコードをかくにんして、もういちどおためしください。',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -90,6 +90,9 @@ export default {
     'gui.classroom.teacherDetail.delete': '削除',
     'gui.classroom.teacherDetail.deleteClassroom': 'クラスを削除',
     'gui.classroom.teacherDetail.deleteConfirm': '本当にこのクラスを削除しますか？全てのメンバーが削除されます。',
+    'gui.classroom.teacherDetail.studentCountTitle': '人数を変更',
+    'gui.classroom.teacherDetail.studentCountHint': '人数を増やすことができます。減らすことはできません。',
+    'gui.classroom.teacherDetail.cancelStudentCount': 'キャンセル',
     'gui.classroom.error.title': 'エラーが発生しました',
     'gui.classroom.error.invalidJoinCode':
         'クラスに参加できませんでした。参加コードを確認して、もう一度お試しください。',


### PR DESCRIPTION
## Summary

先生のクラス詳細画面で、クラスの人数（例: `0/35`）をクリックすると人数を増やせるダイアログを表示する機能を追加。

- メンバー数表示の分母部分をクリック可能なボタンに変更
- ダイアログで [+] ボタンと [OK] ボタンを表示
- 「クラスの人数を増やすことができます」のヒントメッセージを表示
- API 経由で studentCount を更新し、メンバー一覧をリロード

## Changes

- `teacher-class-detail.jsx` — 人数ボタン + ダイアログ UI
- `use-teacher-classroom.js` — `handleUpdateStudentCount` ハンドラ追加
- `classroom-modal.css` — ダイアログのスタイル
- `classroom-modal.jsx`, `classroom-teacher-modal.jsx` — props の受け渡し
- `ja.js`, `ja-Hira.js`, `en.js` — ロケールキー追加

## Test Plan

- [ ] 先生でログイン → クラス詳細 → 人数をクリック → ダイアログ表示
- [ ] [+] ボタンで人数が増える → [OK] で反映
- [ ] ダイアログ外クリックでキャンセル
- [ ] 更新後メンバーグリッドが正しくリロード

🤖 Generated with [Claude Code](https://claude.com/claude-code)
