### PR TITLE
fix: rename クラスコード to 参加コード and show assignment name

### DIFF
--- a/packages/scratch-gui/src/components/classroom-modal/class-code-display.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/class-code-display.jsx
@@ -25,8 +25,8 @@ const ClassCodeDisplay = ({
             <div className={styles.codeFullscreenOverlay}>
                 <span className={styles.codeFullscreenTitle}>
                     <FormattedMessage
-                        defaultMessage="Class Code"
-                        description="Title for class code display"
+                        defaultMessage="Join Code"
+                        description="Title for join code display"
                         id="gui.classroom.codeDisplay.title"
                     />
                 </span>
@@ -49,6 +49,9 @@ const ClassCodeDisplay = ({
                                 id="gui.classroom.teacherDashboard.studentCountSuffix"
                             />
                         </span>
+                        {classroom.assignmentName && (
+                            <span>{classroom.assignmentName}</span>
+                        )}
                         {classroom.createdAt && (
                             <span>
                                 {new Date(
@@ -135,6 +138,9 @@ const ClassCodeDisplay = ({
                             id="gui.classroom.teacherDashboard.studentCountSuffix"
                         />
                     </span>
+                    {classroom.assignmentName && (
+                        <span>{classroom.assignmentName}</span>
+                    )}
                     {classroom.createdAt && (
                         <span>
                             {new Date(

--- a/packages/scratch-gui/src/components/classroom-teacher-modal/classroom-teacher-modal.jsx
+++ b/packages/scratch-gui/src/components/classroom-teacher-modal/classroom-teacher-modal.jsx
@@ -34,7 +34,7 @@ const messages = defineMessages({
     title: {
         defaultMessage: 'Class Management',
         description: 'Title for the teacher class management modal',
-        id: 'gui.menuBar.classroomManagement',
+        id: 'gui.classroom.management.title',
     },
 });
 

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -143,7 +143,7 @@ export default {
     'gui.classroom.studentStatus.returned': 'Returned',
     'gui.classroom.studentStatus.teacherComment': "Teacher's Comment",
     'gui.classroom.teacherDetail.cancelDelete': 'Cancel',
-    'gui.classroom.codeDisplay.title': 'Class Code',
+    'gui.classroom.codeDisplay.title': 'Join Code',
     'gui.classroom.codeDisplay.copyLink': 'Copy invite link',
     'gui.classroom.codeDisplay.copied': 'Copied',
     'gui.classroom.teacherDetail.selectMember': 'Select a member',

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -42,6 +42,7 @@ export default {
     'gui.classroom.title': 'Classroom',
     'gui.menuBar.classroom': 'Classroom',
     'gui.menuBar.classroomManagement': 'Class Management...',
+    'gui.classroom.management.title': 'Class Management',
     'gui.classroom.roleSelect.prompt': 'How do you use the classroom?',
     'gui.classroom.roleSelect.teacher': 'Teacher',
     'gui.classroom.roleSelect.student': 'Student',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -138,7 +138,7 @@ export default {
     'gui.classroom.studentStatus.returned': 'へんきゃくずみ',
     'gui.classroom.studentStatus.teacherComment': 'せんせいからのコメント',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
-    'gui.classroom.codeDisplay.title': 'クラスコード',
+    'gui.classroom.codeDisplay.title': 'さんかコード',
     'gui.classroom.codeDisplay.copyLink': 'しょうたいリンクをコピー',
     'gui.classroom.codeDisplay.copied': 'コピーしました',
     'gui.classroom.teacherDetail.selectMember': 'メンバーをせんたくしてください',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -38,6 +38,7 @@ export default {
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',
     'gui.menuBar.classroomManagement': 'クラスかんり...',
+    'gui.classroom.management.title': 'クラスかんり',
     'gui.classroom.roleSelect.prompt': 'どちらでつかいますか？',
     'gui.classroom.roleSelect.teacher': 'せんせい',
     'gui.classroom.roleSelect.student': 'せいと',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -136,7 +136,7 @@ export default {
     'gui.classroom.studentStatus.returned': '返却済み',
     'gui.classroom.studentStatus.teacherComment': '先生からのコメント',
     'gui.classroom.teacherDetail.cancelDelete': 'キャンセル',
-    'gui.classroom.codeDisplay.title': 'クラスコード',
+    'gui.classroom.codeDisplay.title': '参加コード',
     'gui.classroom.codeDisplay.copyLink': '招待リンクをコピー',
     'gui.classroom.codeDisplay.copied': 'コピーしました',
     'gui.classroom.teacherDetail.selectMember': 'メンバーを選択してください',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -37,6 +37,7 @@ export default {
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',
     'gui.menuBar.classroomManagement': 'クラス管理...',
+    'gui.classroom.management.title': 'クラス管理',
     'gui.classroom.roleSelect.prompt': 'どちらで使いますか？',
     'gui.classroom.roleSelect.teacher': '先生',
     'gui.classroom.roleSelect.student': '生徒',


### PR DESCRIPTION
## Summary
- 参加コード全画面表示のタイトルを「クラスコード」から「参加コード」に修正
- フッターに課題名 (`assignmentName`) を追加表示（全画面・通常の両方）
  - 表示順: クラス名 / 人数 / 課題名 / 日付

## Test plan
- [ ] クラス詳細 → 参加コード全画面表示 → 左上が「参加コード」と表示される
- [ ] 左下にクラス名、人数、課題名、日付が表示される
- [ ] 通常サイズの参加コード表示でも同様

🤖 Generated with [Claude Code](https://claude.com/claude-code)