### PR TITLE
feat: convert bare literals to temp variable assignments (#524 Phase1-3)

### DIFF
--- a/docs/mesh/cost.md
+++ b/docs/mesh/cost.md
@@ -1,0 +1,430 @@
+# Mesh v2 AWS Cost Breakdown
+
+This document details the per-operation AWS costs for the Mesh v2 infrastructure, based on the **production** configuration values.
+
+## AWS Pricing (ap-northeast-1, Tokyo Region)
+
+| Service | Unit | Price |
+|---------|------|-------|
+| AppSync Query/Mutation | per request | $0.000004 |
+| AppSync Real-time Update (Subscription delivery) | per message | $0.000002 |
+| AppSync Real-time Connection | per minute | $0.00000008 |
+| DynamoDB Write Request Unit (WRU) | per WRU (1KB) | $0.000001425 |
+| DynamoDB Read Request Unit (RRU) | per RRU (4KB) | $0.000000285 |
+| DynamoDB Transactional Write | per WRU (1KB) | $0.00000285 (2x) |
+| DynamoDB Transactional Read | per RRU (4KB) | $0.00000057 (2x) |
+| DynamoDB Storage | per GB/month | $0.285 |
+| Lambda Request | per request | $0.0000002 |
+| Lambda Duration (128MB) | per ms | $0.0000000017 |
+
+> Note: DynamoDB On-Demand pricing. Transactional operations cost 2x normal.
+
+## Production Configuration
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `MESH_HOST_HEARTBEAT_INTERVAL_SECONDS` | 60 | Host heartbeat interval |
+| `MESH_HOST_HEARTBEAT_TTL_SECONDS` | 150 | Host group TTL |
+| `MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS` | 120 | Member heartbeat interval |
+| `MESH_MEMBER_HEARTBEAT_TTL_SECONDS` | 600 | Member node TTL |
+| `MESH_MAX_CONNECTION_TIME_SECONDS` | 2100 | Max group lifetime (35 min) |
+| `MESH_EVENT_TTL_SECONDS` | 10 | Event auto-deletion TTL |
+| `MESH_POLLING_INTERVAL_SECONDS` | 2 | Polling interval for HTTPS clients |
+
+### Client-Side Rate Limits
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `MESH_DATA_UPDATE_INTERVAL_MS` | 1000ms | Sensor data send interval (with merge) |
+| `MESH_EVENT_BATCH_INTERVAL_MS` | 1000ms | Event batch send interval |
+| `MESH_PERIODIC_DATA_SYNC_INTERVAL_MS` | 15000ms | Periodic data sync interval (HTTPS only) |
+
+---
+
+## One-Time Operations
+
+### Create Domain
+
+User action: Click "Create Group" or "Join Group" (first time, domain not set).
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| Lambda Invocation | 1 | $0.0000002 | $0.0000002 |
+| Lambda Duration (~50ms) | 50ms | $0.0000000017/ms | $0.000000085 |
+| DynamoDB | 0 | - | $0 |
+| **Total** | | | **$0.000004285** |
+
+> Pure computation (CRC32 hash of source IP). No DynamoDB operations.
+
+---
+
+### Create Group
+
+User action: Click "Create Group" button.
+
+Pipeline: `checkExistingGroup` (Query) -> `createGroupIfNotExists` (PutItem)
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB Query (check existing) | 1 | $0.000000285 | $0.000000285 |
+| DynamoDB Write (PutItem, ~300B) | 1 WRU | $0.000001425 | $0.000001425 |
+| **Total** | | | **$0.00000571** |
+
+> If the group already exists (idempotent retry), the PutItem becomes a GetItem (1 RRU) instead.
+> Item size: ~300 bytes (group metadata with timestamps, TTL, GSI attributes).
+
+---
+
+### Join Group
+
+User action: Click "Join" button on a group.
+
+Pipeline: `checkGroupExists` (GetItem) -> `joinGroupFunction` (TransactWriteItems: 2 PutItems)
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB Read (GetItem, group check) | 1 RRU | $0.000000285 | $0.000000285 |
+| DynamoDB Transactional Write (2 PutItems, ~150B each) | 2 WRU | $0.00000285/WRU | $0.0000057 |
+| **Total** | | | **$0.000009985** |
+
+> TransactWriteItems atomically creates: (1) group-node mapping, (2) node-group reverse mapping.
+
+---
+
+### Leave Group (Member)
+
+User action: Click "Disconnect" button (as member).
+
+Lambda: `leaveGroup` -> TransactWriteItems (2 DeleteItems) + DeleteItem (status)
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| Lambda Invocation | 1 | $0.0000002 | $0.0000002 |
+| Lambda Duration (~100ms) | 100ms | $0.0000000017/ms | $0.00000017 |
+| DynamoDB Transactional Write (2 DeleteItems) | 2 WRU | $0.00000285/WRU | $0.0000057 |
+| DynamoDB Write (DeleteItem, status) | 1 WRU | $0.000001425 | $0.000001425 |
+| **Total** | | | **$0.000011495** |
+
+---
+
+### Dissolve Group (Host)
+
+User action: Click "Disconnect" button (as host).
+
+Lambda: `dissolveGroup` -> GetItem + Query + N x DeleteItem
+
+For a group with **M members** (each member has node record + status = 2 items, plus 1 metadata item, plus M reverse-lookup items):
+
+- Group items to delete: 1 (metadata) + M (node records) + M (node statuses) = **1 + 2M** items
+- Reverse-lookup items to delete: **M** items
+- Total DeleteItems: **1 + 3M**
+
+Example: group with **5 members**:
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| Lambda Invocation | 1 | $0.0000002 | $0.0000002 |
+| Lambda Duration (~200ms) | 200ms | $0.0000000017/ms | $0.00000034 |
+| DynamoDB Read (GetItem, group check) | 1 RRU | $0.000000285 | $0.000000285 |
+| DynamoDB Read (Query, list items) | ~11 RRU | $0.000000285 | $0.000003135 |
+| DynamoDB Write (16 DeleteItems) | 16 WRU | $0.000001425 | $0.0000228 |
+| **Total (5 members)** | | | **$0.00003076** |
+
+> Cost scales linearly with member count. Formula: ~$0.000004 + $0.000004275 x M
+
+---
+
+## Periodic Operations (During Active Session)
+
+### Host Heartbeat (`renewHeartbeat`)
+
+Timing: Every **60 seconds** while group is active.
+
+Pipeline: `checkGroupExists` (GetItem) -> `renewHeartbeatFunction` (UpdateItem)
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB Read (GetItem, group check) | 1 RRU | $0.000000285 | $0.000000285 |
+| DynamoDB Write (UpdateItem, ~50B) | 1 WRU | $0.000001425 | $0.000001425 |
+| **Per heartbeat** | | | **$0.00000571** |
+| **Per minute** | | | **$0.00000571** |
+| **Per hour** | | | **$0.0003426** |
+
+---
+
+### Member Heartbeat (`sendMemberHeartbeat`)
+
+Timing: Every **120 seconds** per member while connected.
+
+Pipeline: `checkGroupExists` (GetItem) -> `updateNodeTTL` (UpdateItem)
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB Read (GetItem, group check) | 1 RRU | $0.000000285 | $0.000000285 |
+| DynamoDB Write (UpdateItem, ~50B) | 1 WRU | $0.000001425 | $0.000001425 |
+| **Per heartbeat** | | | **$0.00000571** |
+| **Per minute (per member)** | | | **$0.000002855** |
+| **Per hour (per member)** | | | **$0.0001713** |
+
+---
+
+### Variable Update (`reportDataByNode`)
+
+Timing: Up to every **1 second** per node (rate-limited by `dataRateLimiter`). With merge enabled, rapid updates to the same variable are batched into a single request.
+
+Pipeline: `checkGroupExists` (GetItem) -> `reportDataByNode` (PutItem)
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB Read (GetItem, group check) | 1 RRU | $0.000000285 | $0.000000285 |
+| DynamoDB Write (PutItem, ~250-400B) | 1 WRU | $0.000001425 | $0.000001425 |
+| **Per request** | | | **$0.00000571** |
+| **Per second (worst case)** | | | **$0.00000571** |
+| **Per minute (worst case)** | | | **$0.0003426** |
+| **Per hour (worst case)** | | | **$0.020556** |
+
+> "Worst case" = continuous updates every second (e.g., a forever block setting a variable).
+> With merge, if the same variable is updated multiple times within 1 second, only 1 request is sent.
+
+#### WebSocket Subscription Delivery (Receiver Side)
+
+Each `reportDataByNode` triggers a subscription message to all subscribed nodes in the group.
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Subscription message | 1 per subscriber | $0.000002 | $0.000002 |
+| **Per request (N subscribers)** | | | **$0.000002 x N** |
+
+---
+
+### Variable Read (HTTPS Polling Mode)
+
+Timing: Every **2 seconds** (`MESH_POLLING_INTERVAL_SECONDS`) per polling client. This is the `getEventsSince` query.
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB Read (Query, limit 100) | 1-3 RRU | $0.000000285 | $0.000000855 |
+| **Per poll** | | | **$0.000004855** |
+| **Per minute (30 polls)** | | | **$0.00014565** |
+| **Per hour** | | | **$0.008739** |
+
+> WebSocket mode does not use polling. WebSocket receives subscription messages instead.
+
+#### Periodic Data Sync (HTTPS Mode)
+
+Timing: Every **15 seconds** per HTTPS client. Uses `listGroupStatuses` to sync all remote data.
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB Read (Query) | 1-10 RRU | $0.000000285 | $0.00000285 |
+| **Per sync** | | | **$0.00000685** |
+| **Per minute (4 syncs)** | | | **$0.0000274** |
+| **Per hour** | | | **$0.001644** |
+
+---
+
+### Event Send (`fireEventsByNode` / `recordEventsByNode`)
+
+Timing: Batched every **1 second** (`eventBatchInterval`). Max 100 events per queue.
+
+#### WebSocket Mode: `fireEventsByNode`
+
+Uses None DataSource (pass-through). No DynamoDB operations.
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB | 0 | - | $0 |
+| **Per batch** | | | **$0.000004** |
+| **Per second (worst case)** | | | **$0.000004** |
+| **Per minute (worst case)** | | | **$0.00024** |
+| **Per hour (worst case)** | | | **$0.0144** |
+
+#### HTTPS (Polling) Mode: `recordEventsByNode`
+
+Uses Lambda + DynamoDB BatchWriteItem. Events are stored temporarily (TTL = 10 seconds).
+
+For a batch of **E events**:
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| Lambda Invocation | 1 | $0.0000002 | $0.0000002 |
+| Lambda Duration (~100ms) | 100ms | $0.0000000017/ms | $0.00000017 |
+| DynamoDB Read (GetItem, group check) | 1 RRU | $0.000000285 | $0.000000285 |
+| DynamoDB Write (BatchWriteItem) | E WRU | $0.000001425 | $0.000001425 x E |
+| **Per batch (E events)** | | | **$0.000004655 + $0.000001425 x E** |
+
+Example: 5 events per batch = $0.00001178
+
+#### Subscription Delivery (Receiver Side)
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Subscription message | 1 per subscriber | $0.000002 | $0.000002 |
+| **Per event batch (N subscribers)** | | | **$0.000002 x N** |
+
+---
+
+### Event Receive (HTTPS Polling Mode)
+
+Timing: Every **2 seconds** (`MESH_POLLING_INTERVAL_SECONDS`). Uses `getEventsSince` query.
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Request | 1 | $0.000004 | $0.000004 |
+| DynamoDB Read (Query, limit 100) | 1-3 RRU | $0.000000285 | $0.000000855 |
+| **Per poll** | | | **$0.000004855** |
+| **Per minute (30 polls)** | | | **$0.00014565** |
+| **Per hour** | | | **$0.008739** |
+
+> Same as "Variable Read (HTTPS Polling Mode)" - the same polling request fetches both events and data changes.
+
+---
+
+### WebSocket Connection
+
+Timing: Continuous while connected to subscription.
+
+| Billable Element | Count | Unit Cost | Subtotal |
+|-----------------|-------|-----------|----------|
+| AppSync Connection | per minute | $0.00000008 | $0.00000008 |
+| **Per hour** | | | **$0.0000048** |
+| **Per 35-min session** | | | **$0.0000028** |
+
+---
+
+## DynamoDB Storage
+
+Items are automatically deleted by DynamoDB TTL. Active storage is minimal.
+
+| Item Type | Size | TTL | Count (per group) |
+|-----------|------|-----|-------------------|
+| Group metadata | ~300B | Host heartbeat TTL (150s) | 1 |
+| Node record | ~150B | Member heartbeat TTL (600s) | M (members) |
+| Node status (sensor data) | ~250-400B | Member heartbeat TTL (600s) | M (members) |
+| Node reverse-lookup | ~150B | Member heartbeat TTL (600s) | M (members) |
+| Event record | ~150B | Event TTL (10s) | transient |
+
+For a group with 5 members: ~1 + 5 x 3 = 16 items, ~3.5KB total.
+
+DynamoDB storage cost: $0.285/GB/month. Even 10,000 concurrent groups (~35MB) = **$0.01/month**.
+
+---
+
+## Scenario Cost Estimates
+
+### Scenario: 1 Group, 5 Members, WebSocket Mode, 35-min Session
+
+Assumptions:
+- Host sends heartbeat every 60s (35 heartbeats)
+- 5 members send heartbeat every 120s (5 x 17 = 85 heartbeats)
+- 3 nodes actively updating variables every 1s for 10 min (3 x 600 = 1800 reportData)
+- 50 event batches total (10 per node average)
+- All 5 members subscribed to messages
+
+| Operation | Count | Unit Cost | Subtotal |
+|-----------|-------|-----------|----------|
+| **Setup** | | | |
+| createDomain | 1 | $0.000004285 | $0.000004 |
+| createGroup | 1 | $0.00000571 | $0.000006 |
+| joinGroup | 5 | $0.000009985 | $0.000050 |
+| **Heartbeats** | | | |
+| renewHeartbeat (host) | 35 | $0.00000571 | $0.000200 |
+| sendMemberHeartbeat | 85 | $0.00000571 | $0.000485 |
+| **Data** | | | |
+| reportDataByNode | 1800 | $0.00000571 | $0.010278 |
+| Subscription delivery | 1800 x 4 | $0.000002 | $0.014400 |
+| **Events** | | | |
+| fireEventsByNode | 50 | $0.000004 | $0.000200 |
+| Subscription delivery | 50 x 4 | $0.000002 | $0.000400 |
+| **Teardown** | | | |
+| dissolveGroup (5 members) | 1 | $0.00003076 | $0.000031 |
+| **WebSocket Connection** | | | |
+| 6 connections x 35 min | 210 min | $0.00000008 | $0.000017 |
+| **Total** | | | **$0.026071** |
+
+### Scenario: 1 Group, 5 Members, HTTPS Polling Mode, 35-min Session
+
+Same assumptions, but using HTTPS polling instead of WebSocket.
+
+| Operation | Count | Unit Cost | Subtotal |
+|-----------|-------|-----------|----------|
+| **Setup** | | | |
+| createDomain | 1 | $0.000004285 | $0.000004 |
+| createGroup | 1 | $0.00000571 | $0.000006 |
+| joinGroup | 5 | $0.000009985 | $0.000050 |
+| **Heartbeats** | | | |
+| renewHeartbeat (host) | 35 | $0.00000571 | $0.000200 |
+| sendMemberHeartbeat | 85 | $0.00000571 | $0.000485 |
+| **Data** | | | |
+| reportDataByNode | 1800 | $0.00000571 | $0.010278 |
+| **Events** | | | |
+| recordEventsByNode (5 events/batch) | 50 | $0.00001178 | $0.000589 |
+| **Polling** | | | |
+| getEventsSince (5 clients x 30/min x 35 min) | 5250 | $0.000004855 | $0.025489 |
+| Periodic data sync (5 clients x 4/min x 35 min) | 700 | $0.00000685 | $0.004795 |
+| **Teardown** | | | |
+| dissolveGroup (5 members) | 1 | $0.00003076 | $0.000031 |
+| **Total** | | | **$0.041927** |
+
+> HTTPS polling mode costs ~60% more than WebSocket mode, primarily due to continuous polling queries.
+
+---
+
+## Cost Summary by Billing Component
+
+### Per Group Per Hour (WebSocket, 5 Members, Active Use)
+
+| Component | Cost/hour | Percentage |
+|-----------|-----------|------------|
+| AppSync Requests (mutations) | $0.0154 | 21% |
+| AppSync Subscriptions (delivery) | $0.0259 | 36% |
+| AppSync Connections | $0.0000288 | 0% |
+| DynamoDB Writes | $0.0148 | 20% |
+| DynamoDB Reads | $0.0017 | 2% |
+| Lambda | $0.00015 | 0% |
+| **Total** | **~$0.058/hour** | 100% |
+
+### Key Cost Drivers
+
+1. **Variable updates (`reportDataByNode`)** - Dominant cost when nodes actively update variables. Each update costs $0.00000571 (AppSync + DynamoDB). With 5 members continuously updating: ~$0.03/hour.
+
+2. **Subscription delivery** - Each mutation triggers delivery to N-1 other subscribers at $0.000002 each. For frequent updates, this becomes significant.
+
+3. **HTTPS Polling** - If using polling instead of WebSocket, the `getEventsSince` query every 2 seconds per client adds ~$0.009/hour per client.
+
+4. **Heartbeats** - Minimal cost. Host heartbeat: $0.00034/hour. Member heartbeat: $0.00017/hour per member.
+
+---
+
+## Appendix: GraphQL Operations Reference
+
+| Operation | Type | Resolver | DynamoDB Operations | Lambda |
+|-----------|------|----------|---------------------|--------|
+| `createDomain` | Mutation | Lambda | None | Yes |
+| `createGroup` | Mutation | Pipeline (JS) | 1 Query + 1 PutItem | No |
+| `joinGroup` | Mutation | Pipeline (JS) | 1 GetItem + 1 TransactWrite (2 PutItems) | No |
+| `leaveGroup` | Mutation | Lambda | 1 TransactWrite (2 Deletes) + 1 DeleteItem | Yes |
+| `dissolveGroup` | Mutation | Lambda | 1 GetItem + 1 Query + (1+3M) DeleteItems | Yes |
+| `renewHeartbeat` | Mutation | Pipeline (JS) | 1 GetItem + 1 UpdateItem | No |
+| `sendMemberHeartbeat` | Mutation | Pipeline (JS) | 1 GetItem + 1 UpdateItem | No |
+| `reportDataByNode` | Mutation | Pipeline (JS) | 1 GetItem + 1 PutItem | No |
+| `fireEventsByNode` | Mutation | Pipeline (JS) | 1 GetItem + None (pass-through) | No |
+| `recordEventsByNode` | Mutation | Lambda | 1 GetItem + BatchWrite (E items) | Yes |
+| `listGroupsByDomain` | Query | Direct (JS) | 1 Query | No |
+| `listGroupStatuses` | Query | Direct (JS) | 1 Query | No |
+| `listNodesInGroup` | Query | Direct (JS) | 1 Query | No |
+| `searchGroupsByNamePrefix` | Query | Direct (JS) | 1 Query (GSI) | No |
+| `getEventsSince` | Query | Direct (JS) | 1 Query | No |
+| `getNodeStatus` | Query | Pipeline (JS) | 2 GetItems | No |

--- a/packages/scratch-gui/src/lib/ruby-generator/data-list.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data-list.js
@@ -87,6 +87,11 @@ export default function (Generator) {
     };
 
     Generator.data_addtolist = function (block) {
+        // === Smalruby: Start of bare literal suppression ===
+        if (block._suppressOutput) {
+            return '';
+        }
+        // === Smalruby: End of bare literal suppression ===
         const comment = Generator.getCommentText(block);
         if (comment && comment.includes('@ruby:array:literal:element')) {
             // Suppressed: handled by data_deletealloflist array literal pattern
@@ -186,6 +191,23 @@ export default function (Generator) {
         const list = getListName(block);
 
         const comment = Generator.getCommentText(block);
+
+        // === Smalruby: Start of bare array literal ===
+        if (comment && comment === '@ruby:literal:array') {
+            const values = [];
+            let nextId = block.next;
+            while (nextId) {
+                const pushBlock = Generator.getBlock(nextId);
+                if (!pushBlock || pushBlock.opcode !== 'data_addtolist') break;
+                const value = Generator.valueToCode(pushBlock, 'ITEM', Generator.ORDER_NONE) || '0';
+                values.push(Generator.nosToCode(value));
+                pushBlock._suppressOutput = true;
+                nextId = pushBlock.next;
+            }
+            return `[${values.join(', ')}]\n`;
+        }
+        // === Smalruby: End of bare array literal ===
+
         const arrayLiteralMatch = comment ? comment.match(/@ruby:array:literal:(\d+)/) : null;
         if (arrayLiteralMatch) {
             const count = parseInt(arrayLiteralMatch[1], 10);

--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -41,6 +41,20 @@ export default function (Generator) {
         const comment = Generator.getCommentText(block);
         const hasValueInput = block.inputs && block.inputs.VALUE && block.inputs.VALUE.block;
 
+        // === Smalruby: Start of bare literal generation ===
+        if (comment && comment.startsWith('@ruby:literal:')) {
+            const value = Generator.valueToCode(block, 'VALUE', Generator.ORDER_NONE) || '""';
+            const litType = comment.replace('@ruby:literal:', '');
+            if (litType === 'string') {
+                return `${value}\n`;
+            }
+            if (litType === 'integer' || litType === 'float') {
+                return `${Generator.nosToCode(value)}\n`;
+            }
+            return `${value}\n`;
+        }
+        // === Smalruby: End of bare literal generation ===
+
         // === Smalruby: Start of regex literal variable generation ===
         if (comment && comment.includes('@ruby:regexp:literal') && hasValueInput) {
             const lvarMatch = comment.match(/@ruby:lvar:([^:,\s]+):\d+/);

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/core.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/core.js
@@ -132,6 +132,16 @@ const CoreHandlers = {
         if (!_.isArray(blocks)) {
             blocks = [blocks];
         }
+        // === Smalruby: Start of bare literal in statement context ===
+        const Primitive = require('../primitive').default;
+        blocks = blocks.map(b => {
+            if (b instanceof Primitive && b.type !== 'sym') {
+                return this._convertBareLiteralToAssignment(b);
+            }
+            return b;
+        });
+        blocks = blocks.flat();
+        // === Smalruby: End of bare literal in statement context ===
         if (blocks.length >= 2 && this._isBlock(blocks[0])) {
             // It's a multi-block result, link them
             for (let i = 0; i < blocks.length - 1; i++) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -138,16 +138,43 @@ class RubyToBlocksConverter extends Visitor {
             // Convert bare Primitive literals to temp variable assignments
             // so they become valid blocks (e.g. "Jimmy" → _lit_1_ = "Jimmy")
             const Primitive = require('./primitive').default;
-            blocks = blocks.map(block => {
+            const newBlocks = [];
+            let convertedPrev = false;
+            for (let i = 0; i < blocks.length; i++) {
+                const block = blocks[i];
                 if (block instanceof Primitive && block.type !== 'sym') {
-                    return this._convertBareLiteralToAssignment(block);
+                    const converted = this._convertBareLiteralToAssignment(block);
+                    const arr = _.isArray(converted) ? converted : [converted];
+                    // Link converted blocks into a chain
+                    for (let j = 0; j < arr.length - 1; j++) {
+                        arr[j].next = arr[j + 1].id;
+                        arr[j + 1].parent = arr[j].id;
+                    }
+                    // Link last converted block to the previous block's chain
+                    if (newBlocks.length > 0) {
+                        const prev = newBlocks[newBlocks.length - 1];
+                        if (this._isBlock(prev) && !prev.next) {
+                            prev.next = arr[0].id;
+                            arr[0].parent = prev.id;
+                        }
+                    }
+                    newBlocks.push(...arr);
+                    convertedPrev = true;
+                } else {
+                    // Link previous converted-literal block to this existing block
+                    if (this._isBlock(block) && !block.parent &&
+                        newBlocks.length > 0 && convertedPrev) {
+                        const prev = newBlocks[newBlocks.length - 1];
+                        if (this._isBlock(prev) && !prev.next) {
+                            prev.next = block.id;
+                            block.parent = prev.id;
+                        }
+                    }
+                    convertedPrev = false;
+                    newBlocks.push(block);
                 }
-                return block;
-            });
-            // Flatten arrays (array literals produce multiple blocks)
-            blocks = blocks.flat();
-            // Re-link blocks so converted literals connect to subsequent blocks
-            blocks = this._linkBlocks(blocks);
+            }
+            blocks = newBlocks;
             // === Smalruby: End of bare literal to temp variable ===
 
             blocks.forEach(block => {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -134,15 +134,27 @@ class RubyToBlocksConverter extends Visitor {
                 rootType !== 'BeginNode') {
                 blocks = this._linkBlocks(blocks);
             }
+            // === Smalruby: Start of bare literal to temp variable ===
+            // Convert bare Primitive literals to temp variable assignments
+            // so they become valid blocks (e.g. "Jimmy" → _lit_1_ = "Jimmy")
+            const Primitive = require('./primitive').default;
+            blocks = blocks.map(block => {
+                if (block instanceof Primitive && block.type !== 'sym') {
+                    return this._convertBareLiteralToAssignment(block);
+                }
+                return block;
+            });
+            // Flatten arrays (array literals produce multiple blocks)
+            blocks = blocks.flat();
+            // === Smalruby: End of bare literal to temp variable ===
+
             blocks.forEach(block => {
                 if (this._isBlock(block)) {
                     if (!block.parent) {
                         block.topLevel = true;
                     }
-                } else {
-                    const Primitive = require('./primitive').default;
-                    if (block instanceof Primitive) {
-                        if (block.type === 'sym') {
+                } else if (block instanceof Primitive) {
+                    if (block.type === 'sym') {
                             const source = this._truncateSource(this._getSource(block.node));
                             const suggestion = `${source}.to_s`;
                             throw new RubyToBlocksConverterError(
@@ -160,9 +172,8 @@ class RubyToBlocksConverter extends Visitor {
                                 {SOURCE: this._truncateSource(this._getSource(block.node))}
                             )
                         );
-                    } else {
-                        throw new Error(`invalid block: ${block}`);
-                    }
+                } else {
+                    throw new Error(`invalid block: ${block}`);
                 }
             });
             Object.keys(this._context.blocks).forEach(blockId => {
@@ -336,6 +347,68 @@ class RubyToBlocksConverter extends Visitor {
             return `::${node.name}`;
         }
         return String(node.name || '');
+    }
+
+    /**
+     * Convert a bare Primitive literal to a temp variable assignment block.
+     * e.g. "Jimmy" → _lit_1_ = "Jimmy" with `@ruby`:literal:string comment
+     * @param {object} primitive - The Primitive instance.
+     * @returns {object|Array} The assignment block(s).
+     */
+    _convertBareLiteralToAssignment (primitive) {
+        const index = (this._context.literalCallIndices._lit_ || 0) + 1;
+        this._context.literalCallIndices._lit_ = index;
+        const varName = `_lit_${index}_`;
+
+        if (primitive.type === 'array') {
+            // Array literal: create list variable + add items
+            const prefixedName = varName;
+            const listVar = this._lookupOrCreateList(prefixedName);
+            const clearBlock = this._createBlock('data_deletealloflist', 'statement');
+            clearBlock.node = primitive.node;
+            clearBlock.fields = {
+                LIST: {name: 'LIST', id: listVar.id, value: listVar.name, variableType: listVar.type}
+            };
+            clearBlock.comment = this._createComment(`@ruby:literal:array`, clearBlock.id);
+
+            const addBlocks = [];
+            const items = primitive.value;
+            items.forEach(item => {
+                const addBlock = this._createBlock('data_addtolist', 'statement');
+                addBlock.node = primitive.node;
+                addBlock.fields = {
+                    LIST: {name: 'LIST', id: listVar.id, value: listVar.name, variableType: listVar.type}
+                };
+                const val = this._isPrimitive(item) ? item.value : item;
+                this._addTextInput(addBlock, 'ITEM', String(val), '');
+                addBlocks.push(addBlock);
+            });
+
+            return [clearBlock, ...addBlocks];
+        }
+
+        // String, integer, float: create scalar variable assignment
+        let commentType;
+        if (primitive.type === 'str') {
+            commentType = 'string';
+        } else if (primitive.type === 'int') {
+            commentType = 'integer';
+        } else if (primitive.type === 'float') {
+            commentType = 'float';
+        } else {
+            commentType = primitive.type;
+        }
+
+        const variable = this._lookupOrCreateVariable(varName);
+        const block = this._createBlock('data_setvariableto', 'statement');
+        block.node = primitive.node;
+        block.fields = {
+            VARIABLE: {name: 'VARIABLE', id: variable.id, value: variable.name, variableType: variable.type}
+        };
+        this._addTextInput(block, 'VALUE', String(primitive.value), '0');
+        block.comment = this._createComment(`@ruby:literal:${commentType}`, block.id);
+
+        return block;
     }
 
     visitProgramNode (node) {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -146,6 +146,8 @@ class RubyToBlocksConverter extends Visitor {
             });
             // Flatten arrays (array literals produce multiple blocks)
             blocks = blocks.flat();
+            // Re-link blocks so converted literals connect to subsequent blocks
+            blocks = this._linkBlocks(blocks);
             // === Smalruby: End of bare literal to temp variable ===
 
             blocks.forEach(block => {

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -134,4 +134,17 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
             opts,
         );
     });
+
+    test('bare string literal', async () => {
+        await expectRoundTrip(converter, target, '"Jimmy"', null, opts);
+    });
+
+    test('bare integer literal', async () => {
+        await expectRoundTrip(converter, target, '42', null, opts);
+    });
+
+    // TODO: bare array literal roundtrip needs further work
+    // test('bare array literal', async () => {
+    //     await expectRoundTrip(converter, target, '[12, 47, 35]', null, opts);
+    // });
 });

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -156,6 +156,21 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         );
     });
 
+    test('bare literal inside when_flag_clicked', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              "hello"
+              say("hello", 2)
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
     // TODO: bare array literal roundtrip needs further work
     // test('bare array literal', async () => {
     //     await expectRoundTrip(converter, target, '[12, 47, 35]', null, opts);

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -143,6 +143,19 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         await expectRoundTrip(converter, target, '42', null, opts);
     });
 
+    test('bare literal followed by say', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            "hello"
+            say("hello")
+        `,
+            null,
+            opts,
+        );
+    });
+
     // TODO: bare array literal roundtrip needs further work
     // test('bare array literal', async () => {
     //     await expectRoundTrip(converter, target, '[12, 47, 35]', null, opts);

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/core-prism.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/core-prism.test.js
@@ -35,20 +35,16 @@ describe('RubyToBlocksConverter Core (Prism)', () => {
         expect(stepsBlock.fields.NUM.value).toBe('10');
     });
 
-    test('it should return false for a simple integer', async () => {
+    test('bare integer is accepted (converted to temp variable)', async () => {
         const code = '10';
         const converter = await targetCodeToBlocks(vm, target, code);
-        expect(converter.result).toBeFalsy();
-        expect(converter.errors).toHaveLength(1);
-        expect(converter.errors[0].text).toContain('could not be converted');
+        expect(converter.result).toBeTruthy();
     });
 
-    test('it should return false for a simple string', async () => {
+    test('bare string is accepted (converted to temp variable)', async () => {
         const code = '"hello"';
         const converter = await targetCodeToBlocks(vm, target, code);
-        expect(converter.result).toBeFalsy();
-        expect(converter.errors).toHaveLength(1);
-        expect(converter.errors[0].text).toContain('could not be converted');
+        expect(converter.result).toBeTruthy();
     });
 
     test('float literal 1.0 should be stored as "1.0" in NUM field', async () => {

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/index.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/index.test.js
@@ -167,17 +167,28 @@ describe('RubyToBlocksConverter', () => {
             });
 
             test('error', async () => {
+                // Bare literals (1, "Hello!") are now auto-converted to temp
+                // variable assignments, so they no longer error.
+                // Only symbols still error.
                 { for (const c of [
-                    '1',
-                    '"Hello!"',
-                    ':symbol',
-                    'move(10); 1',
-                    'move(10); 1; bounce_if_on_edge'
+                    ':symbol'
                 ]) {
                     const res = await converter.targetCodeToBlocks(target, c);
                     expect(converter.errors).toHaveLength(1);
                     expect(converter.errors[0].row).toEqual(0);
                     expect(res).toBeFalsy();
+                } }
+            });
+
+            test('bare literals are accepted', async () => {
+                { for (const c of [
+                    '1',
+                    '"Hello!"',
+                    'move(10); 1',
+                    'move(10); 1; bounce_if_on_edge'
+                ]) {
+                    const res = await converter.targetCodeToBlocks(target, c);
+                    expect(res).toBeTruthy();
                 } }
             });
         });

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/smalruby-ruby.test.js
@@ -122,4 +122,49 @@ describe('RubyToBlocksConverter/SmalrubyRuby', () => {
         });
 
     });
+
+    describe('bare literals', () => {
+        test('should convert bare string literal "Jimmy"', async () => {
+            const code = '"Jimmy"';
+            const result = await converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+            const blocks = Object.values(converter._context.blocks);
+            const setBlock = blocks.find(
+                (b) => b.opcode === 'data_setvariableto',
+            );
+            expect(setBlock).toBeTruthy();
+            expect(setBlock.comment).toBeTruthy();
+        });
+
+        test('should convert bare integer literal 42', async () => {
+            const code = '42';
+            const result = await converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+        });
+
+        test('should convert bare float literal 3.14', async () => {
+            const code = '3.14';
+            const result = await converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+        });
+
+        test('should convert bare empty array []', async () => {
+            const code = '[]';
+            const result = await converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+        });
+
+        test('should convert bare array [12, 47, 35]', async () => {
+            const code = '[12, 47, 35]';
+            const result = await converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(true);
+        });
+
+        test('should still error on bare symbol :foo', async () => {
+            const code = ':foo';
+            const result = await converter.targetCodeToBlocks(target, code);
+            expect(result).toBe(false);
+            expect(converter.errors.length).toBeGreaterThan(0);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
裸のリテラル（`"Jimmy"`, `42`, `[1,2,3]`）を一時変数代入に変換してエラーを回避。`@ruby:literal:type` コメントマーカーでラウンドトリップを実現。

- 文字列: `"Jimmy"` → `_lit_1_ = "Jimmy"` → ジェネレーターで `"Jimmy"` に復元
- 整数: `42` → `_lit_1_ = 42` → `42` に復元
- 配列: `[1,2,3]` → リストブロック → 配列リテラルのラウンドトリップは TODO

## Test Coverage
- コンバーター: 文字列/整数/浮動小数点/空配列/配列/シンボル(エラー維持) 6テスト
- ラウンドトリップ: 文字列/整数 2テスト（配列は TODO）

Refs #524 (Phase 1 #3)