### PR TITLE
fix: prevent bare literal linking to hat/def/value blocks

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/index.js
@@ -139,7 +139,6 @@ class RubyToBlocksConverter extends Visitor {
             // so they become valid blocks (e.g. "Jimmy" → _lit_1_ = "Jimmy")
             const Primitive = require('./primitive').default;
             const newBlocks = [];
-            let convertedPrev = false;
             for (let i = 0; i < blocks.length; i++) {
                 const block = blocks[i];
                 if (block instanceof Primitive && block.type !== 'sym') {
@@ -159,18 +158,7 @@ class RubyToBlocksConverter extends Visitor {
                         }
                     }
                     newBlocks.push(...arr);
-                    convertedPrev = true;
                 } else {
-                    // Link previous converted-literal block to this existing block
-                    if (this._isBlock(block) && !block.parent &&
-                        newBlocks.length > 0 && convertedPrev) {
-                        const prev = newBlocks[newBlocks.length - 1];
-                        if (this._isBlock(prev) && !prev.next) {
-                            prev.next = block.id;
-                            block.parent = prev.id;
-                        }
-                    }
-                    convertedPrev = false;
                     newBlocks.push(block);
                 }
             }

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -144,6 +144,7 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
     });
 
     test('bare literal followed by say', async () => {
+        // Bare literal becomes independent top-level block, generated after say
         await expectRoundTrip(
             converter,
             target,
@@ -151,7 +152,11 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
             "hello"
             say("hello")
         `,
-            null,
+            dedent`
+            say("hello")
+
+            "hello"
+        `,
             opts,
         );
     });
@@ -210,6 +215,70 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
             end
         `,
             null,
+            opts,
+        );
+    });
+
+    test('bare literal before hat block', async () => {
+        // Hat blocks are sorted to top by generator
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            "hi"
+
+            when_flag_clicked do
+              say("a", 2)
+            end
+        `,
+            dedent`
+            when_flag_clicked do
+              say("a", 2)
+            end
+
+            "hi"
+        `,
+            opts,
+        );
+    });
+
+    test('bare literal before def', async () => {
+        // Def blocks are sorted to top by generator
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            "hi"
+
+            def greet
+              say("hello", 2)
+            end
+        `,
+            dedent`
+            def greet
+              say("hello", 2)
+            end
+
+            "hi"
+        `,
+            opts,
+        );
+    });
+
+    test('bare literal before value block', async () => {
+        // Value blocks are sorted independently
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            "hi"
+            2 + 3
+        `,
+            dedent`
+            2 + 3
+
+            "hi"
+        `,
             opts,
         );
     });


### PR DESCRIPTION
## Summary
裸リテラルの一時変数代入ブロックが hat/def/値ブロックに next リンクされ、それらが消失またはリオーダーされるバグを修正。

## Fix
裸リテラルの変換結果は常に独立トップレベルブロック。後続ブロックへのリンクをしない。

## Known limitation
- 裸リテラルは hat/def の後に出力される（ジェネレーターのブロックソート順）
- 連続メソッド呼び出し（say なし）の finishTargets 問題は TODO

Found during Playwright testing on smalruby.app.

Refs #524, #529