### PR TITLE
fix: 参加コードの小文字化・全角変換・入力バリデーション

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -164,6 +164,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/components/palette-toggle.test.jsx`
 - `test/unit/components/project-title-input.test.jsx`
 - `test/unit/components/scanning-step-name-search.test.js`
+- `test/unit/components/student-join-form.test.js`
 - `test/unit/containers/backpack.test.jsx`
 - `test/unit/containers/cards.test.jsx`
 - `test/unit/containers/connection-modal-connected-message.test.jsx`

--- a/infra/smalruby-classroom/lambda/handler.ts
+++ b/infra/smalruby-classroom/lambda/handler.ts
@@ -29,7 +29,7 @@ const MAX_CLASS_NAME_LENGTH = 50;
 const MAX_STUDENT_COUNT = parseInt(process.env.MAX_STUDENT_COUNT || '50', 10);
 const MAX_NICKNAME_LENGTH = 20;
 // 6-digit alphanumeric, excluding confusing chars (I, O, 0, 1)
-const JOIN_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+const JOIN_CODE_CHARS = 'abcdefghjklmnpqrstuvwxyz23456789';
 const JOIN_CODE_LENGTH = 6;
 // Classroom TTL from environment (default 30 days)
 const CLASSROOM_TTL_DAYS = parseInt(process.env.CLASSROOM_TTL_DAYS || '30', 10);
@@ -138,11 +138,11 @@ export function validateJoinCode(code: unknown): string {
   if (typeof code !== 'string' || code.trim().length !== JOIN_CODE_LENGTH) {
     throw new ValidationError(`Join code must be ${JOIN_CODE_LENGTH} characters`);
   }
-  const upper = code.trim().toUpperCase();
-  if (!JOIN_CODE_REGEX.test(upper)) {
+  const lower = code.trim().toLowerCase();
+  if (!JOIN_CODE_REGEX.test(lower)) {
     throw new ValidationError('Join code contains invalid characters');
   }
-  return upper;
+  return lower;
 }
 
 // --- Error classes ---

--- a/infra/smalruby-classroom/lambda/tests/handler.test.ts
+++ b/infra/smalruby-classroom/lambda/tests/handler.test.ts
@@ -18,8 +18,15 @@ describe('generateJoinCode', () => {
     expect(code).toHaveLength(6);
   });
 
-  test('should only contain allowed characters (no I, O, 0, 1)', () => {
-    const forbidden = /[IO01]/;
+  test('should generate lowercase codes', () => {
+    for (let i = 0; i < 20; i++) {
+      const code = generateJoinCode();
+      expect(code).toBe(code.toLowerCase());
+    }
+  });
+
+  test('should only contain allowed characters (no i, o, 0, 1)', () => {
+    const forbidden = /[io01IO]/;
     for (let i = 0; i < 100; i++) {
       const code = generateJoinCode();
       expect(code).not.toMatch(forbidden);
@@ -159,30 +166,34 @@ describe('validateNickname', () => {
 });
 
 describe('validateJoinCode', () => {
-  test('should accept valid 6-char code', () => {
-    expect(validateJoinCode('ABC234')).toBe('ABC234');
+  test('should accept valid 6-char lowercase code', () => {
+    expect(validateJoinCode('abc234')).toBe('abc234');
   });
 
-  test('should uppercase', () => {
-    expect(validateJoinCode('abc234')).toBe('ABC234');
+  test('should lowercase uppercase input', () => {
+    expect(validateJoinCode('ABC234')).toBe('abc234');
+  });
+
+  test('should lowercase mixed case input', () => {
+    expect(validateJoinCode('AbC234')).toBe('abc234');
   });
 
   test('should trim whitespace', () => {
-    expect(validateJoinCode(' ABC234 ')).toBe('ABC234');
+    expect(validateJoinCode(' abc234 ')).toBe('abc234');
   });
 
   test('should reject wrong length', () => {
-    expect(() => validateJoinCode('ABC')).toThrow('6 characters');
-    expect(() => validateJoinCode('ABCDEFG')).toThrow('6 characters');
+    expect(() => validateJoinCode('abc')).toThrow('6 characters');
+    expect(() => validateJoinCode('abcdefg')).toThrow('6 characters');
   });
 
   test('should reject non-string', () => {
     expect(() => validateJoinCode(123456)).toThrow('6 characters');
   });
 
-  test('should reject codes with invalid characters (0, 1, I, O)', () => {
-    expect(() => validateJoinCode('ABC001')).toThrow('invalid characters');
-    expect(() => validateJoinCode('ABCIOO')).toThrow('invalid characters');
+  test('should reject codes with invalid characters (0, 1, i, o)', () => {
+    expect(() => validateJoinCode('abc001')).toThrow('invalid characters');
+    expect(() => validateJoinCode('abcioo')).toThrow('invalid characters');
   });
 });
 

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -227,6 +227,7 @@ test/unit/components/*
 !test/unit/components/palette-toggle.test.jsx
 !test/unit/components/project-title-input.test.jsx
 !test/unit/components/scanning-step-name-search.test.js
+!test/unit/components/student-join-form.test.js
 
 # Level 3: test/unit/containers/*
 test/unit/containers/*

--- a/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
@@ -6,6 +6,35 @@ import ErrorDisplay from './error-display.jsx';
 
 import styles from './classroom-modal.css';
 
+/**
+ * Normalize input for join code: full-width → half-width, then keep only [a-z0-9].
+ * @param {string} raw - Raw input string
+ * @returns {string} Normalized lowercase alphanumeric string
+ */
+const normalizeJoinCodeInput = (raw) => {
+    let result = '';
+    for (let i = 0; i < raw.length; i++) {
+        const cp = raw.charCodeAt(i);
+        let ch;
+        if (cp >= 0xff10 && cp <= 0xff19) {
+            // Full-width digits → half-width
+            ch = String.fromCharCode(cp - 0xff10 + 0x30);
+        } else if (cp >= 0xff21 && cp <= 0xff3a) {
+            // Full-width uppercase → half-width lowercase
+            ch = String.fromCharCode(cp - 0xff21 + 0x61);
+        } else if (cp >= 0xff41 && cp <= 0xff5a) {
+            // Full-width lowercase → half-width lowercase
+            ch = String.fromCharCode(cp - 0xff41 + 0x61);
+        } else {
+            ch = raw[i].toLowerCase();
+        }
+        if (/[a-z0-9]/.test(ch)) {
+            result += ch;
+        }
+    }
+    return result;
+};
+
 const StudentJoinForm = ({
     error,
     errorActionLabel,
@@ -20,19 +49,19 @@ const StudentJoinForm = ({
     const [code, setCode] = React.useState('');
 
     const handleCodeChange = useCallback((e) => {
-        setCode(e.target.value.toUpperCase());
+        setCode(normalizeJoinCodeInput(e.target.value));
     }, []);
 
     const handleSubmit = useCallback(() => {
         if (code.trim().length === 6) {
-            onJoin(code.trim().toUpperCase());
+            onJoin(code.trim());
         }
     }, [code, onJoin]);
 
     const handleKeyDown = useCallback(
         (e) => {
             if (e.key === 'Enter' && code.trim().length === 6) {
-                onJoin(code.trim().toUpperCase());
+                onJoin(code.trim());
             }
         },
         [code, onJoin],

--- a/packages/scratch-gui/src/containers/use-teacher-classroom.js
+++ b/packages/scratch-gui/src/containers/use-teacher-classroom.js
@@ -275,7 +275,7 @@ const useTeacherClassroom = ({
                     accessToken = await requestClassroomAccessToken();
                     setGoogleAccessToken(accessToken);
                 }
-                const link = `${window.location.origin}${window.location.pathname}?classcode=${selectedClassroom.joinCode}`;
+                const link = `${window.location.origin}${window.location.pathname}?classcode=${selectedClassroom.joinCode.toLowerCase()}`;
                 const result = await classroomAPI.postGoogleAssignment(
                     idToken,
                     accessToken,

--- a/packages/scratch-gui/src/lib/url-params.js
+++ b/packages/scratch-gui/src/lib/url-params.js
@@ -84,7 +84,7 @@ const parseUrlParams = () => {
         .filter(f => f.length > 0);
 
     // classcode: auto-join a classroom via invite link
-    const classcode = (params.get('classcode') || '').trim().toUpperCase() || null;
+    const classcode = (params.get('classcode') || '').trim().toLowerCase() || null;
 
     // devlogin: bypass Google auth with a secret token (stg/local only)
     const devlogin = params.get('devlogin') || null;

--- a/packages/scratch-gui/test/unit/components/student-join-form.test.js
+++ b/packages/scratch-gui/test/unit/components/student-join-form.test.js
@@ -1,0 +1,126 @@
+/* eslint-env jest */
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
+import StudentJoinForm from '../../../src/components/classroom-modal/student-join-form.jsx';
+
+const renderForm = (props = {}) =>
+    render(
+        <IntlProvider locale="en">
+            <StudentJoinForm onJoin={jest.fn()} {...props} />
+        </IntlProvider>,
+    );
+
+const getInput = container => container.querySelector('[data-testid="classroom-join-code-input"]');
+
+const getSubmitButton = container => container.querySelector('[data-testid="classroom-join-submit"]');
+
+describe('StudentJoinForm', () => {
+    describe('input normalization', () => {
+        test('should convert half-width uppercase to lowercase', () => {
+            const { container } = renderForm();
+            fireEvent.change(getInput(container), {
+                target: { value: 'ABC234' },
+            });
+            expect(getInput(container).value).toBe('abc234');
+        });
+
+        test('should keep half-width lowercase as-is', () => {
+            const { container } = renderForm();
+            fireEvent.change(getInput(container), {
+                target: { value: 'abc234' },
+            });
+            expect(getInput(container).value).toBe('abc234');
+        });
+
+        test('should convert full-width digits to half-width', () => {
+            const { container } = renderForm();
+            // \uFF12\uFF13\uFF14 = ２３４
+            fireEvent.change(getInput(container), {
+                target: { value: '\uFF12\uFF13\uFF14abc' },
+            });
+            expect(getInput(container).value).toBe('234abc');
+        });
+
+        test('should convert full-width uppercase to half-width lowercase', () => {
+            const { container } = renderForm();
+            // \uFF21\uFF22\uFF23 = ＡＢＣ
+            fireEvent.change(getInput(container), {
+                target: { value: '\uFF21\uFF22\uFF23234' },
+            });
+            expect(getInput(container).value).toBe('abc234');
+        });
+
+        test('should convert full-width lowercase to half-width lowercase', () => {
+            const { container } = renderForm();
+            // \uFF41\uFF42\uFF43 = ａｂｃ
+            fireEvent.change(getInput(container), {
+                target: { value: '\uFF41\uFF42\uFF43234' },
+            });
+            expect(getInput(container).value).toBe('abc234');
+        });
+
+        test('should reject non-alphanumeric characters', () => {
+            const { container } = renderForm();
+            fireEvent.change(getInput(container), {
+                target: { value: 'あいうabc' },
+            });
+            expect(getInput(container).value).toBe('abc');
+        });
+
+        test('should reject special characters', () => {
+            const { container } = renderForm();
+            fireEvent.change(getInput(container), {
+                target: { value: 'a-b.c!2@3#4' },
+            });
+            expect(getInput(container).value).toBe('abc234');
+        });
+
+        test('should handle full-width mixed with hiragana', () => {
+            const { container } = renderForm();
+            // ＡあＢいＣう234
+            fireEvent.change(getInput(container), {
+                target: {
+                    value: '\uFF21\u3042\uFF22\u3044\uFF23\u3046234',
+                },
+            });
+            expect(getInput(container).value).toBe('abc234');
+        });
+
+        test('should have maxLength of 6', () => {
+            const { container } = renderForm();
+            expect(getInput(container).maxLength).toBe(6);
+        });
+    });
+
+    describe('submit behavior', () => {
+        test('should call onJoin with lowercase code on click', () => {
+            const onJoin = jest.fn();
+            const { container } = renderForm({ onJoin });
+            fireEvent.change(getInput(container), {
+                target: { value: 'abc234' },
+            });
+            fireEvent.click(getSubmitButton(container));
+            expect(onJoin).toHaveBeenCalledWith('abc234');
+        });
+
+        test('should disable submit when code is less than 6 chars', () => {
+            const { container } = renderForm();
+            fireEvent.change(getInput(container), {
+                target: { value: 'abc' },
+            });
+            expect(getSubmitButton(container).disabled).toBe(true);
+        });
+
+        test('should call onJoin on Enter key', () => {
+            const onJoin = jest.fn();
+            const { container } = renderForm({ onJoin });
+            fireEvent.change(getInput(container), {
+                target: { value: 'abc234' },
+            });
+            fireEvent.keyDown(getInput(container), { key: 'Enter' });
+            expect(onJoin).toHaveBeenCalledWith('abc234');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

先生へのプレゼンで得たフィードバックに基づく参加コード入力の改善。

- 参加コードを内部的にも小文字で生成・保存・検索するように変更（Google Classroom の慣例に合わせる）
- 全角英数字（ＡＢＣ、１２３等）を半角に自動変換（IME の全角入力ミスに対応）
- 英数字以外の文字（ひらがな、記号等）を入力時に除外

### 変更箇所

**Backend (infra/smalruby-classroom):**
- `JOIN_CODE_CHARS` を小文字に変更
- `validateJoinCode` を `toLowerCase()` に変更
- テスト更新（60テスト通過）

**Frontend (packages/scratch-gui):**
- `student-join-form.jsx`: `normalizeJoinCodeInput` 関数を追加（全角→半角変換 + 非英数字フィルタ + 小文字化）
- `url-params.js`: `classcode` パラメータを `toLowerCase()` に変更
- `use-teacher-classroom.js`: 招待リンク生成時に `toLowerCase()` を追加

**テスト:**
- `student-join-form.test.js`: 12テスト追加（入力正規化 9テスト + 送信動作 3テスト）

### 既存データへの影響

既存のクラスデータは破棄OK（先生確認済み）。新規作成分から小文字で保存される。

### 別Issue

- #503: Microsoft アカウントでの先生ログイン対応（別途対応）
