### PR TITLE
refactor(mesh-v2): fetchAllNodesData で handleDataUpdate を再利用

### DIFF
--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -1385,23 +1385,9 @@ class MeshV2Service {
 
             const nodeStatuses = result.data.listGroupStatuses;
 
-            // Update remoteData
-            nodeStatuses.forEach(status => {
-                if (status.nodeId === this.meshId) return;
-
-                if (!this.remoteData[status.nodeId]) {
-                    this.remoteData[status.nodeId] = {};
-                }
-                const serverTimestamp = status.timestamp ?
-                    new Date(status.timestamp).getTime() :
-                    (log.warn('Mesh V2: Missing server timestamp, using client time'), Date.now());
-                status.data.forEach(item => {
-                    this.remoteData[status.nodeId][item.key] = {
-                        value: item.value,
-                        timestamp: serverTimestamp
-                    };
-                });
-            });
+            // Reuse handleDataUpdate so polling/subscription/periodic-sync
+            // share a single ingestion path.
+            nodeStatuses.forEach(status => this.handleDataUpdate(status));
 
             debug(() => `Mesh V2: Fetched data from ${nodeStatuses.length} nodes`);
         } catch (error) {


### PR DESCRIPTION
## Summary

`fetchAllNodesData` (WebSocket モードの 15 秒周期データ同期) が持っていたノードステータス→`remoteData` 書き込みロジックを `handleDataUpdate` の呼び出しに置き換えるリファクタリング。

これでノードステータスの取り込みパスは以下の 3 経路すべてが `handleDataUpdate` 1 箇所に集約される:

1. WebSocket subscription 受信 (line 687)
2. Polling モードの `pollEvents` → `pollGroupData` (line 775)
3. WebSocket モードの `fetchAllNodesData` (今回統一)

## 背景

`/ultrareview` 相当のレビューで `mesh-service.js` 内の重複として検出。
issue #554 で polling 側を `handleDataUpdate` に統一した際に WebSocket 側も統一すべきだったが見落としていた。

## Changes

- `fetchAllNodesData` の inline 処理 (15 行) を `nodeStatuses.forEach(status => this.handleDataUpdate(status))` に置換
- `mesh-service.js`: 1493 → 1479 行 (-14)

## 挙動の差分

`handleDataUpdate` には `!nodeStatus` (null/undefined) ガードがあるが、inline 版にはなかった。null チェックが追加されるだけなので **より安全側**。それ以外のロジック (self skip / remoteData の lazy init / serverTimestamp フォールバック / data の forEach 書き込み) は完全に同一。

## Test Coverage

- `npm run lint` ✅
- `mesh_service_v2*.js` ユニットテスト 114/114 pass
- `mesh-v2-data-merge.test.js` / `mesh-v2-variable-sync.test.js` integration 19/19 pass

## Related

- 元の重複: issue #554 PR (#564) 後のコードレビューで発見
- 別途、`mesh-service.js` (1479 行) の責務分割は #566 で別管理