### PR TITLE
fix(mesh-v2): バッチイベントの順序を orderKey で保証

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -12,6 +12,61 @@
   - `test/add-coverage` - for test additions
 - All Pull Requests must target `develop` branch
 
+## Git Worktree Setup
+
+Sibling worktrees (e.g. `~/work/smalruby/smalruby3-editor-<feature>/`) are
+recommended for parallel development. The compose project name is pinned to
+`smalruby3-editor`, so `docker compose run` and `bin/dx` from a worktree share
+the main checkout's image and `node_modules` named volume — no rebuild needed.
+
+### Creating a worktree
+
+```bash
+git worktree add ../smalruby3-editor-<feature> -b <type>/<branch-name> develop
+cd ../smalruby3-editor-<feature>
+bin/sync-worktree-env  # copy gitignored .env.* from main checkout
+```
+
+### What `bin/sync-worktree-env` does
+
+`git worktree add` does **not** copy gitignored files. The repo has these
+gitignored env files that are required for CDK deploy / webpack build / mesh
+v2 integration tests:
+
+- `.env` (root, used by webpack at build time)
+- `infra/smalruby-mesh-v2/.env.{stg,stg2,production}`
+- `infra/smalruby-rubytee-relay/.env.{stg,stg2,production}`
+- `infra/smalruby-classroom/.env.{stg,stg2,production}`
+
+The script also **symlinks `node_modules` from the main checkout** into the
+worktree if it is missing/empty. This is required because git worktrees start
+with empty `node_modules` on the host filesystem, but husky git hooks
+(`commit-msg` → `npx --no-install commitlint`) run on the host and need
+`node_modules/.bin` to be populated. (Docker named volumes are unaffected;
+the symlink is only for host-side tools.)
+
+The script is idempotent — running it twice is safe. Pass `--force` to
+overwrite existing env files. Do it once after creating the worktree, then
+set up the `.env` symlink for the stage you want to deploy:
+
+```bash
+(cd infra/smalruby-mesh-v2 && ln -sf .env.stg .env)
+```
+
+### When to re-sync
+
+If `.env.<stage>` is updated in the main checkout (rare, e.g. new env var
+added), re-run `bin/sync-worktree-env --force` in the worktree to pick up
+the change.
+
+### Cleaning up a worktree
+
+```bash
+cd <main-checkout>
+git worktree remove ../smalruby3-editor-<feature>
+git branch -d <type>/<branch-name>  # if branch is merged
+```
+
 ## Commit Message Format
 
 **Enforce Conventional Commits**. All commit messages must follow this format:

--- a/.claude/rules/scratch-vm/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-vm/smalruby-prettier-files.md
@@ -50,6 +50,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/mesh_service_v2_global_vars.js`
 - `test/unit/mesh_service_v2_integration.js`
 - `test/unit/mesh_service_v2_order.js`
+- `test/unit/mesh_service_v2_order_key.js`
 - `test/unit/mesh_service_v2_polling.js`
 - `test/unit/mesh_service_v2_subscription.js`
 - `test/unit/mesh_service_v2_timestamp.js`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ docker compose stop app
 
 The compose project name is pinned to `smalruby3-editor` (see `name:` at the top of `docker-compose.yml`), so `docker compose run` from a git worktree shares the same image and named volumes as the main checkout — no per-worktree rebuild needed.
 
+After `git worktree add`, run **`bin/sync-worktree-env`** once to copy the gitignored `.env.*` files (root + per-infra) from the main checkout. Without these, CDK deploys, webpack builds, and mesh v2 integration tests fail. See `.claude/rules/git-workflow.md` for full worktree workflow.
+
 ### Quick One-Shot Commands: `bin/dx`
 
 For quick lint or single-test invocations, `bin/dx` is a thin `docker run` wrapper that targets the prebuilt `smalruby3-editor-app:latest` image and mounts the same `node_modules` / npm cache volumes used by `docker compose run app`. It bypasses the compose entrypoint (which checks for monorepo setup), so it starts faster than `docker compose run`:

--- a/bin/sync-worktree-env
+++ b/bin/sync-worktree-env
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# bin/sync-worktree-env — copy gitignored .env.* files from the main checkout
+# into the current git worktree.
+#
+# Why: `git worktree add` does not copy gitignored files (.env, .env.stg, etc.)
+# because they are not tracked. CDK deploys, webpack builds, and integration
+# tests need these env files. This script copies them from the main checkout
+# in one step.
+#
+# What is copied:
+#   - <repo-root>/.env.<stage>      (root webpack env)
+#   - infra/<project>/.env.<stage>  (CDK per-stage env)
+# where <stage> ∈ {stg, stg2, production}. Symlinks (.env) and tracked files
+# (.env.example) are NOT copied — set up the .env symlink yourself.
+#
+# Usage (from inside the worktree):
+#   bin/sync-worktree-env
+#
+# Idempotent: existing files are not overwritten unless --force is given.
+set -euo pipefail
+
+FORCE=false
+if [[ "${1:-}" == "--force" || "${1:-}" == "-f" ]]; then
+    FORCE=true
+fi
+
+# In a worktree, `git rev-parse --git-common-dir` points to <main>/.git.
+# In the main checkout itself, it returns ".git".
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [[ -z "${GIT_COMMON_DIR}" ]]; then
+    echo "error: not inside a git repository" >&2
+    exit 1
+fi
+
+# Resolve absolute path of the main checkout's working tree
+# (parent of <main>/.git)
+GIT_COMMON_ABS=$(cd "${GIT_COMMON_DIR}" && pwd)
+MAIN_CHECKOUT=$(dirname "${GIT_COMMON_ABS}")
+WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+
+if [[ "${MAIN_CHECKOUT}" == "${WORKTREE_ROOT}" ]]; then
+    echo "info: current directory is the main checkout, nothing to sync."
+    exit 0
+fi
+
+# Files to consider: <relative-path> form. Each will be copied if it exists in
+# main checkout but not in worktree.
+declare -a FILES=(
+    ".env"
+    ".env.stg"
+    ".env.stg2"
+    ".env.production"
+    "infra/smalruby-mesh-v2/.env.stg"
+    "infra/smalruby-mesh-v2/.env.stg2"
+    "infra/smalruby-mesh-v2/.env.production"
+    "infra/smalruby-rubytee-relay/.env.stg"
+    "infra/smalruby-rubytee-relay/.env.stg2"
+    "infra/smalruby-rubytee-relay/.env.production"
+    "infra/smalruby-classroom/.env.stg"
+    "infra/smalruby-classroom/.env.stg2"
+    "infra/smalruby-classroom/.env.production"
+)
+
+copied=0
+skipped_existing=0
+skipped_missing=0
+for rel in "${FILES[@]}"; do
+    src="${MAIN_CHECKOUT}/${rel}"
+    dst="${WORKTREE_ROOT}/${rel}"
+
+    # Don't copy symlinks (.env is per-stage and stage choice is local)
+    if [[ -L "${src}" ]]; then
+        continue
+    fi
+    if [[ ! -f "${src}" ]]; then
+        skipped_missing=$((skipped_missing + 1))
+        continue
+    fi
+    if [[ -e "${dst}" && "${FORCE}" != "true" ]]; then
+        skipped_existing=$((skipped_existing + 1))
+        continue
+    fi
+    mkdir -p "$(dirname "${dst}")"
+    cp -p "${src}" "${dst}"
+    echo "copied: ${rel}"
+    copied=$((copied + 1))
+done
+
+echo ""
+echo "summary: ${copied} copied, ${skipped_existing} kept (already present), ${skipped_missing} not found in main"
+if [[ ${copied} -gt 0 ]]; then
+    echo "note: set up .env symlinks per stage as needed, e.g.:"
+    echo "  (cd infra/smalruby-mesh-v2 && ln -sf .env.stg .env)"
+fi
+
+# host 側 node_modules への symlink を作成。
+# 理由: husky の git hook (commit-msg → npx --no-install commitlint) が
+# host の node_modules/.bin を必要とするが、git worktree では空のため
+# commit が失敗する。docker のマウント (named volume) は影響しない。
+host_node_modules="${WORKTREE_ROOT}/node_modules"
+main_node_modules="${MAIN_CHECKOUT}/node_modules"
+if [[ ! -e "${host_node_modules}" ]] || [[ -d "${host_node_modules}" && -z "$(ls -A "${host_node_modules}" 2>/dev/null)" ]]; then
+    if [[ -d "${main_node_modules}" && -n "$(ls -A "${main_node_modules}" 2>/dev/null)" ]]; then
+        # 空ディレクトリがあれば削除してから symlink を貼る
+        if [[ -d "${host_node_modules}" ]]; then
+            rmdir "${host_node_modules}"
+        fi
+        ln -s "${main_node_modules}" "${host_node_modules}"
+        echo "linked: node_modules -> ${main_node_modules}"
+    else
+        echo "warn: main checkout has no node_modules. Run 'npm install' in main first."
+    fi
+fi

--- a/infra/smalruby-mesh-v2/docs/api-reference.md
+++ b/infra/smalruby-mesh-v2/docs/api-reference.md
@@ -67,8 +67,31 @@ type Event {
   payload: String
   timestamp: AWSDateTime!
   cursor: String           # NEW: ポーリング用のカーソル（SK）
+  orderKey: String         # NEW (issue #556): クライアント側ソートキー
 }
 ```
+
+##### `orderKey` フィールド (issue #556)
+
+クライアントが `EventInput.orderKey` を送信していたイベントの場合、サーバーは
+DynamoDB の Sort Key と属性に保存し、`Event.orderKey` で返却します。
+ポーリング (`getEventsSince`) や Subscription (`onMessageInGroup` の
+`batchEvent.events`) 経由で受信したクライアントは、同一タイムスタンプの
+イベントを `orderKey` の辞書順でソートすることで送信順を再現できます。
+
+旧クライアントが送信していない場合は `null` が返ります（後方互換）。
+
+##### `EventInput.orderKey` フォーマット
+
+クライアントから送信する場合のフォーマット: `<YYYYMMDDHHMMSS>-<NNNNNNN>`
+
+- `YYYYMMDDHHMMSS`: 14 桁のローカル時刻（人間可読、デバッグ用）
+- `NNNNNNN`: 7 桁 0 詰め連番。クライアントがグループ作成/参加直後に 0 リセット、`fireEvent()` 呼び出しごとに +1
+- 例: `20260428090000-0000001`, `20260428090000-9999999`
+
+**桁数の根拠**: 接続上限 35 分 × min batch interval 100ms × queue 100 件 = **2.1M 件**が理論最大スループット。7 桁 (max 9,999,999) で約 4.7x の余裕。3 桁では 1000 件目で `"1000" < "999"` 辞書順となり順序保証が破綻するため不可。
+
+**サーバー側の扱い**: サーバーは `orderKey` を opaque な文字列として保存します。`#` を含む値も受け付けますが、クライアント側で生成する場合は上記フォーマットに従ってください。同一バッチ内に同じ `orderKey` が複数あっても、SK 末尾の short UUID で一意性が確保されます。
 
 #### NodeStatus
 
@@ -281,6 +304,7 @@ query GetEventsSince($groupId: ID!, $domain: String!, $since: String!) {
     payload
     timestamp
     cursor
+    orderKey
   }
 }
 ```
@@ -288,7 +312,9 @@ query GetEventsSince($groupId: ID!, $domain: String!, $since: String!) {
 **パラメータ**:
 - `since: String!` - 前回の `nextSince` または最後に取得したイベントの `cursor` を指定します。
 
-**戻り値**: イベントの配列。最大 100 件まで取得されます。
+**戻り値**: イベントの配列。最大 100 件まで取得されます。100 件超の場合は最後のイベントの `cursor` を `since` に指定して再 query することでページングできます。
+
+**`orderKey` フィールド** (issue #556): クライアントが `EventInput.orderKey` を送信していたイベントのみ含まれます。受信側クライアントが同一タイムスタンプのイベントを送信順で並べる安定ソートに使用します。詳細は [EventInput](#eventinput) 参照。
 
 ## Mutations
 
@@ -441,6 +467,7 @@ mutation FireEventsByNode(
         firedByNodeId
         payload
         timestamp
+        orderKey   # NEW (issue #556)
       }
       firedByNodeId
       groupId
@@ -453,6 +480,8 @@ mutation FireEventsByNode(
 
 **戻り値**: `MeshMessage` — `batchEvent` フィールドにイベントデータが含まれます。この mutation は `onMessageInGroup` subscription をトリガーします。
 
+`EventInput.orderKey` を送信した場合は `batchEvent.events[].orderKey` でパススルーされ、subscription 受信側のクライアントが安定ソートに使えます (issue #556)。
+
 ### recordEventsByNode
 
 ノードが複数のイベントを一度に送信し、DynamoDB に保存します（ポーリング用）。
@@ -462,7 +491,7 @@ mutation RecordEventsByNode(
   $nodeId: ID!
   $groupId: ID!
   $domain: String!
-  $events: [EventInput!]!
+  $events: [EventInput!]!  # EventInput.orderKey で同一バッチ内の順序保証 (#556)
 ) {
   recordEventsByNode(
     nodeId: $nodeId
@@ -479,6 +508,8 @@ mutation RecordEventsByNode(
 ```
 
 **用途**: WebSocket が使用できない環境でのイベント送信に使用。この mutation は `onMessageInGroup` subscription を**トリガーしません**。
+
+**順序保証** (issue #556): 同一バッチ内のイベントは同じ `server_timestamp` で保存されるため、SK 末尾だけがランダム UUID だと取得時の順序が送信順と一致しません。クライアントは `EventInput.orderKey` (フォーマット: `<YYYYMMDDHHMMSS>-<NNNNNNN>`) を送信することで、SK = `EVENT#<server_timestamp>#<orderKey>#<short_uuid>` 形式で保存され、`getEventsSince` で送信順 = orderKey 辞書順で取得できます。詳細は [Event 型の orderKey](#orderkey-フィールド-issue-556)。
 
 ---
 

--- a/infra/smalruby-mesh-v2/docs/architecture.md
+++ b/infra/smalruby-mesh-v2/docs/architecture.md
@@ -397,26 +397,44 @@ Mesh v2 は Single Table Design を採用し、1つのテーブルにすべて�
 #### 4. イベント (Event)
 
 **PK**: `GROUP#{groupId}@{domain}`
-**SK**: `EVENT#{timestamp}#{eventId}`
+
+**SK** (issue #556 対応):
+- `orderKey` 付き: `EVENT#{server_timestamp}#{orderKey}#{short_uuid}`
+- `orderKey` なし (旧クライアント): `EVENT#{server_timestamp}#{uuid}`
 
 **属性**:
 ```json
 {
   "pk": "GROUP#abc123@192.168.1.1",
-  "sk": "EVENT#2026-01-01T12:00:00.123Z#evt-001",
+  "sk": "EVENT#2026-01-01T12:00:00Z#20260101120000-0000001#a1b2c3d4",
   "eventName": "button_clicked",
   "firedByNodeId": "node-001",
   "groupId": "abc123",
   "domain": "192.168.1.1",
   "payload": "{\"button\":\"A\"}",
-  "timestamp": "2026-01-01T12:00:00.123Z",
+  "timestamp": "2026-01-01T12:00:00Z",
+  "orderKey": "20260101120000-0000001",
   "ttl": 1704067210
 }
 ```
 
 **アクセスパターン**:
-- グループ内イベント一覧: `pk = GROUP#{groupId}@{domain} AND begins_with(sk, "EVENT#")`
-- 時系列イベント取得: Sort Key でソート
+- グループ内イベント以降取得: `pk = GROUP#{groupId}@{domain} AND sk > "EVENT#{since}"` (limit 100)
+- 時系列イベント取得: SK の昇順 (scanIndexForward: true)
+
+##### SK 構造と順序保証 (issue #556)
+
+DynamoDB BatchWriteItem は同一バッチを並列書き込みするため、UUID 末尾だけでは
+取得時に送信順が保証されない。クライアントが `EventInput.orderKey`
+(`<YYYYMMDDHHMMSS>-<NNNNNNN>` 形式) を送信すると、サーバーは SK に組み込み、
+同一 `server_timestamp` 内では `orderKey` の辞書順 = 送信順 でソート可能になる。
+
+`short_uuid` (8 文字) は異なるクライアントが偶然同じ `orderKey` を送ったときの
+一意性確保用。`orderKey` 自体に SK 区切り文字 `#` を含む値も DynamoDB query は
+文字列比較のみなので動作する (cursor 経由のページングも問題なし)。
+
+旧クライアント (`orderKey` 未送信) は従来通り `EVENT#{ts}#{uuid}` で保存され、
+`orderKey` 属性も保存されないため後方互換が保たれる。
 
 ---
 

--- a/infra/smalruby-mesh-v2/docs/operations.md
+++ b/infra/smalruby-mesh-v2/docs/operations.md
@@ -226,6 +226,40 @@ fields @message
 
 ---
 
+#### イベント順序の調査ログ (issue #556)
+
+ポーリングモード (`recordEventsByNode`) で同一バッチに複数イベントを送信
+すると、DynamoDB の `server_timestamp` が全イベントに同じ値で付与される。
+順序を保証するために、クライアントは `EventInput.orderKey`
+(`<YYYYMMDDHHMMSS>-<NNNNNNN>` 形式) を送信し、サーバーは SK に組み込む:
+
+```
+SK (orderKey 付き): EVENT#<server_timestamp>#<orderKey>#<short_uuid>
+SK (orderKey なし): EVENT#<server_timestamp>#<uuid>  ← 旧クライアント互換
+```
+
+イベント順序が想定外の場合、CloudWatch Logs に出る `RequestFunctionEvaluation`
+ログの `result.attributeValues.sk` から SK を確認できる:
+
+```
+fields @timestamp, @message
+| filter @message like /recordEventsByNode/ and @message like /attributeValues/
+| parse @message /"sk":\{"S":"(?<sk>EVENT#[^"]+)"/
+| display @timestamp, sk
+| sort @timestamp desc
+| limit 50
+```
+
+`SK` の 3 セグメント目が `<orderKey>` で送信順（クライアント側の連番昇順）
+であれば仕様通り。orderKey が `null` の場合は旧クライアント、または
+client 実装に問題がある可能性がある (issue #556 以前のクライアントは
+orderKey を送信しない)。
+
+`orderKey` の桁数仕様: `NNNNNNN` (7 桁、0 詰め)。35 分接続上限内で
+最大 9,999,999 まで対応 (理論最大スループット 2.1M events に対し約 4.7x 余裕)。
+
+---
+
 #### Lambda ログ
 
 **設定**: 自動的に有効化

--- a/infra/smalruby-mesh-v2/graphql/schema.graphql
+++ b/infra/smalruby-mesh-v2/graphql/schema.graphql
@@ -62,6 +62,7 @@ type Event {
   payload: String
   timestamp: AWSDateTime!
   cursor: String           # NEW: ポーリング用のカーソル（SK）
+  orderKey: String         # NEW: クライアント側ソートキー (issue #556)
 }
 
 # イベントのバッチ送信用の入力型
@@ -69,6 +70,10 @@ input EventInput {
   eventName: String!
   payload: String
   firedAt: AWSDateTime!  # イベント発火日時（ISO 8601形式、ミリ秒含む）
+  # NEW (issue #556): クライアント側で生成する optional ソートキー
+  # フォーマット: "<YYYYMMDDHHMMSS>-<NNN>" (NNN はクライアント接続後の連番)
+  # 同一サーバータイムスタンプでバッチ書き込みされたイベントの送信順序を保証
+  orderKey: String
 }
 
 # バッチイベント型（複数イベントを含む）

--- a/infra/smalruby-mesh-v2/graphql/schema.graphql
+++ b/infra/smalruby-mesh-v2/graphql/schema.graphql
@@ -71,8 +71,11 @@ input EventInput {
   payload: String
   firedAt: AWSDateTime!  # イベント発火日時（ISO 8601形式、ミリ秒含む）
   # NEW (issue #556): クライアント側で生成する optional ソートキー
-  # フォーマット: "<YYYYMMDDHHMMSS>-<NNN>" (NNN はクライアント接続後の連番)
-  # 同一サーバータイムスタンプでバッチ書き込みされたイベントの送信順序を保証
+  # フォーマット: "<YYYYMMDDHHMMSS>-<NNNNNNN>" (NNNNNNN は接続後 7 桁 0 詰め連番)
+  # 同一サーバータイムスタンプでバッチ書き込みされたイベントの送信順序を保証。
+  # 7 桁の根拠: 接続上限 35 分 × min batch interval 100ms × queue 100 件 = 2.1M
+  # 件が理論最大。9,999,999 で約 4.7x 余裕。3 桁だと 1000 件目で破綻
+  # ("1000" < "999" の辞書順)
   orderKey: String
 }
 

--- a/infra/smalruby-mesh-v2/js/resolvers/Mutation.fireEventsByNode.js
+++ b/infra/smalruby-mesh-v2/js/resolvers/Mutation.fireEventsByNode.js
@@ -37,7 +37,9 @@ export function response(ctx) {
                 groupId: groupId,
                 domain: domain,
                 payload: event.payload || null,
-                timestamp: event.firedAt
+                timestamp: event.firedAt,
+                // issue #556: orderKey をパススルー (subscription 受信側で安定ソート用)
+                orderKey: event.orderKey || null
             })),
             firedByNodeId: nodeId,
             groupId: groupId,

--- a/infra/smalruby-mesh-v2/js/resolvers/Query.getEventsSince.js
+++ b/infra/smalruby-mesh-v2/js/resolvers/Query.getEventsSince.js
@@ -33,6 +33,7 @@ export function response(ctx) {
     domain: item.domain,
     payload: item.payload,
     timestamp: item.timestamp,
-    cursor: item.sk
+    cursor: item.sk,
+    orderKey: item.orderKey || null
   }));
 }

--- a/infra/smalruby-mesh-v2/lambda/repositories/dynamodb_repository.rb
+++ b/infra/smalruby-mesh-v2/lambda/repositories/dynamodb_repository.rb
@@ -203,23 +203,35 @@ class DynamoDBRepository
     # 最大25アイテムまで
     events.each_slice(25) do |slice|
       put_requests = slice.map do |event|
-        sk = "EVENT##{server_timestamp}##{SecureRandom.uuid}"
+        # SK 設計 (issue #556):
+        # - orderKey 付き:    EVENT#<server_timestamp>#<orderKey>#<short_uuid>
+        #   同一 server_timestamp 内のイベントを orderKey の辞書順で並べる。
+        #   orderKey はクライアント時刻 + 連番なので、同一クライアントが連続送信
+        #   した複数イベントの順序が保証される。
+        #   short_uuid は異なるクライアントが偶然同じ orderKey を送った場合の
+        #   一意性確保用。
+        # - orderKey なし:   EVENT#<server_timestamp>#<uuid> (旧クライアント互換)
+        order_key = event["orderKey"]
+        sk = if order_key && !order_key.empty?
+          "EVENT##{server_timestamp}##{order_key}##{SecureRandom.uuid[0, 8]}"
+        else
+          "EVENT##{server_timestamp}##{SecureRandom.uuid}"
+        end
         last_sk = sk
-        {
-          put_request: {
-            item: {
-              "pk" => "GROUP##{group_id}@#{domain}",
-              "sk" => sk,
-              "eventName" => event["eventName"],
-              "firedByNodeId" => node_id,
-              "groupId" => group_id,
-              "domain" => domain,
-              "payload" => event["payload"],
-              "timestamp" => server_timestamp,
-              "ttl" => ttl
-            }
-          }
+        item = {
+          "pk" => "GROUP##{group_id}@#{domain}",
+          "sk" => sk,
+          "eventName" => event["eventName"],
+          "firedByNodeId" => node_id,
+          "groupId" => group_id,
+          "domain" => domain,
+          "payload" => event["payload"],
+          "timestamp" => server_timestamp,
+          "ttl" => ttl
         }
+        # orderKey が来ていたら属性として保存し、レスポンスでクライアントへ返す
+        item["orderKey"] = order_key if order_key && !order_key.empty?
+        {put_request: {item: item}}
       end
 
       @dynamodb.batch_write_item(

--- a/infra/smalruby-mesh-v2/spec/fixtures/mutations/record_events_by_node.graphql
+++ b/infra/smalruby-mesh-v2/spec/fixtures/mutations/record_events_by_node.graphql
@@ -1,0 +1,18 @@
+mutation RecordEventsByNode(
+  $groupId: ID!
+  $domain: String!
+  $nodeId: ID!
+  $events: [EventInput!]!
+) {
+  recordEventsByNode(
+    groupId: $groupId
+    domain: $domain
+    nodeId: $nodeId
+    events: $events
+  ) {
+    groupId
+    domain
+    recordedCount
+    nextSince
+  }
+}

--- a/infra/smalruby-mesh-v2/spec/fixtures/queries/get_events_since.graphql
+++ b/infra/smalruby-mesh-v2/spec/fixtures/queries/get_events_since.graphql
@@ -1,0 +1,12 @@
+query GetEventsSince($groupId: ID!, $domain: String!, $since: String!) {
+  getEventsSince(groupId: $groupId, domain: $domain, since: $since) {
+    name
+    firedByNodeId
+    groupId
+    domain
+    payload
+    timestamp
+    cursor
+    orderKey
+  }
+}

--- a/infra/smalruby-mesh-v2/spec/requests/event_order_key_spec.rb
+++ b/infra/smalruby-mesh-v2/spec/requests/event_order_key_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "Event ordering with orderKey", type: :request do
   describe "recordEventsByNode mutation with orderKey" do
     it "orderKey を付けて送信した複数イベントが送信順で取得できる" do
       events = [
-        {eventName: "first",  payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
+        {eventName: "first", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
         {eventName: "second", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-002"},
-        {eventName: "third",  payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-003"}
+        {eventName: "third", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-003"}
       ]
 
       record_response = execute_graphql(record_events_query, {
@@ -85,7 +85,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
 
     it "新旧クライアント混在（orderKey あり/なし）のイベントを記録できる" do
       events = [
-        {eventName: "with_key",    payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
+        {eventName: "with_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
         {eventName: "without_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z"}
       ]
 
@@ -112,6 +112,244 @@ RSpec.describe "Event ordering with orderKey", type: :request do
       without_key = retrieved.find { |e| e["name"] == "without_key" }
       expect(with_key["orderKey"]).to eq("20260428090000-001")
       expect(without_key["orderKey"]).to be_nil
+    end
+  end
+
+  describe "corner cases" do
+    # コーナーケース 1: 26 件以上のバッチ
+    # record_events.rb は each_slice(25) で BatchWriteItem を分割する。
+    # 分割境界で SK の orderKey 部分が辞書順を保つことを確認。
+    it "26+ events split across BatchWriteItem boundaries preserve send order" do
+      total = 30
+      events = (1..total).map do |i|
+        {
+          eventName: "evt#{format("%02d", i)}",
+          payload: nil,
+          firedAt: "2026-04-28T00:00:00.000Z",
+          orderKey: "20260428090000-#{format("%03d", i)}"
+        }
+      end
+
+      record_response = execute_graphql(record_events_query, {
+        groupId: group_id, domain: domain, nodeId: node_id, events: events
+      })
+      expect(record_response["errors"]).to be_nil
+      expect(record_response["data"]["recordEventsByNode"]["recordedCount"]).to eq(total)
+
+      sleep 0.5
+      events_response = execute_graphql(get_events_since_query, {
+        groupId: group_id, domain: domain, since: ""
+      })
+      expect(events_response["errors"]).to be_nil
+      retrieved = events_response["data"]["getEventsSince"]
+      # getEventsSince の limit:100 以下なので一度で取得可能
+      expect(retrieved.size).to eq(total)
+      expected_names = (1..total).map { |i| "evt#{format("%02d", i)}" }
+      expect(retrieved.map { |e| e["name"] }).to eq(expected_names)
+    end
+
+    # コーナーケース 2: getEventsSince ページング
+    # query は limit:100 を指定。100 件超のイベントを記録して、cursor で
+    # 複数回呼び出しても全件取得・順序保持できることを確認。
+    it "events beyond limit:100 are retrievable via cursor pagination in correct order" do
+      total = 150
+      events = (1..total).map do |i|
+        {
+          eventName: "evt#{format("%03d", i)}",
+          payload: nil,
+          firedAt: "2026-04-28T00:00:00.000Z",
+          orderKey: "20260428090000-#{format("%03d", i)}"
+        }
+      end
+
+      record_response = execute_graphql(record_events_query, {
+        groupId: group_id, domain: domain, nodeId: node_id, events: events
+      })
+      expect(record_response["errors"]).to be_nil
+      expect(record_response["data"]["recordEventsByNode"]["recordedCount"]).to eq(total)
+
+      sleep 0.5
+      # 1 ページ目: 最大 100 件
+      page1 = execute_graphql(get_events_since_query, {
+        groupId: group_id, domain: domain, since: ""
+      })["data"]["getEventsSince"]
+      expect(page1.size).to eq(100)
+
+      # 2 ページ目: cursor で続きを取得
+      page2 = execute_graphql(get_events_since_query, {
+        groupId: group_id, domain: domain, since: page1.last["cursor"]
+      })["data"]["getEventsSince"]
+      expect(page2.size).to eq(50)
+
+      # 結合して全件・送信順を確認
+      combined_names = (page1 + page2).map { |e| e["name"] }
+      expected_names = (1..total).map { |i| "evt#{format("%03d", i)}" }
+      expect(combined_names).to eq(expected_names)
+    end
+
+    # コーナーケース 3: orderKey に SK 区切り文字 '#' を含む
+    # SK は EVENT#<ts>#<orderKey>#<short_uuid> 形式。orderKey に '#' が含まれると
+    # SK のセグメント数が変わるが、DynamoDB query は文字列比較のみなのでクラッシュ
+    # しない。orderKey 属性も元の値が保たれる。
+    it "orderKey containing '#' separator does not break SK parsing or cursor pagination" do
+      events = [
+        {
+          eventName: "with_hash",
+          payload: nil,
+          firedAt: "2026-04-28T00:00:00.000Z",
+          orderKey: "20260428090000-001#injected"
+        }
+      ]
+
+      record_response = execute_graphql(record_events_query, {
+        groupId: group_id, domain: domain, nodeId: node_id, events: events
+      })
+      expect(record_response["errors"]).to be_nil
+      expect(record_response["data"]["recordEventsByNode"]["recordedCount"]).to eq(1)
+
+      sleep 0.5
+      events_response = execute_graphql(get_events_since_query, {
+        groupId: group_id, domain: domain, since: ""
+      })
+      expect(events_response["errors"]).to be_nil
+      retrieved = events_response["data"]["getEventsSince"]
+      expect(retrieved.size).to eq(1)
+      expect(retrieved[0]["name"]).to eq("with_hash")
+      # orderKey 属性は元の値そのまま（SK の '#' 分割では破壊されない）
+      expect(retrieved[0]["orderKey"]).to eq("20260428090000-001#injected")
+
+      # cursor で再 query しても crash しない
+      page2 = execute_graphql(get_events_since_query, {
+        groupId: group_id, domain: domain, since: retrieved[0]["cursor"]
+      })["data"]["getEventsSince"]
+      expect(page2).to eq([])
+    end
+
+    # コーナーケース 4: 複数ノードの並行送信
+    # 異なる nodeId が同時に recordEventsByNode を呼び出す。各ノードの送信順は
+    # 保持される (per-client orderKey が単調増加なので)。ノード間順序は
+    # server_timestamp 依存で interleave しうる。
+    it "events from multiple nodes preserve per-client send order" do
+      node_a = "node-a-#{timestamp}"
+      node_b = "node-b-#{timestamp}"
+      join_test_node(group_id, domain, node_a)
+      join_test_node(group_id, domain, node_b)
+
+      events_a = (1..3).map do |i|
+        {
+          eventName: "a#{i}",
+          payload: nil,
+          firedAt: "2026-04-28T00:00:00.000Z",
+          orderKey: "20260428090000-#{format("%03d", i)}"
+        }
+      end
+      # 同じ orderKey 連番だが nodeId が異なる。SK の short_uuid suffix で
+      # 一意性が確保される
+      events_b = (1..3).map do |i|
+        {
+          eventName: "b#{i}",
+          payload: nil,
+          firedAt: "2026-04-28T00:00:00.000Z",
+          orderKey: "20260428090000-#{format("%03d", i)}"
+        }
+      end
+
+      threads = [
+        Thread.new {
+          execute_graphql(record_events_query, {
+            groupId: group_id, domain: domain, nodeId: node_a, events: events_a
+          })
+        },
+        Thread.new {
+          execute_graphql(record_events_query, {
+            groupId: group_id, domain: domain, nodeId: node_b, events: events_b
+          })
+        }
+      ]
+      threads.each(&:join)
+
+      sleep 1
+      events_response = execute_graphql(get_events_since_query, {
+        groupId: group_id, domain: domain, since: ""
+      })
+      retrieved = events_response["data"]["getEventsSince"]
+      expect(retrieved.size).to eq(6)
+
+      # 各ノード内の順序が保たれる
+      a_events = retrieved.select { |e| e["name"].start_with?("a") }.map { |e| e["name"] }
+      b_events = retrieved.select { |e| e["name"].start_with?("b") }.map { |e| e["name"] }
+      expect(a_events).to eq(%w[a1 a2 a3])
+      expect(b_events).to eq(%w[b1 b2 b3])
+    end
+
+    # コーナーケース 5: WebSocket subscription 経由の orderKey
+    # fireEventsByNode (WebSocket モード時) のレスポンスは subscription
+    # ペイロードと同じ。batchEvent.events に orderKey が含まれることで、
+    # 受信側のクライアントが安定ソートに使える。
+    it "fireEventsByNode passes orderKey through batchEvent (subscription payload)" do
+      ws_domain = "ws-#{domain}"
+      ws_group = create_test_group(
+        "WS Group", "host-ws-#{timestamp}", ws_domain, use_websocket: true
+      )
+      ws_group_id = ws_group["id"]
+      ws_node_id = "ws-node-#{timestamp}"
+      join_test_node(ws_group_id, ws_domain, ws_node_id)
+
+      fire_events_query = <<~GRAPHQL
+        mutation FireEventsByNode($groupId: ID!, $domain: String!, $nodeId: ID!, $events: [EventInput!]!) {
+          fireEventsByNode(groupId: $groupId, domain: $domain, nodeId: $nodeId, events: $events) {
+            groupId
+            domain
+            batchEvent {
+              events {
+                name
+                orderKey
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      events = [
+        {eventName: "ws_evt1", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
+        {eventName: "ws_evt2", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-002"}
+      ]
+      response = execute_graphql(fire_events_query, {
+        groupId: ws_group_id, domain: ws_domain, nodeId: ws_node_id, events: events
+      })
+      expect(response["errors"]).to be_nil
+      retrieved = response["data"]["fireEventsByNode"]["batchEvent"]["events"]
+      expect(retrieved.map { |e| e["name"] }).to eq(%w[ws_evt1 ws_evt2])
+      expect(retrieved.map { |e| e["orderKey"] }).to eq(%w[20260428090000-001 20260428090000-002])
+    end
+
+    # コーナーケース 6: orderKey の時刻部分が巻き戻る (NTP ずれ等)
+    # クライアント時計が前後しても、SK は orderKey の辞書順で並ぶ。
+    # つまり「送信順」ではなく「orderKey 順」で取得される、という制限の確認。
+    # この挙動は仕様上のトレードオフ（送信順を厳密に追うには別途
+    # シーケンス番号のみで構成する選択肢もあるが、人間可読性とのバランスで
+    # 時刻+連番を採用）。
+    it "documents orderKey lexicographic order beats actual send order on clock skew" do
+      # 後で送ったが orderKey の時刻部分は早い (NTP 巻き戻し)
+      events = [
+        {eventName: "later_send", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090005-001"},
+        {eventName: "earlier_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-002"}
+      ]
+
+      record_response = execute_graphql(record_events_query, {
+        groupId: group_id, domain: domain, nodeId: node_id, events: events
+      })
+      expect(record_response["errors"]).to be_nil
+
+      sleep 0.5
+      events_response = execute_graphql(get_events_since_query, {
+        groupId: group_id, domain: domain, since: ""
+      })
+      retrieved = events_response["data"]["getEventsSince"]
+
+      # SK ソート = orderKey 辞書順。送信順 (later_send → earlier_key) ではなく
+      # orderKey 順 (earlier_key → later_send) で並ぶ。
+      expect(retrieved.map { |e| e["name"] }).to eq(%w[earlier_key later_send])
     end
   end
 end

--- a/infra/smalruby-mesh-v2/spec/requests/event_order_key_spec.rb
+++ b/infra/smalruby-mesh-v2/spec/requests/event_order_key_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "Event ordering with orderKey", type: :request do
   describe "recordEventsByNode mutation with orderKey" do
     it "orderKey を付けて送信した複数イベントが送信順で取得できる" do
       events = [
-        {eventName: "first", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
-        {eventName: "second", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-002"},
-        {eventName: "third", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-003"}
+        {eventName: "first", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-0000001"},
+        {eventName: "second", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-0000002"},
+        {eventName: "third", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-0000003"}
       ]
 
       record_response = execute_graphql(record_events_query, {
@@ -53,7 +53,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
 
       # orderKey がレスポンスに含まれる
       order_keys = retrieved.map { |e| e["orderKey"] }
-      expect(order_keys).to eq(%w[20260428090000-001 20260428090000-002 20260428090000-003])
+      expect(order_keys).to eq(%w[20260428090000-0000001 20260428090000-0000002 20260428090000-0000003])
     end
 
     it "orderKey を省略しても録画でき、orderKey は null で返る（後方互換）" do
@@ -85,7 +85,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
 
     it "新旧クライアント混在（orderKey あり/なし）のイベントを記録できる" do
       events = [
-        {eventName: "with_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
+        {eventName: "with_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-0000001"},
         {eventName: "without_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z"}
       ]
 
@@ -110,7 +110,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
 
       with_key = retrieved.find { |e| e["name"] == "with_key" }
       without_key = retrieved.find { |e| e["name"] == "without_key" }
-      expect(with_key["orderKey"]).to eq("20260428090000-001")
+      expect(with_key["orderKey"]).to eq("20260428090000-0000001")
       expect(without_key["orderKey"]).to be_nil
     end
   end
@@ -126,7 +126,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
           eventName: "evt#{format("%02d", i)}",
           payload: nil,
           firedAt: "2026-04-28T00:00:00.000Z",
-          orderKey: "20260428090000-#{format("%03d", i)}"
+          orderKey: "20260428090000-#{format("%07d", i)}"
         }
       end
 
@@ -155,10 +155,10 @@ RSpec.describe "Event ordering with orderKey", type: :request do
       total = 150
       events = (1..total).map do |i|
         {
-          eventName: "evt#{format("%03d", i)}",
+          eventName: "evt#{format("%07d", i)}",
           payload: nil,
           firedAt: "2026-04-28T00:00:00.000Z",
-          orderKey: "20260428090000-#{format("%03d", i)}"
+          orderKey: "20260428090000-#{format("%07d", i)}"
         }
       end
 
@@ -183,7 +183,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
 
       # 結合して全件・送信順を確認
       combined_names = (page1 + page2).map { |e| e["name"] }
-      expected_names = (1..total).map { |i| "evt#{format("%03d", i)}" }
+      expected_names = (1..total).map { |i| "evt#{format("%07d", i)}" }
       expect(combined_names).to eq(expected_names)
     end
 
@@ -197,7 +197,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
           eventName: "with_hash",
           payload: nil,
           firedAt: "2026-04-28T00:00:00.000Z",
-          orderKey: "20260428090000-001#injected"
+          orderKey: "20260428090000-0000001#injected"
         }
       ]
 
@@ -216,7 +216,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
       expect(retrieved.size).to eq(1)
       expect(retrieved[0]["name"]).to eq("with_hash")
       # orderKey 属性は元の値そのまま（SK の '#' 分割では破壊されない）
-      expect(retrieved[0]["orderKey"]).to eq("20260428090000-001#injected")
+      expect(retrieved[0]["orderKey"]).to eq("20260428090000-0000001#injected")
 
       # cursor で再 query しても crash しない
       page2 = execute_graphql(get_events_since_query, {
@@ -240,7 +240,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
           eventName: "a#{i}",
           payload: nil,
           firedAt: "2026-04-28T00:00:00.000Z",
-          orderKey: "20260428090000-#{format("%03d", i)}"
+          orderKey: "20260428090000-#{format("%07d", i)}"
         }
       end
       # 同じ orderKey 連番だが nodeId が異なる。SK の short_uuid suffix で
@@ -250,7 +250,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
           eventName: "b#{i}",
           payload: nil,
           firedAt: "2026-04-28T00:00:00.000Z",
-          orderKey: "20260428090000-#{format("%03d", i)}"
+          orderKey: "20260428090000-#{format("%07d", i)}"
         }
       end
 
@@ -311,8 +311,8 @@ RSpec.describe "Event ordering with orderKey", type: :request do
       GRAPHQL
 
       events = [
-        {eventName: "ws_evt1", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
-        {eventName: "ws_evt2", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-002"}
+        {eventName: "ws_evt1", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-0000001"},
+        {eventName: "ws_evt2", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-0000002"}
       ]
       response = execute_graphql(fire_events_query, {
         groupId: ws_group_id, domain: ws_domain, nodeId: ws_node_id, events: events
@@ -320,7 +320,7 @@ RSpec.describe "Event ordering with orderKey", type: :request do
       expect(response["errors"]).to be_nil
       retrieved = response["data"]["fireEventsByNode"]["batchEvent"]["events"]
       expect(retrieved.map { |e| e["name"] }).to eq(%w[ws_evt1 ws_evt2])
-      expect(retrieved.map { |e| e["orderKey"] }).to eq(%w[20260428090000-001 20260428090000-002])
+      expect(retrieved.map { |e| e["orderKey"] }).to eq(%w[20260428090000-0000001 20260428090000-0000002])
     end
 
     # コーナーケース 6: orderKey の時刻部分が巻き戻る (NTP ずれ等)
@@ -332,8 +332,8 @@ RSpec.describe "Event ordering with orderKey", type: :request do
     it "documents orderKey lexicographic order beats actual send order on clock skew" do
       # 後で送ったが orderKey の時刻部分は早い (NTP 巻き戻し)
       events = [
-        {eventName: "later_send", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090005-001"},
-        {eventName: "earlier_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-002"}
+        {eventName: "later_send", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090005-0000001"},
+        {eventName: "earlier_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-0000002"}
       ]
 
       record_response = execute_graphql(record_events_query, {

--- a/infra/smalruby-mesh-v2/spec/requests/event_order_key_spec.rb
+++ b/infra/smalruby-mesh-v2/spec/requests/event_order_key_spec.rb
@@ -1,0 +1,117 @@
+require "spec_helper"
+
+# issue #556: orderKey によるバッチイベント順序保証の integration test。
+RSpec.describe "Event ordering with orderKey", type: :request do
+  let(:timestamp) { (Time.now.to_f * 1000).to_i }
+  let(:domain) { "test-event-order-#{timestamp}.example.com" }
+  let(:host_id) { "host-event-order-#{timestamp}" }
+  let(:node_id) { "node-event-order-#{timestamp}" }
+  let(:group) { create_test_group("Event Order Test Group", host_id, domain, use_websocket: false) }
+  let(:group_id) { group["id"] }
+
+  let(:record_events_query) {
+    File.read(File.join(__dir__, "../fixtures/mutations/record_events_by_node.graphql"))
+  }
+  let(:get_events_since_query) {
+    File.read(File.join(__dir__, "../fixtures/queries/get_events_since.graphql"))
+  }
+
+  before do
+    # メンバーノードを参加させてからイベントを送信
+    join_test_node(group_id, domain, node_id)
+  end
+
+  describe "recordEventsByNode mutation with orderKey" do
+    it "orderKey を付けて送信した複数イベントが送信順で取得できる" do
+      events = [
+        {eventName: "first",  payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
+        {eventName: "second", payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-002"},
+        {eventName: "third",  payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-003"}
+      ]
+
+      record_response = execute_graphql(record_events_query, {
+        groupId: group_id,
+        domain: domain,
+        nodeId: node_id,
+        events: events
+      })
+      expect(record_response["errors"]).to be_nil
+      expect(record_response["data"]["recordEventsByNode"]["recordedCount"]).to eq(3)
+
+      # 取得して送信順と一致するか確認
+      sleep 0.5  # DynamoDB の書き込み伝播待ち（GSI ではなくメインテーブル参照だが念のため）
+      events_response = execute_graphql(get_events_since_query, {
+        groupId: group_id,
+        domain: domain,
+        since: ""
+      })
+      expect(events_response["errors"]).to be_nil
+      retrieved = events_response["data"]["getEventsSince"]
+
+      names = retrieved.map { |e| e["name"] }
+      expect(names).to eq(%w[first second third])
+
+      # orderKey がレスポンスに含まれる
+      order_keys = retrieved.map { |e| e["orderKey"] }
+      expect(order_keys).to eq(%w[20260428090000-001 20260428090000-002 20260428090000-003])
+    end
+
+    it "orderKey を省略しても録画でき、orderKey は null で返る（後方互換）" do
+      events = [
+        {eventName: "legacy1", payload: nil, firedAt: "2026-04-28T00:00:00.000Z"},
+        {eventName: "legacy2", payload: nil, firedAt: "2026-04-28T00:00:00.000Z"}
+      ]
+
+      record_response = execute_graphql(record_events_query, {
+        groupId: group_id,
+        domain: domain,
+        nodeId: node_id,
+        events: events
+      })
+      expect(record_response["errors"]).to be_nil
+      expect(record_response["data"]["recordEventsByNode"]["recordedCount"]).to eq(2)
+
+      sleep 0.5
+      events_response = execute_graphql(get_events_since_query, {
+        groupId: group_id,
+        domain: domain,
+        since: ""
+      })
+      expect(events_response["errors"]).to be_nil
+      retrieved = events_response["data"]["getEventsSince"]
+      expect(retrieved.size).to eq(2)
+      expect(retrieved.map { |e| e["orderKey"] }).to all(be_nil)
+    end
+
+    it "新旧クライアント混在（orderKey あり/なし）のイベントを記録できる" do
+      events = [
+        {eventName: "with_key",    payload: nil, firedAt: "2026-04-28T00:00:00.000Z", orderKey: "20260428090000-001"},
+        {eventName: "without_key", payload: nil, firedAt: "2026-04-28T00:00:00.000Z"}
+      ]
+
+      record_response = execute_graphql(record_events_query, {
+        groupId: group_id,
+        domain: domain,
+        nodeId: node_id,
+        events: events
+      })
+      expect(record_response["errors"]).to be_nil
+      expect(record_response["data"]["recordEventsByNode"]["recordedCount"]).to eq(2)
+
+      sleep 0.5
+      events_response = execute_graphql(get_events_since_query, {
+        groupId: group_id,
+        domain: domain,
+        since: ""
+      })
+      expect(events_response["errors"]).to be_nil
+      retrieved = events_response["data"]["getEventsSince"]
+      expect(retrieved.size).to eq(2)
+
+      with_key = retrieved.find { |e| e["name"] == "with_key" }
+      without_key = retrieved.find { |e| e["name"] == "without_key" }
+      expect(with_key["orderKey"]).to eq("20260428090000-001")
+      expect(without_key["orderKey"]).to be_nil
+    end
+  end
+end

--- a/infra/smalruby-mesh-v2/spec/unit/repositories/dynamodb_repository_record_events_spec.rb
+++ b/infra/smalruby-mesh-v2/spec/unit/repositories/dynamodb_repository_record_events_spec.rb
@@ -20,26 +20,26 @@ RSpec.describe DynamoDBRepository, "#record_events" do
   context "orderKey が指定されている場合" do
     it "SK に EVENT#<server_timestamp>#<orderKey>#<short_uuid> 形式を使う" do
       events = [
-        {"eventName" => "e1", "payload" => nil, "orderKey" => "20260428090000-001"}
+        {"eventName" => "e1", "payload" => nil, "orderKey" => "20260428090000-0000001"}
       ]
 
       expect(dynamodb_client).to receive(:batch_write_item) do |args|
         put = args[:request_items][table_name].first[:put_request][:item]
-        expect(put["sk"]).to match(/\AEVENT#[^#]+#20260428090000-001#[a-f0-9]{8}\z/)
-        expect(put["orderKey"]).to eq("20260428090000-001")
+        expect(put["sk"]).to match(/\AEVENT#[^#]+#20260428090000-0000001#[a-f0-9]{8}\z/)
+        expect(put["orderKey"]).to eq("20260428090000-0000001")
       end
 
       result = repository.record_events(group_id, domain, node_id, events, 10)
       expect(result[:success]).to eq(true)
       expect(result[:recordedCount]).to eq(1)
-      expect(result[:last_sk]).to match(/\AEVENT#[^#]+#20260428090000-001#[a-f0-9]{8}\z/)
+      expect(result[:last_sk]).to match(/\AEVENT#[^#]+#20260428090000-0000001#[a-f0-9]{8}\z/)
     end
 
     it "同一バッチで送られた異なる orderKey のイベントは orderKey 部分の辞書順で並ぶ SK になる" do
       events = [
-        {"eventName" => "first", "payload" => nil, "orderKey" => "20260428090000-001"},
-        {"eventName" => "second", "payload" => nil, "orderKey" => "20260428090000-002"},
-        {"eventName" => "third", "payload" => nil, "orderKey" => "20260428090000-003"}
+        {"eventName" => "first", "payload" => nil, "orderKey" => "20260428090000-0000001"},
+        {"eventName" => "second", "payload" => nil, "orderKey" => "20260428090000-0000002"},
+        {"eventName" => "third", "payload" => nil, "orderKey" => "20260428090000-0000003"}
       ]
       captured = []
       expect(dynamodb_client).to receive(:batch_write_item) do |args|
@@ -84,7 +84,7 @@ RSpec.describe DynamoDBRepository, "#record_events" do
   context "orderKey 付きと未指定が混在する場合（新旧クライアント混在）" do
     it "それぞれ適切な SK 形式で保存される" do
       events = [
-        {"eventName" => "new", "payload" => nil, "orderKey" => "20260428090000-001"},
+        {"eventName" => "new", "payload" => nil, "orderKey" => "20260428090000-0000001"},
         {"eventName" => "old", "payload" => nil}
       ]
       captured = []
@@ -94,7 +94,7 @@ RSpec.describe DynamoDBRepository, "#record_events" do
 
       repository.record_events(group_id, domain, node_id, events, 10)
 
-      expect(captured[0]["sk"]).to include("#20260428090000-001#")
+      expect(captured[0]["sk"]).to include("#20260428090000-0000001#")
       expect(captured[0]).to have_key("orderKey")
       expect(captured[1]["sk"]).to match(/\A.*#[a-f0-9]{8}-[a-f0-9]{4}-/)
       expect(captured[1]).not_to have_key("orderKey")

--- a/infra/smalruby-mesh-v2/spec/unit/repositories/dynamodb_repository_record_events_spec.rb
+++ b/infra/smalruby-mesh-v2/spec/unit/repositories/dynamodb_repository_record_events_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lambda/repositories/dynamodb_repository"
+
+# issue #556: orderKey 対応を含む record_events の挙動を検証する。
+RSpec.describe DynamoDBRepository, "#record_events" do
+  let(:dynamodb_client) { double("DynamoDBClient") }
+  let(:table_name) { "MeshV2Table-test" }
+  let(:repository) { described_class.new(dynamodb_client, table_name) }
+  let(:group_id) { "g-1" }
+  let(:domain) { "d-1" }
+  let(:node_id) { "n-1" }
+
+  before do
+    # find_group は記録時に直接呼ばれないが、固定して念のため許可しておく
+    allow(dynamodb_client).to receive(:batch_write_item)
+  end
+
+  context "orderKey が指定されている場合" do
+    it "SK に EVENT#<server_timestamp>#<orderKey>#<short_uuid> 形式を使う" do
+      events = [
+        {"eventName" => "e1", "payload" => nil, "orderKey" => "20260428090000-001"}
+      ]
+
+      expect(dynamodb_client).to receive(:batch_write_item) do |args|
+        put = args[:request_items][table_name].first[:put_request][:item]
+        expect(put["sk"]).to match(/\AEVENT#[^#]+#20260428090000-001#[a-f0-9]{8}\z/)
+        expect(put["orderKey"]).to eq("20260428090000-001")
+      end
+
+      result = repository.record_events(group_id, domain, node_id, events, 10)
+      expect(result[:success]).to eq(true)
+      expect(result[:recordedCount]).to eq(1)
+      expect(result[:last_sk]).to match(/\AEVENT#[^#]+#20260428090000-001#[a-f0-9]{8}\z/)
+    end
+
+    it "同一バッチで送られた異なる orderKey のイベントは orderKey 部分の辞書順で並ぶ SK になる" do
+      events = [
+        {"eventName" => "first", "payload" => nil, "orderKey" => "20260428090000-001"},
+        {"eventName" => "second", "payload" => nil, "orderKey" => "20260428090000-002"},
+        {"eventName" => "third", "payload" => nil, "orderKey" => "20260428090000-003"}
+      ]
+      captured = []
+      expect(dynamodb_client).to receive(:batch_write_item) do |args|
+        captured = args[:request_items][table_name].map { |r| r[:put_request][:item] }
+      end
+
+      repository.record_events(group_id, domain, node_id, events, 10)
+      sks = captured.map { |i| i["sk"] }
+      # 同一 server_timestamp 配下では orderKey の辞書順 = 送信順
+      expect(sks.sort).to eq(sks)
+      expect(captured.map { |i| i["eventName"] }).to eq(%w[first second third])
+    end
+  end
+
+  context "orderKey が未指定（旧クライアント）の場合" do
+    it "SK は EVENT#<server_timestamp>#<uuid> 形式（後方互換）" do
+      events = [{"eventName" => "legacy", "payload" => nil}]
+
+      expect(dynamodb_client).to receive(:batch_write_item) do |args|
+        put = args[:request_items][table_name].first[:put_request][:item]
+        # UUID v4 形式（8-4-4-4-12）
+        expect(put["sk"]).to match(/\AEVENT#[^#]+#[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\z/)
+        expect(put).not_to have_key("orderKey")
+      end
+
+      repository.record_events(group_id, domain, node_id, events, 10)
+    end
+
+    it "orderKey が空文字でも uuid 形式にフォールバックする" do
+      events = [{"eventName" => "empty", "payload" => nil, "orderKey" => ""}]
+
+      expect(dynamodb_client).to receive(:batch_write_item) do |args|
+        put = args[:request_items][table_name].first[:put_request][:item]
+        expect(put["sk"]).to match(/\AEVENT#[^#]+#[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\z/)
+        expect(put).not_to have_key("orderKey")
+      end
+
+      repository.record_events(group_id, domain, node_id, events, 10)
+    end
+  end
+
+  context "orderKey 付きと未指定が混在する場合（新旧クライアント混在）" do
+    it "それぞれ適切な SK 形式で保存される" do
+      events = [
+        {"eventName" => "new", "payload" => nil, "orderKey" => "20260428090000-001"},
+        {"eventName" => "old", "payload" => nil}
+      ]
+      captured = []
+      expect(dynamodb_client).to receive(:batch_write_item) do |args|
+        captured = args[:request_items][table_name].map { |r| r[:put_request][:item] }
+      end
+
+      repository.record_events(group_id, domain, node_id, events, 10)
+
+      expect(captured[0]["sk"]).to include("#20260428090000-001#")
+      expect(captured[0]).to have_key("orderKey")
+      expect(captured[1]["sk"]).to match(/\A.*#[a-f0-9]{8}-[a-f0-9]{4}-/)
+      expect(captured[1]).not_to have_key("orderKey")
+    end
+  end
+end

--- a/packages/scratch-vm/.prettierignore
+++ b/packages/scratch-vm/.prettierignore
@@ -84,6 +84,7 @@ test/unit/*
 !test/unit/mesh_service_v2_global_vars.js
 !test/unit/mesh_service_v2_integration.js
 !test/unit/mesh_service_v2_order.js
+!test/unit/mesh_service_v2_order_key.js
 !test/unit/mesh_service_v2_polling.js
 !test/unit/mesh_service_v2_subscription.js
 !test/unit/mesh_service_v2_timestamp.js

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/gql-operations.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/gql-operations.js
@@ -136,6 +136,7 @@ const FIRE_EVENTS = gql`
           domain
           payload
           timestamp
+          orderKey
         }
         firedByNodeId
         groupId
@@ -169,6 +170,7 @@ const GET_EVENTS_SINCE = gql`
       payload
       timestamp
       cursor
+      orderKey
     }
   }
 `;
@@ -196,6 +198,7 @@ const ON_MESSAGE_IN_GROUP = gql`
           domain
           payload
           timestamp
+          orderKey
         }
         firedByNodeId
         groupId

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -1294,12 +1294,20 @@ class MeshV2Service {
 
     /**
      * Generate a sortable order key for an event.
-     * Format: `<YYYYMMDDHHMMSS>-<NNN>` where NNN is a 0-padded sequence
-     * counter incremented per call (resets on group create/join).
+     * Format: `<YYYYMMDDHHMMSS>-<NNNNNNN>` where NNNNNNN is a 7-digit
+     * 0-padded sequence counter incremented per call (resets on group
+     * create/join).
      *
      * Same client guarantees lexicographic order = send order across batches.
      * Cross-client collisions are possible but extremely unlikely; the server
      * appends a short UUID to the SK to ensure uniqueness.
+     *
+     * Why 7 digits: connection cap is 35 min = 2100s. Worst-case throughput
+     * is bounded by MAX_EVENT_QUEUE_SIZE (100) draining every
+     * eventBatchInterval (min 100ms) → 1000 events/s max → ~2.1M per
+     * session. 7 digits (max 9,999,999) gives ~4.7x margin even at the
+     * minimum interval. 3 digits would overflow at the 1000th event,
+     * silently breaking lexicographic order ("1000" < "999").
      * @param {Date} firedAt - The event fire time.
      * @returns {string} Sortable order key.
      * @private
@@ -1312,7 +1320,7 @@ class MeshV2Service {
         const mi = String(firedAt.getMinutes()).padStart(2, '0');
         const ss = String(firedAt.getSeconds()).padStart(2, '0');
         this.eventSequence += 1;
-        const seq = String(this.eventSequence).padStart(3, '0');
+        const seq = String(this.eventSequence).padStart(7, '0');
         return `${yyyy}${mm}${dd}${hh}${mi}${ss}-${seq}`;
     }
 

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -134,6 +134,11 @@ class MeshV2Service {
             lastReportTime: Date.now()
         };
 
+        // issue #556: orderKey 生成用のシーケンスカウンタ。
+        // グループ接続後の連番。`<YYYYMMDDHHMMSS>-<NNN>` 形式を構成する NNN 部分。
+        // createGroup / joinGroup で 0 にリセット。
+        this.eventSequence = 0;
+
         // Last sent data to detect changes (confirmed by server)
         this.lastSentData = {};
         // Latest data queued for sending (may not be confirmed yet)
@@ -375,6 +380,8 @@ class MeshV2Service {
 
             this.costTracking.mutationCount++;
             this.lastFetchTime = new Date().toISOString();
+            // issue #556: orderKey の連番をリセット
+            this.eventSequence = 0;
             debug(() => `Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before createGroup)`);
             const result = await this.client.mutate({
                 mutation: CREATE_GROUP,
@@ -481,6 +488,8 @@ class MeshV2Service {
 
             this.costTracking.mutationCount++;
             this.lastFetchTime = new Date().toISOString();
+            // issue #556: orderKey の連番をリセット
+            this.eventSequence = 0;
             debug(() => `Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before joinGroup)`);
             const result = await this.client.mutate({
                 mutation: JOIN_GROUP,
@@ -810,8 +819,18 @@ class MeshV2Service {
     _queueEventsForPlayback (events) {
         if (!events || events.length === 0) return;
 
-        // タイムスタンプでソート（副作用を避けるためコピーを作成）
-        const sortedEvents = [...events].sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+        // タイムスタンプでソート（副作用を避けるためコピーを作成）。
+        // issue #556: 同一タイムスタンプ内では orderKey の辞書順で安定ソートする。
+        // どちらか一方でも orderKey がない場合は元の順序を維持（タイムスタンプ比較のみ）。
+        const sortedEvents = [...events].sort((a, b) => {
+            const tDiff = new Date(a.timestamp) - new Date(b.timestamp);
+            if (tDiff !== 0) return tDiff;
+            if (a.orderKey && b.orderKey) {
+                if (a.orderKey < b.orderKey) return -1;
+                if (a.orderKey > b.orderKey) return 1;
+            }
+            return 0;
+        });
 
         // 最初のイベントを基準にオフセットを計算
         const baseTime = new Date(sortedEvents[0].timestamp).getTime();
@@ -1262,12 +1281,39 @@ class MeshV2Service {
         debug(() => `Mesh V2: Queuing event for sending: ${eventName} ` +
             `(queue size: ${this.eventQueue.length})`);
 
-        // キューに追加（発火日時を記録）
+        // キューに追加（発火日時と orderKey を記録）
+        const firedAt = new Date();
         this.eventQueue.push({
             eventName: eventName,
             payload: payload,
-            firedAt: new Date().toISOString()
+            firedAt: firedAt.toISOString(),
+            // issue #556: 同一バッチ内のイベント順序保証用
+            orderKey: this._generateOrderKey(firedAt)
         });
+    }
+
+    /**
+     * Generate a sortable order key for an event.
+     * Format: `<YYYYMMDDHHMMSS>-<NNN>` where NNN is a 0-padded sequence
+     * counter incremented per call (resets on group create/join).
+     *
+     * Same client guarantees lexicographic order = send order across batches.
+     * Cross-client collisions are possible but extremely unlikely; the server
+     * appends a short UUID to the SK to ensure uniqueness.
+     * @param {Date} firedAt - The event fire time.
+     * @returns {string} Sortable order key.
+     * @private
+     */
+    _generateOrderKey (firedAt) {
+        const yyyy = firedAt.getFullYear().toString();
+        const mm = String(firedAt.getMonth() + 1).padStart(2, '0');
+        const dd = String(firedAt.getDate()).padStart(2, '0');
+        const hh = String(firedAt.getHours()).padStart(2, '0');
+        const mi = String(firedAt.getMinutes()).padStart(2, '0');
+        const ss = String(firedAt.getSeconds()).padStart(2, '0');
+        this.eventSequence += 1;
+        const seq = String(this.eventSequence).padStart(3, '0');
+        return `${yyyy}${mm}${dd}${hh}${mi}${ss}-${seq}`;
     }
 
     /**

--- a/packages/scratch-vm/test/unit/mesh_service_v2_order_key.js
+++ b/packages/scratch-vm/test/unit/mesh_service_v2_order_key.js
@@ -22,7 +22,7 @@ const createMockBlocks = () => ({
 });
 
 test('MeshV2Service orderKey generation (issue #556)', t => {
-    t.test('_generateOrderKey produces YYYYMMDDHHMMSS-NNN format', st => {
+    t.test('_generateOrderKey produces YYYYMMDDHHMMSS-NNNNNNN format', st => {
         const blocks = createMockBlocks();
         const service = new MeshV2Service(blocks, 'node1', 'domain1');
         service.eventSequence = 0;
@@ -30,9 +30,9 @@ test('MeshV2Service orderKey generation (issue #556)', t => {
         const date = new Date('2026-04-28T09:00:00');
         const key = service._generateOrderKey(date);
 
-        // Local-time interpretation: format must be 14 digits + - + 3 digits
-        st.match(key, /^\d{14}-\d{3}$/, 'matches YYYYMMDDHHMMSS-NNN');
-        st.equal(key.endsWith('-001'), true, 'starts at sequence 001');
+        // Local-time interpretation: format must be 14 digits + - + 7 digits
+        st.match(key, /^\d{14}-\d{7}$/, 'matches YYYYMMDDHHMMSS-NNNNNNN');
+        st.equal(key.endsWith('-0000001'), true, 'starts at sequence 0000001');
         st.end();
     });
 
@@ -46,9 +46,9 @@ test('MeshV2Service orderKey generation (issue #556)', t => {
         const k2 = service._generateOrderKey(date);
         const k3 = service._generateOrderKey(date);
 
-        st.equal(k1.split('-')[1], '001');
-        st.equal(k2.split('-')[1], '002');
-        st.equal(k3.split('-')[1], '003');
+        st.equal(k1.split('-')[1], '0000001');
+        st.equal(k2.split('-')[1], '0000002');
+        st.equal(k3.split('-')[1], '0000003');
         // Lexicographic sort matches generation order
         st.same([...[k3, k1, k2]].sort(), [k1, k2, k3]);
         st.end();
@@ -62,8 +62,8 @@ test('MeshV2Service orderKey generation (issue #556)', t => {
         const k1 = service._generateOrderKey(new Date('2026-04-28T09:00:00'));
         const k2 = service._generateOrderKey(new Date('2026-04-28T09:00:01'));
 
-        st.equal(k1.split('-')[1], '001');
-        st.equal(k2.split('-')[1], '002');
+        st.equal(k1.split('-')[1], '0000001');
+        st.equal(k2.split('-')[1], '0000002');
         st.end();
     });
 
@@ -77,9 +77,30 @@ test('MeshV2Service orderKey generation (issue #556)', t => {
         service.fireEvent('hello', '');
         st.equal(service.eventQueue.length, 1);
         const queued = service.eventQueue[0];
-        st.match(queued.orderKey, /^\d{14}-001$/);
+        st.match(queued.orderKey, /^\d{14}-0000001$/);
         st.equal(queued.eventName, 'hello');
         st.ok(queued.firedAt);
+        st.end();
+    });
+
+    t.test('eventSequence above 999 keeps lexicographic order (no overflow)', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.eventSequence = 998; // next call → 999, then 1000
+
+        const date = new Date('2026-04-28T09:00:00');
+        const k999 = service._generateOrderKey(date);
+        const k1000 = service._generateOrderKey(date);
+        const k9999999 = (() => {
+            service.eventSequence = 9999998;
+            return service._generateOrderKey(date);
+        })();
+
+        st.equal(k999.split('-')[1], '0000999');
+        st.equal(k1000.split('-')[1], '0001000');
+        st.equal(k9999999.split('-')[1], '9999999');
+        // 7-digit padding keeps lexicographic order across the 999→1000 boundary
+        st.ok(k999 < k1000, '0000999 < 0001000 in lex order');
         st.end();
     });
 

--- a/packages/scratch-vm/test/unit/mesh_service_v2_order_key.js
+++ b/packages/scratch-vm/test/unit/mesh_service_v2_order_key.js
@@ -1,0 +1,239 @@
+const test = require('tap').test;
+const minilog = require('minilog');
+// Suppress debug and info logs during tests
+minilog.suggest.deny('vm', 'debug');
+minilog.suggest.deny('vm', 'info');
+
+const MeshV2Service = require('../../src/extensions/scratch3_mesh_v2/mesh-service');
+
+const createMockBlocks = () => ({
+    runtime: {
+        sequencer: {},
+        emit: () => {},
+        on: () => {},
+        off: () => {},
+        getTargetForStage: () => ({
+            variables: {},
+        }),
+    },
+    opcodeFunctions: {
+        event_broadcast: () => {},
+    },
+});
+
+test('MeshV2Service orderKey generation (issue #556)', t => {
+    t.test('_generateOrderKey produces YYYYMMDDHHMMSS-NNN format', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.eventSequence = 0;
+
+        const date = new Date('2026-04-28T09:00:00');
+        const key = service._generateOrderKey(date);
+
+        // Local-time interpretation: format must be 14 digits + - + 3 digits
+        st.match(key, /^\d{14}-\d{3}$/, 'matches YYYYMMDDHHMMSS-NNN');
+        st.equal(key.endsWith('-001'), true, 'starts at sequence 001');
+        st.end();
+    });
+
+    t.test('eventSequence increments per call within the same second', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.eventSequence = 0;
+
+        const date = new Date('2026-04-28T09:00:00');
+        const k1 = service._generateOrderKey(date);
+        const k2 = service._generateOrderKey(date);
+        const k3 = service._generateOrderKey(date);
+
+        st.equal(k1.split('-')[1], '001');
+        st.equal(k2.split('-')[1], '002');
+        st.equal(k3.split('-')[1], '003');
+        // Lexicographic sort matches generation order
+        st.same([...[k3, k1, k2]].sort(), [k1, k2, k3]);
+        st.end();
+    });
+
+    t.test('sequence does not reset across seconds (continues monotonically)', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.eventSequence = 0;
+
+        const k1 = service._generateOrderKey(new Date('2026-04-28T09:00:00'));
+        const k2 = service._generateOrderKey(new Date('2026-04-28T09:00:01'));
+
+        st.equal(k1.split('-')[1], '001');
+        st.equal(k2.split('-')[1], '002');
+        st.end();
+    });
+
+    t.test('fireEvent attaches orderKey to queued event', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.groupId = 'group1';
+        service.client = { mutate: () => Promise.resolve({ data: {} }) };
+        service.eventSequence = 0;
+
+        service.fireEvent('hello', '');
+        st.equal(service.eventQueue.length, 1);
+        const queued = service.eventQueue[0];
+        st.match(queued.orderKey, /^\d{14}-001$/);
+        st.equal(queued.eventName, 'hello');
+        st.ok(queued.firedAt);
+        st.end();
+    });
+
+    t.test('createGroup resets eventSequence to 0', async st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.eventSequence = 5;
+        service.testWebSocket = () => Promise.resolve(true);
+        service.client = {
+            mutate: () =>
+                Promise.resolve({
+                    data: {
+                        createGroup: {
+                            id: 'g1',
+                            domain: 'domain1',
+                            name: 'G1',
+                            expiresAt: '2099-01-01T00:00:00Z',
+                            heartbeatIntervalSeconds: 60,
+                            useWebSocket: true,
+                            pollingIntervalSeconds: null,
+                        },
+                    },
+                }),
+            subscribe: () => ({ subscribe: () => ({ unsubscribe: () => {} }) }),
+        };
+
+        await service.createGroup('G1');
+        st.equal(service.eventSequence, 0, 'sequence reset on createGroup');
+        service.cleanup();
+        st.end();
+    });
+
+    t.test('joinGroup resets eventSequence to 0', async st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+        service.eventSequence = 7;
+        service.client = {
+            mutate: () =>
+                Promise.resolve({
+                    data: {
+                        joinGroup: {
+                            id: 'node1',
+                            name: 'Node node1',
+                            groupId: 'g1',
+                            domain: 'd1',
+                            expiresAt: '2099-01-01T00:00:00Z',
+                            heartbeatIntervalSeconds: 120,
+                            useWebSocket: true,
+                            pollingIntervalSeconds: null,
+                        },
+                    },
+                }),
+            query: () => Promise.resolve({ data: { listGroupStatuses: [] } }),
+            subscribe: () => ({ subscribe: () => ({ unsubscribe: () => {} }) }),
+        };
+
+        await service.joinGroup('g1', 'd1', 'G1');
+        st.equal(service.eventSequence, 0, 'sequence reset on joinGroup');
+        service.cleanup();
+        st.end();
+    });
+
+    t.end();
+});
+
+test('MeshV2Service _queueEventsForPlayback stable sort (issue #556)', t => {
+    t.test('events with same timestamp are ordered by orderKey', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
+        // Server returns events in arbitrary order (e.g. UUID-shuffled)
+        // but same timestamp; orderKey should restore send order.
+        const events = [
+            { name: 'b', timestamp: '2026-04-28T00:00:00Z', orderKey: '20260428090000-002', firedByNodeId: 'other' },
+            { name: 'c', timestamp: '2026-04-28T00:00:00Z', orderKey: '20260428090000-003', firedByNodeId: 'other' },
+            { name: 'a', timestamp: '2026-04-28T00:00:00Z', orderKey: '20260428090000-001', firedByNodeId: 'other' },
+        ];
+        service._queueEventsForPlayback(events);
+        const order = service.pendingBroadcasts.map(b => b.event.name);
+        st.same(order, ['a', 'b', 'c']);
+        st.end();
+    });
+
+    t.test('events with different timestamps sort by timestamp first', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
+        const events = [
+            {
+                name: 'late',
+                timestamp: '2026-04-28T00:00:02Z',
+                orderKey: '20260428090002-001',
+                firedByNodeId: 'other',
+            },
+            {
+                name: 'early',
+                timestamp: '2026-04-28T00:00:00Z',
+                orderKey: '20260428090000-099',
+                firedByNodeId: 'other',
+            },
+            {
+                name: 'middle',
+                timestamp: '2026-04-28T00:00:01Z',
+                orderKey: '20260428090001-001',
+                firedByNodeId: 'other',
+            },
+        ];
+        service._queueEventsForPlayback(events);
+        const order = service.pendingBroadcasts.map(b => b.event.name);
+        st.same(order, ['early', 'middle', 'late']);
+        st.end();
+    });
+
+    t.test('events without orderKey use timestamp-only comparison (backward compat)', st => {
+        const blocks = createMockBlocks();
+        const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
+        // Old-client events (no orderKey) with same timestamp:
+        // sort is stable in V8 so original input order is preserved.
+        const events = [
+            { name: 'first', timestamp: '2026-04-28T00:00:00Z', firedByNodeId: 'other' },
+            { name: 'second', timestamp: '2026-04-28T00:00:00Z', firedByNodeId: 'other' },
+            { name: 'third', timestamp: '2026-04-28T00:00:00Z', firedByNodeId: 'other' },
+        ];
+        service._queueEventsForPlayback(events);
+        const order = service.pendingBroadcasts.map(b => b.event.name);
+        st.same(order, ['first', 'second', 'third']);
+        st.end();
+    });
+
+    t.test(
+        'mix of orderKey present and absent: orderKey-having pairs sort, others fall back to original order',
+        st => {
+            const blocks = createMockBlocks();
+            const service = new MeshV2Service(blocks, 'node1', 'domain1');
+
+            // When sort comparator returns 0 (one side missing orderKey), V8's
+            // stable sort keeps the input order. So if input is [no-key, key]
+            // with the same timestamp, output = [no-key, key].
+            const events = [
+                { name: 'no-key', timestamp: '2026-04-28T00:00:00Z', firedByNodeId: 'other' },
+                {
+                    name: 'with-key',
+                    timestamp: '2026-04-28T00:00:00Z',
+                    orderKey: '20260428090000-001',
+                    firedByNodeId: 'other',
+                },
+            ];
+            service._queueEventsForPlayback(events);
+            const order = service.pendingBroadcasts.map(b => b.event.name);
+            st.same(order, ['no-key', 'with-key']);
+            st.end();
+        },
+    );
+
+    t.end();
+});


### PR DESCRIPTION
## Summary

ポーリングモード (HTTPS フォールバック) で複数イベントが同一バッチで送信された場合、受信側での順序が保証されない問題を修正する (Issue #556)。

`EventInput` に optional フィールド `orderKey` を追加し、クライアントが `<YYYYMMDDHHMMSS>-<NNN>` 形式の連番をイベントごとに付与。サーバーは SK に `orderKey` を組み込み、同一サーバータイムスタンプ内でも送信順を保証する。

## Changes

### サーバー (infra/smalruby-mesh-v2)

| ファイル | 変更 |
|---------|------|
| `graphql/schema.graphql` | `EventInput` / `Event` 型に optional `orderKey: String` を追加 |
| `lambda/repositories/dynamodb_repository.rb` | `orderKey` あり: SK = `EVENT#<ts>#<orderKey>#<short_uuid>`, なし: 従来通り `EVENT#<ts>#<uuid>` (後方互換)。`orderKey` 属性も保存 |
| `js/resolvers/Query.getEventsSince.js` | レスポンスに `orderKey` を含める |
| `js/resolvers/Mutation.fireEventsByNode.js` | `orderKey` をパススルー (subscription 受信側でソート用) |

### クライアント (packages/scratch-vm)

| ファイル | 変更 |
|---------|------|
| `src/extensions/scratch3_mesh_v2/mesh-service.js` | `eventSequence` カウンタ (createGroup/joinGroup でリセット)、`_generateOrderKey()`、`fireEvent()` で orderKey 付与、`_queueEventsForPlayback()` の安定ソート |
| `src/extensions/scratch3_mesh_v2/gql-operations.js` | `FIRE_EVENTS` / `GET_EVENTS_SINCE` / `ON_MESSAGE_IN_GROUP` のレスポンスに `orderKey` を追加 |

### テスト

| ファイル | 件数 |
|---------|------|
| `infra/smalruby-mesh-v2/spec/unit/repositories/dynamodb_repository_record_events_spec.rb` | 5 ケース (orderKey あり/なし/混在) |
| `infra/smalruby-mesh-v2/spec/requests/event_order_key_spec.rb` | 3 ケース (stg integration) |
| `packages/scratch-vm/test/unit/mesh_service_v2_order_key.js` | 10 ケース (生成、リセット、安定ソート) |

### worktree 開発の改善 (別 commit)

`bin/sync-worktree-env` を追加。git worktree で作業を始める際に必要な gitignored ファイル (.env.*) のコピーと、host 側 node_modules への symlink を 1 コマンドで実行する (husky の commit-msg hook を有効化)。詳細は `.claude/rules/git-workflow.md`。

## SK フォーマット比較

```
# 旧 (orderKey なし、現状の問題):
EVENT#2026-04-28T00:00:00+00:00#a1b2c3d4-e5f6-...
EVENT#2026-04-28T00:00:00+00:00#f7e8d9c0-b1a2-...
                                ↑ UUID ランダムで順序不定

# 新 (orderKey あり):
EVENT#2026-04-28T00:00:00+00:00#20260428090000-001#a1b2c3d4
EVENT#2026-04-28T00:00:00+00:00#20260428090000-002#f7e8d9c0
                                ↑ orderKey 辞書順 = 送信順
```

## 後方互換性

| コンポーネント | 互換性 |
|---------------|-------|
| `EventInput.orderKey` | optional → 旧クライアントは送信しない、サーバーは UUID にフォールバック |
| `Event.orderKey` | optional → 旧クライアントは無視 |
| `record_events.rb` SK | `orderKey` 未指定 / 空文字 → 従来の UUID フォーマットを維持 |
| `_queueEventsForPlayback` | `orderKey` なしイベントは V8 stable sort で元の順序維持 |
| WebSocket モード | `orderKey` は `Event` 型でパススルー |

## stg 検証結果

- `cdk deploy` 成功 (70.19s)
- RSpec ユニットテスト全パス (38/38)
- integration test 3/3 パス (`spec/requests/event_order_key_spec.rb`)
  - orderKey 付き 3 イベントが送信順 (`first → second → third`) で取得できることを確認
  - 旧クライアント形式 (orderKey 省略) で `orderKey: null` 返却を確認
  - 新旧混在パターンを確認
- scratch-vm ユニットテスト 20/20 パス、関連既存テスト 146/146 リグレッションなし
- scratch-vm lint パス

## Test Plan

- [x] RSpec unit (38/38)
- [x] RSpec integration (3/3 on stg)
- [x] scratch-vm unit (20 new + 146 related, all pass)
- [x] scratch-vm lint
- [x] stg deploy
- [ ] CI 全チェック
- [ ] prod deploy (マージ後)

## Related Issues

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
