### PR TITLE
feat: enable classroom feature by default

### DIFF
--- a/.claude/rules/scratch-gui/e2e-test.md
+++ b/.claude/rules/scratch-gui/e2e-test.md
@@ -158,15 +158,11 @@ http://localhost:8601?no_beforeunload=1&tab=ruby&ruby_version=2&rubyMode=ruby
 | `tab` | `ruby` | Ruby タブを初期表示 |
 | `ruby_version` | `2` | Ruby バージョン |
 | `rubyMode` | `ruby`, `furigana`, `dncl` | Ruby タブの初期モード |
-| `features` | カンマ区切り（例: `classroom`) | 隠し機能の有効化 |
+| `features` | カンマ区切り | 隠し機能の有効化（現在は未使用） |
 
-### Feature Flags
+### クラスルーム機能
 
-`?features=xxx` で隠し機能を有効化できる。カンマ区切りで複数指定可能。
-
-| Flag | 機能 |
-|------|------|
-| `classroom` | クラスルーム機能（メニューバーに「クラス」ボタン表示） |
+クラスルーム機能は `CLASSROOM_API_ENDPOINT` 環境変数が設定されていれば常に有効です（`?features=classroom` は不要）。
 
 ## Monaco Editor の操作
 

--- a/docs/classroom/README.md
+++ b/docs/classroom/README.md
@@ -21,7 +21,7 @@ Smalruby Classroom は、日本の学校の授業で Smalruby を使うための
 
 ### 先生
 
-1. Smalruby を開く（`https://smalruby.app?features=classroom`）
+1. Smalruby を開く（`https://smalruby.app`）
 2. メニューバーの「クラス」をクリック
 3. 「先生」を選択 → Google ログイン
 4. 「クラスをつくる」→ クラス名と人数を入力
@@ -30,7 +30,7 @@ Smalruby Classroom は、日本の学校の授業で Smalruby を使うための
 ### 生徒
 
 1. 先生から参加コードを受け取る
-2. Smalruby を開く（参加リンク or `?features=classroom`）
+2. Smalruby を開く（参加リンク or `https://smalruby.app`）
 3. 「生徒」→ 参加コード入力 → 席番号を選択
 4. プロジェクトを作成し「提出」ボタンで提出
 
@@ -40,6 +40,6 @@ Smalruby Classroom は、日本の学校の授業で Smalruby を使うための
 - モダンブラウザ（Chrome / Edge / Firefox / Safari）
 - インターネット接続
 
-## 機能フラグ
+## 前提: API エンドポイント
 
-クラス機能は `?features=classroom` URL パラメータで有効化されます。将来的にデフォルト有効に切り替える予定です。
+クラス機能は `CLASSROOM_API_ENDPOINT` 環境変数が設定されている場合に有効です（メニューバーに「クラス」ボタンが表示されます）。

--- a/docs/classroom/testing.md
+++ b/docs/classroom/testing.md
@@ -178,13 +178,13 @@ Playwright MCP および Selenium integration tests で使用する `data-testid
 ### 基本的なテスト URL
 
 ```
-http://localhost:8601?no_beforeunload=1&features=classroom
+http://localhost:8601?no_beforeunload=1
 ```
 
 ### devlogin でのテスト（stg 環境）
 
 ```
-http://localhost:8601?no_beforeunload=1&features=classroom&devlogin=1
+http://localhost:8601?no_beforeunload=1&classrole=teacher&devlogin=<DEV_BYPASS_TOKEN>
 ```
 
 `devlogin=1` を指定すると、Google ログインをバイパスして `DEV_BYPASS_TOKEN` で先生モードにログインできます（stg/ローカル環境のみ）。

--- a/docs/classroom/ui-ux.md
+++ b/docs/classroom/ui-ux.md
@@ -49,7 +49,7 @@ stateDiagram-v2
 
 ## メニューバー
 
-メニューバーの右端に「クラス」ボタンが表示されます（`?features=classroom` が必要）。
+メニューバーの右端に「クラス」ボタンが表示されます（`CLASSROOM_API_ENDPOINT` 環境変数が設定されている場合）。
 
 ![メニューバー](images/01-menu-bar.png)
 

--- a/docs/classroom/user-stories.md
+++ b/docs/classroom/user-stories.md
@@ -174,7 +174,7 @@ sequenceDiagram
 先生が共有した参加リンクからアクセスすると、自動的にクラス参加フローが開始されます。
 
 ```
-https://smalruby.app?features=classroom&classcode=ABC123
+https://smalruby.app?classcode=ABC123
 ```
 
 URL に `classcode` パラメータがあると、モーダルが自動で開き、参加コード入力をスキップして席番号選択画面に遷移します。

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -115,7 +115,6 @@ import {isFirmwareFlashSupported} from '../../lib/smalrubot-firmware-flasher';
 // === Smalruby: Start of classroom button ===
 import {openClassroomModal} from '../../reducers/classroom';
 import {isClassroomConfigured} from '../../lib/classroom-api';
-import {getUrlParams} from '../../lib/url-params';
 // === Smalruby: End of classroom button ===
 import collectMetadata from '../../lib/collect-metadata';
 import {PLATFORM} from '../../lib/platform';
@@ -1235,7 +1234,7 @@ class MenuBar extends React.Component {
                         })()}
                         {/* === Smalruby: End of smalrubot firmware menu === */}
                         {/* === Smalruby: Start of classroom button === */}
-                        {isClassroomConfigured() && getUrlParams().features.includes('classroom') && (
+                        {isClassroomConfigured() && (
                             <React.Fragment>
                                 <div
                                     className={classNames(styles.menuBarItem, styles.hoverable)}

--- a/packages/scratch-gui/src/components/menu-bar/settings-menu.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/settings-menu.jsx
@@ -27,7 +27,6 @@ import rubyIcon from '../../containers/ruby-tab/icon--ruby.svg';
 import blockDisplayIcon from './block-display-icon.png';
 // === Smalruby: Start of classroom management menu ===
 import {isClassroomConfigured} from '../../lib/classroom-api';
-import {getUrlParams} from '../../lib/url-params';
 import {openTeacherModal} from '../../reducers/classroom';
 import googleClassroomIcon from '../classroom-teacher-modal/google-classroom-icon.png';
 // === Smalruby: End of classroom management menu ===
@@ -195,7 +194,7 @@ const SettingsMenu = ({
                         </div>
                     </MenuItem>
                     {/* === Smalruby: Start of classroom management menu === */}
-                    {isClassroomConfigured() && getUrlParams().features.includes('classroom') && (
+                    {isClassroomConfigured() && (
                         <MenuItem onClick={onOpenTeacherModal}>
                             <div className={styles.option}>
                                 <img

--- a/packages/scratch-gui/src/containers/use-teacher-classroom.js
+++ b/packages/scratch-gui/src/containers/use-teacher-classroom.js
@@ -278,7 +278,7 @@ const useTeacherClassroom = ({
                     accessToken = await requestClassroomAccessToken();
                     setGoogleAccessToken(accessToken);
                 }
-                const link = `${window.location.origin}${window.location.pathname}?features=classroom&classcode=${selectedClassroom.joinCode}`;
+                const link = `${window.location.origin}${window.location.pathname}?classcode=${selectedClassroom.joinCode}`;
                 const result = await classroomAPI.postGoogleAssignment(
                     idToken,
                     accessToken,
@@ -674,16 +674,8 @@ const useTeacherClassroom = ({
     const handleCopyInviteLink = useCallback(classroom => {
         const url = new URL(window.location.href);
         url.searchParams.set('classcode', classroom.joinCode.toLowerCase());
-        // Ensure features=classroom is included
-        const features = url.searchParams.get('features') || '';
-        if (
-            !features
-                .split(',')
-                .map(f => f.trim())
-                .includes('classroom')
-        ) {
-            url.searchParams.set('features', features ? `${features},classroom` : 'classroom');
-        }
+        // Remove feature flags from invite link (classroom is always enabled)
+        url.searchParams.delete('features');
         navigator.clipboard.writeText(url.toString()).catch(() => {
             // Clipboard API failed, ignore silently
         });


### PR DESCRIPTION
## Summary
クラス機能を常に有効化。`?features=classroom` URL パラメータは不要になりました。

- `CLASSROOM_API_ENDPOINT` が設定されていれば「クラス」ボタンが常に表示
- 招待リンクから `features=classroom` を削除
- ドキュメント更新

## Test plan
- [ ] `?features=classroom` なしでメニューバーに「クラス」ボタンが表示される
- [ ] 設定メニューに「クラス管理」が表示される
- [ ] 招待リンクに `features=classroom` が含まれない

🤖 Generated with [Claude Code](https://claude.com/claude-code)