### PR TITLE
refactor: split smalruby_ruby VM files by class responsibility

### DIFF
--- a/packages/scratch-vm/src/extensions/smalruby_ruby/block-definitions.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/block-definitions.js
@@ -1,4 +1,6 @@
 const ArgumentType = require('../../extension-support/argument-type');
+const BlockType = require('../../extension-support/block-type');
+const formatMessage = require('format-message');
 
 /**
  * argumentsByMethod, menuItems, and menus definitions for
@@ -461,12 +463,130 @@ const menus = {
     },
 };
 
+/**
+ * Build the blocks array for getInfo().
+ * Organized by class: String, Array, Hash, Number, block param, return value.
+ * @returns {Array} Block definitions.
+ */
+const getBlocks = () => [
+    // --- String method (COMMAND, isDynamic) ---
+    {
+        opcode: 'stringMethod',
+        text: formatMessage({
+            id: 'smalrubyRuby.stringMethod',
+            default: 'String [RECEIVER] . [METHOD]',
+            description: 'String method call',
+        }),
+        blockType: BlockType.COMMAND,
+        isDynamic: true,
+        arguments: {
+            RECEIVER: { type: ArgumentType.STRING, defaultValue: 'hello' },
+            METHOD: { type: ArgumentType.STRING, menu: 'stringMethodMenu', defaultValue: 'reverse' },
+        },
+        argumentsByMethod: stringMethodArgumentsByMethod,
+        menuItems: { stringMethodMenu: stringMethodMenuItems },
+    },
+    // --- Array method (COMMAND, isDynamic) ---
+    {
+        opcode: 'arrayMethod',
+        text: formatMessage({
+            id: 'smalrubyRuby.arrayMethod',
+            default: 'Array [RECEIVER] . [METHOD]',
+            description: 'Array method call',
+        }),
+        blockType: BlockType.COMMAND,
+        isDynamic: true,
+        arguments: {
+            RECEIVER: { type: ArgumentType.STRING, defaultValue: 'list' },
+            METHOD: { type: ArgumentType.STRING, menu: 'arrayMethodMenu', defaultValue: 'max' },
+        },
+        argumentsByMethod: arrayMethodArgumentsByMethod,
+        menuItems: { arrayMethodMenu: arrayMethodMenuItems },
+    },
+    // --- Hash method (COMMAND, isDynamic) ---
+    {
+        opcode: 'hashMethod',
+        text: formatMessage({
+            id: 'smalrubyRuby.hashMethod',
+            default: 'Hash [RECEIVER] . [METHOD]',
+            description: 'Hash method call',
+        }),
+        blockType: BlockType.COMMAND,
+        isDynamic: true,
+        arguments: {
+            RECEIVER: { type: ArgumentType.STRING, defaultValue: 'hash' },
+            METHOD: { type: ArgumentType.STRING, menu: 'hashMethodMenu', defaultValue: 'keys' },
+        },
+        argumentsByMethod: hashMethodArgumentsByMethod,
+        menuItems: { hashMethodMenu: hashMethodMenuItems },
+    },
+    // --- Array method with block (CONDITIONAL, C-shape) ---
+    {
+        opcode: 'arrayMethodWithBlock',
+        text: formatMessage({
+            id: 'smalrubyRuby.arrayMethodWithBlock',
+            default: 'Array [RECEIVER] . [METHOD] do',
+            description: 'Array method call with block (C-shape)',
+        }),
+        blockType: BlockType.CONDITIONAL,
+        arguments: {
+            RECEIVER: { type: ArgumentType.STRING, defaultValue: '' },
+            METHOD: { type: ArgumentType.STRING, menu: 'arrayMethodWithBlockMenu', defaultValue: 'each' },
+        },
+    },
+    // --- Number method with block (CONDITIONAL, C-shape) ---
+    {
+        opcode: 'numberMethodWithBlock',
+        text: formatMessage({
+            id: 'smalrubyRuby.numberMethodWithBlock',
+            default: 'Number [RECEIVER] . [METHOD] do',
+            description: 'Number method call with block (C-shape)',
+        }),
+        blockType: BlockType.CONDITIONAL,
+        arguments: {
+            RECEIVER: { type: ArgumentType.NUMBER, defaultValue: 5 },
+            METHOD: { type: ArgumentType.STRING, menu: 'numberMethodWithBlockMenu', defaultValue: 'times' },
+        },
+    },
+    // --- Block parameter (REPORTER) ---
+    {
+        opcode: 'blockParam',
+        text: formatMessage({
+            id: 'smalrubyRuby.blockParam',
+            default: 'block param [PARAM]',
+            description: 'Block parameter for block-accepting methods (each, times, etc.)',
+        }),
+        blockType: BlockType.REPORTER,
+        disableMonitor: true,
+        arguments: {
+            PARAM: { type: ArgumentType.STRING, menu: 'blockParamMenu', defaultValue: '_1' },
+        },
+    },
+    // --- Return value (REPORTER) ---
+    {
+        opcode: 'returnValue',
+        text: formatMessage({
+            id: 'smalrubyRuby.returnValue',
+            default: 'return value',
+            description: 'Return value of the last Ruby method call',
+        }),
+        blockType: BlockType.REPORTER,
+        disableMonitor: true,
+    },
+    // --- Return value truthy? (BOOLEAN) ---
+    {
+        opcode: 'returnValueTruthy',
+        text: formatMessage({
+            id: 'smalrubyRuby.returnValueTruthy',
+            default: 'return value truthy?',
+            description: 'Whether the return value is truthy (Ruby semantics: nil/false are falsy)',
+        }),
+        blockType: BlockType.BOOLEAN,
+        disableMonitor: true,
+    },
+];
+
 module.exports = {
-    stringMethodArgumentsByMethod,
-    stringMethodMenuItems,
-    arrayMethodArgumentsByMethod,
-    arrayMethodMenuItems,
-    hashMethodArgumentsByMethod,
-    hashMethodMenuItems,
+    getBlocks,
     menus,
 };

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js
@@ -1,0 +1,81 @@
+/**
+ * Executors for block-accepting methods (C-shape blocks).
+ * Each class (Array, Number, etc.) has its own executor function.
+ */
+
+/**
+ * Set block params on the current thread for blockParam REPORTER.
+ * @param {object} util - Block utility.
+ * @param {string} key - Parameter key (e.g., '_1').
+ * @param {*} value - The value to set.
+ */
+const setBlockParam = (util, key, value) => {
+    if (!util.thread._smalrubyBlockParams) {
+        util.thread._smalrubyBlockParams = {};
+    }
+    util.thread._smalrubyBlockParams[key] = value;
+};
+
+/**
+ * Execute an array method with block (C-shape).
+ * @param {object} args - Block arguments (RECEIVER, METHOD).
+ * @param {object} util - Block utility.
+ * @param {Function} setReturnValue - Callback to store the return value.
+ */
+const executeArrayMethodWithBlock = (args, util, setReturnValue) => {
+    const method = args.METHOD;
+    const toItems = (s) => (s === '' ? [] : String(s).split(' '));
+
+    switch (method) {
+        case 'each': {
+            const items = toItems(String(args.RECEIVER || ''));
+            if (typeof util.stackFrame.index === 'undefined') {
+                util.stackFrame.index = 0;
+            }
+            if (util.stackFrame.index < items.length) {
+                const value = items[util.stackFrame.index];
+                setReturnValue(util, value);
+                setBlockParam(util, '_1', value);
+                util.stackFrame.index++;
+                util.startBranch(1, true);
+            }
+            break;
+        }
+        default:
+            break;
+    }
+};
+
+/**
+ * Execute a number method with block (C-shape).
+ * @param {object} args - Block arguments (RECEIVER, METHOD).
+ * @param {object} util - Block utility.
+ * @param {Function} setReturnValue - Callback to store the return value.
+ */
+const executeNumberMethodWithBlock = (args, util, setReturnValue) => {
+    const method = args.METHOD;
+
+    switch (method) {
+        case 'times': {
+            const times = Math.round(Number(args.RECEIVER) || 0);
+            if (typeof util.stackFrame.index === 'undefined') {
+                util.stackFrame.index = 0;
+            }
+            if (util.stackFrame.index < times) {
+                const value = util.stackFrame.index;
+                setReturnValue(util, value);
+                setBlockParam(util, '_1', value);
+                util.stackFrame.index++;
+                util.startBranch(1, true);
+            }
+            break;
+        }
+        default:
+            break;
+    }
+};
+
+module.exports = {
+    executeArrayMethodWithBlock,
+    executeNumberMethodWithBlock,
+};

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/index.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/index.js
@@ -1,26 +1,19 @@
-const ArgumentType = require('../../extension-support/argument-type');
-const BlockType = require('../../extension-support/block-type');
 const formatMessage = require('format-message');
 const Variable = require('../../engine/variable');
 const translations = require('./translations.json');
 
-const {
-    stringMethodArgumentsByMethod,
-    stringMethodMenuItems,
-    arrayMethodArgumentsByMethod,
-    arrayMethodMenuItems,
-    hashMethodArgumentsByMethod,
-    hashMethodMenuItems,
-    menus,
-} = require('./block-definitions');
+const { getBlocks, menus } = require('./block-definitions');
 
 const {
     executeStringMethod,
     executeArrayMethod,
     executeHashMethod,
+} = require('./method-executors');
+
+const {
     executeArrayMethodWithBlock,
     executeNumberMethodWithBlock,
-} = require('./method-executors');
+} = require('./block-method-executors');
 
 /**
  * Icon svg to be displayed at the left edge of each extension block, encoded as a data URI.
@@ -68,173 +61,7 @@ class SmalrubyRubyBlocks {
                 description: 'Label for the ruby extension category',
             }),
             blockIconURI: blockIconURI,
-            blocks: [
-                // --- String method (COMMAND, isDynamic) ---
-                {
-                    opcode: 'stringMethod',
-                    text: formatMessage({
-                        id: 'smalrubyRuby.stringMethod',
-                        default: 'String [RECEIVER] . [METHOD]',
-                        description: 'String method call',
-                    }),
-                    blockType: BlockType.COMMAND,
-                    isDynamic: true,
-                    arguments: {
-                        RECEIVER: {
-                            type: ArgumentType.STRING,
-                            defaultValue: 'hello',
-                        },
-                        METHOD: {
-                            type: ArgumentType.STRING,
-                            menu: 'stringMethodMenu',
-                            defaultValue: 'reverse',
-                        },
-                    },
-                    argumentsByMethod: stringMethodArgumentsByMethod,
-                    menuItems: {
-                        stringMethodMenu: stringMethodMenuItems,
-                    },
-                },
-                // --- Array method (COMMAND, isDynamic) ---
-                {
-                    opcode: 'arrayMethod',
-                    text: formatMessage({
-                        id: 'smalrubyRuby.arrayMethod',
-                        default: 'Array [RECEIVER] . [METHOD]',
-                        description: 'Array method call',
-                    }),
-                    blockType: BlockType.COMMAND,
-                    isDynamic: true,
-                    arguments: {
-                        RECEIVER: {
-                            type: ArgumentType.STRING,
-                            defaultValue: 'list',
-                        },
-                        METHOD: {
-                            type: ArgumentType.STRING,
-                            menu: 'arrayMethodMenu',
-                            defaultValue: 'max',
-                        },
-                    },
-                    argumentsByMethod: arrayMethodArgumentsByMethod,
-                    menuItems: {
-                        arrayMethodMenu: arrayMethodMenuItems,
-                    },
-                },
-                // --- Hash method (COMMAND, isDynamic) ---
-                {
-                    opcode: 'hashMethod',
-                    text: formatMessage({
-                        id: 'smalrubyRuby.hashMethod',
-                        default: 'Hash [RECEIVER] . [METHOD]',
-                        description: 'Hash method call',
-                    }),
-                    blockType: BlockType.COMMAND,
-                    isDynamic: true,
-                    arguments: {
-                        RECEIVER: {
-                            type: ArgumentType.STRING,
-                            defaultValue: 'hash',
-                        },
-                        METHOD: {
-                            type: ArgumentType.STRING,
-                            menu: 'hashMethodMenu',
-                            defaultValue: 'keys',
-                        },
-                    },
-                    argumentsByMethod: hashMethodArgumentsByMethod,
-                    menuItems: {
-                        hashMethodMenu: hashMethodMenuItems,
-                    },
-                },
-                // --- Array method with block (CONDITIONAL, C-shape) ---
-                {
-                    opcode: 'arrayMethodWithBlock',
-                    text: formatMessage({
-                        id: 'smalrubyRuby.arrayMethodWithBlock',
-                        default: 'Array [RECEIVER] . [METHOD] do',
-                        description:
-                            'Array method call with block (C-shape)',
-                    }),
-                    blockType: BlockType.CONDITIONAL,
-                    arguments: {
-                        RECEIVER: {
-                            type: ArgumentType.STRING,
-                            defaultValue: '',
-                        },
-                        METHOD: {
-                            type: ArgumentType.STRING,
-                            menu: 'arrayMethodWithBlockMenu',
-                            defaultValue: 'each',
-                        },
-                    },
-                },
-                // --- Number method with block (CONDITIONAL, C-shape) ---
-                {
-                    opcode: 'numberMethodWithBlock',
-                    text: formatMessage({
-                        id: 'smalrubyRuby.numberMethodWithBlock',
-                        default: 'Number [RECEIVER] . [METHOD] do',
-                        description:
-                            'Number method call with block (C-shape)',
-                    }),
-                    blockType: BlockType.CONDITIONAL,
-                    arguments: {
-                        RECEIVER: {
-                            type: ArgumentType.NUMBER,
-                            defaultValue: 5,
-                        },
-                        METHOD: {
-                            type: ArgumentType.STRING,
-                            menu: 'numberMethodWithBlockMenu',
-                            defaultValue: 'times',
-                        },
-                    },
-                },
-                // --- Block parameter (REPORTER) ---
-                {
-                    opcode: 'blockParam',
-                    text: formatMessage({
-                        id: 'smalrubyRuby.blockParam',
-                        default: 'block param [PARAM]',
-                        description:
-                            'Block parameter for block-accepting methods (each, times, etc.)',
-                    }),
-                    blockType: BlockType.REPORTER,
-                    disableMonitor: true,
-                    arguments: {
-                        PARAM: {
-                            type: ArgumentType.STRING,
-                            menu: 'blockParamMenu',
-                            defaultValue: '_1',
-                        },
-                    },
-                },
-                // --- Return value (REPORTER) ---
-                {
-                    opcode: 'returnValue',
-                    text: formatMessage({
-                        id: 'smalrubyRuby.returnValue',
-                        default: 'return value',
-                        description:
-                            'Return value of the last Ruby method call',
-                    }),
-                    blockType: BlockType.REPORTER,
-                    disableMonitor: true,
-                },
-                // --- Return value truthy? (BOOLEAN) ---
-                {
-                    opcode: 'returnValueTruthy',
-                    text: formatMessage({
-                        id: 'smalrubyRuby.returnValueTruthy',
-                        default: 'return value truthy?',
-                        description:
-                            'Whether the return value is truthy (Ruby semantics: nil/false are falsy)',
-                    }),
-                    blockType: BlockType.BOOLEAN,
-                    disableMonitor: true,
-                },
-            ],
+            blocks: getBlocks(),
             menus: menus,
             translationMap: translations,
         };
@@ -282,7 +109,18 @@ class SmalrubyRubyBlocks {
         return true;
     }
 
-    // --- Method execution blocks ---
+    // --- Block parameter ---
+
+    blockParam(args, util) {
+        const param = args.PARAM || '_1';
+        const params = util.thread._smalrubyBlockParams;
+        if (params && params[param] !== undefined) {
+            return params[param];
+        }
+        return '';
+    }
+
+    // --- Method execution blocks (per class) ---
 
     stringMethod(args, util) {
         executeStringMethod(args, util, this._setReturnValue);
@@ -302,15 +140,6 @@ class SmalrubyRubyBlocks {
 
     numberMethodWithBlock(args, util) {
         executeNumberMethodWithBlock(args, util, this._setReturnValue);
-    }
-
-    blockParam(args, util) {
-        const param = args.PARAM || '_1';
-        const params = util.thread._smalrubyBlockParams;
-        if (params && params[param] !== undefined) {
-            return params[param];
-        }
-        return '';
     }
 
     // --- Variable names menu ---

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/method-executors.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/method-executors.js
@@ -220,76 +220,8 @@ const executeHashMethod = (args, util, setReturnValue) => {
     setReturnValue(util, result);
 };
 
-/**
- * Execute an array method with block (C-shape).
- * @param {object} args - Block arguments (RECEIVER, METHOD).
- * @param {object} util - Block utility (has util.target, util.thread, util.stackFrame, util.startBranch).
- * @param {Function} setReturnValue - Callback to store the return value.
- */
-const executeArrayMethodWithBlock = (args, util, setReturnValue) => {
-    const method = args.METHOD;
-    const toItems = (s) => (s === '' ? [] : String(s).split(' '));
-
-    switch (method) {
-        case 'each': {
-            const items = toItems(String(args.RECEIVER || ''));
-            if (typeof util.stackFrame.index === 'undefined') {
-                util.stackFrame.index = 0;
-            }
-            if (util.stackFrame.index < items.length) {
-                const value = items[util.stackFrame.index];
-                setReturnValue(util, value);
-                // Set block params for blockParam REPORTER
-                if (!util.thread._smalrubyBlockParams) {
-                    util.thread._smalrubyBlockParams = {};
-                }
-                util.thread._smalrubyBlockParams._1 = value;
-                util.stackFrame.index++;
-                util.startBranch(1, true);
-            }
-            break;
-        }
-        default:
-            break;
-    }
-};
-
-/**
- * Execute a number method with block (C-shape).
- * @param {object} args - Block arguments (RECEIVER, METHOD).
- * @param {object} util - Block utility.
- * @param {Function} setReturnValue - Callback to store the return value.
- */
-const executeNumberMethodWithBlock = (args, util, setReturnValue) => {
-    const method = args.METHOD;
-
-    switch (method) {
-        case 'times': {
-            const times = Math.round(Number(args.RECEIVER) || 0);
-            if (typeof util.stackFrame.index === 'undefined') {
-                util.stackFrame.index = 0;
-            }
-            if (util.stackFrame.index < times) {
-                const value = util.stackFrame.index;
-                setReturnValue(util, value);
-                if (!util.thread._smalrubyBlockParams) {
-                    util.thread._smalrubyBlockParams = {};
-                }
-                util.thread._smalrubyBlockParams._1 = value;
-                util.stackFrame.index++;
-                util.startBranch(1, true);
-            }
-            break;
-        }
-        default:
-            break;
-    }
-};
-
 module.exports = {
     executeStringMethod,
     executeArrayMethod,
     executeHashMethod,
-    executeArrayMethodWithBlock,
-    executeNumberMethodWithBlock,
 };


### PR DESCRIPTION
## Summary

scratch-vm の smalrubyRuby 拡張機能ファイルをリファクタリング。クラス毎の責任分離を明確にし、今後のクラス追加を容易にする。

## File Structure After Refactoring

| ファイル | 行数 | 役割 |
|---------|------|------|
| `index.js` | 156 (←327) | クラスシェル + 実行ディスパッチのみ |
| `block-definitions.js` | 592 (←472) | ブロック定義データ + `getBlocks()` |
| `method-executors.js` | 227 (←295) | COMMAND メソッド実行 (String/Array/Hash) |
| `block-method-executors.js` | 81 (新規) | C形状ブロック実行 (Array each / Number times) |

## 新クラス追加ガイド

新しいクラスのメソッドを追加する場合:
1. `block-definitions.js`: `getBlocks()` にブロック定義追加 + メニュー追加
2. `method-executors.js`: COMMAND メソッドの実行関数追加
3. `block-method-executors.js`: ブロック付きメソッドの実行関数追加
4. `index.js`: 実行メソッドの import + dispatch 追加

## Test Plan

- [x] 全 25 roundtrip テスト pass
- [x] lint pass (scratch-gui + scratch-vm)
