### PR TITLE
fix: handle CJK variable names in ruby-to-dncl conversion

### DIFF
--- a/packages/scratch-gui/src/lib/dncl/ruby-to-dncl.js
+++ b/packages/scratch-gui/src/lib/dncl/ruby-to-dncl.js
@@ -1,5 +1,8 @@
 // === Smalruby: This file is Smalruby-specific (Ruby to DNCL reverse transpiler) ===
 
+/** Regex character class for identifiers: word chars + CJK (hiragana, katakana, kanji). */
+const ID = '\\w\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF'
+
 /**
  * Context for tracking whether the current `end` should become
  * `を実行する`, `を繰り返す`, or `と定義する`.
@@ -16,11 +19,11 @@ let blockStack = []
 const convertVarRefs = (segment) => {
   let result = segment
   // @_array_Name_ → Name
-  result = result.replace(/@_array_(\w+)_/g, '$1')
+  result = result.replace(new RegExp(`@_array_([${ID}]+)_`, 'g'), '$1')
   // @_var_Name_ → Name
-  result = result.replace(/@_var_(\w+)_/g, '$1')
+  result = result.replace(new RegExp(`@_var_([${ID}]+)_`, 'g'), '$1')
   // @name → name (but not @@ or @_ prefixed patterns already handled)
-  result = result.replace(/@(\w+)/g, '$1')
+  result = result.replace(new RegExp(`@([${ID}]+)`, 'g'), '$1')
   return result
 }
 
@@ -37,7 +40,7 @@ const convertOperators = (segment) => {
   result = result.replace(/(?<=\s|^)false(?=\s|$)/g, '偽')
 
   // !expr → expr でない (handle @-prefixed vars too)
-  result = result.replace(/!(@?\w+)/g, '$1 でない')
+  result = result.replace(new RegExp(`!(@?[${ID}]+)`, 'g'), '$1 でない')
 
   return result
 }
@@ -74,35 +77,56 @@ const convertBuiltins = (line) => {
   )
 
   // expr.include?(sub) → 含む(expr, sub)
-  // expr can be a variable (word chars) or a string literal ("...")
+  // expr can be a variable (word chars + CJK) or a string literal ("...")
   result = result.replace(
-    /("[^"]*"|\w+)\.include\?\(([^)]*)\)/g,
+    new RegExp(`("[^"]*"|[${ID}]+)\\.include\\?\\(([^)]*)\\)`, 'g'),
     (_, expr, sub) => `含む(${expr}, ${sub})`,
   )
 
   // expr.to_i → 整数(expr)
-  result = result.replace(/(\w+)\.to_i/g, (_, expr) => `整数(${expr})`)
+  result = result.replace(
+    new RegExp(`([${ID}]+)\\.to_i`, 'g'),
+    (_, expr) => `整数(${expr})`,
+  )
 
   // expr.to_s → 文字列(expr)
-  result = result.replace(/(\w+)\.to_s/g, (_, expr) => `文字列(${expr})`)
+  result = result.replace(
+    new RegExp(`([${ID}]+)\\.to_s`, 'g'),
+    (_, expr) => `文字列(${expr})`,
+  )
 
   // expr.round → 四捨五入(expr)
-  result = result.replace(/(\w+)\.round/g, (_, expr) => `四捨五入(${expr})`)
+  result = result.replace(
+    new RegExp(`([${ID}]+)\\.round`, 'g'),
+    (_, expr) => `四捨五入(${expr})`,
+  )
 
   // expr.floor → 切り捨て(expr)
-  result = result.replace(/(\w+)\.floor/g, (_, expr) => `切り捨て(${expr})`)
+  result = result.replace(
+    new RegExp(`([${ID}]+)\\.floor`, 'g'),
+    (_, expr) => `切り捨て(${expr})`,
+  )
 
   // expr.ceil → 切り上げ(expr)
-  result = result.replace(/(\w+)\.ceil/g, (_, expr) => `切り上げ(${expr})`)
+  result = result.replace(
+    new RegExp(`([${ID}]+)\\.ceil`, 'g'),
+    (_, expr) => `切り上げ(${expr})`,
+  )
 
   // expr.abs → 絶対値(expr)
-  result = result.replace(/(\w+)\.abs/g, (_, expr) => `絶対値(${expr})`)
+  result = result.replace(
+    new RegExp(`([${ID}]+)\\.abs`, 'g'),
+    (_, expr) => `絶対値(${expr})`,
+  )
 
   // rand(n) → 乱数(n)
   result = result.replace(/rand\(([^)]*)\)/g, (_, n) => `乱数(${n})`)
 
   // expr.length → 要素数(expr)
-  result = result.replace(/(\w+)\.length/g, (_, expr) => `要素数(${expr})`)
+  result = result.replace(
+    new RegExp(`([${ID}]+)\\.length`, 'g'),
+    (_, expr) => `要素数(${expr})`,
+  )
 
   return result
 }
@@ -241,7 +265,9 @@ const convertLine = (line) => {
 
   // (from..to).step(step) do |var| → ascending for loop
   const forAscMatch = trimmed.match(
-    /^\((.+?)\.\.(.+?)\)\.step\((.+?)\)\s+do\s+\|(\w+)\|$/,
+    new RegExp(
+      `^\\((.+?)\\.\\.(.+?)\\)\\.step\\((.+?)\\)\\s+do\\s+\\|([${ID}]+)\\|$`,
+    ),
   )
   if (forAscMatch) {
     blockStack.push('loop')
@@ -254,7 +280,9 @@ const convertLine = (line) => {
 
   // from.step(to, -step) do |var| → descending for loop
   const forDescMatch = trimmed.match(
-    /^(.+?)\.step\((.+?),\s*-(.+?)\)\s+do\s+\|(\w+)\|$/,
+    new RegExp(
+      `^(.+?)\\.step\\((.+?),\\s*-(.+?)\\)\\s+do\\s+\\|([${ID}]+)\\|$`,
+    ),
   )
   if (forDescMatch) {
     blockStack.push('loop')
@@ -266,7 +294,9 @@ const convertLine = (line) => {
   }
 
   // def name(params) → 関数 name(params)
-  const defMatch = trimmed.match(/^def\s+(\w+)\(([^)]*)\)$/)
+  const defMatch = trimmed.match(
+    new RegExp(`^def\\s+([${ID}]+)\\(([^)]*)\\)$`),
+  )
   if (defMatch) {
     blockStack.push('func')
     return `${indent}関数 ${defMatch[1]}(${defMatch[2]})`
@@ -317,7 +347,7 @@ const detectForLoopPattern = (pending, whileLine, whileIndent) => {
 
   // Match: while @var <= expr  or  while @var >= expr
   const whileMatch = whileLine.match(
-    /^while\s+(@\w+)\s*(<=|>=)\s*(.+)$/,
+    new RegExp(`^while\\s+(@[${ID}]+)\\s*(<=|>=)\\s*(.+)$`),
   )
   if (!whileMatch) return null
   if (whileMatch[1] !== pending.varRef) return null
@@ -358,7 +388,9 @@ const rubyToDncl = (source) => {
     const indent = indentMatch ? indentMatch[1] : ''
 
     // Check if this is an assignment that could be a for-loop init
-    const assignMatch = trimmed.match(/^(@\w+)\s*=\s*(.+)$/)
+    const assignMatch = trimmed.match(
+      new RegExp(`^(@[${ID}]+)\\s*=\\s*(.+)$`),
+    )
     if (assignMatch && !trimmed.includes('answer')) {
       // Extract var name for DNCL display (strip @, @_var_, @_array_)
       const varRef = assignMatch[1]

--- a/packages/scratch-gui/test/unit/lib/dncl/ruby-to-dncl.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/ruby-to-dncl.test.js
@@ -250,6 +250,124 @@ describe('rubyToDncl', () => {
     })
   })
 
+  describe('CJK variable names', () => {
+    test('kanji variable assignment', () => {
+      expect(convert('@合計 = 0')).toBe('合計 = 0')
+    })
+
+    test('kanji variable reference in expression', () => {
+      expect(convert('@合計 = @合計 + @i')).toBe('合計 = 合計 + i')
+    })
+
+    test('hiragana variable', () => {
+      expect(convert('@けっか = 1')).toBe('けっか = 1')
+    })
+
+    test('katakana variable', () => {
+      expect(convert('@カウント = 0')).toBe('カウント = 0')
+    })
+
+    test('negation of CJK variable', () => {
+      expect(convert('if !@合計\n  @a = 1\nend')).toBe(
+        'もし 合計 でない ならば\n  a = 1\nを実行する',
+      )
+    })
+
+    test('CJK uppercase scalar variable', () => {
+      expect(convert('@_var_合計_ = 0')).toBe('合計 = 0')
+    })
+
+    test('CJK uppercase array variable', () => {
+      expect(convert('@_array_配列_ = [1, 2, 3]')).toBe('配列 = [1, 2, 3]')
+    })
+  })
+
+  describe('CJK for-loop (while pattern)', () => {
+    test('for-loop with CJK body variable', () => {
+      const ruby = [
+        '@合計 = 0',
+        '@i = 1',
+        'while @i <= 10',
+        '  @合計 += @i',
+        '  @i += 1',
+        'end',
+      ].join('\n')
+      const dncl = [
+        '合計 = 0',
+        'i を 1 から 10 まで 1 ずつ増やしながら',
+        '  合計 += i',
+        'を繰り返す',
+      ].join('\n')
+      expect(convert(ruby)).toBe(dncl)
+    })
+
+    test('for-loop with CJK loop variable', () => {
+      const ruby = [
+        '@回数 = 1',
+        'while @回数 <= 5',
+        '  say(@回数, 1)',
+        '  @回数 += 1',
+        'end',
+      ].join('\n')
+      const dncl = [
+        '回数 を 1 から 5 まで 1 ずつ増やしながら',
+        '  表示する(回数)',
+        'を繰り返す',
+      ].join('\n')
+      expect(convert(ruby)).toBe(dncl)
+    })
+  })
+
+  describe('CJK built-in methods', () => {
+    test('.to_i on CJK variable', () => {
+      expect(convert('@a = @合計.to_i')).toBe('a = 整数(合計)')
+    })
+
+    test('.to_s on CJK variable', () => {
+      expect(convert('@a = @合計.to_s')).toBe('a = 文字列(合計)')
+    })
+
+    test('.length on CJK variable', () => {
+      expect(convert('@a = @配列.length')).toBe('a = 要素数(配列)')
+    })
+
+    test('.round on CJK variable', () => {
+      expect(convert('@a = @平均.round')).toBe('a = 四捨五入(平均)')
+    })
+
+    test('.abs on CJK variable', () => {
+      expect(convert('@a = @差分.abs')).toBe('a = 絶対値(差分)')
+    })
+
+    test('.include? on CJK variable', () => {
+      expect(convert('@a = @文字列.include?("ell")')).toBe(
+        'a = 含む(文字列, "ell")',
+      )
+    })
+  })
+
+  describe('CJK roundtrip: reported bug', () => {
+    test('DNCL program with 合計 variable roundtrips correctly', () => {
+      const ruby = [
+        '@合計 = 0',
+        '@i = 1',
+        'while @i <= 10',
+        '  @合計 += @i',
+        '  @i += 1',
+        'end',
+        'say(@合計, 1)',
+      ].join('\n')
+      const expectedDncl = [
+        '合計 = 0',
+        'i を 1 から 10 まで 1 ずつ増やしながら',
+        '  合計 += i',
+        'を繰り返す',
+        '表示する(合計)',
+      ].join('\n')
+      expect(convert(ruby)).toBe(expectedDncl)
+    })
+  })
+
   describe('comments', () => {
     test('preserves comments', () => {
       expect(convert('# コメント')).toBe('# コメント')


### PR DESCRIPTION
## Summary

日本語モード（DNCL）で CJK 文字を含む変数名（例: `合計`）を使ったプログラムを Ruby モードに切り替えてから再度日本語モードに戻すと、`@合計` のまま変換されずエラーが発生するバグを修正。

`ruby-to-dncl.js` の正規表現で `\w`（ASCII のみ）を使っていた箇所を、`dncl-to-ruby.js` と同じ CJK Unicode 範囲（ひらがな・カタカナ・漢字）を含むパターンに統一した。

## Changes Made

- `ruby-to-dncl.js`: 共通の識別子文字クラス定数 `ID` を追加し、全17箇所の `\w` パターンを CJK 対応に更新
  - `convertVarRefs()`: `@合計` → `合計` の変換が正しく動作
  - `convertOperators()`: `!@合計` → `合計 でない` の変換が正しく動作
  - `convertBuiltins()`: `@合計.to_i` 等のメソッド呼び出し変換が正しく動作
  - `detectForLoopPattern()` / `rubyToDncl()`: CJK ループ変数の for-loop パターン検出が正しく動作
  - `.step()` / `def` パターン: 一貫性のため CJK 対応
- `ruby-to-dncl.test.js`: CJK 変数名のテスト16件追加（変数参照、for-loop、メソッド呼び出し、ラウンドトリップ）

## Implementation Steps

- [x] CJK 変数参照・for-loop検出・メソッド呼び出し・ラウンドトリップの修正とテスト追加

## Definition of Done

- [x] ユニットテスト pass（60件 → 全パス）
- [x] DNCL テスト全体 pass（173件 → 全パス）
- [x] lint pass
- [ ] CI green
- [ ] ブラウザ確認（Playwright MCP）:
  - [ ] 日本語モードで報告されたプログラムを入力
  - [ ] Ruby モードに切替 → エラーなし
  - [ ] 日本語モードに戻す → エラーなし、元のプログラムが正しく表示される

Fixes #518
