### PR TITLE
feat: worktree でメインと同じ Docker イメージを共有する仕組み

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,19 @@ docker compose run --rm app bash -c "COMMAND"
 docker compose stop app
 ```
 
+The compose project name is pinned to `smalruby3-editor` (see `name:` at the top of `docker-compose.yml`), so `docker compose run` from a git worktree shares the same image and named volumes as the main checkout — no per-worktree rebuild needed.
+
+### Quick One-Shot Commands: `bin/dx`
+
+For quick lint or single-test invocations, `bin/dx` is a thin `docker run` wrapper that targets the prebuilt `smalruby3-editor-app:latest` image and mounts the same `node_modules` / npm cache volumes used by `docker compose run app`. It bypasses the compose entrypoint (which checks for monorepo setup), so it starts faster than `docker compose run`:
+
+```bash
+bin/dx bash -c "cd packages/scratch-vm && npm run lint"
+bin/dx bash -c "cd packages/scratch-gui && npm exec jest test/unit/your-test.test.js"
+```
+
+`docker compose run` is still preferred when you need the full setup (port mapping, container reuse, etc.). Use `bin/dx` for one-shot commands where startup speed matters.
+
 ## Development Commands
 
 ### Installation

--- a/bin/dx
+++ b/bin/dx
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# bin/dx — run a one-shot command inside the smalruby3-editor-app docker image.
+#
+# Use this from any directory (worktree or main checkout) to invoke npm/lint/test
+# commands without rebuilding the docker image. The current directory is
+# bind-mounted to /app, and the same node_modules / npm cache volumes used by
+# `docker compose run app` are reused so dependencies don't need to be reinstalled.
+#
+# Usage:
+#   bin/dx bash -c "cd packages/scratch-gui && npm exec jest test/unit/foo.test.js"
+#   bin/dx bash -c "cd packages/scratch-vm && npm run lint"
+#
+# Customize the image with DX_IMAGE if needed:
+#   DX_IMAGE=smalruby3-editor-app:dev bin/dx bash -lc "..."
+#
+# This is a thin wrapper around `docker run`. If the image is missing, build it
+# via the normal flow first: `docker compose build app` from the main checkout.
+set -euo pipefail
+
+IMAGE="${DX_IMAGE:-smalruby3-editor-app:latest}"
+PROJECT="${DX_PROJECT:-smalruby3-editor}"
+
+if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+    echo "error: docker image '${IMAGE}' not found." >&2
+    echo "Build it first from the main checkout: docker compose build app" >&2
+    exit 1
+fi
+
+# Mount the same named volumes that docker compose uses for service `app`.
+# These persist node_modules and npm/playwright caches across invocations.
+exec docker run --rm \
+    -v "$(pwd):/app" \
+    -v "${PROJECT}_smalruby3-editor_node_modules:/app/node_modules" \
+    -v "${PROJECT}_smalruby3-editor_root_npm:/root/.npm" \
+    -v "${PROJECT}_smalruby3-editor_root_cache:/root/.cache" \
+    -w /app \
+    --shm-size=4gb \
+    --entrypoint "" \
+    "${IMAGE}" \
+    "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: smalruby3-editor
+
 services:
   app:
     build: .


### PR DESCRIPTION
## Summary

worktree でも main の Docker イメージ・volume をそのまま共有できるようにします。これにより、`docker compose run --rm app ...` を worktree から実行してもイメージの再ビルドが走らず即座に作業を開始できます。

Closes #559

## Changes

- `docker-compose.yml`: `name: smalruby3-editor` を追加して compose プロジェクト名を固定
- `bin/dx`: 既存の `smalruby3-editor-app:latest` イメージをエントリーポイントなしで直接実行する薄いラッパースクリプトを追加。compose と同じ named volume を明示的にマウントするので `node_modules` / npm cache が共有される
- `CLAUDE.md`: 新しい Docker セットアップの説明を Docker Environment セクションに追記

## Test plan

- [x] worktree から `docker compose run --rm app bash -c "ls /app/node_modules | wc -l && ls /app/built-monorepo"` を実行して、メインのイメージと volume が再利用されていることを確認（1542 packages, /app/built-monorepo 存在）
- [x] `bin/dx bash -c "cd /app/packages/scratch-vm && npm exec tap test/unit/extension_smalrubot_s1.js"` を worktree から実行して 29/29 tests pass を ~10 秒で確認
- [x] `bin/dx echo "OK"` で簡単な動作確認

## Notes

- `bin/dx` は entrypoint をスキップする — フルセットアップが必要な場合は通常通り `docker compose run --rm app ...` を使う
- `DX_IMAGE` / `DX_PROJECT` 環境変数で対象イメージとプロジェクトをカスタマイズ可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)
