### PR TITLE
fix: DNCL for ループと【外部からの入力】のブロック変換対応

### DIFF
--- a/packages/scratch-gui/src/lib/dncl/dncl-to-ruby.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-to-ruby.js
@@ -110,6 +110,13 @@ const RUBY_LITERALS = new Set([
 let arrayNames = new Set()
 
 /**
+ * Stack tracking for-loop state for increment insertion at `を繰り返す`.
+ * Each entry: { varName, stepRuby, ascending, indent }
+ * @type {Array<object>}
+ */
+let forLoopStack = []
+
+/**
  * Detect array names from the full source before line-by-line conversion.
  * An uppercase identifier assigned to an array literal is an array name.
  * @param {string} source - The full DNCL source code.
@@ -450,8 +457,18 @@ const convertLine = (line) => {
     return `${indent}end`
   }
 
-  // を繰り返す → end
+  // を繰り返す → end (with for-loop increment insertion)
   if (trimmed === 'を繰り返す') {
+    if (forLoopStack.length > 0) {
+      const top = forLoopStack[forLoopStack.length - 1]
+      // Check if this end matches the innermost for-loop by indent level
+      if (top.indent === indent) {
+        forLoopStack.pop()
+        const stepExpr = top.ascending ? top.stepRuby : `-${top.stepRuby}`
+        const bodyIndent = `${indent}  `
+        return `${bodyIndent}${top.varName} += ${stepExpr}\n${indent}end`
+      }
+    }
     return `${indent}end`
   }
 
@@ -460,28 +477,32 @@ const convertLine = (line) => {
     return `${indent}end`
   }
 
-  // i を N1 から N2 まで N3 ずつ増やしながら → (N1..N2).step(N3) do |i|
+  // i を N1 から N2 まで N3 ずつ増やしながら → @i = N1 + while @i <= N2
   const forAscMatch = trimmed.match(
     /^(\w+)\s+を\s+(.+?)\s+から\s+(.+?)\s+まで\s+(.+?)\s+ずつ増やしながら$/,
   )
   if (forAscMatch) {
     const [, loopVar, from, to, step] = forAscMatch
+    const varName = convertIdentifier(loopVar)
     const fromRuby = processSegments(from)
     const toRuby = processSegments(to)
     const stepRuby = processSegments(step)
-    return `${indent}(${fromRuby}..${toRuby}).step(${stepRuby}) do |${loopVar}|`
+    forLoopStack.push({ varName, stepRuby, ascending: true, indent })
+    return `${indent}${varName} = ${fromRuby}\n${indent}while ${varName} <= ${toRuby}`
   }
 
-  // i を N1 から N2 まで N3 ずつ減らしながら → N1.step(N2, -N3) do |i|
+  // i を N1 から N2 まで N3 ずつ減らしながら → @i = N1 + while @i >= N2
   const forDescMatch = trimmed.match(
     /^(\w+)\s+を\s+(.+?)\s+から\s+(.+?)\s+まで\s+(.+?)\s+ずつ減らしながら$/,
   )
   if (forDescMatch) {
     const [, loopVar, from, to, step] = forDescMatch
+    const varName = convertIdentifier(loopVar)
     const fromRuby = processSegments(from)
     const toRuby = processSegments(to)
     const stepRuby = processSegments(step)
-    return `${indent}${fromRuby}.step(${toRuby}, -${stepRuby}) do |${loopVar}|`
+    forLoopStack.push({ varName, stepRuby, ascending: false, indent })
+    return `${indent}${varName} = ${fromRuby}\n${indent}while ${varName} >= ${toRuby}`
   }
 
   // condition の間 → while condition
@@ -519,7 +540,7 @@ const convertLine = (line) => {
     const inputIndent = inputMatch[1]
     const varPart = inputMatch[2].trim()
     const processedVar = processSegments(varPart)
-    return `${inputIndent}ask_and_wait("")\n${inputIndent}${processedVar} = answer`
+    return `${inputIndent}ask("")\n${inputIndent}${processedVar} = answer`
   }
 
   // Process segments (strings vs code)
@@ -591,6 +612,7 @@ const dnclToRuby = (source) => {
   }
 
   detectArrayNames(source)
+  forLoopStack = []
 
   const lines = source.split('\n')
   const rubyLines = lines.map((line) => convertLine(line))

--- a/packages/scratch-gui/src/lib/dncl/ruby-to-dncl.js
+++ b/packages/scratch-gui/src/lib/dncl/ruby-to-dncl.js
@@ -190,8 +190,8 @@ const convertLine = (line) => {
     return line
   }
 
-  // ask_and_wait("") — will be combined with next line
-  if (trimmed === 'ask_and_wait("")') {
+  // ask("") or ask_and_wait("") — will be combined with next line
+  if (trimmed === 'ask("")' || trimmed === 'ask_and_wait("")') {
     return null // sentinel: combine with next line
   }
 
@@ -300,6 +300,41 @@ const convertLine = (line) => {
 }
 
 /**
+ * Try to detect a while-based for-loop pattern:
+ *   `@var` = from  (pending assignment)
+ *   while `@var` <= to  OR  while `@var` >= to
+ *
+ * If detected, push a for-loop context and return the DNCL header placeholder.
+ * The step is unknown until `end` is reached.
+ * @param {object} pending - The buffered assignment.
+ * @param {string} whileLine - The current `while` line (trimmed).
+ * @param {string} whileIndent - The indent of the while line.
+ * @returns {object|null} For-loop info or null if not a for-loop pattern.
+ */
+const detectForLoopPattern = (pending, whileLine, whileIndent) => {
+  if (!pending) return null
+  if (pending.indent !== whileIndent) return null
+
+  // Match: while @var <= expr  or  while @var >= expr
+  const whileMatch = whileLine.match(
+    /^while\s+(@\w+)\s*(<=|>=)\s*(.+)$/,
+  )
+  if (!whileMatch) return null
+  if (whileMatch[1] !== pending.varRef) return null
+
+  const ascending = whileMatch[2] === '<='
+  return {
+    varName: pending.varName,
+    varRef: pending.varRef,
+    from: pending.expr,
+    to: processSegments(whileMatch[3]),
+    ascending,
+    indent: whileIndent,
+    headerIndex: -1, // will be set by caller
+  }
+}
+
+/**
  * Transpile Ruby source code to DNCL.
  * @param {string} source - The Ruby source code.
  * @returns {object} An object with `dncl` (the transpiled DNCL code).
@@ -317,24 +352,96 @@ const rubyToDncl = (source) => {
       continue
     }
 
-    const result = convertLine(lines[i])
+    const line = lines[i]
+    const trimmed = line.trim()
+    const indentMatch = line.match(/^(\s*)/)
+    const indent = indentMatch ? indentMatch[1] : ''
 
-    // Handle ask_and_wait("") + next line assignment → 入力
+    // Check if this is an assignment that could be a for-loop init
+    const assignMatch = trimmed.match(/^(@\w+)\s*=\s*(.+)$/)
+    if (assignMatch && !trimmed.includes('answer')) {
+      // Extract var name for DNCL display (strip @, @_var_, @_array_)
+      const varRef = assignMatch[1]
+      const exprRaw = assignMatch[2].trim()
+
+      // Peek at next line for while pattern
+      if (i + 1 < lines.length) {
+        const nextTrimmed = lines[i + 1].trim()
+        const nextIndentMatch = lines[i + 1].match(/^(\s*)/)
+        const nextIndent = nextIndentMatch ? nextIndentMatch[1] : ''
+
+        const forInfo = detectForLoopPattern(
+          { indent, varName: processSegments(varRef), varRef, expr: processSegments(exprRaw) },
+          nextTrimmed,
+          nextIndent,
+        )
+        if (forInfo) {
+          // This is a for-loop! Output header placeholder, skip the while line
+          forInfo.headerIndex = dnclLines.length
+          blockStack.push({ type: 'for', info: forInfo })
+          dnclLines.push('__FOR_HEADER_PLACEHOLDER__')
+          skipNext = true
+          continue
+        }
+      }
+
+    }
+
+    // Handle `end` for for-loop BEFORE calling convertLine
+    // (convertLine would pop from blockStack and misidentify the block type)
+    if (trimmed === 'end' && blockStack.length > 0) {
+      const top = blockStack[blockStack.length - 1]
+      if (typeof top === 'object' && top.type === 'for' && top.info.indent === indent) {
+        blockStack.pop()
+        const info = top.info
+        // Check last body line for increment: varName += step
+        const lastLine = dnclLines.length > 0 ? dnclLines[dnclLines.length - 1].trim() : ''
+        const incMatch = lastLine.match(
+          /^(.+?)\s*\+=\s*(.+)$/,
+        )
+        if (incMatch && incMatch[1] === info.varName) {
+          // Remove the increment line from output
+          dnclLines.pop()
+          const stepExpr = incMatch[2].trim()
+
+          // Determine step value and direction
+          let step
+          let ascending = info.ascending
+          const negMatch = stepExpr.match(/^-(.+)$/)
+          if (negMatch) {
+            step = negMatch[1]
+            ascending = false
+          } else {
+            step = stepExpr
+          }
+
+          const direction = ascending ? '増やしながら' : '減らしながら'
+          const header = `${indent}${info.varName} を ${info.from} から ${info.to} まで ${step} ずつ${direction}`
+          dnclLines[info.headerIndex] = header
+        }
+        dnclLines.push(`${indent}を繰り返す`)
+        continue
+      }
+    }
+
+    const result = convertLine(line)
+
+    // Handle ask("") or ask_and_wait("") + next line assignment → 入力
     if (result === null) {
       // Combine with next line: @var = answer → var = 【外部からの入力】
       if (i + 1 < lines.length) {
         const nextLine = lines[i + 1]
-        const assignMatch = nextLine.match(/^(\s*)(.+?)\s*=\s*answer\s*$/)
-        if (assignMatch) {
-          const indent = assignMatch[1]
-          const varPart = processSegments(assignMatch[2])
-          dnclLines.push(`${indent}${varPart} = 【外部からの入力】`)
+        const answerMatch = nextLine.match(/^(\s*)(.+?)\s*=\s*answer\s*$/)
+        if (answerMatch) {
+          const answerIndent = answerMatch[1]
+          const varPart = processSegments(answerMatch[2])
+          dnclLines.push(`${answerIndent}${varPart} = 【外部からの入力】`)
           skipNext = true
           continue
         }
       }
       // Fallback: just output as-is
-      dnclLines.push(lines[i])
+      dnclLines.push(line)
       continue
     }
 

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-to-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-to-ruby.test.js
@@ -96,13 +96,13 @@ describe('dnclToRuby', () => {
   describe('入力 (input)', () => {
     test('input assigned to lowercase variable', () => {
       expect(convert('a = 【外部からの入力】')).toBe(
-        'ask_and_wait("")\n@a = answer',
+        'ask("")\n@a = answer',
       )
     })
 
     test('input assigned to uppercase variable', () => {
       expect(convert('A = 【外部からの入力】')).toBe(
-        'ask_and_wait("")\n@_var_A_ = answer',
+        'ask("")\n@_var_A_ = answer',
       )
     })
   })
@@ -261,7 +261,7 @@ describe('dnclToRuby', () => {
         convert(
           'i を 1 から 10 まで 1 ずつ増やしながら\n  表示する(i)\nを繰り返す',
         ),
-      ).toBe('(1..10).step(1) do |i|\n  say(@i, 1)\nend')
+      ).toBe('@i = 1\nwhile @i <= 10\n  say(@i, 1)\n  @i += 1\nend')
     })
 
     test('descending for loop', () => {
@@ -269,7 +269,7 @@ describe('dnclToRuby', () => {
         convert(
           'i を 10 から 0 まで 1 ずつ減らしながら\n  表示する(i)\nを繰り返す',
         ),
-      ).toBe('10.step(0, -1) do |i|\n  say(@i, 1)\nend')
+      ).toBe('@i = 10\nwhile @i >= 0\n  say(@i, 1)\n  @i += -1\nend')
     })
 
     test('for loop with expression bounds', () => {
@@ -277,7 +277,29 @@ describe('dnclToRuby', () => {
         convert(
           'i を 0 から n まで 2 ずつ増やしながら\n  表示する(i)\nを繰り返す',
         ),
-      ).toBe('(0..@n).step(2) do |i|\n  say(@i, 1)\nend')
+      ).toBe('@i = 0\nwhile @i <= @n\n  say(@i, 1)\n  @i += 2\nend')
+    })
+
+    test('nested for loops', () => {
+      const dncl = [
+        'i を 1 から 3 まで 1 ずつ増やしながら',
+        '  j を 1 から 3 まで 1 ずつ増やしながら',
+        '    表示する(i)',
+        '  を繰り返す',
+        'を繰り返す',
+      ].join('\n')
+      const ruby = [
+        '@i = 1',
+        'while @i <= 3',
+        '  @j = 1',
+        '  while @j <= 3',
+        '    say(@i, 1)',
+        '    @j += 1',
+        '  end',
+        '  @i += 1',
+        'end',
+      ].join('\n')
+      expect(convert(dncl)).toBe(ruby)
     })
   })
 

--- a/packages/scratch-gui/test/unit/lib/dncl/ruby-to-dncl.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/ruby-to-dncl.test.js
@@ -54,7 +54,13 @@ describe('rubyToDncl', () => {
       expect(convert('say(@a, @b, @c, 1)')).toBe('表示する(a, b, c)')
     })
 
-    test('ask_and_wait + answer → 入力', () => {
+    test('ask + answer → 入力', () => {
+      expect(convert('ask("")\n@a = answer')).toBe(
+        'a = 【外部からの入力】',
+      )
+    })
+
+    test('ask_and_wait + answer → 入力 (legacy)', () => {
       expect(convert('ask_and_wait("")\n@a = answer')).toBe(
         'a = 【外部からの入力】',
       )
@@ -169,17 +175,62 @@ describe('rubyToDncl', () => {
     })
   })
 
-  describe('control flow: for loop', () => {
-    test('ascending for loop', () => {
+  describe('control flow: for loop (step syntax)', () => {
+    test('ascending step for loop', () => {
       expect(convert('(1..10).step(1) do |i|\n  say(@i, 1)\nend')).toBe(
         'i を 1 から 10 まで 1 ずつ増やしながら\n  表示する(i)\nを繰り返す',
       )
     })
 
-    test('descending for loop', () => {
+    test('descending step for loop', () => {
       expect(convert('10.step(0, -1) do |i|\n  say(@i, 1)\nend')).toBe(
         'i を 10 から 0 まで 1 ずつ減らしながら\n  表示する(i)\nを繰り返す',
       )
+    })
+  })
+
+  describe('control flow: for loop (while pattern)', () => {
+    test('ascending while-based for loop', () => {
+      const ruby = '@i = 1\nwhile @i <= 10\n  say(@i, 1)\n  @i += 1\nend'
+      expect(convert(ruby)).toBe(
+        'i を 1 から 10 まで 1 ずつ増やしながら\n  表示する(i)\nを繰り返す',
+      )
+    })
+
+    test('descending while-based for loop', () => {
+      const ruby = '@i = 10\nwhile @i >= 0\n  say(@i, 1)\n  @i += -1\nend'
+      expect(convert(ruby)).toBe(
+        'i を 10 から 0 まで 1 ずつ減らしながら\n  表示する(i)\nを繰り返す',
+      )
+    })
+
+    test('ascending while-based for loop with step 2', () => {
+      const ruby = '@i = 0\nwhile @i <= @n\n  say(@i, 1)\n  @i += 2\nend'
+      expect(convert(ruby)).toBe(
+        'i を 0 から n まで 2 ずつ増やしながら\n  表示する(i)\nを繰り返す',
+      )
+    })
+
+    test('nested while-based for loops', () => {
+      const ruby = [
+        '@i = 1',
+        'while @i <= 3',
+        '  @j = 1',
+        '  while @j <= 3',
+        '    say(@i, 1)',
+        '    @j += 1',
+        '  end',
+        '  @i += 1',
+        'end',
+      ].join('\n')
+      const dncl = [
+        'i を 1 から 3 まで 1 ずつ増やしながら',
+        '  j を 1 から 3 まで 1 ずつ増やしながら',
+        '    表示する(i)',
+        '  を繰り返す',
+        'を繰り返す',
+      ].join('\n')
+      expect(convert(ruby)).toBe(dncl)
     })
   })
 


### PR DESCRIPTION
## Summary

DNCL（日本語モード）の for ループと `【外部からの入力】` がブロックに変換できない問題を修正。

### 修正内容

- **for ループ**: DNCL→Ruby の出力を `.step()` から `while` ループパターンに変更。既存の converter がすべて対応済みのパターンのみ使用
- **【外部からの入力】**: `ask_and_wait("")` → `ask("")` に修正（sensing converter が `ask` を期待）
- **変数スコープバグ修正**: ブロックパラメータ `|i|` と本体内 `@i` の不一致を解消（`@i` で統一）
- **ラウンドトリップ対応**: ruby-to-dncl で while パターンから for ループ構文を復元するパターン認識を追加
- **ネスト対応**: スタックベースのステート管理で for ループのネストに対応

Fixes #512

## Implementation Steps

- [x] Phase 1: `ask_and_wait` → `ask` 修正
- [x] Phase 2: dncl-to-ruby の for ループ出力を while パターンに変更
- [x] Phase 3: ruby-to-dncl の for ループ復元パターン認識
- [x] Phase 4: ラウンドトリップテスト更新
- [x] Phase DoD: CI 完了待ち + ブラウザ確認

## Definition of Done

- [x] ユニットテスト pass (157 tests)
- [x] lint pass
- [x] CI green
- [x] ブラウザ確認（Playwright MCP）:
  - [x] DNCL for ループ（昇順）がブロックに変換されてエラーなし
  - [x] DNCL for ループ（降順）がブロックに変換されてエラーなし
  - [x] `【外部からの入力】` がブロックに変換されてエラーなし
  - [x] ブロック → Ruby タブ切り替えで for ループ構文が DNCL で復元される
  - [x] FizzBuzz サンプルが完全に動作する
  - [x] ネスト for ループが動作する

## Test Coverage

- `dncl-to-ruby.test.js`: 58 tests (for ループ while 変換 + ネスト + ask 修正)
- `ruby-to-dncl.test.js`: 44 tests (while パターン復元 + ask 互換 + ネスト)
- `dncl-roundtrip.test.js`: 25 tests (DNCL → Ruby → DNCL 往復)
