### PR TITLE
feat: add sprite clone, array/hash constructor support

### DIFF
--- a/packages/scratch-gui/src/lib/furigana-label-map.js
+++ b/packages/scratch-gui/src/lib/furigana-label-map.js
@@ -93,6 +93,7 @@ const TOPLEVEL_METHOD_LABELS = {
     sleep: '待つ',
     loop: 'ずっと繰り返す',
     stop: '止める',
+    clone: 'クローンを作る',
     create_clone: 'クローンを作る',
     delete_this_clone: 'このクローンを削除',
     when_start_as_a_clone: 'クローンされたとき',

--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -313,7 +313,7 @@ export default function (Generator) {
     Generator.control_create_clone_of = function (block) {
         const comment = Generator.getCommentText(block);
         if (comment && comment.includes('@ruby:method:clone')) {
-            return `self.clone\n`;
+            return `clone\n`;
         }
         const target = Generator.valueToCode(block, 'CLONE_OPTION', Generator.ORDER_NONE);
         return `create_clone(${target})\n`;

--- a/packages/scratch-gui/src/lib/ruby-generator/control.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/control.js
@@ -311,6 +311,10 @@ export default function (Generator) {
     };
 
     Generator.control_create_clone_of = function (block) {
+        const comment = Generator.getCommentText(block);
+        if (comment && comment.includes('@ruby:method:clone')) {
+            return `self.clone\n`;
+        }
         const target = Generator.valueToCode(block, 'CLONE_OPTION', Generator.ORDER_NONE);
         return `create_clone(${target})\n`;
     };

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/expressions.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/ast-handlers/expressions.js
@@ -1,6 +1,7 @@
 import {defineMessages} from 'react-intl';
 import _ from 'lodash';
 import {RubyToBlocksConverterError} from '../errors';
+import Primitive from '../primitive';
 import ExpressionsLiterals from './expressions-literals';
 
 const messages = defineMessages({
@@ -73,6 +74,46 @@ const ExpressionHandlers = {
             }
         }
         // === Smalruby: End of attr_accessor getter/setter resolution ===
+
+        // === Smalruby: Start of Array.new / Hash.new constructor ===
+        if (node.name === 'new' && node.receiver) {
+            const recvType = this._getNodeTypeName(node.receiver);
+            if (recvType === 'ConstantReadNode') {
+                const className = node.receiver.name;
+                const ctorArgs = node.arguments_ ? node.arguments_.arguments_ : [];
+
+                if (className === 'Array') {
+                    if (ctorArgs.length === 0) {
+                        return new Primitive('array', [], node);
+                    }
+                    if (ctorArgs.length <= 2) {
+                        const sizeNode = ctorArgs[0];
+                        const sizeType = this._getNodeTypeName(sizeNode);
+                        if (sizeType === 'IntegerNode') {
+                            const size = sizeNode.value;
+                            const fillVal = ctorArgs.length === 2
+                                ? this.visit(ctorArgs[1])
+                                : '';
+                            const items = Array.from({length: size}, () => fillVal);
+                            return new Primitive('array', items, node);
+                        }
+                    }
+                }
+
+                if (className === 'Hash') {
+                    if (ctorArgs.length === 0) {
+                        return new Primitive('hash', new Map(), node);
+                    }
+                    // Hash.new(default) → error
+                    throw new RubyToBlocksConverterError(
+                        node,
+                        `Hash.new(${this._getSource(ctorArgs[0])}) — ` +
+                        'ハッシュのデフォルト値には対応していません。{} を使ってください。'
+                    );
+                }
+            }
+        }
+        // === Smalruby: End of Array.new / Hash.new constructor ===
 
         const saved = this._saveContext();
 

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
@@ -102,8 +102,12 @@ const ControlConverter = {
             return block;
         });
 
-        // self.clone - control_create_clone_of("myself") with @ruby:method:clone
-        converter.registerOnSend('self', 'clone', 0, () => {
+        // clone / self.clone - control_create_clone_of("myself") with @ruby:method:clone
+        // Stage cannot be cloned
+        converter.registerOnSend('self', 'clone', 0, params => {
+            if (converter._context.target && converter._context.target.isStage) {
+                return null; // fall through to ruby_statement (Stage cannot clone)
+            }
             const block = converter._createBlock('control_create_clone_of', 'statement');
             const optionBlock = converter._createBlock('control_create_clone_of_menu', 'value', {
                 shadow: true

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/control.js
@@ -102,6 +102,18 @@ const ControlConverter = {
             return block;
         });
 
+        // self.clone - control_create_clone_of("myself") with @ruby:method:clone
+        converter.registerOnSend('self', 'clone', 0, () => {
+            const block = converter._createBlock('control_create_clone_of', 'statement');
+            const optionBlock = converter._createBlock('control_create_clone_of_menu', 'value', {
+                shadow: true
+            });
+            converter._addField(optionBlock, 'CLONE_OPTION', '_myself_');
+            converter._addInput(block, 'CLONE_OPTION', optionBlock, optionBlock);
+            block.comment = converter._createComment('@ruby:method:clone', block.id);
+            return block;
+        });
+
         // number.times (without block) - returns control_repeat for chaining with with_screen_refresh
         converter.registerOnSend('any', 'times', 0, params => {
             const {receiver} = params;

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -437,7 +437,21 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         );
     });
 
-    test('self.clone roundtrip', async () => {
+    test('clone roundtrip', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              clone
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
+    test('self.clone converts to clone', async () => {
         await expectRoundTrip(
             converter,
             target,
@@ -446,7 +460,11 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
               self.clone
             end
         `,
-            null,
+            dedent`
+            when_flag_clicked do
+              clone
+            end
+        `,
             opts,
         );
     });

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -436,4 +436,48 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
             opts,
         );
     });
+
+    test('self.clone roundtrip', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              self.clone
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
+    test('Hash.new(0) produces conversion error', async () => {
+        const code = dedent`
+            when_flag_clicked do
+              votes = Hash.new(0)
+            end
+        `;
+        const result = await converter.targetCodeToBlocks(target, code);
+        expect(result).toBeFalsy();
+        expect(converter.errors.length).toBeGreaterThan(0);
+        expect(converter.errors[0].text).toContain('デフォルト値');
+    });
+
+    test('Array.new(5, 0) expands to array literal', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              arr = Array.new(5, 0)
+            end
+        `,
+            dedent`
+            when_flag_clicked do
+              arr = [0, 0, 0, 0, 0]
+            end
+        `,
+            opts,
+        );
+    });
 });


### PR DESCRIPTION
## Summary

- `self.clone` → `create_clone_of("myself")` + `@ruby:method:clone` でラウンドトリップ
- `Array.new` → `[]`, `Array.new(n, val)` → 配列リテラルに展開
- `Hash.new` → `{}`, `Hash.new(default)` → 変換エラー

## Test Plan

- [x] `self.clone` ラウンドトリップ pass
- [x] `Array.new(5, 0)` → `[0, 0, 0, 0, 0]` pass  
- [x] `Hash.new(0)` 変換エラー pass
- [x] 既存テスト 30件 pass
- [x] lint pass

Closes #548