### PR TITLE
chore: Microsoft パブリッシャードメイン検証ファイルの配置

### DIFF
--- a/packages/scratch-gui/legal/.well-known/microsoft-identity-association.json
+++ b/packages/scratch-gui/legal/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "0cf0f36a-2ee8-4904-a31e-68e956197775"
+    }
+  ]
+}

--- a/packages/scratch-gui/webpack.config.js
+++ b/packages/scratch-gui/webpack.config.js
@@ -279,7 +279,8 @@ const buildConfig = baseConfig.clone()
             },
             {
                 from: 'legal',
-                to: '.'
+                to: '.',
+                globOptions: { dot: true }
             },
             {
                 from: 'extensions/**',


### PR DESCRIPTION
## Summary

Microsoft Entra ID のパブリッシャードメイン検証用ファイルを配置。

- `legal/.well-known/microsoft-identity-association.json` を追加
- webpack CopyWebpackPlugin に `globOptions: { dot: true }` を追加（`.well-known` ディレクトリがビルド出力に含まれるように）

デプロイ後、`https://smalruby.app/.well-known/microsoft-identity-association.json` でアクセス可能になります。
