### PR TITLE
feat: silent re-authentication for teacher session on 401

### DIFF
--- a/packages/scratch-gui/src/containers/alert.jsx
+++ b/packages/scratch-gui/src/containers/alert.jsx
@@ -8,7 +8,7 @@ import {openConnectionModal} from '../reducers/modals';
 import {setConnectionModalExtensionId} from '../reducers/connection-modal';
 import {manualUpdateProject} from '../reducers/project-state';
 // === Smalruby: Start of classroom session expired ===
-import {openClassroomModal, openTeacherModal, clearClassroomSession} from '../reducers/classroom';
+import {openClassroomModal, openTeacherModal, requestRelogin} from '../reducers/classroom';
 import {closeAlertsWithId} from '../reducers/alerts';
 // === Smalruby: End of classroom session expired ===
 
@@ -88,8 +88,13 @@ const mapDispatchToProps = dispatch => ({
     // === Smalruby: Start of classroom session expired ===
     onRejoinClassroom: isTeacher => {
         dispatch(closeAlertsWithId('classroomSessionExpired'));
-        dispatch(clearClassroomSession());
-        dispatch(isTeacher ? openTeacherModal() : openClassroomModal());
+        dispatch(closeAlertsWithId('classroomTeacherSessionExpired'));
+        dispatch(requestRelogin());
+        if (isTeacher) {
+            dispatch(openTeacherModal());
+        } else {
+            dispatch(openClassroomModal());
+        }
     }
     // === Smalruby: End of classroom session expired ===
 });

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -109,6 +109,14 @@ const ClassroomModal = ({ mode = 'student' }) => {
         setPhase(mode === 'teacher' ? 'teacher-login' : 'student-join');
     }, [mode, clearError, dispatch, teacher]);
 
+    // Handle relogin request from Alert "参加しなおす" button
+    useEffect(() => {
+        if (classroomState.reloginRequested) {
+            dispatch(clearClassroomSession()); // clears flag + student session
+            handleGoToLogin();
+        }
+    }, [classroomState.reloginRequested, dispatch, handleGoToLogin]);
+
     // Show session-expired alert banner (replaces inline error)
     const showSessionExpiredError = useCallback(() => {
         const alertId = mode === 'teacher' ? 'classroomTeacherSessionExpired' : 'classroomSessionExpired';

--- a/packages/scratch-gui/src/containers/use-teacher-classroom.js
+++ b/packages/scratch-gui/src/containers/use-teacher-classroom.js
@@ -162,31 +162,48 @@ const useTeacherClassroom = ({
     const attemptSilentReauth = useCallback(async () => {
         try {
             await loadGoogleIdentity();
-            const newToken = await new Promise((resolve, reject) => {
-                google.accounts.id.initialize({
-                    client_id: GOOGLE_CLIENT_ID,
-                    auto_select: true,
-                    callback: response => {
-                        if (response.credential) {
-                            resolve(response.credential);
-                        } else {
-                            reject(new Error('Silent reauth failed'));
+            const REAUTH_TIMEOUT_MS = 5000;
+            const newToken = await Promise.race([
+                new Promise((resolve, reject) => {
+                    google.accounts.id.initialize({
+                        client_id: GOOGLE_CLIENT_ID,
+                        auto_select: true,
+                        callback: response => {
+                            if (response.credential) {
+                                resolve(response.credential);
+                            } else {
+                                reject(new Error('Silent reauth failed'));
+                            }
+                        },
+                    });
+                    google.accounts.id.prompt(notification => {
+                        // Only accept truly automatic sign-in (no UI shown)
+                        if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+                            reject(new Error('Silent reauth not available'));
                         }
-                    },
-                });
-                google.accounts.id.prompt(notification => {
-                    if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
-                        reject(new Error('Silent reauth not available'));
-                    }
-                    // If isDismissedMoment(), user closed One Tap — also fail
-                    if (notification.isDismissedMoment()) {
-                        reject(new Error('User dismissed reauth'));
-                    }
-                });
-            });
+                        if (notification.isDismissedMoment()) {
+                            reject(new Error('User dismissed reauth'));
+                        }
+                        // If One Tap UI is displayed, cancel it — we only want silent
+                        if (notification.isDisplayMoment() && !notification.isNotDisplayed()) {
+                            google.accounts.id.cancel();
+                            reject(new Error('One Tap displayed, not silent'));
+                        }
+                    });
+                }),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('Silent reauth timeout')), REAUTH_TIMEOUT_MS),
+                ),
+            ]);
             setIdToken(newToken);
             return newToken;
         } catch {
+            // Ensure One Tap UI is closed on any failure
+            try {
+                google.accounts.id.cancel();
+            } catch {
+                // google may not be loaded
+            }
             return null;
         }
     }, []);

--- a/packages/scratch-gui/src/containers/use-teacher-classroom.js
+++ b/packages/scratch-gui/src/containers/use-teacher-classroom.js
@@ -157,6 +157,54 @@ const useTeacherClassroom = ({
         setPhase(mode === 'teacher' ? 'teacher-login' : 'student-join');
     }, [mode, clearError, setPhase]);
 
+    // --- Teacher: Silent re-authentication on 401 ---
+
+    const attemptSilentReauth = useCallback(async () => {
+        try {
+            await loadGoogleIdentity();
+            const newToken = await new Promise((resolve, reject) => {
+                google.accounts.id.initialize({
+                    client_id: GOOGLE_CLIENT_ID,
+                    auto_select: true,
+                    callback: response => {
+                        if (response.credential) {
+                            resolve(response.credential);
+                        } else {
+                            reject(new Error('Silent reauth failed'));
+                        }
+                    },
+                });
+                google.accounts.id.prompt(notification => {
+                    if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+                        reject(new Error('Silent reauth not available'));
+                    }
+                    // If isDismissedMoment(), user closed One Tap — also fail
+                    if (notification.isDismissedMoment()) {
+                        reject(new Error('User dismissed reauth'));
+                    }
+                });
+            });
+            setIdToken(newToken);
+            return newToken;
+        } catch {
+            return null;
+        }
+    }, []);
+
+    /**
+     * Handle a 401 error from a teacher API call.
+     * Tries silent re-authentication first; falls back to alert if that fails.
+     * @returns {string|null} new ID token if reauth succeeded, null otherwise
+     */
+    const handleTeacher401 = useCallback(async () => {
+        const newToken = await attemptSilentReauth();
+        if (newToken) {
+            return newToken;
+        }
+        showSessionExpiredError();
+        return null;
+    }, [attemptSilentReauth, showSessionExpiredError]);
+
     // --- Google Classroom: Import flow ---
 
     const handleShowGoogleCourses = useCallback(() => {
@@ -262,23 +310,30 @@ const useTeacherClassroom = ({
         if (phase === 'teacher-dashboard' && idToken) {
             setIsLoading(true);
             clearError();
-            classroomAPI
-                .listClassrooms(idToken)
-                .then(data => {
+            (async () => {
+                try {
+                    const data = await classroomAPI.listClassrooms(idToken);
                     setClassrooms(data.classrooms || []);
-                })
-                .catch(err => {
+                } catch (err) {
                     if (err.status === 401) {
-                        showSessionExpiredError();
+                        const newToken = await handleTeacher401();
+                        if (newToken) {
+                            try {
+                                const data = await classroomAPI.listClassrooms(newToken);
+                                setClassrooms(data.classrooms || []);
+                            } catch {
+                                // Retry also failed
+                            }
+                        }
                     } else {
                         showError(translateError(intl, err));
                     }
-                })
-                .finally(() => {
+                } finally {
                     setIsLoading(false);
-                });
+                }
+            })();
         }
-    }, [phase, idToken, clearError, showError, showSessionExpiredError, intl, setIsLoading]);
+    }, [phase, idToken, clearError, showError, handleTeacher401, intl, setIsLoading]);
 
     // --- Teacher: Create classroom ---
 
@@ -303,7 +358,7 @@ const useTeacherClassroom = ({
                 setPhase('teacher-dashboard');
             } catch (err) {
                 if (err.status === 401) {
-                    showSessionExpiredError();
+                    await handleTeacher401();
                 } else {
                     showError(translateError(intl, err));
                 }
@@ -311,7 +366,7 @@ const useTeacherClassroom = ({
                 setIsLoading(false);
             }
         },
-        [idToken, selectedGoogleCourse, clearError, showError, showSessionExpiredError, intl, setIsLoading, setPhase],
+        [idToken, selectedGoogleCourse, clearError, showError, handleTeacher401, intl, setIsLoading, setPhase],
     );
 
     // --- Teacher: Delete classroom ---
@@ -327,7 +382,7 @@ const useTeacherClassroom = ({
                 setPhase('teacher-dashboard');
             } catch (err) {
                 if (err.status === 401) {
-                    showSessionExpiredError();
+                    await handleTeacher401();
                 } else {
                     showError(translateError(intl, err));
                 }
@@ -335,76 +390,85 @@ const useTeacherClassroom = ({
                 setIsLoading(false);
             }
         },
-        [idToken, clearError, showError, showSessionExpiredError, intl, setIsLoading, setPhase],
+        [idToken, clearError, showError, handleTeacher401, intl, setIsLoading, setPhase],
     );
 
     // --- Teacher: Select classroom to view details ---
 
+    const fetchClassroomDetail = useCallback(async (token, classroomId) => {
+        const [classroomData, membersData, submissionsData] = await Promise.all([
+            classroomAPI.getClassroom(token, classroomId),
+            classroomAPI.listMembers(token, classroomId),
+            classroomAPI.listSubmissions(token, classroomId),
+        ]);
+        const subMap = {};
+        for (const sub of submissionsData.submissions || []) {
+            const existing = subMap[sub.memberId];
+            if (!existing || sub.submittedAt > existing.submittedAt) {
+                subMap[sub.memberId] = sub;
+            }
+        }
+        const memberIds = new Set();
+        const enrichedMembers = (membersData.members || []).map(m => {
+            memberIds.add(m.memberId);
+            const sub = subMap[m.memberId];
+            return sub
+                ? {
+                      ...m,
+                      submissionId: sub.submissionId,
+                      submissionStatus: sub.status || 'submitted',
+                      thumbnailUrl: sub.thumbnailUrl || null,
+                      projectUrl: sub.projectUrl || null,
+                      projectName: sub.projectName || null,
+                      screenshotUrls: sub.screenshotUrls || [],
+                      teacherComment: sub.teacherComment || '',
+                  }
+                : m;
+        });
+        for (const [memberId, sub] of Object.entries(subMap)) {
+            if (!memberIds.has(memberId)) {
+                enrichedMembers.push({
+                    memberId,
+                    hasSubmission: true,
+                    submissionId: sub.submissionId,
+                    submissionStatus: sub.status || 'submitted',
+                    submittedAt: sub.submittedAt || null,
+                    thumbnailUrl: sub.thumbnailUrl || null,
+                    projectUrl: sub.projectUrl || null,
+                    projectName: sub.projectName || null,
+                    screenshotUrls: sub.screenshotUrls || [],
+                    teacherComment: sub.teacherComment || '',
+                    left: true,
+                });
+            }
+        }
+        setSelectedClassroom(classroomData);
+        setMembers(enrichedMembers);
+    }, []);
+
     const loadClassroomDetail = useCallback(
         async classroomId => {
             try {
-                const [classroomData, membersData, submissionsData] = await Promise.all([
-                    classroomAPI.getClassroom(idToken, classroomId),
-                    classroomAPI.listMembers(idToken, classroomId),
-                    classroomAPI.listSubmissions(idToken, classroomId),
-                ]);
-                // Merge submission thumbnailUrl/projectUrl into members
-                const subMap = {};
-                for (const sub of submissionsData.submissions || []) {
-                    const existing = subMap[sub.memberId];
-                    if (!existing || sub.submittedAt > existing.submittedAt) {
-                        subMap[sub.memberId] = sub;
-                    }
-                }
-                const memberIds = new Set();
-                const enrichedMembers = (membersData.members || []).map(m => {
-                    memberIds.add(m.memberId);
-                    const sub = subMap[m.memberId];
-                    if (sub) {
-                        return {
-                            ...m,
-                            submissionId: sub.submissionId,
-                            submissionStatus: sub.status || 'submitted',
-                            thumbnailUrl: sub.thumbnailUrl || null,
-                            projectUrl: sub.projectUrl || null,
-                            projectName: sub.projectName || null,
-                            screenshotUrls: sub.screenshotUrls || [],
-                            teacherComment: sub.teacherComment || '',
-                        };
-                    }
-                    return m;
-                });
-                // Add submissions from members who have left
-                for (const [memberId, sub] of Object.entries(subMap)) {
-                    if (!memberIds.has(memberId)) {
-                        enrichedMembers.push({
-                            memberId,
-                            hasSubmission: true,
-                            submissionId: sub.submissionId,
-                            submissionStatus: sub.status || 'submitted',
-                            submittedAt: sub.submittedAt || null,
-                            thumbnailUrl: sub.thumbnailUrl || null,
-                            projectUrl: sub.projectUrl || null,
-                            projectName: sub.projectName || null,
-                            screenshotUrls: sub.screenshotUrls || [],
-                            teacherComment: sub.teacherComment || '',
-                            left: true,
-                        });
-                    }
-                }
-                setSelectedClassroom(classroomData);
-                setMembers(enrichedMembers);
+                await fetchClassroomDetail(idToken, classroomId);
                 return true;
             } catch (err) {
                 if (err.status === 401) {
-                    showSessionExpiredError(translateError(intl, err, 'session'));
-                } else {
-                    showError(translateError(intl, err));
+                    const newToken = await handleTeacher401();
+                    if (newToken) {
+                        try {
+                            await fetchClassroomDetail(newToken, classroomId);
+                            return true;
+                        } catch {
+                            // Retry also failed
+                        }
+                    }
+                    return false;
                 }
+                showError(translateError(intl, err));
                 return false;
             }
         },
-        [idToken, showError, showSessionExpiredError, intl],
+        [idToken, fetchClassroomDetail, showError, handleTeacher401, intl],
     );
 
     const handleSelectClassroom = useCallback(
@@ -468,13 +532,13 @@ const useTeacherClassroom = ({
                 setSelectedMember(null);
             } catch (err) {
                 if (err.status === 401) {
-                    showSessionExpiredError();
+                    await handleTeacher401();
                 } else {
                     showError(translateError(intl, err));
                 }
             }
         },
-        [idToken, selectedClassroom, clearError, showError, showSessionExpiredError, intl],
+        [idToken, selectedClassroom, clearError, showError, handleTeacher401, intl],
     );
 
     // --- Teacher: Open student submission ---
@@ -553,7 +617,7 @@ const useTeacherClassroom = ({
                 await loadClassroomDetail(selectedClassroom.classroomId);
             } catch (err) {
                 if (err.status === 401) {
-                    showSessionExpiredError();
+                    await handleTeacher401();
                 } else {
                     showError(translateError(intl, err));
                 }
@@ -566,7 +630,7 @@ const useTeacherClassroom = ({
             selectedClassroom,
             clearError,
             showError,
-            showSessionExpiredError,
+            handleTeacher401,
             intl,
             loadClassroomDetail,
             setIsLoading,
@@ -663,13 +727,13 @@ const useTeacherClassroom = ({
                 }));
             } catch (err) {
                 if (err.status === 401) {
-                    showSessionExpiredError();
+                    await handleTeacher401();
                 } else {
                     showError(translateError(intl, err));
                 }
             }
         },
-        [idToken, selectedClassroom, clearError, showError, showSessionExpiredError, intl],
+        [idToken, selectedClassroom, clearError, showError, handleTeacher401, intl],
     );
 
     const handleUpdateStudentCount = useCallback(
@@ -686,13 +750,13 @@ const useTeacherClassroom = ({
                 setMembers(memberList.members || []);
             } catch (err) {
                 if (err.status === 401) {
-                    showSessionExpiredError();
+                    await handleTeacher401();
                 } else {
                     showError(translateError(intl, err));
                 }
             }
         },
-        [idToken, selectedClassroom, clearError, showError, showSessionExpiredError, intl],
+        [idToken, selectedClassroom, clearError, showError, handleTeacher401, intl],
     );
 
     // --- Teacher: Select member ---

--- a/packages/scratch-gui/src/css/z-index.css
+++ b/packages/scratch-gui/src/css/z-index.css
@@ -13,10 +13,10 @@ $z-index-monitor: 48; /* monitors go over add buttons */
 $z-index-stage-question: 49; /* "ask" block text input goes above monitors */
 
 $z-index-card: 480;
-$z-index-alerts: 490;
 $z-index-menu-bar: 491; /* menu-bar should go over monitors, alerts and tutorials */
 $z-index-loader: 500;
 $z-index-modal: 510;
+$z-index-alerts: 520; /* === Smalruby: alerts above modals so session-expired is visible === */
 
 $z-index-drag-layer: 1000;
 /* Block drag z-index: 1000; default 50 is overriden in blocks.css */

--- a/packages/scratch-gui/src/reducers/classroom.js
+++ b/packages/scratch-gui/src/reducers/classroom.js
@@ -5,6 +5,7 @@ const CLOSE_TEACHER_MODAL = 'scratch-gui/classroom/CLOSE_TEACHER_MODAL';
 const SET_SESSION = 'scratch-gui/classroom/SET_SESSION';
 const CLEAR_SESSION = 'scratch-gui/classroom/CLEAR_SESSION';
 const SET_SUBMISSION_STATUS = 'scratch-gui/classroom/SET_SUBMISSION_STATUS';
+const REQUEST_RELOGIN = 'scratch-gui/classroom/REQUEST_RELOGIN';
 
 const STORAGE_KEY = 'smalruby:classroom';
 
@@ -66,6 +67,7 @@ const initialState = {
     joinedAt: storedSession?.joinedAt || null,
     submissionStatus: storedSession?.submissionStatus || null,
     lastSubmittedAt: storedSession?.lastSubmittedAt || null,
+    reloginRequested: false,
 };
 
 const reducer = (state, action) => {
@@ -111,6 +113,7 @@ const reducer = (state, action) => {
                 joinedAt: null,
                 submissionStatus: null,
                 lastSubmittedAt: null,
+                reloginRequested: false,
             };
         case SET_SUBMISSION_STATUS: {
             const updates = {
@@ -123,6 +126,8 @@ const reducer = (state, action) => {
             }
             return { ...state, ...updates };
         }
+        case REQUEST_RELOGIN:
+            return { ...state, reloginRequested: true };
         default:
             return state;
     }
@@ -157,6 +162,7 @@ const setClassroomSession = ({
 });
 
 const clearClassroomSession = () => ({ type: CLEAR_SESSION });
+const requestRelogin = () => ({ type: REQUEST_RELOGIN });
 
 const setSubmissionStatus = (submissionStatus, lastSubmittedAt) => ({
     type: SET_SUBMISSION_STATUS,
@@ -173,5 +179,6 @@ export {
     closeTeacherModal,
     setClassroomSession,
     clearClassroomSession,
+    requestRelogin,
     setSubmissionStatus,
 };


### PR DESCRIPTION
## Summary
- 先生の Google ID Token が期限切れ (401) になった場合、Alert を表示する前にサイレント再認証を試行
- `google.accounts.id` の `auto_select: true` で、ユーザー操作なしに新しい ID Token を取得
- 再認証成功時は API を自動的に再試行（先生は操作の中断を意識しない）
- 再認証失敗時のみ従来通り Alert バナー「参加しなおす」を表示

## 実装詳細
- `attemptSilentReauth()`: GIS の auto_select で新しい ID Token 取得を試行
- `handleTeacher401()`: silent reauth → 成功なら新トークン返却、失敗なら Alert 表示
- `loadClassroomDetail`: 401 → reauth → 新トークンで再試行（30秒自動リフレッシュで最重要）
- `listClassrooms` useEffect: 同様に再試行
- 他の先生用 API: reauth 成功で idToken が更新されるため、次の手動操作で自動的に新トークンが使われる

## Test plan
- [ ] 先生としてログイン → 1時間経過 → クラス詳細が自動的にリフレッシュされ続ける（サイレント再認証成功）
- [ ] サイレント再認証が失敗する場合 → Alert バナー「参加しなおす」が表示される
- [ ] 「参加しなおす」→ クラス管理モーダルが開く

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)