### PR TITLE
fix: use separate locale key for classroom management modal title

### DIFF
--- a/packages/scratch-gui/src/components/classroom-teacher-modal/classroom-teacher-modal.jsx
+++ b/packages/scratch-gui/src/components/classroom-teacher-modal/classroom-teacher-modal.jsx
@@ -34,7 +34,7 @@ const messages = defineMessages({
     title: {
         defaultMessage: 'Class Management',
         description: 'Title for the teacher class management modal',
-        id: 'gui.menuBar.classroomManagement',
+        id: 'gui.classroom.management.title',
     },
 });
 

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -42,6 +42,7 @@ export default {
     'gui.classroom.title': 'Classroom',
     'gui.menuBar.classroom': 'Classroom',
     'gui.menuBar.classroomManagement': 'Class Management...',
+    'gui.classroom.management.title': 'Class Management',
     'gui.classroom.roleSelect.prompt': 'How do you use the classroom?',
     'gui.classroom.roleSelect.teacher': 'Teacher',
     'gui.classroom.roleSelect.student': 'Student',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -38,6 +38,7 @@ export default {
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',
     'gui.menuBar.classroomManagement': 'クラスかんり...',
+    'gui.classroom.management.title': 'クラスかんり',
     'gui.classroom.roleSelect.prompt': 'どちらでつかいますか？',
     'gui.classroom.roleSelect.teacher': 'せんせい',
     'gui.classroom.roleSelect.student': 'せいと',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -37,6 +37,7 @@ export default {
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',
     'gui.menuBar.classroomManagement': 'クラス管理...',
+    'gui.classroom.management.title': 'クラス管理',
     'gui.classroom.roleSelect.prompt': 'どちらで使いますか？',
     'gui.classroom.roleSelect.teacher': '先生',
     'gui.classroom.roleSelect.student': '生徒',


### PR DESCRIPTION
## Summary
- クラス管理モーダルのタイトルが「クラス管理...」になっていたのを「クラス管理」に修正
- メニューアイテム用キー (`gui.menuBar.classroomManagement`) とモーダルタイトル用キー (`gui.classroom.management.title`) を分離

## Test plan
- [ ] 設定 → クラス管理... をクリック → モーダルタイトルが「クラス管理」と表示される
- [ ] メニューアイテムは「クラス管理...」のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)