### PR TITLE
fix: classroom UI polish round 3 — icons, loading, spacing

### DIFF
--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
@@ -205,6 +205,8 @@
 .status-row {
     display: flex;
     justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
     padding: 0.3rem 0;
     border-bottom: 1px solid #e0e0e0;
 }
@@ -217,11 +219,13 @@
     font-weight: bold;
     color: #575e75;
     font-size: 0.85rem;
+    flex-shrink: 0;
 }
 
 .status-value {
     color: #575e75;
     font-size: 0.85rem;
+    text-align: right;
 }
 
 .role-button {
@@ -374,9 +378,20 @@
     margin-bottom: 1rem;
 }
 
-.post-assignment-actions {
+.post-assignment-success-area {
     text-align: center;
+    padding: 2rem 0;
+}
+
+.post-assignment-actions {
     margin-bottom: 1rem;
+}
+
+.post-assignment-hint-center {
+    font-size: 0.8rem;
+    color: #888;
+    line-height: 1.5;
+    text-align: center;
 }
 
 .class-item-main {
@@ -505,13 +520,14 @@
 .success-details {
     color: #575e75;
     margin-top: 0.5rem;
-    font-size: 1.1rem;
+    font-size: 0.9rem;
 }
 
 .success-assignment {
     color: #575e75;
     margin-top: 0.3rem;
-    font-size: 0.95rem;
+    font-size: 1.15rem;
+    font-weight: bold;
 }
 
 .status-footer {

--- a/packages/scratch-gui/src/components/classroom-modal/teacher-post-assignment.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/teacher-post-assignment.jsx
@@ -62,15 +62,11 @@ const TeacherPostAssignment = ({
                     id="gui.classroom.back"
                 />
             </button>
-            <div className={styles.phaseTitle}>
-                <FormattedMessage
-                    defaultMessage="Post assignment to Google Classroom"
-                    description="Post assignment page title"
-                    id="gui.classroom.postAssignment.pageTitle"
-                />
-            </div>
             {posted ? (
-                <div data-testid="classroom-post-assignment-success">
+                <div
+                    className={styles.postAssignmentSuccessArea}
+                    data-testid="classroom-post-assignment-success"
+                >
                     <div className={styles.successMessage}>
                         <FormattedMessage
                             defaultMessage="Assignment posted!"
@@ -81,17 +77,12 @@ const TeacherPostAssignment = ({
                     {alternateLink && (
                         <div className={styles.postAssignmentActions}>
                             <a
-                                className={styles.primaryButton}
+                                className={styles.linkButton}
                                 data-testid="classroom-view-posted-assignment"
                                 href={alternateLink}
                                 rel="noopener noreferrer"
                                 target="_blank"
                             >
-                                <img
-                                    alt=""
-                                    className={styles.gcImportIcon}
-                                    src={googleClassroomIcon}
-                                />
                                 <FormattedMessage
                                     defaultMessage="View on Google Classroom"
                                     description="View posted assignment on Google Classroom"
@@ -100,7 +91,7 @@ const TeacherPostAssignment = ({
                             </a>
                         </div>
                     )}
-                    <div className={styles.postAssignmentHint}>
+                    <div className={styles.postAssignmentHintCenter}>
                         <FormattedMessage
                             defaultMessage="You can edit or delete this assignment on Google Classroom."
                             description="Hint after posting assignment"
@@ -110,6 +101,13 @@ const TeacherPostAssignment = ({
                 </div>
             ) : (
                 <>
+                    <div className={styles.phaseTitle}>
+                        <FormattedMessage
+                            defaultMessage="Post assignment to Google Classroom"
+                            description="Post assignment page title"
+                            id="gui.classroom.postAssignment.pageTitle"
+                        />
+                    </div>
                     <div className={styles.postAssignmentTarget}>
                         <FormattedMessage
                             defaultMessage="Target: {className}"

--- a/packages/scratch-gui/src/components/classroom-teacher-modal/classroom-teacher-modal.jsx
+++ b/packages/scratch-gui/src/components/classroom-teacher-modal/classroom-teacher-modal.jsx
@@ -19,6 +19,7 @@ import TeacherClassDetail from '../classroom-modal/teacher-class-detail.jsx';
 import TeacherCreateForm from '../classroom-modal/teacher-create-form.jsx';
 import TeacherPostAssignment from '../classroom-modal/teacher-post-assignment.jsx';
 import ClassroomTutorial from '../classroom-tutorial/classroom-tutorial.jsx';
+import Spinner from '../spinner/spinner.jsx';
 
 import {
     isTutorialSeen,
@@ -493,6 +494,13 @@ const ClassroomTeacherModal = ({ containerProps, onClose }) => {
         }
 
         // Default: dashboard (no class selected)
+        if (isLoading) {
+            return (
+                <div className={styles.mainEmpty}>
+                    <Spinner large level="primary" />
+                </div>
+            );
+        }
         return (
             <div className={styles.mainEmpty}>
                 <FormattedMessage

--- a/packages/scratch-gui/src/components/menu-bar/settings-menu.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/settings-menu.jsx
@@ -29,6 +29,7 @@ import blockDisplayIcon from './block-display-icon.png';
 import {isClassroomConfigured} from '../../lib/classroom-api';
 import {getUrlParams} from '../../lib/url-params';
 import {openTeacherModal} from '../../reducers/classroom';
+import googleClassroomIcon from '../classroom-teacher-modal/google-classroom-icon.png';
 // === Smalruby: End of classroom management menu ===
 import {
     colorModeMenuOpen,
@@ -197,6 +198,10 @@ const SettingsMenu = ({
                     {isClassroomConfigured() && getUrlParams().features.includes('classroom') && (
                         <MenuItem onClick={onOpenTeacherModal}>
                             <div className={styles.option}>
+                                <img
+                                    className={styles.icon}
+                                    src={googleClassroomIcon}
+                                />
                                 <FormattedMessage
                                     defaultMessage="Class Management..."
                                     description="Class management menu item"

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -41,7 +41,7 @@ export default {
     'gui.connection.error.flashFirmwareButton': 'Write Firmware',
     'gui.classroom.title': 'Classroom',
     'gui.menuBar.classroom': 'Classroom',
-    'gui.menuBar.classroomManagement': 'Class Management',
+    'gui.menuBar.classroomManagement': 'Class Management...',
     'gui.classroom.roleSelect.prompt': 'How do you use the classroom?',
     'gui.classroom.roleSelect.teacher': 'Teacher',
     'gui.classroom.roleSelect.student': 'Student',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -37,7 +37,7 @@ export default {
     'gui.connection.error.flashFirmwareButton': 'ファームウェアかきこみ',
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',
-    'gui.menuBar.classroomManagement': 'クラスかんり',
+    'gui.menuBar.classroomManagement': 'クラスかんり...',
     'gui.classroom.roleSelect.prompt': 'どちらでつかいますか？',
     'gui.classroom.roleSelect.teacher': 'せんせい',
     'gui.classroom.roleSelect.student': 'せいと',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -36,7 +36,7 @@ export default {
     'gui.connection.error.flashFirmwareButton': 'ファームウェア書き込み',
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',
-    'gui.menuBar.classroomManagement': 'クラス管理',
+    'gui.menuBar.classroomManagement': 'クラス管理...',
     'gui.classroom.roleSelect.prompt': 'どちらで使いますか？',
     'gui.classroom.roleSelect.teacher': '先生',
     'gui.classroom.roleSelect.student': '生徒',


### PR DESCRIPTION
## Summary
クラス管理 UI の細かい改善 5 点。

### 変更内容

1. **設定メニュー**: 「クラス管理」に Google Classroom アイコン追加、ラベルに「...」を付加（モーダルを開く操作であることを示す）
2. **サイドバーから課題選択時のローディング**: 課題をクリックした後、詳細が表示されるまで中央ペインにスピナーを表示（2秒間の無反応を解消）
3. **課題配信成功画面の簡素化**: ページタイトルを削除し、全体を中央配置。「Google Classroomで確認する」をボタンからリンクに変更
4. **生徒参加完了画面**: 課題名のフォントを大きく太く（1.15rem bold）、クラス名を小さく（0.9rem）
5. **生徒ステータス画面**: ラベルと値の間にgapを追加、値を右寄せして「提出状況未提出」が読みやすくなるように修正

## Test plan
- [ ] 設定メニューに GC アイコンと「クラス管理...」が表示されること
- [ ] サイドバーで課題クリック → スピナー表示 → 詳細表示の流れが自然なこと
- [ ] 配信成功画面がセンター配置・リンクスタイルで表示されること
- [ ] 生徒参加完了画面で課題名が大きく表示されること
- [ ] 生徒ステータスで「提出状況」と「未提出」が分離して読めること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
