### PR TITLE
chore: rust 開発環境用の vscode 設定と .gitignore 整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,8 @@ built-monorepo
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
 .*-mcp/
 
 /notes

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,9 @@ built-monorepo
 .claude/worktrees/
 .*-mcp/
 
+# VSCode local-only settings (machine-specific, e.g. rust-analyzer envFile)
+.vscode/cargo.env.local
+
 /notes
 
 # CDK (infra/)

--- a/.vscode/cargo.env.example
+++ b/.vscode/cargo.env.example
@@ -1,0 +1,19 @@
+# rust-analyzer 用の環境変数（マシン固有設定）
+#
+# このファイルを `.vscode/cargo.env.local` にコピーし、各自の環境に合わせて編集してください。
+# `.vscode/cargo.env.local` は `.gitignore` 対象です。
+#
+# 用途:
+#   ruby/smalruby3/ext/smalruby3_imageutil の Rust ビルド (magnus crate 経由) で
+#   システム Ruby ではなく rbenv 配下の Ruby を使うために必要。
+#
+# 設定例:
+#   RUBY=/Users/<user>/.anyenv/envs/rbenv/versions/3.4.1/bin/ruby
+#   PATH=/Users/<user>/.anyenv/envs/rbenv/versions/3.4.1/bin:/usr/bin:/bin
+#
+# Linux + rbenv の場合:
+#   RUBY=/home/<user>/.rbenv/versions/3.4.1/bin/ruby
+#   PATH=/home/<user>/.rbenv/versions/3.4.1/bin:/usr/bin:/bin
+
+RUBY=/path/to/your/ruby
+PATH=/path/to/your/ruby/bin:/usr/bin:/bin

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -106,6 +106,7 @@
     "listcontents",
     "Lvar",
     "Lvasgn",
+    "magnus",
     "Makey",
     "makeymakey",
     "mathop",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   "editor.wordWrap": "on",
   "rust-analyzer.linkedProjects": [
     "ruby/smalruby3/ext/smalruby3_imageutil/Cargo.toml"
-  ]
+  ],
+  "rust-analyzer.cargo.envFile": "${workspaceFolder}/.vscode/cargo.env.local"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,12 @@
 {
-    "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true,
-    "git.ignoreLimitWarning": true,
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.wordWrap": "on"
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "git.ignoreLimitWarning": true,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.wordWrap": "on",
+  "rust-analyzer.linkedProjects": [
+    "ruby/smalruby3/ext/smalruby3_imageutil/Cargo.toml"
+  ]
 }


### PR DESCRIPTION
## Summary

Rust 開発環境（`ruby/smalruby3/ext/smalruby3_imageutil`）用の VSCode 設定と、Claude Code 関連のローカル専用ファイルを `.gitignore` に追加。

## Changes Made

### `.vscode/settings.json`
- `rust-analyzer.linkedProjects` に `ruby/smalruby3/ext/smalruby3_imageutil/Cargo.toml` を追加
  - これにより VSCode の rust-analyzer が当該 Rust crate を認識する
- 環境変数 (`RUBY`, `PATH`) は user-specific な絶対パスを含むためコミットしない（各自の環境で必要に応じて個別に設定）

### `.vscode/cspell.json`
- `magnus` を辞書に追加（Rust の Ruby bindings crate 名）

### `.gitignore`
- `.claude/scheduled_tasks.lock` を追加（Claude Code のスケジュールタスクロック、ローカル専用）
- `.claude/worktrees/` を追加（Claude Code の worktree ディレクトリ、ローカル専用）

## Test Plan

- [x] `git status` で対象 3 ファイルのみ変更されていることを確認
- [x] `.vscode/settings.json` に user-specific な絶対パスが残っていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
