### PR TITLE
feat: 参加コード履歴ドロップダウンで簡単再参加

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -85,6 +85,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/lib/google-drive-api.js`
 - `src/lib/google-script-loader.js`
 - `src/lib/insert-class.js`
+- `src/lib/join-code-history.js`
 - `src/lib/log-suppression.js`
 - `src/lib/microbit-more-update.js`
 - `src/lib/module-sync.js`
@@ -184,6 +185,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/lib/furigana-annotator.test.js`
 - `test/unit/lib/google-drive-api.test.js`
 - `test/unit/lib/insert-class.test.js`
+- `test/unit/lib/join-code-history.test.js`
 - `test/unit/lib/layout-constants.test.js`
 - `test/unit/lib/legacy-storage.test.js`
 - `test/unit/lib/make-toolbox-xml.test.js`

--- a/infra/smalruby-classroom/lambda/handler.ts
+++ b/infra/smalruby-classroom/lambda/handler.ts
@@ -681,8 +681,11 @@ async function handleLookupClassroom(sourceIp: string, body: Record<string, unkn
     statusCode: 200,
     body: JSON.stringify({
       classroomId: classroom.classroomId,
+      className: classroom.className,
+      assignmentName: classroom.assignmentName || null,
       studentCount: classroom.studentCount,
       takenSeats,
+      expiresAt: classroom.ttl ? new Date((classroom.ttl as number) * 1000).toISOString() : null,
     }),
   };
 }

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -108,6 +108,7 @@ src/lib/*
 !src/lib/google-drive-api.js
 !src/lib/google-script-loader.js
 !src/lib/insert-class.js
+!src/lib/join-code-history.js
 !src/lib/log-suppression.js
 !src/lib/microbit-more-update.js
 !src/lib/module-sync.js
@@ -261,6 +262,7 @@ test/unit/lib/*
 !test/unit/lib/furigana-annotator.test.js
 !test/unit/lib/google-drive-api.test.js
 !test/unit/lib/insert-class.test.js
+!test/unit/lib/join-code-history.test.js
 !test/unit/lib/layout-constants.test.js
 !test/unit/lib/legacy-storage.test.js
 !test/unit/lib/make-toolbox-xml.test.js

--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.css
@@ -1207,6 +1207,26 @@
     color: #3373cc;
 }
 
+.history-select {
+    flex: 1;
+    min-width: 0;
+    padding: 0.5rem 0.4rem;
+    border: 1px solid #d9d9d9;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    color: #575e75;
+    background-color: white;
+    cursor: pointer;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+.history-select:focus {
+    outline: none;
+    border-color: #4c97ff;
+}
+
 .student-count-button {
     background: none;
     border: 1px solid #4c97ff;

--- a/packages/scratch-gui/src/components/classroom-modal/classroom-modal.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/classroom-modal.jsx
@@ -32,6 +32,7 @@ const ClassroomModal = ({
     errorActionLabel,
     errorTitle,
     isLoading,
+    joinCodeHistory,
     onSelectTeacher,
     onJoinWithCode,
     onSelectSeat,
@@ -65,6 +66,7 @@ const ClassroomModal = ({
                         errorActionLabel={errorActionLabel}
                         errorTitle={errorTitle}
                         isLoading={isLoading}
+                        joinCodeHistory={joinCodeHistory}
                         noBackButton
                         onJoin={onJoinWithCode}
                         onTeacherLink={onSelectTeacher}
@@ -133,6 +135,13 @@ ClassroomModal.propTypes = {
     errorActionLabel: PropTypes.string,
     errorTitle: PropTypes.string,
     isLoading: PropTypes.bool,
+    joinCodeHistory: PropTypes.arrayOf(
+        PropTypes.shape({
+            joinCode: PropTypes.string.isRequired,
+            className: PropTypes.string,
+            assignmentName: PropTypes.string,
+        }),
+    ),
     joinedInfo: PropTypes.shape({
         assignmentName: PropTypes.string,
         className: PropTypes.string,

--- a/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
@@ -131,11 +131,11 @@ const StudentJoinForm = ({
                         onChange={handleHistorySelect}
                     >
                         <option value="">
-                            {`\u25BC ${intl.formatMessage({
-                                defaultMessage: 'Past classes',
+                            {intl.formatMessage({
+                                defaultMessage: 'Previously joined classes',
                                 description: 'Placeholder for join code history dropdown',
                                 id: 'gui.classroom.studentJoin.historyPlaceholder',
-                            })}`}
+                            })}
                         </option>
                         {joinCodeHistory.map((entry) => (
                             <option

--- a/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
@@ -7,7 +7,7 @@ import ErrorDisplay from './error-display.jsx';
 import styles from './classroom-modal.css';
 
 /**
- * Normalize input for join code: full-width → half-width, then keep only [a-z0-9].
+ * Normalize input for join code: full-width to half-width, then keep only [a-z0-9].
  * @param {string} raw - Raw input string
  * @returns {string} Normalized lowercase alphanumeric string
  */
@@ -17,13 +17,13 @@ const normalizeJoinCodeInput = (raw) => {
         const cp = raw.charCodeAt(i);
         let ch;
         if (cp >= 0xff10 && cp <= 0xff19) {
-            // Full-width digits → half-width
+            // Full-width digits -> half-width
             ch = String.fromCharCode(cp - 0xff10 + 0x30);
         } else if (cp >= 0xff21 && cp <= 0xff3a) {
-            // Full-width uppercase → half-width lowercase
+            // Full-width uppercase -> half-width lowercase
             ch = String.fromCharCode(cp - 0xff21 + 0x61);
         } else if (cp >= 0xff41 && cp <= 0xff5a) {
-            // Full-width lowercase → half-width lowercase
+            // Full-width lowercase -> half-width lowercase
             ch = String.fromCharCode(cp - 0xff41 + 0x61);
         } else {
             ch = raw[i].toLowerCase();
@@ -41,6 +41,7 @@ const StudentJoinForm = ({
     errorActionHandler,
     errorTitle,
     isLoading,
+    joinCodeHistory,
     noBackButton,
     onBack,
     onJoin,
@@ -66,6 +67,19 @@ const StudentJoinForm = ({
         },
         [code, onJoin],
     );
+
+    const handleHistorySelect = useCallback(
+        (e) => {
+            const selectedCode = e.target.value;
+            if (selectedCode) {
+                setCode(selectedCode);
+            }
+        },
+        [],
+    );
+
+    const hasHistory =
+        Array.isArray(joinCodeHistory) && joinCodeHistory.length > 0;
 
     return (
         <div data-testid="classroom-phase-student-join">
@@ -108,6 +122,31 @@ const StudentJoinForm = ({
                 />
             </div>
             <div className={styles.buttonRow}>
+                {hasHistory && (
+                    <select
+                        className={styles.historySelect}
+                        data-testid="classroom-join-history"
+                        value=""
+                        onChange={handleHistorySelect}
+                    >
+                        <option value="">
+                            {'\u25BC '}
+                            <FormattedMessage
+                                defaultMessage="Past classes"
+                                description="Placeholder for join code history dropdown"
+                                id="gui.classroom.studentJoin.historyPlaceholder"
+                            />
+                        </option>
+                        {joinCodeHistory.map((entry) => (
+                            <option
+                                key={entry.joinCode}
+                                value={entry.joinCode}
+                            >
+                                {`${entry.className}${entry.assignmentName ? `/${entry.assignmentName}` : ''} ${entry.joinCode}`}
+                            </option>
+                        ))}
+                    </select>
+                )}
                 <button
                     className={styles.primaryButton}
                     data-testid="classroom-join-submit"
@@ -184,6 +223,15 @@ StudentJoinForm.propTypes = {
     errorActionLabel: PropTypes.string,
     errorTitle: PropTypes.string,
     isLoading: PropTypes.bool,
+    joinCodeHistory: PropTypes.arrayOf(
+        PropTypes.shape({
+            joinCode: PropTypes.string.isRequired,
+            className: PropTypes.string,
+            assignmentName: PropTypes.string,
+            expiresAt: PropTypes.string,
+            joinedAt: PropTypes.string,
+        }),
+    ),
     noBackButton: PropTypes.bool,
     onBack: PropTypes.func,
     onJoin: PropTypes.func.isRequired,

--- a/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
@@ -82,6 +82,12 @@ const StudentJoinForm = ({
     const hasHistory =
         Array.isArray(joinCodeHistory) && joinCodeHistory.length > 0;
 
+    // Show selected state if current code matches a history entry
+    const historySelectValue =
+        hasHistory && joinCodeHistory.some((e) => e.joinCode === code)
+            ? code
+            : '';
+
     return (
         <div data-testid="classroom-phase-student-join">
             {!noBackButton && (
@@ -127,12 +133,12 @@ const StudentJoinForm = ({
                     <select
                         className={styles.historySelect}
                         data-testid="classroom-join-history"
-                        value=""
+                        value={historySelectValue}
                         onChange={handleHistorySelect}
                     >
                         <option value="">
                             {intl.formatMessage({
-                                defaultMessage: 'Previously joined classes',
+                                defaultMessage: 'Join codes from previously joined classes',
                                 description: 'Placeholder for join code history dropdown',
                                 id: 'gui.classroom.studentJoin.historyPlaceholder',
                             })}

--- a/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
+++ b/packages/scratch-gui/src/components/classroom-modal/student-join-form.jsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
 
@@ -47,6 +47,7 @@ const StudentJoinForm = ({
     onJoin,
     onTeacherLink,
 }) => {
+    const intl = useIntl();
     const [code, setCode] = React.useState('');
 
     const handleCodeChange = useCallback((e) => {
@@ -130,12 +131,11 @@ const StudentJoinForm = ({
                         onChange={handleHistorySelect}
                     >
                         <option value="">
-                            {'\u25BC '}
-                            <FormattedMessage
-                                defaultMessage="Past classes"
-                                description="Placeholder for join code history dropdown"
-                                id="gui.classroom.studentJoin.historyPlaceholder"
-                            />
+                            {`\u25BC ${intl.formatMessage({
+                                defaultMessage: 'Past classes',
+                                description: 'Placeholder for join code history dropdown',
+                                id: 'gui.classroom.studentJoin.historyPlaceholder',
+                            })}`}
                         </option>
                         {joinCodeHistory.map((entry) => (
                             <option

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -6,6 +6,7 @@ import ClassroomModalComponent from '../components/classroom-modal/classroom-mod
 import ClassroomTeacherModalComponent from '../components/classroom-teacher-modal/classroom-teacher-modal.jsx';
 import { renderBlocksToCanvas } from '../lib/blocks-screenshot.js';
 import classroomAPI from '../lib/classroom-api.js';
+import { loadHistory, addToHistory } from '../lib/join-code-history.js';
 import { getProjectThumbnail } from '../lib/store-project-thumbnail.js';
 import { getUrlParams, clearClasscode } from '../lib/url-params.js';
 import { showAlertWithTimeout } from '../reducers/alerts.js';
@@ -133,10 +134,12 @@ const ClassroomModal = ({ mode = 'student' }) => {
 
     // --- Student state ---
 
+    const [joinCodeHistory, setJoinCodeHistory] = useState(() => loadHistory());
     const [pendingJoinCode, setPendingJoinCode] = useState(null);
     const [seatCount, setSeatCount] = useState(0);
     const [takenSeats, setTakenSeats] = useState([]);
     const [selectedSeat, setSelectedSeat] = useState(null);
+    const [pendingClassroomInfo, setPendingClassroomInfo] = useState(null);
     const [joinedInfo, setJoinedInfo] = useState(null);
     const [thumbnailDataUrl, setThumbnailDataUrl] = useState(null);
     const [submitProgress, setSubmitProgress] = useState(null);
@@ -150,6 +153,11 @@ const ClassroomModal = ({ mode = 'student' }) => {
             try {
                 const data = await classroomAPI.lookupClassroom(joinCode);
                 setPendingJoinCode(joinCode);
+                setPendingClassroomInfo({
+                    className: data.className || '',
+                    assignmentName: data.assignmentName || '',
+                    expiresAt: data.expiresAt || null,
+                });
                 setSeatCount(data.studentCount);
                 setTakenSeats(data.takenSeats || []);
                 setSelectedSeat(null);
@@ -196,6 +204,13 @@ const ClassroomModal = ({ mode = 'student' }) => {
             if (data.assignmentName) {
                 dispatch(setProjectTitle(data.assignmentName));
             }
+            addToHistory({
+                joinCode: pendingJoinCode,
+                className: data.className,
+                assignmentName: data.assignmentName || '',
+                expiresAt: pendingClassroomInfo?.expiresAt || null,
+            });
+            setJoinCodeHistory(loadHistory());
             setJoinedInfo({
                 className: data.className,
                 assignmentName: data.assignmentName || null,
@@ -478,6 +493,7 @@ const ClassroomModal = ({ mode = 'student' }) => {
             errorActionLabel={errorActionLabel}
             errorTitle={errorTitle}
             isLoading={isLoading}
+            joinCodeHistory={joinCodeHistory}
             joinedInfo={joinedInfo}
             phase={phase}
             seatCount={seatCount}

--- a/packages/scratch-gui/src/lib/join-code-history.js
+++ b/packages/scratch-gui/src/lib/join-code-history.js
@@ -1,0 +1,75 @@
+/**
+ * Manage join code history in localStorage for quick re-join.
+ *
+ * Each entry: { joinCode, className, assignmentName, expiresAt, joinedAt }
+ * - Sorted by joinedAt descending (most recent first)
+ * - Maximum 10 entries
+ * - Expired entries are pruned on load
+ */
+
+const STORAGE_KEY = 'smalruby:joinCodeHistory';
+const MAX_ENTRIES = 10;
+
+/**
+ * Load join code history from localStorage, pruning expired entries.
+ * @returns {Array<object>} Array of history entries (most recent first)
+ */
+const loadHistory = () => {
+    if (typeof window === 'undefined' || !window.localStorage) return [];
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return [];
+        const entries = JSON.parse(raw);
+        if (!Array.isArray(entries)) return [];
+
+        const now = new Date();
+        const valid = entries.filter(e => {
+            if (!e.joinCode || !e.joinedAt) return false;
+            if (e.expiresAt && new Date(e.expiresAt) <= now) return false;
+            return true;
+        });
+
+        // Save back if expired entries were removed
+        if (valid.length !== entries.length) {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(valid));
+        }
+
+        return valid;
+    } catch {
+        return [];
+    }
+};
+
+/**
+ * Add or update a join code entry in the history.
+ * @param {object} entry - { joinCode, className, assignmentName, expiresAt }
+ */
+const addToHistory = entry => {
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    if (!entry.joinCode) return;
+
+    try {
+        const entries = loadHistory();
+
+        // Remove existing entry with same joinCode
+        const filtered = entries.filter(e => e.joinCode !== entry.joinCode);
+
+        // Add new entry at the top
+        filtered.unshift({
+            joinCode: entry.joinCode,
+            className: entry.className || '',
+            assignmentName: entry.assignmentName || '',
+            expiresAt: entry.expiresAt || null,
+            joinedAt: new Date().toISOString(),
+        });
+
+        // Keep only the latest MAX_ENTRIES
+        const trimmed = filtered.slice(0, MAX_ENTRIES);
+
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+    } catch {
+        // Ignore storage errors
+    }
+};
+
+export { loadHistory, addToHistory };

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -67,7 +67,7 @@ export default {
     'gui.classroom.studentJoin.next': 'Next',
     'gui.classroom.studentJoin.hintTitle': 'Hint',
     'gui.classroom.studentJoin.hintAskTeacher': 'Ask your teacher for the join code.',
-    'gui.classroom.studentJoin.historyPlaceholder': 'Past classes',
+    'gui.classroom.studentJoin.historyPlaceholder': 'Previously joined classes',
     'gui.classroom.studentJoin.hintTeacherPath':
         'Teachers can find the join code in {settingsIcon} Settings → Class Management.',
     'gui.classroom.studentSeat.prompt': 'Select your seat number',

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -67,6 +67,7 @@ export default {
     'gui.classroom.studentJoin.next': 'Next',
     'gui.classroom.studentJoin.hintTitle': 'Hint',
     'gui.classroom.studentJoin.hintAskTeacher': 'Ask your teacher for the join code.',
+    'gui.classroom.studentJoin.historyPlaceholder': 'Past classes',
     'gui.classroom.studentJoin.hintTeacherPath':
         'Teachers can find the join code in {settingsIcon} Settings → Class Management.',
     'gui.classroom.studentSeat.prompt': 'Select your seat number',

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -67,7 +67,7 @@ export default {
     'gui.classroom.studentJoin.next': 'Next',
     'gui.classroom.studentJoin.hintTitle': 'Hint',
     'gui.classroom.studentJoin.hintAskTeacher': 'Ask your teacher for the join code.',
-    'gui.classroom.studentJoin.historyPlaceholder': 'Previously joined classes',
+    'gui.classroom.studentJoin.historyPlaceholder': 'Join codes from previously joined classes',
     'gui.classroom.studentJoin.hintTeacherPath':
         'Teachers can find the join code in {settingsIcon} Settings → Class Management.',
     'gui.classroom.studentSeat.prompt': 'Select your seat number',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -65,6 +65,7 @@ export default {
     'gui.classroom.studentJoin.hintAskTeacher': 'せんせいからさんかコードをきいてください。',
     'gui.classroom.studentJoin.hintTeacherPath':
         'せんせいは「{settingsIcon} せってい → クラスかんり」からさんかコードをかくにんできます。',
+    'gui.classroom.studentJoin.historyPlaceholder': 'かこのクラス',
     'gui.classroom.studentJoin.teacherLink': 'せんせいのかたはこちら（クラスかんり）',
     'gui.classroom.studentSeat.prompt': 'しゅっせきばんごうをえらんでください',
     'gui.classroom.studentSeat.join': 'さんかする',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -65,7 +65,7 @@ export default {
     'gui.classroom.studentJoin.hintAskTeacher': 'せんせいからさんかコードをきいてください。',
     'gui.classroom.studentJoin.hintTeacherPath':
         'せんせいは「{settingsIcon} せってい → クラスかんり」からさんかコードをかくにんできます。',
-    'gui.classroom.studentJoin.historyPlaceholder': 'かこのクラス',
+    'gui.classroom.studentJoin.historyPlaceholder': 'かこにさんかしたクラス・かだい',
     'gui.classroom.studentJoin.teacherLink': 'せんせいのかたはこちら（クラスかんり）',
     'gui.classroom.studentSeat.prompt': 'しゅっせきばんごうをえらんでください',
     'gui.classroom.studentSeat.join': 'さんかする',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -65,7 +65,7 @@ export default {
     'gui.classroom.studentJoin.hintAskTeacher': 'せんせいからさんかコードをきいてください。',
     'gui.classroom.studentJoin.hintTeacherPath':
         'せんせいは「{settingsIcon} せってい → クラスかんり」からさんかコードをかくにんできます。',
-    'gui.classroom.studentJoin.historyPlaceholder': 'かこにさんかしたクラス・かだい',
+    'gui.classroom.studentJoin.historyPlaceholder': 'これまでにさんかしたクラス・かだいのさんかコード',
     'gui.classroom.studentJoin.teacherLink': 'せんせいのかたはこちら（クラスかんり）',
     'gui.classroom.studentSeat.prompt': 'しゅっせきばんごうをえらんでください',
     'gui.classroom.studentSeat.join': 'さんかする',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -64,6 +64,7 @@ export default {
     'gui.classroom.studentJoin.hintAskTeacher': '先生から参加コードを聞いてください。',
     'gui.classroom.studentJoin.hintTeacherPath':
         '先生は「{settingsIcon} 設定 → クラス管理」から参加コードを確認できます。',
+    'gui.classroom.studentJoin.historyPlaceholder': '過去のクラス',
     'gui.classroom.studentJoin.teacherLink': '先生の方はこちら（クラス管理）',
     'gui.classroom.studentSeat.prompt': '出席番号を選んでください',
     'gui.classroom.studentSeat.join': '参加する',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -64,7 +64,7 @@ export default {
     'gui.classroom.studentJoin.hintAskTeacher': '先生から参加コードを聞いてください。',
     'gui.classroom.studentJoin.hintTeacherPath':
         '先生は「{settingsIcon} 設定 → クラス管理」から参加コードを確認できます。',
-    'gui.classroom.studentJoin.historyPlaceholder': '過去のクラス',
+    'gui.classroom.studentJoin.historyPlaceholder': '過去に参加したクラス・課題',
     'gui.classroom.studentJoin.teacherLink': '先生の方はこちら（クラス管理）',
     'gui.classroom.studentSeat.prompt': '出席番号を選んでください',
     'gui.classroom.studentSeat.join': '参加する',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -64,7 +64,7 @@ export default {
     'gui.classroom.studentJoin.hintAskTeacher': '先生から参加コードを聞いてください。',
     'gui.classroom.studentJoin.hintTeacherPath':
         '先生は「{settingsIcon} 設定 → クラス管理」から参加コードを確認できます。',
-    'gui.classroom.studentJoin.historyPlaceholder': '過去に参加したクラス・課題',
+    'gui.classroom.studentJoin.historyPlaceholder': 'これまでに参加したクラス・課題の参加コード',
     'gui.classroom.studentJoin.teacherLink': '先生の方はこちら（クラス管理）',
     'gui.classroom.studentSeat.prompt': '出席番号を選んでください',
     'gui.classroom.studentSeat.join': '参加する',

--- a/packages/scratch-gui/test/unit/lib/join-code-history.test.js
+++ b/packages/scratch-gui/test/unit/lib/join-code-history.test.js
@@ -1,0 +1,122 @@
+/* eslint-env jest */
+import { loadHistory, addToHistory } from '../../../src/lib/join-code-history.js';
+
+const STORAGE_KEY = 'smalruby:joinCodeHistory';
+
+describe('join-code-history', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    describe('loadHistory', () => {
+        test('returns empty array when no history', () => {
+            expect(loadHistory()).toEqual([]);
+        });
+
+        test('returns stored entries', () => {
+            const entries = [
+                {
+                    joinCode: 'abc234',
+                    className: 'Class1',
+                    assignmentName: 'Task1',
+                    expiresAt: new Date(Date.now() + 86400000).toISOString(),
+                    joinedAt: new Date().toISOString(),
+                },
+            ];
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+            expect(loadHistory()).toEqual(entries);
+        });
+
+        test('prunes expired entries', () => {
+            const entries = [
+                {
+                    joinCode: 'abc234',
+                    className: 'Active',
+                    assignmentName: '',
+                    expiresAt: new Date(Date.now() + 86400000).toISOString(),
+                    joinedAt: new Date().toISOString(),
+                },
+                {
+                    joinCode: 'xyz789',
+                    className: 'Expired',
+                    assignmentName: '',
+                    expiresAt: new Date(Date.now() - 1000).toISOString(),
+                    joinedAt: new Date(Date.now() - 86400000).toISOString(),
+                },
+            ];
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+            const result = loadHistory();
+            expect(result).toHaveLength(1);
+            expect(result[0].joinCode).toBe('abc234');
+            // localStorage should also be updated
+            const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY));
+            expect(stored).toHaveLength(1);
+        });
+
+        test('keeps entries without expiresAt', () => {
+            const entries = [
+                {
+                    joinCode: 'abc234',
+                    className: 'NoExpiry',
+                    assignmentName: '',
+                    expiresAt: null,
+                    joinedAt: new Date().toISOString(),
+                },
+            ];
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+            expect(loadHistory()).toHaveLength(1);
+        });
+
+        test('handles invalid JSON gracefully', () => {
+            window.localStorage.setItem(STORAGE_KEY, 'not json');
+            expect(loadHistory()).toEqual([]);
+        });
+    });
+
+    describe('addToHistory', () => {
+        test('adds entry to empty history', () => {
+            addToHistory({
+                joinCode: 'abc234',
+                className: 'Class1',
+                assignmentName: 'Task1',
+                expiresAt: new Date(Date.now() + 86400000).toISOString(),
+            });
+            const result = loadHistory();
+            expect(result).toHaveLength(1);
+            expect(result[0].joinCode).toBe('abc234');
+            expect(result[0].className).toBe('Class1');
+            expect(result[0].assignmentName).toBe('Task1');
+            expect(result[0].joinedAt).toBeTruthy();
+        });
+
+        test('moves existing entry to top on re-join', () => {
+            addToHistory({ joinCode: 'aaa111', className: 'First' });
+            addToHistory({ joinCode: 'bbb222', className: 'Second' });
+            addToHistory({ joinCode: 'aaa111', className: 'First Updated' });
+            const result = loadHistory();
+            expect(result).toHaveLength(2);
+            expect(result[0].joinCode).toBe('aaa111');
+            expect(result[0].className).toBe('First Updated');
+            expect(result[1].joinCode).toBe('bbb222');
+        });
+
+        test('limits to 10 entries', () => {
+            for (let i = 0; i < 15; i++) {
+                addToHistory({
+                    joinCode: `code${String(i).padStart(2, '0')}`,
+                    className: `Class${i}`,
+                    expiresAt: new Date(Date.now() + 86400000).toISOString(),
+                });
+            }
+            const result = loadHistory();
+            expect(result).toHaveLength(10);
+            // Most recent should be first
+            expect(result[0].joinCode).toBe('code14');
+        });
+
+        test('ignores entries without joinCode', () => {
+            addToHistory({ className: 'NoCode' });
+            expect(loadHistory()).toEqual([]);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

過去に参加したクラスの参加コードを localStorage に記憶し、ワンクリックで再入力できるドロップダウンを追加。

### 変更内容

**新機能: 参加コード履歴ドロップダウン**
- 参加成功時に joinCode/className/assignmentName/expiresAt を localStorage に保存
- クラスモーダルの参加コード入力画面にドロップダウンを表示
- 選択すると参加コードが自動入力され「次へ」ボタンがアクティブに
- 表示フォーマット: `クラス名/課題名 参加コード`
- 最新10件のみ保持、参加日時の近いものが上に表示
- モーダル表示時に有効期限切れのエントリを自動削除
- 履歴がない場合はドロップダウン非表示

**Backend (infra/smalruby-classroom)**
- lookup API のレスポンスに `className`, `assignmentName`, `expiresAt` を追加

**国際化**
- `gui.classroom.studentJoin.historyPlaceholder` を en/ja/ja-Hira に追加

**テスト**
- `join-code-history.test.js`: 9テスト（保存、重複更新、最大件数、期限切れ削除、異常系）
- `student-join-form.test.js`: 12テスト（既存の入力正規化テスト）

### 新規ファイル
- `src/lib/join-code-history.js` — localStorage ヘルパー
- `test/unit/lib/join-code-history.test.js` — ユニットテスト
