### PR TITLE
feat: support .times do |i| block parameter in Ruby roundtrip

### DIFF
--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -38,6 +38,14 @@ export default function (Generator) {
         const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
         const wait = hasWaitComment(block) ? `${Generator.INDENT}wait\n` : '';
         const suffix = needsWithScreenRefresh(block) ? '.with_screen_refresh' : '';
+        // === Smalruby: Start of times with block parameter ===
+        const comment = Generator.getCommentText(block);
+        const timesParamMatch = comment && comment.match(/@ruby:syntax:times_param:(\S+)/);
+        if (timesParamMatch) {
+            const paramName = timesParamMatch[1];
+            return `${times}.times${suffix} do |${paramName}|\n${branch}${wait}end\n`;
+        }
+        // === Smalruby: End of times with block parameter ===
         return `${times}.times${suffix} do\n${branch}${wait}end\n`;
     };
 

--- a/packages/scratch-gui/src/lib/ruby-generator/data.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/data.js
@@ -41,6 +41,12 @@ export default function (Generator) {
         const comment = Generator.getCommentText(block);
         const hasValueInput = block.inputs && block.inputs.VALUE && block.inputs.VALUE.block;
 
+        // === Smalruby: Start of times block param init suppression ===
+        if (comment && comment.includes('@ruby:syntax:times_param_init')) {
+            return '';
+        }
+        // === Smalruby: End of times block param init suppression ===
+
         // === Smalruby: Start of bare literal generation ===
         if (comment && comment.startsWith('@ruby:literal:')) {
             const value = Generator.valueToCode(block, 'VALUE', Generator.ORDER_NONE) || '""';
@@ -152,6 +158,12 @@ export default function (Generator) {
     };
 
     Generator.data_changevariableby = function (block) {
+        // === Smalruby: Start of times block param incr suppression ===
+        const comment = Generator.getCommentText(block);
+        if (comment && comment.includes('@ruby:syntax:times_param_incr')) {
+            return '';
+        }
+        // === Smalruby: End of times block param incr suppression ===
         const variable = Generator.variableName(Generator.getFieldId(block, 'VARIABLE'));
         const value = Generator.valueToCode(block, 'VALUE', Generator.ORDER_NONE) || 0;
         return `${variable} += ${Generator.nosToCode(value)}\n`;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
@@ -122,6 +122,76 @@ const ControlConverter = {
             return block;
         });
 
+        // number.times { |i| block } - control_repeat with counter variable
+        converter.registerOnSendWithBlock('any', 'times', 0, 1, params => {
+            const {receiver, rubyBlockArgs, rubyBlock} = params;
+            if (!rubyBlock || !converter._isNumberOrBlock(receiver)) return null;
+            if (!rubyBlockArgs || rubyBlockArgs.length !== 1) return null;
+
+            const paramName = rubyBlockArgs[0];
+            const variable = converter._lookupOrCreateVariable(paramName);
+
+            // Create: paramVar = 0 (with marker comment)
+            const initBlock = converter._createBlock('data_setvariableto', 'statement', {
+                fields: {
+                    VARIABLE: {
+                        name: 'VARIABLE',
+                        id: variable.id,
+                        value: variable.name,
+                        variableType: variable.type
+                    }
+                }
+            });
+            converter._addTextInput(initBlock, 'VALUE', '0', '0');
+            initBlock.comment = converter._createComment(
+                `@ruby:syntax:times_param_init:${paramName}`, initBlock.id
+            );
+
+            // Create: control_repeat with marker comment
+            const cleanedRubyBlock = converter._removeWaitBlocks(rubyBlock);
+            const repeatBlock = createControlRepeatBlock(converter, receiver, null);
+            if (converter._hadWaitInLastRemove) {
+                repeatBlock.comment = converter._createComment(
+                    `@ruby:method:wait\n@ruby:syntax:times_param:${paramName}`, repeatBlock.id
+                );
+            } else {
+                repeatBlock.comment = converter._createComment(
+                    `@ruby:syntax:times_param:${paramName}`, repeatBlock.id
+                );
+            }
+
+            // Create: paramVar += 1 (with marker comment) — append to end of body
+            const incrBlock = converter._createBlock('data_changevariableby', 'statement', {
+                fields: {
+                    VARIABLE: {
+                        name: 'VARIABLE',
+                        id: variable.id,
+                        value: variable.name,
+                        variableType: variable.type
+                    }
+                }
+            });
+            converter._addNumberInput(incrBlock, 'VALUE', 'math_number', 1, 1);
+            incrBlock.comment = converter._createComment(
+                `@ruby:syntax:times_param_incr`, incrBlock.id
+            );
+
+            // Link body: cleanedRubyBlock → incrBlock at end
+            if (cleanedRubyBlock) {
+                let lastBody = cleanedRubyBlock;
+                while (lastBody.next) {
+                    lastBody = converter._context.blocks[lastBody.next];
+                }
+                lastBody.next = incrBlock.id;
+                incrBlock.parent = lastBody.id;
+                converter._addSubstack(repeatBlock, cleanedRubyBlock);
+            } else {
+                converter._addSubstack(repeatBlock, incrBlock);
+            }
+
+            return [initBlock, repeatBlock];
+        });
+
         // number.times.with_screen_refresh { block } - control_repeat + comment
         converter.registerOnSendWithBlock('any', 'with_screen_refresh', 0, 0, params => {
             const {receiver, rubyBlock} = params;

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -367,6 +367,22 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         );
     });
 
+    test('.times do |i| with block parameter', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              5.times do |i|
+                say(i, 1)
+              end
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
     // TODO: 2 ** 8 (non-10 base) is not yet supported as a block
     // Only 10 ** n and Math::E ** n are supported via operator_mathop
 


### PR DESCRIPTION
## Summary

- `.times do |i|` のブロックパラメーター付きラウンドトリップを実装
- `control_repeat` + カウンター変数 + `@ruby:syntax:times_param` コメントマーカーで実現
- TryRuby レッスン 300 のコードパターンに対応

## 変換パターン

```ruby
# Ruby 入力
5.times do |i|
  say(i, 1)
end

# ブロック表現
[i を 0 にする]             ← @ruby:syntax:times_param_init:i (出力抑制)
[5 回繰り返す]              ← @ruby:syntax:times_param:i
  [i と 1 秒言う]
  [i を 1 ずつ変える]        ← @ruby:syntax:times_param_incr (出力抑制)

# ジェネレーター出力 → 元のコードに復元
5.times do |i|
  say(i, 1)
end
```

## Changes Made

- `control.js` (converter) — `registerOnSendWithBlock('any', 'times', 0, 1, ...)` で |i| 付き times を登録
- `control.js` (generator) — `@ruby:syntax:times_param:name` 検出時に `do |name|` を出力
- `data.js` (generator) — init/incr ブロックの出力抑制
- `smalruby-ruby.test.js` — ラウンドトリップテスト追加

## Test Plan

- [x] `.times do |i|` ラウンドトリップテスト pass
- [x] 既存テスト 24件 pass
- [x] lint pass
