### PR TITLE
feat: add String#reverse for TryRuby compatibility (#524 Phase1-1)

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/smalruby-ruby.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/smalruby-ruby.js
@@ -10,6 +10,12 @@ export default function (Generator) {
         const order = Generator.ORDER_FUNCTION_CALL;
         const string = Generator.valueToCode(block, 'STRING', order) || Generator.quote_('');
         const method = Generator.getFieldValue(block, 'METHOD') || 'delete';
+        const hasArg1 = block.inputs && block.inputs.ARG1;
+        if (!hasArg1) {
+            // Methods without arguments (e.g. reverse)
+            return [`${string}.${method}`, order];
+        }
+
         const arg1 = Generator.valueToCode(block, 'ARG1', order) || Generator.quote_('');
         const arg2 = Generator.valueToCode(block, 'ARG2', order);
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js
@@ -31,6 +31,13 @@ const buildMutation = function (blockType, method, menuName, argumentsByMethod, 
 
 // Shared argumentsByMethod configs
 const stringMethodRArgs = {
+    reverse: {
+        text: '文字列 [STRING] . [METHOD]',
+        arguments: {
+            STRING: {type: 'string', defaultValue: ''},
+            METHOD: {type: 'string', menu: 'stringMethodRMenu', defaultValue: 'reverse'},
+        }
+    },
     delete: {
         text: '文字列 [STRING] . [METHOD] ( [ARG1] )',
         arguments: {
@@ -70,7 +77,7 @@ const stringMethodCArgs = {
     }
 };
 
-const stringMethodRMenuItems = {stringMethodRMenu: [['delete', 'delete'], ['gsub', 'gsub']]};
+const stringMethodRMenuItems = {stringMethodRMenu: [['reverse', 'reverse'], ['delete', 'delete'], ['gsub', 'gsub']]};
 const stringMethodCMenuItems = {stringMethodCMenu: [['delete!', 'delete!'], ['gsub!', 'gsub!']]};
 
 /**
@@ -78,6 +85,20 @@ const stringMethodCMenuItems = {stringMethodCMenu: [['delete!', 'delete!'], ['gs
  */
 const SmalrubyRubyConverter = {
     register: function (converter) {
+        // String#reverse (returns value - REPORTER, 0 args)
+        converter.registerOnSend(['string', 'block', 'variable'], 'reverse', 0, params => {
+            const {receiver} = params;
+
+            const mutation = buildMutation(
+                'reporter', 'reverse', 'stringMethodRMenu',
+                stringMethodRArgs, stringMethodRMenuItems
+            );
+            const block = converter._createBlock('smalrubyRuby_stringMethodR', 'value', {mutation});
+            converter._addTextInput(block, 'STRING', receiver, 'string');
+            converter._addField(block, 'METHOD', 'reverse');
+            return block;
+        });
+
         // String#delete (returns value - REPORTER)
         converter.registerOnSend(['string', 'block', 'variable'], 'delete', 1, params => {
             const {receiver, args} = params;

--- a/packages/scratch-gui/test/unit/lib/ruby-generator/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-generator/smalruby-ruby.test.js
@@ -11,6 +11,20 @@ describe('RubyGenerator/SmalrubyRuby', () => {
     });
 
     describe('smalrubyRuby_stringMethodR', () => {
+        test('should generate reverse method call (no args)', () => {
+            RubyGenerator.valueToCode = (block, name, _order) => {
+                const map = {STRING: '"Jimmy"'};
+                return map[name] || '';
+            };
+
+            const block = {
+                opcode: 'smalrubyRuby_stringMethodR',
+                fields: {METHOD: {value: 'reverse'}}
+            };
+            const result = RubyGenerator.smalrubyRuby_stringMethodR(block);
+            expect(result[0]).toEqual('"Jimmy".reverse');
+        });
+
         test('should generate delete method call', () => {
             RubyGenerator.valueToCode = (block, name, _order) => {
                 const map = {
@@ -22,9 +36,8 @@ describe('RubyGenerator/SmalrubyRuby', () => {
 
             const block = {
                 opcode: 'smalrubyRuby_stringMethodR',
-                fields: {
-                    METHOD: {value: 'delete'}
-                }
+                fields: {METHOD: {value: 'delete'}},
+                inputs: {ARG1: {}}
             };
             const result = RubyGenerator.smalrubyRuby_stringMethodR(block);
             expect(result[0]).toEqual('"hello world".delete("l")');
@@ -35,9 +48,8 @@ describe('RubyGenerator/SmalrubyRuby', () => {
 
             const block = {
                 opcode: 'smalrubyRuby_stringMethodR',
-                fields: {
-                    METHOD: {value: 'delete'}
-                }
+                fields: {METHOD: {value: 'delete'}},
+                inputs: {ARG1: {}}
             };
             const result = RubyGenerator.smalrubyRuby_stringMethodR(block);
             expect(result[0]).toEqual('"".delete("")');
@@ -55,9 +67,8 @@ describe('RubyGenerator/SmalrubyRuby', () => {
 
             const block = {
                 opcode: 'smalrubyRuby_stringMethodR',
-                fields: {
-                    METHOD: {value: 'delete'}
-                }
+                fields: {METHOD: {value: 'delete'}},
+                inputs: {ARG1: {}, ARG2: {}}
             };
             const result = RubyGenerator.smalrubyRuby_stringMethodR(block);
             expect(result[0]).toEqual('"hello".delete("l", "o")');
@@ -70,7 +81,8 @@ describe('RubyGenerator/SmalrubyRuby', () => {
             };
             const block = {
                 opcode: 'smalrubyRuby_stringMethodR',
-                fields: {METHOD: {value: 'gsub'}}
+                fields: {METHOD: {value: 'gsub'}},
+                inputs: {ARG1: {}, ARG2: {}}
             };
             const result = RubyGenerator.smalrubyRuby_stringMethodR(block);
             expect(result[0]).toEqual('"hello".gsub("l", "r")');

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/smalruby-ruby.test.js
@@ -14,6 +14,35 @@ describe('RubyToBlocksConverter/SmalrubyRuby', () => {
         target = null;
     });
 
+    describe('String#reverse (REPORTER, 0 args)', () => {
+        test('should convert string literal receiver', async () => {
+            const code = '"Jimmy".reverse';
+            const expected = [
+                {
+                    opcode: 'smalrubyRuby_stringMethodR',
+                    fields: [
+                        {name: 'METHOD', value: 'reverse'}
+                    ],
+                    inputs: [
+                        {name: 'STRING', block: expectedInfo.makeText('Jimmy')}
+                    ],
+                    mutation: {blockInfo: expect.any(Object)}
+                }
+            ];
+            await convertAndExpectToEqualBlocks(converter, target, code, expected);
+        });
+
+        test('should convert variable receiver', async () => {
+            const code = 'name = "Jimmy"\nname.reverse';
+            const result = await converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+        });
+
+        test('should reject with arguments', async () => {
+            await convertAndExpectRubyBlockError(converter, target, '"hello".reverse("x")');
+        });
+    });
+
     describe('String#delete (REPORTER)', () => {
         test('should convert string literal receiver with string arg', async () => {
             const code = '"hello world".delete("l")';

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/index.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/index.js
@@ -81,6 +81,17 @@ class SmalrubyRubyBlocks {
                         }
                     },
                     argumentsByMethod: {
+                        reverse: {
+                            text: '\u6587\u5b57\u5217 [STRING] . [METHOD]',
+                            arguments: {
+                                STRING: {type: ArgumentType.STRING, defaultValue: 'string'},
+                                METHOD: {
+                                    type: ArgumentType.STRING,
+                                    menu: 'stringMethodRMenu',
+                                    defaultValue: 'reverse'
+                                }
+                            }
+                        },
                         delete: {
                             text: '\u6587\u5b57\u5217 [STRING] . [METHOD] ( [ARG1] )',
                             arguments: {
@@ -108,7 +119,7 @@ class SmalrubyRubyBlocks {
                         }
                     },
                     menuItems: {
-                        stringMethodRMenu: [['delete', 'delete'], ['gsub', 'gsub']]
+                        stringMethodRMenu: [['reverse', 'reverse'], ['delete', 'delete'], ['gsub', 'gsub']]
                     }
                 },
                 {
@@ -172,6 +183,7 @@ class SmalrubyRubyBlocks {
                 stringMethodRMenu: {
                     acceptReporters: false,
                     items: [
+                        {text: 'reverse', value: 'reverse'},
                         {text: 'delete', value: 'delete'},
                         {text: 'gsub', value: 'gsub'}
                     ]
@@ -206,6 +218,8 @@ class SmalrubyRubyBlocks {
         const arg1 = String(args.ARG1 || '');
         const arg2 = (args.ARG2 === undefined) ? undefined : String(args.ARG2);
         switch (method) {
+        case 'reverse':
+            return string.split('').reverse().join('');
         case 'delete':
             return string.split('')
                 .filter(c => !arg1.includes(c))


### PR DESCRIPTION
## Summary
- String#reverse を smalrubyRuby_stringMethodR ブロックとして登録（コンバーター + ジェネレーター + VM 実行ロジック）
- 引数なしメソッドに対応するため、ジェネレーターで `block.inputs.ARG1` の有無を判定して括弧なし出力（`str.reverse`）を生成

## Changes
- `packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js` — `.reverse` コンバーター登録
- `packages/scratch-gui/src/lib/ruby-generator/smalruby-ruby.js` — 引数なしメソッドの括弧なし生成
- `packages/scratch-vm/src/extensions/smalruby_ruby/index.js` — VM 側 `argumentsByMethod` + メニュー + 実行ロジック追加
- テスト追加: コンバーター 3 tests + ジェネレーター 1 test

## Test Coverage
- `test/unit/lib/ruby-to-blocks-converter/smalruby-ruby.test.js` — reverse の変換テスト
- `test/unit/lib/ruby-generator/smalruby-ruby.test.js` — reverse の生成テスト
- 既存テストの mock ブロックに `inputs` プロパティを追加（引数有無判定の影響）

## Related Issues
Refs #524 (Phase 1 #1)
