### PR TITLE
fix(smalruby_ruby): array.each で list 要素が正しくイテレートされない + hash.each 新規実装

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -21,33 +21,49 @@ the main checkout's image and `node_modules` named volume — no rebuild needed.
 
 ### Creating a worktree
 
+**推奨**: `bin/setup-worktree` を一度実行するだけで、env ファイルのコピー、
+node_modules のセットアップ、ワークスペースパッケージのビルドまで一括で
+完了する。
+
 ```bash
 git worktree add ../smalruby3-editor-<feature> -b <type>/<branch-name> develop
 cd ../smalruby3-editor-<feature>
-bin/sync-worktree-env  # copy gitignored .env.* from main checkout
+bin/setup-worktree   # all-in-one setup: env + node_modules + dist/
 ```
 
-### What `bin/sync-worktree-env` does
+**最小限のセットアップだけしたい場合**（lint だけ走らせたい、テストは
+動かさないなど）は `bin/sync-worktree-env` を直接呼んでも良い。
 
-`git worktree add` does **not** copy gitignored files. The repo has these
-gitignored env files that are required for CDK deploy / webpack build / mesh
-v2 integration tests:
+### Why setup is required beyond `git worktree add`
 
-- `.env` (root, used by webpack at build time)
-- `infra/smalruby-mesh-v2/.env.{stg,stg2,production}`
-- `infra/smalruby-rubytee-relay/.env.{stg,stg2,production}`
-- `infra/smalruby-classroom/.env.{stg,stg2,production}`
+`git worktree add` は **gitignore された / build artifact なファイルを
+コピーしない**。以下が手動で必要になる:
 
-The script also **symlinks `node_modules` from the main checkout** into the
-worktree if it is missing/empty. This is required because git worktrees start
-with empty `node_modules` on the host filesystem, but husky git hooks
-(`commit-msg` → `npx --no-install commitlint`) run on the host and need
-`node_modules/.bin` to be populated. (Docker named volumes are unaffected;
-the symlink is only for host-side tools.)
+| 何が無い | 必要になる場面 | 解決方法 |
+|---------|-------------|---------|
+| `.env`, `infra/*/.env.*` | webpack build / CDK deploy / mesh v2 integration test | `bin/sync-worktree-env` |
+| host 側 `node_modules` symlink | husky の commit-msg hook（`npx --no-install commitlint`） | `bin/sync-worktree-env` |
+| `packages/*/node_modules` (per-package) | jest の workspace 依存解決（例: `scratch-blocks` は scratch-gui の local node_modules にある） | `npm install`（docker 経由） |
+| `packages/scratch-vm/dist/`, `packages/scratch-svg-renderer/dist/`, `packages/scratch-render/dist/` | jest が `@smalruby/scratch-vm` 等の bare package import を解決するときに `package.json` の `"main"` / `"exports"` が指す `dist/...` を読む | `npm run build:dev`（docker 経由） |
 
-The script is idempotent — running it twice is safe. Pass `--force` to
-overwrite existing env files. Do it once after creating the worktree, then
-set up the `.env` symlink for the stage you want to deploy:
+`bin/setup-worktree` は上記 4 ステップを順に実行する。
+
+### What `bin/sync-worktree-env` does (低レベル)
+
+`bin/sync-worktree-env` だけを使う場合は以下のみ実行される:
+
+- 以下の gitignored env ファイルを main checkout からコピー:
+  - `.env` (root, used by webpack at build time)
+  - `infra/smalruby-mesh-v2/.env.{stg,stg2,production}`
+  - `infra/smalruby-rubytee-relay/.env.{stg,stg2,production}`
+  - `infra/smalruby-classroom/.env.{stg,stg2,production}`
+- worktree の host 側 `node_modules` を main checkout のものに symlink
+  （host 側 husky hook が `node_modules/.bin` を必要とするため。docker named
+  volume には影響しない）
+
+idempotent — 何度実行しても安全。`--force` で既存ファイルを上書き。
+
+`.env` symlink（stage 切り替え用）は手動で:
 
 ```bash
 (cd infra/smalruby-mesh-v2 && ln -sf .env.stg .env)
@@ -55,9 +71,11 @@ set up the `.env` symlink for the stage you want to deploy:
 
 ### When to re-sync
 
-If `.env.<stage>` is updated in the main checkout (rare, e.g. new env var
-added), re-run `bin/sync-worktree-env --force` in the worktree to pick up
-the change.
+- `.env.<stage>` が main checkout で更新された場合（稀、新しい env var が
+  追加されたなど）: `bin/sync-worktree-env --force` を再実行
+- npm の依存が変わった場合: `docker compose run --rm app npm install` を実行
+- workspace package のソースが変わって他 package のテストが影響を受ける場合:
+  `docker compose run --rm app npm run build:dev` で `dist/` を更新
 
 ### Cleaning up a worktree
 

--- a/.claude/rules/scratch-vm/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-vm/smalruby-prettier-files.md
@@ -46,6 +46,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/extension_mesh_v2_service.js`
 - `test/unit/extension_mesh_v2.js`
 - `test/unit/extension_smalrubot_s1.js`
+- `test/unit/extension_smalruby_ruby_each.js`
 - `test/unit/mesh_service_v2_cost.js`
 - `test/unit/mesh_service_v2_global_vars.js`
 - `test/unit/mesh_service_v2_integration.js`

--- a/bin/setup-worktree
+++ b/bin/setup-worktree
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# bin/setup-worktree — one-shot setup for a freshly created git worktree.
+#
+# Why: `git worktree add` does not copy gitignored files (.env), per-package
+# `node_modules/`, or the workspace `dist/` directories. Without these:
+#   - webpack/CDK builds fail (missing .env)
+#   - jest tests fail with "Cannot find module 'scratch-blocks'" because
+#     scratch-gui's local node_modules is empty
+#   - jest tests fail with "Cannot find module '@smalruby/scratch-svg-renderer'"
+#     because the workspace package's `dist/` does not exist yet (jest resolves
+#     the bare package name through the package's "main"/"exports" field)
+#
+# This script chains the per-step setup so a worktree is ready for development
+# in a single command.
+#
+# Usage (from inside the worktree):
+#   bin/setup-worktree           # idempotent — safe to re-run
+#   bin/setup-worktree --force   # also overwrite existing .env.* files
+#
+# Steps:
+#   1. bin/sync-worktree-env       — copy .env.* + symlink host node_modules
+#   2. docker compose run app npm install
+#                                  — populate per-package node_modules
+#                                    (root node_modules uses shared docker volume,
+#                                     packages/*/node_modules is host-side)
+#   3. docker compose run app npm run build:dev
+#                                  — build workspace packages (scratch-vm,
+#                                    scratch-render, scratch-svg-renderer, GUI)
+#                                    so their dist/ directories exist for jest
+#                                    module resolution and integration tests
+set -euo pipefail
+
+WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+GIT_COMMON_ABS=$(cd "${GIT_COMMON_DIR}" && pwd)
+MAIN_CHECKOUT=$(dirname "${GIT_COMMON_ABS}")
+
+if [[ "${MAIN_CHECKOUT}" == "${WORKTREE_ROOT}" ]]; then
+    echo "error: this script is for worktrees, not the main checkout." >&2
+    exit 1
+fi
+
+cd "${WORKTREE_ROOT}"
+
+echo "==> Step 1/3: bin/sync-worktree-env"
+bin/sync-worktree-env "$@"
+
+echo ""
+echo "==> Step 2/3: npm install (inside docker, populates per-package node_modules)"
+docker compose run --rm app npm install
+
+echo ""
+echo "==> Step 3/3: npm run build:dev (workspace packages dist/)"
+docker compose run --rm app npm run build:dev
+
+echo ""
+echo "Setup complete. The worktree is now ready for development and testing."
+echo "Tip: set up the .env symlink per stage you want to deploy, e.g.:"
+echo "  (cd infra/smalruby-mesh-v2 && ln -sf .env.stg .env)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "100m"
+        max-size: "10m"
         max-file: "3"
 
   smalruby3:

--- a/packages/scratch-gui/src/lib/ruby-generator/smalruby-ruby.js
+++ b/packages/scratch-gui/src/lib/ruby-generator/smalruby-ruby.js
@@ -95,6 +95,20 @@ export default function (Generator) {
         return `${receiver}.${method} do${resolved.paramStr}\n${resolved.branch}`;
     };
 
+    // --- Hash method with block (CONDITIONAL, C-shape) ---
+    Generator.smalrubyRuby_hashMethodWithBlock = function (block) {
+        const order = Generator.ORDER_FUNCTION_CALL;
+        const receiver =
+            Generator.valueToCode(block, 'RECEIVER', order) ||
+            Generator.quote_('');
+        const method = Generator.getFieldValue(block, 'METHOD') || 'each';
+        const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
+        const resolved = resolveBlockParams(block, branch);
+
+        block.isStatement = true;
+        return `${receiver}.${method} do${resolved.paramStr}\n${resolved.branch}`;
+    };
+
     // --- Number method with block (CONDITIONAL, C-shape) ---
     Generator.smalrubyRuby_numberMethodWithBlock = function (block) {
         const receiver =

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js
@@ -501,21 +501,33 @@ const SmalrubyRubyConverter = {
                 value: valuesList.name,
             };
 
+            // Encode list refs into the block's comment text so the VM can
+            // recover them at execution time. Hidden block fields like
+            // KEYS_LIST_ID don't survive Blockly's XML round-trip (only
+            // arguments referenced in the block's `text` template are
+            // registered as known fields), but comment text does.
+            const listRefLines = [
+                `@ruby:list_ref:KEYS:${keysList.id}:${keysList.name}`,
+                `@ruby:list_ref:VALUES:${valuesList.id}:${valuesList.name}`,
+            ];
+
             // Handle block parameters (|k, v|): same comment-based mapping as
             // arrayMethodWithBlock, then walk the body replacing variable
             // references with smalrubyRuby_blockParam reporters.
+            const commentParts = listRefLines.slice();
             if (rubyBlockArgs && rubyBlockArgs.length > 0) {
-                const commentParts = [];
                 rubyBlockArgs.forEach((paramName, idx) => {
                     commentParts.push(
                         `@ruby:block_param:${idx + 1}:${paramName}`,
                     );
                 });
-                block.comment = converter._createComment(
-                    commentParts.join('\n'),
-                    block.id,
-                );
+            }
+            block.comment = converter._createComment(
+                commentParts.join('\n'),
+                block.id,
+            );
 
+            if (rubyBlockArgs && rubyBlockArgs.length > 0) {
                 if (rubyBlock) {
                     const varNameToParamIdx = {};
                     rubyBlockArgs.forEach((paramName, idx) => {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js
@@ -286,6 +286,29 @@ const SmalrubyRubyConverter = {
             );
             converter._addField(block, 'METHOD', method);
 
+            // When the receiver is a list (data_listcontents), propagate the
+            // LIST id/name as hidden fields so the VM can iterate the list
+            // directly instead of split-by-space-ing the joined string. The
+            // joined string is lossy: single-character items collapse to
+            // "abc" with no separator, and items containing spaces split
+            // incorrectly.
+            if (
+                converter._isBlock(receiver) &&
+                receiver.opcode === 'data_listcontents' &&
+                receiver.fields &&
+                receiver.fields.LIST
+            ) {
+                const listField = receiver.fields.LIST;
+                block.fields.LIST_ID = {
+                    name: 'LIST_ID',
+                    value: listField.id,
+                };
+                block.fields.LIST_NAME = {
+                    name: 'LIST_NAME',
+                    value: listField.value,
+                };
+            }
+
             // Handle block parameters: store mapping in comment
             if (rubyBlockArgs && rubyBlockArgs.length > 0) {
                 const commentParts = [];

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/smalruby-ruby.js
@@ -433,6 +433,168 @@ const SmalrubyRubyConverter = {
                 );
             },
         );
+
+        // --- Helper: resolve prefixed name from a variable receiver ---
+        // For hash variables stored as 2 parallel lists. Returns null if the
+        // receiver isn't a recognised variable.
+        const prefixedNameForReceiver = (receiver) => {
+            if (
+                !converter._isBlock(receiver) ||
+                receiver.opcode !== 'data_variable' ||
+                !receiver.fields ||
+                !receiver.fields.VARIABLE
+            ) {
+                return null;
+            }
+            const varName = receiver.fields.VARIABLE.value;
+            const variable =
+                converter._context.variables[varName] ||
+                converter._context.localVariables[varName];
+            if (!variable) return null;
+            if (variable.scope === 'global') return `$${varName}`;
+            if (variable.scope === 'instance') return `@${varName}`;
+            if (variable.scope === 'local') return variable.originalName;
+            return null;
+        };
+
+        // --- Helper: create hashMethodWithBlock ---
+        // Hashes are stored as two parallel lists (<name>_keys / <name>_values).
+        // Resolve those lists from the receiver variable and propagate their
+        // ID/name as hidden fields so the VM can iterate without going through
+        // the lossy joined string of either list.
+        const createHashMethodWithBlock = (
+            method,
+            receiver,
+            rubyBlock,
+            rubyBlockArgs,
+        ) => {
+            if (typeof rubyBlock === 'undefined') return null;
+            const prefixedName = prefixedNameForReceiver(receiver);
+            if (!prefixedName) return null;
+
+            const keysListName = converter._hashKeysListName(prefixedName);
+            const valuesListName = converter._hashValuesListName(prefixedName);
+            const keysList = converter._lookupOrCreateList(keysListName);
+            const valuesList = converter._lookupOrCreateList(valuesListName);
+            if (!keysList || !valuesList) return null;
+
+            const block = converter._createBlock(
+                'smalrubyRuby_hashMethodWithBlock',
+                'statement',
+            );
+            converter._addTextInput(block, 'RECEIVER', receiver, '');
+            converter._addField(block, 'METHOD', method);
+            block.fields.KEYS_LIST_ID = {
+                name: 'KEYS_LIST_ID',
+                value: keysList.id,
+            };
+            block.fields.KEYS_LIST_NAME = {
+                name: 'KEYS_LIST_NAME',
+                value: keysList.name,
+            };
+            block.fields.VALUES_LIST_ID = {
+                name: 'VALUES_LIST_ID',
+                value: valuesList.id,
+            };
+            block.fields.VALUES_LIST_NAME = {
+                name: 'VALUES_LIST_NAME',
+                value: valuesList.name,
+            };
+
+            // Handle block parameters (|k, v|): same comment-based mapping as
+            // arrayMethodWithBlock, then walk the body replacing variable
+            // references with smalrubyRuby_blockParam reporters.
+            if (rubyBlockArgs && rubyBlockArgs.length > 0) {
+                const commentParts = [];
+                rubyBlockArgs.forEach((paramName, idx) => {
+                    commentParts.push(
+                        `@ruby:block_param:${idx + 1}:${paramName}`,
+                    );
+                });
+                block.comment = converter._createComment(
+                    commentParts.join('\n'),
+                    block.id,
+                );
+
+                if (rubyBlock) {
+                    const varNameToParamIdx = {};
+                    rubyBlockArgs.forEach((paramName, idx) => {
+                        const variable =
+                            converter._lookupOrCreateVariable(paramName);
+                        varNameToParamIdx[variable.name] = idx;
+                    });
+
+                    const replaceParamVars = (blockId) => {
+                        if (!blockId) return;
+                        const b = converter._context.blocks[blockId];
+                        if (!b) return;
+                        if (b.inputs) {
+                            for (const inputName of Object.keys(b.inputs)) {
+                                const input = b.inputs[inputName];
+                                const childBlock =
+                                    converter._context.blocks[input.block];
+                                if (
+                                    childBlock &&
+                                    childBlock.opcode === 'data_variable' &&
+                                    childBlock.fields &&
+                                    childBlock.fields.VARIABLE
+                                ) {
+                                    const varName =
+                                        childBlock.fields.VARIABLE.value;
+                                    const paramIdx =
+                                        varNameToParamIdx[varName];
+                                    if (paramIdx >= 0) {
+                                        childBlock.opcode =
+                                            'smalrubyRuby_blockParam';
+                                        delete childBlock.fields.VARIABLE;
+                                        childBlock.fields.PARAM = {
+                                            name: 'PARAM',
+                                            value: `_${paramIdx + 1}`,
+                                        };
+                                        converter._setBlockType(
+                                            childBlock,
+                                            'value',
+                                        );
+                                    }
+                                }
+                                if (input.block) {
+                                    replaceParamVars(input.block);
+                                }
+                            }
+                        }
+                        if (b.next) replaceParamVars(b.next);
+                        if (
+                            b.inputs &&
+                            b.inputs.SUBSTACK &&
+                            b.inputs.SUBSTACK.block
+                        ) {
+                            replaceParamVars(b.inputs.SUBSTACK.block);
+                        }
+                    };
+                    replaceParamVars(rubyBlock.id);
+                }
+            }
+
+            converter._addSubstack(block, rubyBlock);
+            return block;
+        };
+
+        // --- Register hash.each with two block params: h.each do |k, v| ---
+        converter.registerOnSendWithBlock(
+            ['hash', 'variable'],
+            'each',
+            0,
+            2,
+            (params) => {
+                const { receiver, rubyBlockArgs, rubyBlock } = params;
+                return createHashMethodWithBlock(
+                    'each',
+                    receiver,
+                    rubyBlock,
+                    rubyBlockArgs,
+                );
+            },
+        );
     },
 };
 

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -401,6 +401,40 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         );
     });
 
+    test('Array#each with single-char string items round-trips', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              letters = ["a", "b", "c"]
+              letters.each do |c|
+                say(c, 1)
+              end
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
+    test('Array#each with space-containing strings round-trips', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              words = ["hello world", "foo bar"]
+              words.each do |w|
+                say(w, 1)
+              end
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
     test('Array#each receiver list propagates LIST_ID/LIST_NAME on arrayMethodWithBlock', async () => {
         const code = dedent`
             when_flag_clicked do

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -384,6 +384,44 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         );
     });
 
+    test('Array#each with single-char items round-trips', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              ticket = [1, 2, 3]
+              ticket.each do |item|
+                say(item, 1)
+              end
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
+    test('Array#each receiver list propagates LIST_ID/LIST_NAME on arrayMethodWithBlock', async () => {
+        const code = dedent`
+            when_flag_clicked do
+              ticket = [1, 2, 3]
+              ticket.each do |item|
+                say(item, 1)
+              end
+            end
+        `;
+        const result = await converter.targetCodeToBlocks(target, code);
+        expect(result).toBe(true);
+        const blocks = Object.values(converter._context.blocks);
+        const eachBlock = blocks.find(
+            (b) => b.opcode === 'smalrubyRuby_arrayMethodWithBlock',
+        );
+        expect(eachBlock).toBeDefined();
+        expect(eachBlock.fields.LIST_ID).toBeDefined();
+        expect(eachBlock.fields.LIST_NAME).toBeDefined();
+        expect(eachBlock.fields.LIST_NAME.value).toContain('ticket');
+    });
+
     test('.times do |i| with block parameter', async () => {
         await expectRoundTrip(
             converter,

--- a/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-roundtrip/smalruby-ruby.test.js
@@ -422,6 +422,49 @@ describe('Ruby Roundtrip: smalrubyRuby extension', () => {
         expect(eachBlock.fields.LIST_NAME.value).toContain('ticket');
     });
 
+    test('Hash#each with block parameters round-trips', async () => {
+        await expectRoundTrip(
+            converter,
+            target,
+            dedent`
+            when_flag_clicked do
+              h = {a: 1, b: 2}
+              h.each do |k, v|
+                say(k, 1)
+                say(v, 1)
+              end
+            end
+        `,
+            null,
+            opts,
+        );
+    });
+
+    test('Hash#each receiver hash propagates KEYS_/VALUES_LIST_ID/NAME', async () => {
+        const code = dedent`
+            when_flag_clicked do
+              h = {a: 1, b: 2}
+              h.each do |k, v|
+                say(k, 1)
+              end
+            end
+        `;
+        const result = await converter.targetCodeToBlocks(target, code);
+        expect(result).toBe(true);
+        const blocks = Object.values(converter._context.blocks);
+        const eachBlock = blocks.find(
+            (b) => b.opcode === 'smalrubyRuby_hashMethodWithBlock',
+        );
+        expect(eachBlock).toBeDefined();
+        expect(eachBlock.fields.METHOD.value).toBe('each');
+        expect(eachBlock.fields.KEYS_LIST_ID).toBeDefined();
+        expect(eachBlock.fields.KEYS_LIST_NAME).toBeDefined();
+        expect(eachBlock.fields.KEYS_LIST_NAME.value).toContain('keys');
+        expect(eachBlock.fields.VALUES_LIST_ID).toBeDefined();
+        expect(eachBlock.fields.VALUES_LIST_NAME).toBeDefined();
+        expect(eachBlock.fields.VALUES_LIST_NAME.value).toContain('values');
+    });
+
     test('.times do |i| with block parameter', async () => {
         await expectRoundTrip(
             converter,

--- a/packages/scratch-vm/.prettierignore
+++ b/packages/scratch-vm/.prettierignore
@@ -80,6 +80,7 @@ test/unit/*
 !test/unit/extension_mesh_v2_service.js
 !test/unit/extension_mesh_v2.js
 !test/unit/extension_smalrubot_s1.js
+!test/unit/extension_smalruby_ruby_each.js
 !test/unit/mesh_service_v2_cost.js
 !test/unit/mesh_service_v2_global_vars.js
 !test/unit/mesh_service_v2_integration.js

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/block-definitions.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/block-definitions.js
@@ -439,6 +439,10 @@ const menus = {
         acceptReporters: false,
         items: [{ text: 'each', value: 'each' }],
     },
+    hashMethodWithBlockMenu: {
+        acceptReporters: false,
+        items: [{ text: 'each', value: 'each' }],
+    },
     numberMethodWithBlockMenu: {
         acceptReporters: false,
         items: [{ text: 'times', value: 'times' }],
@@ -532,6 +536,24 @@ const getBlocks = () => [
         arguments: {
             RECEIVER: { type: ArgumentType.STRING, defaultValue: '' },
             METHOD: { type: ArgumentType.STRING, menu: 'arrayMethodWithBlockMenu', defaultValue: 'each' },
+        },
+    },
+    // --- Hash method with block (CONDITIONAL, C-shape) ---
+    // Hashes are stored as two parallel lists in Scratch (`<name>_keys` and
+    // `<name>_values`). KEYS_LIST_ID/NAME and VALUES_LIST_ID/NAME are hidden
+    // fields populated by the converter so the executor can iterate both
+    // lists in parallel without going through lossy joined-string receivers.
+    {
+        opcode: 'hashMethodWithBlock',
+        text: formatMessage({
+            id: 'smalrubyRuby.hashMethodWithBlock',
+            default: 'Hash [RECEIVER] . [METHOD] do',
+            description: 'Hash method call with block (C-shape)',
+        }),
+        blockType: BlockType.CONDITIONAL,
+        arguments: {
+            RECEIVER: { type: ArgumentType.STRING, defaultValue: '' },
+            METHOD: { type: ArgumentType.STRING, menu: 'hashMethodWithBlockMenu', defaultValue: 'each' },
         },
     },
     // --- Number method with block (CONDITIONAL, C-shape) ---

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js
@@ -68,6 +68,78 @@ const executeArrayMethodWithBlock = (args, util, setReturnValue) => {
 };
 
 /**
+ * Look up the keys/values lists referenced by a hash each block.
+ * Hashes are stored as two parallel lists in Scratch (`<name>_keys` and
+ * `<name>_values`). Both list references must be present in args.
+ * @param {object} args - Block arguments.
+ * @param {object} util - Block utility.
+ * @returns {{keys: Array, values: Array}} Snapshot of both list contents.
+ */
+const resolveHashEntries = (args, util) => {
+    if (
+        !args.KEYS_LIST_ID ||
+        !args.VALUES_LIST_ID ||
+        !util.target ||
+        !util.target.lookupOrCreateList
+    ) {
+        return { keys: [], values: [] };
+    }
+    const keysList = util.target.lookupOrCreateList(
+        args.KEYS_LIST_ID,
+        args.KEYS_LIST_NAME,
+    );
+    const valuesList = util.target.lookupOrCreateList(
+        args.VALUES_LIST_ID,
+        args.VALUES_LIST_NAME,
+    );
+    return {
+        keys: keysList && keysList.value ? keysList.value.slice() : [],
+        values: valuesList && valuesList.value ? valuesList.value.slice() : [],
+    };
+};
+
+/**
+ * Execute a hash method with block (C-shape). Currently supports `each` only,
+ * iterating key/value pairs in parallel from the hash's keys and values lists.
+ * Block params are set as `_1` = key, `_2` = value.
+ * @param {object} args - Block arguments (METHOD, KEYS_LIST_ID/NAME, VALUES_LIST_ID/NAME).
+ * @param {object} util - Block utility.
+ * @param {Function} setReturnValue - Callback to store the return value.
+ */
+const executeHashMethodWithBlock = (args, util, setReturnValue) => {
+    const method = args.METHOD;
+
+    switch (method) {
+        case 'each': {
+            if (typeof util.stackFrame.entries === 'undefined') {
+                const entries = resolveHashEntries(args, util);
+                // Iterate up to the shorter list to avoid undefined values
+                // when the two lists are inconsistent.
+                util.stackFrame.entries = {
+                    keys: entries.keys,
+                    values: entries.values,
+                    length: Math.min(entries.keys.length, entries.values.length),
+                };
+                util.stackFrame.index = 0;
+            }
+            const { keys, values, length } = util.stackFrame.entries;
+            if (util.stackFrame.index < length) {
+                const k = keys[util.stackFrame.index];
+                const v = values[util.stackFrame.index];
+                setReturnValue(util, v);
+                setBlockParam(util, '_1', k);
+                setBlockParam(util, '_2', v);
+                util.stackFrame.index++;
+                util.startBranch(1, true);
+            }
+            break;
+        }
+        default:
+            break;
+    }
+};
+
+/**
  * Execute a number method with block (C-shape).
  * @param {object} args - Block arguments (RECEIVER, METHOD).
  * @param {object} util - Block utility.
@@ -98,5 +170,6 @@ const executeNumberMethodWithBlock = (args, util, setReturnValue) => {
 
 module.exports = {
     executeArrayMethodWithBlock,
+    executeHashMethodWithBlock,
     executeNumberMethodWithBlock,
 };

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js
@@ -17,21 +17,42 @@ const setBlockParam = (util, key, value) => {
 };
 
 /**
+ * Resolve the items to iterate for Array#each. Prefer the LIST referenced by
+ * LIST_ID/LIST_NAME when available, since data_listcontents joins items with
+ * "" (all-single-char) or " " (otherwise) — both lossy for arbitrary values.
+ * Fall back to space-splitting RECEIVER for receivers that aren't lists.
+ * @param {object} args - Block arguments.
+ * @param {object} util - Block utility.
+ * @returns {Array} Snapshot of items to iterate.
+ */
+const resolveArrayItems = (args, util) => {
+    if (args.LIST_ID && util.target && util.target.lookupOrCreateList) {
+        const list = util.target.lookupOrCreateList(args.LIST_ID, args.LIST_NAME);
+        return list && list.value ? list.value.slice() : [];
+    }
+    const recv = String(args.RECEIVER || '');
+    return recv === '' ? [] : recv.split(' ');
+};
+
+/**
  * Execute an array method with block (C-shape).
- * @param {object} args - Block arguments (RECEIVER, METHOD).
+ * @param {object} args - Block arguments (RECEIVER, METHOD, optional LIST_ID/LIST_NAME).
  * @param {object} util - Block utility.
  * @param {Function} setReturnValue - Callback to store the return value.
  */
 const executeArrayMethodWithBlock = (args, util, setReturnValue) => {
     const method = args.METHOD;
-    const toItems = (s) => (s === '' ? [] : String(s).split(' '));
 
     switch (method) {
         case 'each': {
-            const items = toItems(String(args.RECEIVER || ''));
-            if (typeof util.stackFrame.index === 'undefined') {
+            // Snapshot items on the first invocation so mutation during the
+            // loop body (e.g. push from inside the block) doesn't extend it,
+            // matching Ruby Array#each semantics.
+            if (typeof util.stackFrame.items === 'undefined') {
+                util.stackFrame.items = resolveArrayItems(args, util);
                 util.stackFrame.index = 0;
             }
+            const items = util.stackFrame.items;
             if (util.stackFrame.index < items.length) {
                 const value = items[util.stackFrame.index];
                 setReturnValue(util, value);

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js
@@ -17,19 +17,89 @@ const setBlockParam = (util, key, value) => {
 };
 
 /**
- * Resolve the items to iterate for Array#each. Prefer the LIST referenced by
- * LIST_ID/LIST_NAME when available, since data_listcontents joins items with
- * "" (all-single-char) or " " (otherwise) — both lossy for arbitrary values.
- * Fall back to space-splitting RECEIVER for receivers that aren't lists.
+ * Look up a list variable by id+name (defensive — id is authoritative,
+ * name is used as a fallback).
+ * @param {object} target - VM target.
+ * @param {string} id - List id.
+ * @param {string} name - List name.
+ * @returns {?object} List variable or null.
+ */
+const lookupList = (target, id, name) => {
+    if (!target || !target.lookupOrCreateList) return null;
+    return target.lookupOrCreateList(id, name);
+};
+
+/**
+ * Read the source RECEIVER input block of the currently executing block.
+ * Returns null if the call site is not the standard primitive flow (e.g.
+ * unit tests that invoke the executor directly without a thread).
+ * @param {object} util - Block utility.
+ * @returns {?object} Receiver block or null.
+ */
+const peekReceiverBlock = (util) => {
+    const target = util.target;
+    if (!util.thread || typeof util.thread.peekStack !== 'function') return null;
+    if (!target || !target.blocks || typeof target.blocks.getBlock !== 'function') return null;
+    const blockId = util.thread.peekStack();
+    if (!blockId) return null;
+    const block = target.blocks.getBlock(blockId);
+    if (!block || !block.inputs || !block.inputs.RECEIVER) return null;
+    return target.blocks.getBlock(block.inputs.RECEIVER.block) || null;
+};
+
+/**
+ * Read the comment text attached to the currently executing block.
+ * Returns '' if absent.
+ * @param {object} util - Block utility.
+ * @returns {string} Comment text.
+ */
+const peekBlockCommentText = (util) => {
+    const target = util.target;
+    if (!util.thread || typeof util.thread.peekStack !== 'function') return '';
+    if (!target || !target.blocks || typeof target.blocks.getBlock !== 'function') return '';
+    const blockId = util.thread.peekStack();
+    if (!blockId) return '';
+    const block = target.blocks.getBlock(blockId);
+    if (!block || !block.comment || !target.comments) return '';
+    const comment = target.comments[block.comment];
+    return (comment && comment.text) || '';
+};
+
+/**
+ * Resolve the items to iterate for Array#each.
+ *
+ * Strategy (in order):
+ * 1. Read the source RECEIVER block (data_listcontents) and use its LIST
+ *    field. Survives Blockly XML round-trip because LIST is a standard
+ *    Scratch field on data_listcontents.
+ * 2. Fall back to args.LIST_ID/LIST_NAME (used by unit tests that bypass
+ *    the block container).
+ * 3. Final fallback: space-split args.RECEIVER. Lossy but preserves
+ *    behavior for receivers that aren't lists.
  * @param {object} args - Block arguments.
  * @param {object} util - Block utility.
  * @returns {Array} Snapshot of items to iterate.
  */
 const resolveArrayItems = (args, util) => {
-    if (args.LIST_ID && util.target && util.target.lookupOrCreateList) {
-        const list = util.target.lookupOrCreateList(args.LIST_ID, args.LIST_NAME);
-        return list && list.value ? list.value.slice() : [];
+    const target = util.target;
+
+    const receiverBlock = peekReceiverBlock(util);
+    if (
+        receiverBlock &&
+        receiverBlock.opcode === 'data_listcontents' &&
+        receiverBlock.fields &&
+        receiverBlock.fields.LIST
+    ) {
+        const listField = receiverBlock.fields.LIST;
+        const list = lookupList(target, listField.id, listField.value);
+        if (list && list.value) return list.value.slice();
     }
+
+    if (args.LIST_ID) {
+        const list = lookupList(target, args.LIST_ID, args.LIST_NAME);
+        if (list && list.value) return list.value.slice();
+    }
+
     const recv = String(args.RECEIVER || '');
     return recv === '' ? [] : recv.split(' ');
 };
@@ -68,41 +138,76 @@ const executeArrayMethodWithBlock = (args, util, setReturnValue) => {
 };
 
 /**
- * Look up the keys/values lists referenced by a hash each block.
- * Hashes are stored as two parallel lists in Scratch (`<name>_keys` and
- * `<name>_values`). Both list references must be present in args.
+ * Parse `@ruby:list_ref:<key>:<id>:<name>` directives from a comment text
+ * into a map keyed by the directive name.
+ * @param {string} commentText - Block's comment text.
+ * @returns {Object<string, {id: string, name: string}>} Parsed list refs.
+ */
+const parseListRefsFromComment = (commentText) => {
+    const refs = {};
+    if (!commentText) return refs;
+    // Format: @ruby:list_ref:<KEY>:<id>:<name>
+    // <id> contains arbitrary chars including colons; we split on the last
+    // colon by anchoring the prefix and capturing the remainder.
+    const re = /@ruby:list_ref:([A-Z_]+):([^\n]+)/g;
+    let m;
+    while ((m = re.exec(commentText)) !== null) {
+        const key = m[1];
+        const rest = m[2];
+        // rest is "<id>:<name>". Names cannot contain newlines but may contain
+        // colons in theory; ids are random short strings without ":\n". We split
+        // on the LAST ":" to allow colons in name (defensive).
+        const idx = rest.indexOf(':');
+        if (idx < 0) continue;
+        const id = rest.slice(0, idx);
+        const name = rest.slice(idx + 1);
+        refs[key] = { id, name };
+    }
+    return refs;
+};
+
+/**
+ * Resolve key/value lists for Hash#each.
+ *
+ * Strategy (in order):
+ * 1. Read `@ruby:list_ref:KEYS:<id>:<name>` and `:VALUES:` directives from
+ *    the executing block's comment. Comments are preserved through Blockly
+ *    XML round-trip.
+ * 2. Fall back to args.KEYS_LIST_ID etc. (used by unit tests).
  * @param {object} args - Block arguments.
  * @param {object} util - Block utility.
- * @returns {{keys: Array, values: Array}} Snapshot of both list contents.
+ * @returns {{keys: Array, values: Array}} Snapshot of key/value lists.
  */
 const resolveHashEntries = (args, util) => {
-    if (
-        !args.KEYS_LIST_ID ||
-        !args.VALUES_LIST_ID ||
-        !util.target ||
-        !util.target.lookupOrCreateList
-    ) {
-        return { keys: [], values: [] };
+    const target = util.target;
+
+    const refs = parseListRefsFromComment(peekBlockCommentText(util));
+    if (refs.KEYS && refs.VALUES) {
+        const keysList = lookupList(target, refs.KEYS.id, refs.KEYS.name);
+        const valuesList = lookupList(target, refs.VALUES.id, refs.VALUES.name);
+        return {
+            keys: keysList && keysList.value ? keysList.value.slice() : [],
+            values: valuesList && valuesList.value ? valuesList.value.slice() : [],
+        };
     }
-    const keysList = util.target.lookupOrCreateList(
-        args.KEYS_LIST_ID,
-        args.KEYS_LIST_NAME,
-    );
-    const valuesList = util.target.lookupOrCreateList(
-        args.VALUES_LIST_ID,
-        args.VALUES_LIST_NAME,
-    );
-    return {
-        keys: keysList && keysList.value ? keysList.value.slice() : [],
-        values: valuesList && valuesList.value ? valuesList.value.slice() : [],
-    };
+
+    if (args.KEYS_LIST_ID && args.VALUES_LIST_ID) {
+        const keysList = lookupList(target, args.KEYS_LIST_ID, args.KEYS_LIST_NAME);
+        const valuesList = lookupList(target, args.VALUES_LIST_ID, args.VALUES_LIST_NAME);
+        return {
+            keys: keysList && keysList.value ? keysList.value.slice() : [],
+            values: valuesList && valuesList.value ? valuesList.value.slice() : [],
+        };
+    }
+
+    return { keys: [], values: [] };
 };
 
 /**
  * Execute a hash method with block (C-shape). Currently supports `each` only,
  * iterating key/value pairs in parallel from the hash's keys and values lists.
  * Block params are set as `_1` = key, `_2` = value.
- * @param {object} args - Block arguments (METHOD, KEYS_LIST_ID/NAME, VALUES_LIST_ID/NAME).
+ * @param {object} args - Block arguments (METHOD, optional KEYS_LIST_* / VALUES_LIST_*).
  * @param {object} util - Block utility.
  * @param {Function} setReturnValue - Callback to store the return value.
  */
@@ -113,8 +218,6 @@ const executeHashMethodWithBlock = (args, util, setReturnValue) => {
         case 'each': {
             if (typeof util.stackFrame.entries === 'undefined') {
                 const entries = resolveHashEntries(args, util);
-                // Iterate up to the shorter list to avoid undefined values
-                // when the two lists are inconsistent.
                 util.stackFrame.entries = {
                     keys: entries.keys,
                     values: entries.values,

--- a/packages/scratch-vm/src/extensions/smalruby_ruby/index.js
+++ b/packages/scratch-vm/src/extensions/smalruby_ruby/index.js
@@ -12,6 +12,7 @@ const {
 
 const {
     executeArrayMethodWithBlock,
+    executeHashMethodWithBlock,
     executeNumberMethodWithBlock,
 } = require('./block-method-executors');
 
@@ -126,6 +127,10 @@ class SmalrubyRubyBlocks {
 
     arrayMethodWithBlock(args, util) {
         executeArrayMethodWithBlock(args, util, this._setReturnValue);
+    }
+
+    hashMethodWithBlock(args, util) {
+        executeHashMethodWithBlock(args, util, this._setReturnValue);
     }
 
     numberMethodWithBlock(args, util) {

--- a/packages/scratch-vm/test/unit/extension_smalruby_ruby_each.js
+++ b/packages/scratch-vm/test/unit/extension_smalruby_ruby_each.js
@@ -1,6 +1,9 @@
 const test = require('tap').test;
 
-const { executeArrayMethodWithBlock } = require('../../src/extensions/smalruby_ruby/block-method-executors');
+const {
+    executeArrayMethodWithBlock,
+    executeHashMethodWithBlock,
+} = require('../../src/extensions/smalruby_ruby/block-method-executors');
 
 /**
  * Build a util/list pair for testing the each executor.
@@ -122,6 +125,140 @@ test('Array#each: empty list does not invoke substack', t => {
     runUntilDone();
 
     t.equal(calls.length, 0, 'should not iterate for empty list');
+    t.end();
+});
+
+/**
+ * Build a util/two-list pair for testing the hash each executor.
+ * @param {Array} keysValue - Keys list contents.
+ * @param {Array} valuesValue - Values list contents.
+ * @returns {{args: object, util: object, calls: object[], runUntilDone: Function}} Test harness.
+ */
+const setupHashEach = (keysValue, valuesValue) => {
+    const keysList = {
+        id: 'list-h-keys',
+        name: 'h_keys',
+        value: keysValue.slice(),
+    };
+    const valuesList = {
+        id: 'list-h-values',
+        name: 'h_values',
+        value: valuesValue.slice(),
+    };
+    const calls = [];
+    const util = {
+        thread: {},
+        target: {
+            lookupOrCreateList: (id, name) => {
+                if (id === keysList.id && name === keysList.name) return keysList;
+                if (id === valuesList.id && name === valuesList.name) return valuesList;
+                throw new Error(`unexpected list lookup: ${id}/${name}`);
+            },
+        },
+        stackFrame: {},
+        startBranch: () => {
+            calls.push({
+                blockParam1: util.thread._smalrubyBlockParams ? util.thread._smalrubyBlockParams._1 : undefined,
+                blockParam2: util.thread._smalrubyBlockParams ? util.thread._smalrubyBlockParams._2 : undefined,
+            });
+        },
+    };
+    const args = {
+        METHOD: 'each',
+        KEYS_LIST_ID: keysList.id,
+        KEYS_LIST_NAME: keysList.name,
+        VALUES_LIST_ID: valuesList.id,
+        VALUES_LIST_NAME: valuesList.name,
+    };
+    const setReturnValue = (u, value) => {
+        u.thread._smalrubyReturnValue = value;
+    };
+    const runUntilDone = () => {
+        for (let i = 0; i < 100; i++) {
+            const before = calls.length;
+            executeHashMethodWithBlock(args, util, setReturnValue);
+            if (calls.length === before) break;
+        }
+    };
+    return { args, util, keysList, valuesList, calls, runUntilDone };
+};
+
+test('Hash#each: iterates {a: 1, b: 2} with parallel keys/values', t => {
+    const { calls, runUntilDone } = setupHashEach(['a', 'b'], ['1', '2']);
+
+    runUntilDone();
+
+    t.equal(calls.length, 2, 'should iterate 2 times');
+    t.equal(calls[0].blockParam1, 'a');
+    t.equal(calls[0].blockParam2, '1');
+    t.equal(calls[1].blockParam1, 'b');
+    t.equal(calls[1].blockParam2, '2');
+    t.end();
+});
+
+test('Hash#each: handles single-char values that would collapse via data_listcontents', t => {
+    // {a: 1, b: 2, c: 3} — all single-char items → data_listcontents joins
+    // with no separator. Verify direct list access is used.
+    const { calls, runUntilDone } = setupHashEach(['a', 'b', 'c'], ['1', '2', '3']);
+
+    runUntilDone();
+
+    t.equal(calls.length, 3);
+    t.equal(calls[0].blockParam1, 'a');
+    t.equal(calls[0].blockParam2, '1');
+    t.equal(calls[2].blockParam1, 'c');
+    t.equal(calls[2].blockParam2, '3');
+    t.end();
+});
+
+test('Hash#each: empty hash does not invoke substack', t => {
+    const { calls, runUntilDone } = setupHashEach([], []);
+
+    runUntilDone();
+
+    t.equal(calls.length, 0);
+    t.end();
+});
+
+test('Hash#each: snapshots both lists at first call (mutation ignored)', t => {
+    const harness = setupHashEach(['a', 'b'], ['1', '2']);
+    const { args, util, keysList, valuesList, calls } = harness;
+    const setReturnValue = (u, value) => {
+        u.thread._smalrubyReturnValue = value;
+    };
+    let mutated = false;
+    util.startBranch = () => {
+        calls.push({
+            blockParam1: util.thread._smalrubyBlockParams._1,
+            blockParam2: util.thread._smalrubyBlockParams._2,
+        });
+        if (!mutated) {
+            keysList.value.push('c');
+            valuesList.value.push('3');
+            mutated = true;
+        }
+    };
+    for (let i = 0; i < 100; i++) {
+        const before = calls.length;
+        executeHashMethodWithBlock(args, util, setReturnValue);
+        if (calls.length === before) break;
+    }
+    t.equal(calls.length, 2, 'still iterates only the original 2 entries');
+    t.end();
+});
+
+test('Hash#each: keys list shorter than values list — iterate min of both', t => {
+    // Defensive behavior when the two lists are inconsistent. Iterate up to
+    // the shorter length to avoid undefined values.
+    const { calls, runUntilDone } = setupHashEach(['a', 'b'], ['1', '2', '3']);
+
+    runUntilDone();
+
+    t.equal(calls.length, 2, 'should iterate 2 times (min of 2 and 3)');
+    t.equal(calls[0].blockParam1, 'a');
+    t.equal(calls[0].blockParam2, '1');
+    t.equal(calls[1].blockParam1, 'b');
+    t.equal(calls[1].blockParam2, '2');
     t.end();
 });
 

--- a/packages/scratch-vm/test/unit/extension_smalruby_ruby_each.js
+++ b/packages/scratch-vm/test/unit/extension_smalruby_ruby_each.js
@@ -1,0 +1,162 @@
+const test = require('tap').test;
+
+const { executeArrayMethodWithBlock } = require('../../src/extensions/smalruby_ruby/block-method-executors');
+
+/**
+ * Build a util/list pair for testing the each executor.
+ *
+ * The list is keyed by ID/name; lookupOrCreateList returns the same instance
+ * across calls so multiple iteration steps share a single list.
+ * @param {Array} listValue - Items in the list.
+ * @param {object} extraArgs - Additional args merged with RECEIVER/METHOD/LIST_ID/LIST_NAME.
+ * @returns {{args: object, util: object, list: object, calls: object[], runUntilDone: Function}} Test harness.
+ */
+const setupArrayEach = (listValue, extraArgs = {}) => {
+    const list = {
+        id: 'list-a',
+        name: 'a',
+        value: listValue.slice(),
+    };
+    const calls = [];
+    const util = {
+        thread: {},
+        target: {
+            lookupOrCreateList: (id, name) => {
+                if (id === list.id && name === list.name) return list;
+                throw new Error(`unexpected list lookup: ${id}/${name}`);
+            },
+        },
+        stackFrame: {},
+        startBranch: () => {
+            calls.push({
+                returnValue: util.thread._smalrubyReturnValue,
+                blockParam1: util.thread._smalrubyBlockParams ? util.thread._smalrubyBlockParams._1 : undefined,
+            });
+        },
+    };
+    const args = Object.assign(
+        {
+            RECEIVER: list.value.join(' '),
+            METHOD: 'each',
+            LIST_ID: list.id,
+            LIST_NAME: list.name,
+        },
+        extraArgs,
+    );
+    const setReturnValue = (u, value) => {
+        u.thread._smalrubyReturnValue = value;
+    };
+    const runUntilDone = () => {
+        for (let i = 0; i < 100; i++) {
+            const before = calls.length;
+            executeArrayMethodWithBlock(args, util, setReturnValue);
+            if (calls.length === before) break;
+        }
+    };
+    return { args, util, list, calls, runUntilDone };
+};
+
+test('Array#each: iterates [1, 2, 3] sequentially when LIST_ID is provided', t => {
+    // RECEIVER would be the joined "123" (single-char items concatenated by data_listcontents).
+    // The executor must ignore RECEIVER and use LIST_ID/LIST_NAME to read the list directly.
+    const { calls, runUntilDone } = setupArrayEach(['1', '2', '3'], {
+        RECEIVER: '123',
+    });
+
+    runUntilDone();
+
+    t.equal(calls.length, 3, 'should iterate 3 times');
+    t.equal(calls[0].blockParam1, '1');
+    t.equal(calls[1].blockParam1, '2');
+    t.equal(calls[2].blockParam1, '3');
+    t.end();
+});
+
+test('Array#each: iterates strings containing spaces correctly via LIST_ID', t => {
+    // RECEIVER would be "hello world foo" (joined with space) which would mis-split.
+    const { calls, runUntilDone } = setupArrayEach(['hello world', 'foo'], {
+        RECEIVER: 'hello world foo',
+    });
+
+    runUntilDone();
+
+    t.equal(calls.length, 2, 'should iterate 2 times');
+    t.equal(calls[0].blockParam1, 'hello world');
+    t.equal(calls[1].blockParam1, 'foo');
+    t.end();
+});
+
+test('Array#each: snapshots list at first call (mutation during iteration is ignored)', t => {
+    const harness = setupArrayEach(['a', 'b', 'c']);
+    const { args, util, list, calls } = harness;
+    const setReturnValue = (u, value) => {
+        u.thread._smalrubyReturnValue = value;
+    };
+
+    let mutated = false;
+    util.startBranch = () => {
+        calls.push({ blockParam1: util.thread._smalrubyBlockParams._1 });
+        if (!mutated) {
+            list.value.push('d');
+            list.value.push('e');
+            mutated = true;
+        }
+    };
+
+    for (let i = 0; i < 100; i++) {
+        const before = calls.length;
+        executeArrayMethodWithBlock(args, util, setReturnValue);
+        if (calls.length === before) break;
+    }
+
+    t.equal(calls.length, 3, 'should still iterate 3 times despite mutation');
+    t.equal(calls[0].blockParam1, 'a');
+    t.equal(calls[1].blockParam1, 'b');
+    t.equal(calls[2].blockParam1, 'c');
+    t.end();
+});
+
+test('Array#each: empty list does not invoke substack', t => {
+    const { calls, runUntilDone } = setupArrayEach([], { RECEIVER: '' });
+
+    runUntilDone();
+
+    t.equal(calls.length, 0, 'should not iterate for empty list');
+    t.end();
+});
+
+test('Array#each: falls back to RECEIVER split when LIST_ID is absent', t => {
+    // Backward compatibility: receiver is a string literal or scalar variable,
+    // so LIST_ID is not set. Fall back to space-split behavior.
+    const calls = [];
+    const util = {
+        thread: {},
+        target: {
+            lookupOrCreateList: () => {
+                throw new Error('should not be called when LIST_ID is absent');
+            },
+        },
+        stackFrame: {},
+        startBranch: () => {
+            calls.push({ blockParam1: util.thread._smalrubyBlockParams._1 });
+        },
+    };
+    const args = {
+        RECEIVER: 'hello world',
+        METHOD: 'each',
+    };
+    const setReturnValue = (u, value) => {
+        u.thread._smalrubyReturnValue = value;
+    };
+
+    for (let i = 0; i < 100; i++) {
+        const before = calls.length;
+        executeArrayMethodWithBlock(args, util, setReturnValue);
+        if (calls.length === before) break;
+    }
+
+    t.equal(calls.length, 2);
+    t.equal(calls[0].blockParam1, 'hello');
+    t.equal(calls[1].blockParam1, 'world');
+    t.end();
+});


### PR DESCRIPTION
## Summary

`array.each do |i| ... end` でリストの実際の要素が順次イテレートされないバグを修正し、`hash.each do |k, v| ... end` を新規実装する。

詳細は #567 を参照。

## Phase 進捗

- [x] **Phase 1: Array#each VM 修正**
- [x] **Phase 2: Array#each コンバーター LIST 伝搬**
- [x] **Phase 3: Hash#each VM 実装**
- [x] **Phase 4: Hash#each コンバーター + ジェネレーター**
- [x] **Phase 5: 統合テスト追加（エッジケース）**
- [x] **Phase DoD: CI green + ローカル Playwright MCP ブラウザ確認**

## 根本原因

`packages/scratch-vm/src/extensions/smalruby_ruby/block-method-executors.js` の `each` 実装は `args.RECEIVER`（接続された `data_listcontents` ブロックの戻り値）を `split(' ')` でアイテム化していた。Scratch の `getListContents` は全要素が 1 文字の場合「区切り文字なし」で結合するため、`[1, 2, 3]` → `"123"` → `["123"]` と潰れていた。スペース含み文字列も `["hello world", "foo"]` → `"hello world foo"` → `["hello", "world", "foo"]` と誤分割された。

加えて、初期実装のように block.fields に hidden field (LIST_ID 等) を入れる方法は **scratch-blocks の XML round-trip で削除される** ことが判明（ruby tab → code tab 遷移時）。`text` 内に placeholder のない field は scratch-blocks の `interpolate_` で登録されないため。

## 修正方針

### Array#each
- 執行時に `util.thread.peekStack()` から自身のブロック ID を取得し、`inputs.RECEIVER` 経由で source の `data_listcontents` ブロックを取得
- `data_listcontents.fields.LIST.id/name` で list を解決（LIST field は Scratch 標準の field なので XML round-trip で保持される）
- フォールバック: args.LIST_ID（unit test 互換）→ args.RECEIVER 文字列分割

### Hash#each
- 新規 opcode `hashMethodWithBlock` を追加
- コンバーターで block の comment text に `@ruby:list_ref:KEYS:<id>:<name>` と `@ruby:list_ref:VALUES:<id>:<name>` を埋め込む（comment は XML round-trip で保持される）
- 執行時に comment text を parse して keys/values list を解決
- 並列イテレートで `_1` = key, `_2` = value をブロック変数に設定

## おまけ: Worktree セットアップ改善 + Docker ログサイズ調整

- `bin/setup-worktree` を追加: env ファイル / per-package node_modules / workspace dist の用意を 1 コマンドで完結
- `.claude/rules/git-workflow.md` 更新
- `docker-compose.yml`: app サービスのログを 100MB × 3 → 10MB × 3 に縮小（webpack-dev-server の進捗ログで肥大化していた）

## ローカル動作確認結果（Playwright MCP, code tab 表示状態で実行）

| # | Case | 結果 |
|---|------|------|
| 1 | `[1,2,3].each` | 「1」→「2」→「3」順 ✅ |
| 2 | `["hello world","foo"].each` | 「hello world」→「foo」順（誤分割なし）✅ |
| 3 | `["a","b","c"].each` | 「a」→「b」→「c」順 ✅ |
| 4 | `[35,12,47].each` | 「35」→「12」→「47」順（regression なし）✅ |
| 5 | `5.times` | 「0」〜「4」順（numberMethodWithBlock regression なし）✅ |
| 6 | `{a:1, b:2, c:3}.each` | 「:a」→「1」→「:b」→「2」→「:c」→「3」順 ✅ |

(注: case 6 の symbol が `:a` 形式で表示されるのは hash の symbol キー保存仕様で、本 PR の対象外)

## Test Plan

- [x] VM ユニットテスト: `extension_smalruby_ruby_each.js`（10 ケース）
- [x] コンバーター roundtrip テスト（8 ケース）
- [x] CI green（9/9 checks）
- [x] ローカルブラウザ動作確認（Playwright MCP, ruby tab → code tab → green flag フロー）

## Related Issues

Fixes #567
