### PR TITLE
test: enable bare array literal roundtrip test

### DIFF
--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -418,8 +418,22 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         );
     });
 
-    // TODO: bare array literal roundtrip needs further work
-    // test('bare array literal', async () => {
-    //     await expectRoundTrip(converter, target, '[12, 47, 35]', null, opts);
-    // });
+    test('bare array literal', async () => {
+        await expectRoundTrip(converter, target, '[12, 47, 35]', null, opts);
+    });
+
+    test('array variable assignment and method', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              ticket = [35, 12, 47]
+              say(ticket.max, 2)
+            end
+        `,
+            null,
+            opts,
+        );
+    });
 });


### PR DESCRIPTION
配列リテラルのラウンドトリップは既に動作していたが、テストが TODO コメントで無効化されていた。テストを有効化し、変数代入+メソッド呼び出しのテストも追加。