### PR TITLE
docs: add Playwright block palette garble workaround

### DIFF
--- a/.claude/rules/scratch-gui/e2e-test.md
+++ b/.claude/rules/scratch-gui/e2e-test.md
@@ -164,6 +164,22 @@ http://localhost:8601?no_beforeunload=1&tab=ruby&ruby_version=2&rubyMode=ruby
 
 クラスルーム機能は `CLASSROOM_API_ENDPOINT` 環境変数が設定されていれば常に有効です（`?features=classroom` は不要）。
 
+### ブロックパレットの文字化け回避
+
+Playwright でルビータブ（またはコスチューム/音タブ）からコードタブに切り替えると、ブロックパレットの文字が乱れることがある。これはコードタブ非表示中に Blockly が SVG を再構築する際、`getBBox()` が `0` を返すためブロックパスの幅が最小値で固定されることが原因。
+
+**回避策**: タブ切り替え後に `resize` イベントを発火してブロックを再描画させる:
+
+```javascript
+// コードタブに切り替えた後
+await page.locator('[role="tab"]').first().click();
+await page.waitForTimeout(500);
+await page.evaluate(() => window.dispatchEvent(new Event('resize')));
+await page.waitForTimeout(500);
+```
+
+この問題は通常のブラウザ操作では発生しない（Playwright 環境固有）。
+
 ## Monaco Editor の操作
 
 ```javascript


### PR DESCRIPTION
## Summary

Playwright MCP でタブ切り替え時にブロックパレットの文字が乱れる問題の原因と回避策を `.claude/rules/scratch-gui/e2e-test.md` に追記。

## 原因

コードタブが非表示（`display: none`）の間に Blockly が SVG ブロックを再構築すると、`getBBox()` が `0` を返すため、ブロックの SVG パス幅が最小値（12px）で固定される。再表示後もパスは更新されず、文字がはみ出して表示される。

## 回避策

タブ切り替え後に `window.dispatchEvent(new Event('resize'))` を発火すると、Blockly がブロック幅を再計算して正常に描画される。

## 補足

- 通常のブラウザ操作では発生しない（Playwright 環境固有）
- Playwright MCP 設定に `--browser chrome` を追加済み（別途）

## Test plan

- [x] 回避策（resize イベント発火）で文字化け解消を確認済み
