### PR TITLE
fix: DNCLモード切替時にふりがなが消えない

### DIFF
--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -86,8 +86,9 @@ const RubyToolbar = props => {
 
     const handleSelectDnclMode = useCallback(() => {
         if (props.onDismissBubble) props.onDismissBubble();
-        // Switch to DNCL mode
+        // Switch to DNCL mode (disable furigana since DNCL is already in Japanese)
         if (!props.dnclMode && props.onToggleDnclMode) props.onToggleDnclMode();
+        if (props.furiganaEnabled && props.onToggleFurigana) props.onToggleFurigana();
     }, [props]);
     // === Smalruby: End of mode selection handlers ===
 


### PR DESCRIPTION
## Summary

DNCLモード（日本語モード）は日本語表記のため、ふりがなは不要で常にOFFにすべき。しかし、「ふりがなモード → 日本語モード」に直接切り替えると、ふりがなが表示されたままになるバグがあった。

`handleSelectDnclMode` にふりがなOFF処理を1行追加して修正。

## Changes Made

- `ruby-toolbar.jsx`: `handleSelectDnclMode` でふりがなが有効な場合にOFFにする処理を追加（`handleSelectRubyMode` と同じパターン）

## Definition of Done

- [ ] lint pass
- [ ] CI green
- [ ] ブラウザ確認（Playwright MCP）:
  - [ ] ふりがなモード → 日本語モードに直接切替で、ふりがなが消えること
  - [ ] 日本語モード → ふりがなモードに戻すと、ふりがなが再表示されること
  - [ ] 日本語モード → Rubyモード → ふりがなモードの遷移が正常に動作すること

Fixes #514
