### PR TITLE
fix: correct power operator guard (`!value === 10` → `value !== 10`)

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators-math.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/operators-math.js
@@ -155,7 +155,7 @@ const OperatorsMath = {
                 rh = rh[0];
             }
 
-            if (!receiver.value === 10) return null;
+            if (receiver.value !== 10) return null;
             if (!converter._isNumberOrBlock(rh)) return null;
 
             const block = converter._createBlock('operator_mathop', 'value');

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -283,6 +283,23 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         );
     });
 
+    // TODO: 2 ** 8 (non-10 base) is not yet supported as a block
+    // Only 10 ** n and Math::E ** n are supported via operator_mathop
+
+    test('power operator 10 ** 3', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              say(10 ** 3, 2)
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
     // TODO: bare array literal roundtrip needs further work
     // test('bare array literal', async () => {
     //     await expectRoundTrip(converter, target, '[12, 47, 35]', null, opts);


### PR DESCRIPTION
## Summary
`!receiver.value === 10` は `(!receiver.value) === 10` と解釈され常に false。2 ** 8 が 10 ** 8 に変換されるバグの原因。

## Fix
`receiver.value !== 10` に修正。10 ** n のみ `10 ^` 演算子にマッピング。

## Note
10 以外のべき乗（2 ** 8 等）はブロックに変換できない（Scratch に等価な演算子がない）。既知の制限。

Found during Playwright testing on smalruby.app.

Refs #529