### PR TITLE
fix: use explicit PixelFormat::ARGB8888 in screenshot and update ruby-sdl2

### DIFF
--- a/ruby/smalruby3/lib/smalruby3/render/renderer/screenshot.rb
+++ b/ruby/smalruby3/lib/smalruby3/render/renderer/screenshot.rb
@@ -19,8 +19,8 @@ module Smalruby3
           return unless @screenshot_path && !File.symlink?(@screenshot_path)
 
           require "smalruby3/smalruby3_imageutil"
-          # read_pixels returns ARGB8888 (little-endian: BGRA bytes)
-          argb_data = @sdl_renderer.read_pixels(nil, 0)
+          # Explicitly request ARGB8888 for consistent byte order across platforms
+          argb_data = @sdl_renderer.read_pixels(nil, SDL2::PixelFormat::ARGB8888)
           # Convert BGRA → RGBA for PNG encoding
           rgba_data = convert_bgra_to_rgba(argb_data)
           Smalruby3::ImageUtil.save_png(rgba_data, @width, @height, @screenshot_path)


### PR DESCRIPTION
## Summary

- `screenshot.rb` で `SDL2::PixelFormat::ARGB8888` を明示指定（環境依存を排除）
- ruby-sdl2 サブモジュールを master に更新（read_pixels のレビューフィードバック対応を含む）

## Changes Made

### ruby/smalruby3
- `read_pixels(nil, 0)` → `read_pixels(nil, SDL2::PixelFormat::ARGB8888)` に変更
- Wayland 等で format=0 のデフォルトが ARGB8888 でない環境でも正しく動作するように

### ruby/ruby-sdl2 (submodule update)
- `SDL2::PixelFormat` オブジェクトを受け付けるように修正
- format=0 のとき ARGB8888 への上書きを削除（SDL2 仕様に準拠）
- format=0 のとき正しい pitch を計算するためにレンダラー情報をクエリ

## Test Coverage

- macOS Metal レンダラーでスクリーンショットが正常に保存されることを確認

## Related Issues

- smalruby/ruby-sdl2#9
- Upstream: ohai/ruby-sdl2#29
