### PR TITLE
fix: output auth-redirect.js without contenthash in dist build

### DIFF
--- a/packages/scratch-gui/webpack.config.js
+++ b/packages/scratch-gui/webpack.config.js
@@ -338,7 +338,13 @@ const distWithHtmlConfig = buildConfig.clone()
     .merge({
         devtool: false, // Disable source maps for production
         output: {
-            filename: '[name].[contenthash].js', // Add contenthash for cache busting
+            // Add contenthash for cache busting, except auth-redirect which is
+            // referenced by a static HTML file (legal/auth-redirect.html) with a
+            // fixed <script src="auth-redirect.js"> tag.
+            filename: (pathData) =>
+                pathData.chunk.name === 'auth-redirect'
+                    ? '[name].js'
+                    : '[name].[contenthash].js',
             path: path.resolve(__dirname, 'dist'),
             clean: false
         },


### PR DESCRIPTION
## Summary

smalruby.app で Microsoft ログイン時に `auth-redirect.js` が 404 になり、認証が完了しないバグを修正。

## 原因

- `auth-redirect.html`（`legal/` からコピー）は `<script src="auth-redirect.js">` と固定パスで参照
- `distWithHtmlConfig` の `output.filename` が `[name].[contenthash].js` のため、実際には `auth-redirect.<hash>.js` として出力されていた
- smalruby.app は `dist/` からデプロイされるため、`auth-redirect.js` が見つからず 404

## 修正

`distWithHtmlConfig` の `output.filename` を関数に変更し、`auth-redirect` エントリーのみ contenthash なしのファイル名で出力するようにした。

## Playwright MCP での確認

```
auth-redirect.html → 200 OK
auth-redirect.js   → 404 Not Found  ← これが原因
```

## Test plan

- [x] `BUILD_TYPE=dist-html` ビルドで `dist/auth-redirect.js` が contenthash なしで出力されることを確認
- [x] `dist/auth-redirect.html` が存在することを確認
- [ ] デプロイ後に smalruby.app で Microsoft ログインが正常に動作することを確認
