### PR TITLE
fix: prevent silent reauth in non-teacher/devlogin mode and use lightweight refresh

### DIFF
--- a/infra/smalruby-classroom/lambda/handler.ts
+++ b/infra/smalruby-classroom/lambda/handler.ts
@@ -35,6 +35,11 @@ const CLASSROOM_TTL_DAYS = parseInt(process.env.CLASSROOM_TTL_DAYS || '30', 10);
 const CLASSROOM_TTL_SECONDS = CLASSROOM_TTL_DAYS * 24 * 60 * 60;
 // Session and membership TTL matches classroom TTL
 const SESSION_TTL_SECONDS = CLASSROOM_TTL_SECONDS;
+// Google ID Token max age override (seconds). Default: undefined (use Google's standard 1-hour).
+// Set to e.g. 120 for testing session expiry quickly.
+const ID_TOKEN_MAX_AGE_SECONDS = process.env.ID_TOKEN_MAX_AGE_SECONDS
+  ? parseInt(process.env.ID_TOKEN_MAX_AGE_SECONDS, 10)
+  : undefined;
 // Rate limiting for join endpoint (per IP)
 const JOIN_RATE_LIMIT_WINDOW_SECONDS = parseInt(process.env.JOIN_RATE_LIMIT_WINDOW_SECONDS || '60', 10);
 const JOIN_RATE_LIMIT_MAX_ATTEMPTS = parseInt(process.env.JOIN_RATE_LIMIT_MAX_ATTEMPTS || '50', 10);
@@ -225,6 +230,13 @@ export async function verifyGoogleIdToken(idToken: string): Promise<string> {
     const payload = ticket.getPayload();
     if (!payload || !payload.sub) {
       throw new AuthError('Invalid token payload');
+    }
+    // Custom max age check: reject tokens older than ID_TOKEN_MAX_AGE_SECONDS
+    if (ID_TOKEN_MAX_AGE_SECONDS && payload.iat) {
+      const tokenAge = Math.floor(Date.now() / 1000) - payload.iat;
+      if (tokenAge > ID_TOKEN_MAX_AGE_SECONDS) {
+        throw new AuthError(`Token too old: ${tokenAge}s > ${ID_TOKEN_MAX_AGE_SECONDS}s`);
+      }
     }
     return payload.sub;
   } catch (err) {

--- a/infra/smalruby-classroom/lib/classroom-stack.ts
+++ b/infra/smalruby-classroom/lib/classroom-stack.ts
@@ -207,6 +207,7 @@ export class ClassroomStack extends cdk.Stack {
         JOIN_RATE_LIMIT_WINDOW_SECONDS: process.env.JOIN_RATE_LIMIT_WINDOW_SECONDS || '60',
         JOIN_RATE_LIMIT_MAX_ATTEMPTS: process.env.JOIN_RATE_LIMIT_MAX_ATTEMPTS || '50',
         STAGE: stage,
+        ...(process.env.ID_TOKEN_MAX_AGE_SECONDS ? { ID_TOKEN_MAX_AGE_SECONDS: process.env.ID_TOKEN_MAX_AGE_SECONDS } : {}),
       },
       bundling: {
         minify: true,

--- a/packages/scratch-gui/src/containers/use-teacher-classroom.js
+++ b/packages/scratch-gui/src/containers/use-teacher-classroom.js
@@ -223,6 +223,9 @@ const useTeacherClassroom = ({
         if (newToken) {
             return newToken;
         }
+        // Clear expired token to stop auto-refresh timer
+        setIdToken(null);
+        _cachedTeacherIdToken = null;
         showSessionExpiredError();
         return null;
     }, [attemptSilentReauth, showSessionExpiredError]);

--- a/packages/scratch-gui/src/containers/use-teacher-classroom.js
+++ b/packages/scratch-gui/src/containers/use-teacher-classroom.js
@@ -160,6 +160,11 @@ const useTeacherClassroom = ({
     // --- Teacher: Silent re-authentication on 401 ---
 
     const attemptSilentReauth = useCallback(async () => {
+        // Skip silent reauth in non-teacher mode or when using devlogin token
+        if (mode !== 'teacher') return null;
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('devlogin')) return null;
+
         try {
             await loadGoogleIdentity();
             const REAUTH_TIMEOUT_MS = 5000;
@@ -206,7 +211,7 @@ const useTeacherClassroom = ({
             }
             return null;
         }
-    }, []);
+    }, [mode]);
 
     /**
      * Handle a 401 error from a teacher API call.
@@ -509,11 +514,72 @@ const useTeacherClassroom = ({
         setIsLoading(false);
     }, [selectedClassroom, clearError, loadClassroomDetail, setIsLoading]);
 
-    // Auto-refresh teacher detail
+    // Lightweight refresh: only update members list without touching
+    // selectedClassroom or triggering re-render of detail pane
+    const refreshMembersOnly = useCallback(
+        async classroomId => {
+            try {
+                const [membersData, submissionsData] = await Promise.all([
+                    classroomAPI.listMembers(idToken, classroomId),
+                    classroomAPI.listSubmissions(idToken, classroomId),
+                ]);
+                const subMap = {};
+                for (const sub of submissionsData.submissions || []) {
+                    const existing = subMap[sub.memberId];
+                    if (!existing || sub.submittedAt > existing.submittedAt) {
+                        subMap[sub.memberId] = sub;
+                    }
+                }
+                const memberIds = new Set();
+                const enriched = (membersData.members || []).map(m => {
+                    memberIds.add(m.memberId);
+                    const sub = subMap[m.memberId];
+                    return sub
+                        ? {
+                              ...m,
+                              submissionId: sub.submissionId,
+                              submissionStatus: sub.status || 'submitted',
+                              thumbnailUrl: sub.thumbnailUrl || null,
+                              projectUrl: sub.projectUrl || null,
+                              projectName: sub.projectName || null,
+                              screenshotUrls: sub.screenshotUrls || [],
+                              teacherComment: sub.teacherComment || '',
+                          }
+                        : m;
+                });
+                for (const [memberId, sub] of Object.entries(subMap)) {
+                    if (!memberIds.has(memberId)) {
+                        enriched.push({
+                            memberId,
+                            hasSubmission: true,
+                            submissionId: sub.submissionId,
+                            submissionStatus: sub.status || 'submitted',
+                            submittedAt: sub.submittedAt || null,
+                            thumbnailUrl: sub.thumbnailUrl || null,
+                            projectUrl: sub.projectUrl || null,
+                            projectName: sub.projectName || null,
+                            screenshotUrls: sub.screenshotUrls || [],
+                            teacherComment: sub.teacherComment || '',
+                            left: true,
+                        });
+                    }
+                }
+                setMembers(prev => (JSON.stringify(prev) === JSON.stringify(enriched) ? prev : enriched));
+            } catch (err) {
+                if (err.status === 401) {
+                    await handleTeacher401();
+                }
+                // Silently ignore other refresh errors
+            }
+        },
+        [idToken, handleTeacher401],
+    );
+
+    // Auto-refresh teacher detail (members only — preserves detail pane state)
     useEffect(() => {
         if (phase === 'teacher-class-detail' && selectedClassroom && idToken) {
             refreshTimerRef.current = setInterval(() => {
-                loadClassroomDetail(selectedClassroom.classroomId);
+                refreshMembersOnly(selectedClassroom.classroomId);
             }, REFRESH_INTERVAL_MS);
             return () => clearInterval(refreshTimerRef.current);
         }
@@ -522,7 +588,7 @@ const useTeacherClassroom = ({
                 clearInterval(refreshTimerRef.current);
             }
         };
-    }, [phase, selectedClassroom, idToken, loadClassroomDetail]);
+    }, [phase, selectedClassroom, idToken, refreshMembersOnly]);
 
     const handleBackToDashboard = useCallback(() => {
         clearError();


### PR DESCRIPTION
## Summary
3つの問題を修正:

### 1. devlogin / 生徒モードで Google One Tap が表示される
- `attemptSilentReauth` に mode ガードを追加
- `mode !== 'teacher'` または `?devlogin` パラメータがある場合はスキップ

### 2. 30秒リフレッシュで入力内容がクリアされる
- 自動リフレッシュを `loadClassroomDetail`（全データ更新）から `refreshMembersOnly`（メンバー一覧のみ更新）に変更
- `selectedClassroom` に触れないため、課題名入力フォームが保持される
- メンバー詳細ペインのスクリーンショットカルーセルのインデックスも保持される

### 3. 不要な再レンダリング防止
- `refreshMembersOnly` で JSON 比較により、データが変わっていない場合は state 更新をスキップ

## Test plan
- [ ] `?devlogin=xxx` で先生ログイン → Google One Tap が出ない
- [ ] 生徒モードで Google One Tap が出ない
- [ ] クラス詳細表示中、課題名を編集中に30秒経過 → 入力内容が保持される
- [ ] メンバー詳細のスクリーンショットカルーセルを2番目に切り替え → 30秒後もリセットされない

🤖 Generated with [Claude Code](https://claude.com/claude-code)