### PR TITLE
fix: sync assignment name when switching classrooms in teacher detail

### DIFF
--- a/packages/scratch-gui/src/components/classroom-modal/teacher-class-detail.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/teacher-class-detail.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import ClassCodeDisplay from './class-code-display.jsx';
 import ErrorDisplay from './error-display.jsx';
@@ -46,6 +46,14 @@ const TeacherClassDetail = ({
     const [editAssignmentName, setEditAssignmentName] = useState(
         selectedClassroom.assignmentName || '',
     );
+
+    // Sync local state when a different classroom is selected
+    useEffect(() => {
+        setEditAssignmentName(selectedClassroom.assignmentName || '');
+        setShowDeleteConfirm(false);
+        setShowCodeDisplay(false);
+        setShowStudentCountDialog(false);
+    }, [selectedClassroom.classroomId]);
 
     const memberMap = React.useMemo(() => {
         const map = {};


### PR DESCRIPTION
## Summary

先生のクラス管理画面で、サイドバーからクラスを切り替えたときに課題名（assignmentName）が前のクラスの値のまま更新されない不具合を修正。

`TeacherClassDetail` コンポーネントの `editAssignmentName` が `useState` の初期値のみで設定されており、同じフェーズ内でクラスを切り替えてもコンポーネントが再マウントされないため、ローカル state が古い値のまま残っていた。

`useEffect` を追加し、`selectedClassroom.classroomId` が変わったときに課題名入力とダイアログ表示状態をリセットするようにした。

## Changes

- `teacher-class-detail.jsx`: `useEffect` で `classroomId` 変更時に `editAssignmentName` と各ダイアログ state をリセット

## Test plan

- [x] Playwright で手動確認: クラスA → クラスB → クラスA の切り替えで課題名が毎回正しく更新される
- [x] 30秒リフレッシュは `classroomId` を変えないため、編集中の課題名が保持される（影響なし）
- [x] lint パス
