### PR TITLE
refactor(mesh-v2): mesh-service.js (1479行) を責務ごとに 9 ミックスインに分割

### DIFF
--- a/.claude/rules/scratch-gui/mesh.md
+++ b/.claude/rules/scratch-gui/mesh.md
@@ -1,0 +1,247 @@
+# Mesh v2 Extension
+
+Smalruby の mesh 拡張は、複数の Smalruby インスタンス間で **broadcast event** と **global variable** をリアルタイム共有する機能。AWS AppSync (GraphQL) をバックエンドに使う。
+
+mesh は **最重要機能** のため、関連コードを変更したときは必ず本ドキュメントの「デグレ確認手順」に従って Playwright で検証する。
+
+## 機能概要
+
+| 共有対象 | 仕組み | 関連クライアント API |
+|---------|--------|---------------------|
+| Broadcast event | host/member が `broadcast` ブロックを発火 → AppSync mutation → 全ノードに配信 | `fireEvent(name, payload)` |
+| Global variable (scalar) | ステージのグローバル変数を 1 秒ごとに rate-limit してデルタ送信 | `sendData([{key, value}])` |
+| Sensor value (read) | 他ノードから受信した変数を最新タイムスタンプ優先で読む | `mesh.sensor_value(name)` (Ruby) / `meshV2_getSensorValue` (block) |
+
+### 通信モード (host / member の両方が同じモードで動く)
+
+| モード | リアルタイム配信 | 1 秒未満の遅延 | 環境制約 |
+|--------|----------------|--------------|----------|
+| **WebSocket** | AppSync subscription (`onMessageInGroup`) | ✅ | プロキシ/フィルタが WebSocket をブロックしない環境 |
+| **Polling** | クライアントが 2 秒ごとに `pollGroupData` を query (issue #554) | ⚠️ 最大 2 秒 | フォールバック。403/503 で WebSocket が張れない環境 |
+
+WebSocket / Polling の判定は `testWebSocket()` で行い、`useWebSocket: false` をサーバーに送ると polling グループとして作成される。URL パラメータ `?force_polling=1` でクライアント側から強制的に polling にできる。
+
+### グループライフサイクル
+
+- グループの最大接続時間は **35 分** (サーバー側 `MESH_MAX_CONNECTION_TIME_SECONDS` で制御)
+- ただし **stg / 開発時の試験的な再接続では heartbeat TTL が 5 分** になる構成があり、デグレ確認では **5 分以内に検証を完了** すること
+- host が `dissolveGroup` を呼ぶか接続上限に達すると全 member が自動切断される
+
+## ファイル構成
+
+### scratch-vm (本体)
+
+`packages/scratch-vm/src/extensions/scratch3_mesh_v2/`
+
+| ファイル | 行数目安 | 責務 |
+|---------|---------|------|
+| `index.js` | ~620 | scratch 拡張ブロック定義、UI 連携、`new MeshV2Service` |
+| `mesh-service.js` | ~320 | ファサード。constructor / cleanup / listGroups / Object.assign で mixin 集約 |
+| `mesh-client.js` | ~40 | Apollo Client, GraphQL endpoint URL |
+| `gql-operations.js` | ~290 | GraphQL queries / mutations / subscription の定義 |
+| `network-filter.js` | ~170 | エラー分類, 503 検出, testWebSocket |
+| `periodic-sync.js` | ~70 | WebSocket モード時の 15 秒 fallback (`fetchAllNodesData`) |
+| `polling-client.js` | ~110 | Polling モードの 2 秒周期 (`pollEvents` / `POLL_GROUP_DATA`) |
+| `subscription-manager.js` | ~100 | WebSocket subscription 受信 (`onMessageInGroup`) と dispatch |
+| `heartbeat-manager.js` | ~140 | host/member heartbeat と接続タイマー |
+| `data-sender.js` | ~180 | グローバル変数送信 (REPORT_DATA), `getRemoteVariable` |
+| `broadcast-receiver.js` | ~175 | 受信した event を順序保証して Scratch broadcast に流す |
+| `event-sender.js` | ~220 | `fireEvent` キューイング + バッチ送信 (FIRE_EVENTS / RECORD_EVENTS) + orderKey 生成 |
+| `group-lifecycle.js` | ~230 | createDomain / createGroup / joinGroup / leaveGroup |
+| `rate-limiter.js` | ~220 | `sendData` の rate limit + マージ |
+| `utils.js` | ~70 | URL パラメータパース, ドメイン localStorage |
+| `name-search-utils.js` | ~55 | グループ名検索のひらがな→hex 変換 |
+
+mesh-service.js は **mixin パターン** で各 manager を `Object.assign(MeshV2Service.prototype, XxxMixin)` として集約している (issue #566)。`this.X` 参照はすべて MeshV2Service インスタンスを指すため、外部 API は単一のクラスに見える。
+
+### scratch-gui (UI / 接続ダイアログ)
+
+| ファイル | 責務 |
+|---------|------|
+| `src/components/connection-modal/mesh-v2-*.jsx` | 接続ステップの UI |
+| `src/reducers/mesh-v2.js` | 接続状態の Redux state |
+| `src/lib/ruby-generator/mesh_v2.js` | Ruby コード → mesh ブロックへの変換 |
+| `src/lib/ruby-to-blocks-converter/mesh_v2.js` | mesh ブロック → Ruby コード |
+
+### infra/smalruby-mesh-v2
+
+サーバー側 (CDK + AppSync + DynamoDB)。詳細は `.claude/rules/infra/smalruby-mesh-v2.md`。
+
+### 関連ドキュメント
+
+- `infra/smalruby-mesh-v2/docs/architecture.md` — システム全体図
+- `infra/smalruby-mesh-v2/docs/api-reference.md` — GraphQL スキーマ
+- `infra/smalruby-mesh-v2/docs/operations.md` — CloudWatch ログ運用
+- `docs/mesh/cost.md` — コスト試算
+
+## 開発の流れ
+
+### 1. クライアント側の変更
+
+1. **TDD で書く** — `test/unit/mesh_service_v2_*.js` (tap) で RED → GREEN → REFACTOR
+2. `bin/dx bash -c "cd packages/scratch-vm && npm run lint"`
+3. 関連 unit test を実行: `bin/dx bash -c "cd packages/scratch-vm && npm exec tap -- test/unit/mesh_service_v2_*.js test/unit/extension_mesh_v2*.js"`
+4. push (CI が integration を含む全テストを実行)
+5. **マージ前に必ず本書「デグレ確認手順」を実行**
+
+### 2. mixin に変更を入れる場合
+
+各 mixin は **MeshV2Service.prototype** に `Object.assign` で集約される。新しい mixin を追加する場合:
+
+```javascript
+// new-mixin.js
+const NewMixin = {
+    myMethod() { /* uses this.* */ },
+};
+module.exports = { NewMixin };
+
+// mesh-service.js
+const { NewMixin } = require('./new-mixin');
+// ...
+Object.assign(MeshV2Service.prototype, NewMixin);
+```
+
+### 3. サーバー側の変更
+
+`.claude/rules/infra/smalruby-mesh-v2.md` を参照。CDK deploy の前後で:
+1. `infra/smalruby-mesh-v2/spec/requests/` の RSpec を更新
+2. `bundle exec rspec spec/requests/<対象>` で stg 確認
+3. stg → prod の順でデプロイ
+4. クライアント側のデグレ確認 (本書) を実行
+
+## デグレ確認手順 (Playwright)
+
+mesh 関連の変更時は必ず実行する。 **5 分以内** に完了すること (heartbeat TTL 制約)。
+
+### 事前準備
+
+1. dev server を **対象の worktree** からマウントする:
+   ```bash
+   docker compose stop app && docker compose rm -f app
+   docker compose up -d app   # CWD の worktree から /app にマウント
+   docker inspect smalruby3-editor-app-1 --format '{{ range .Mounts }}{{ if eq .Destination "/app" }}{{ .Source }}{{ end }}{{ end }}'
+   ```
+2. `until curl -sf -o /dev/null http://localhost:8601; do sleep 5; done`
+
+### Step 1: 単体テスト + 整形チェック (group 時間消費なし)
+
+```bash
+bin/dx bash -c "cd packages/scratch-vm && npm run lint"
+bin/dx bash -c "cd packages/scratch-vm && npm exec tap -- test/unit/mesh_service_v2*.js test/unit/extension_mesh_v2*.js test/integration/extensions/mesh-v2-*.test.js"
+```
+
+すべて pass しないと先に進まない。
+
+### Step 2: Playwright 事前チェック (group 時間消費なし)
+
+接続前に検証可能なものをすべてここでやる。**5 分タイマーは消費しない**。
+
+```javascript
+// http://localhost:8601/?no_beforeunload=1&tab=ruby&ruby_version=2 を開いてから:
+const vm = window.smalruby.vm;
+await vm.extensionManager.loadExtensionURL('meshV2');
+await new Promise(r => setTimeout(r, 500));
+
+let req;
+await new Promise(resolve => {
+    window.webpackChunkGUI.push([['__probe__'], {}, r => { req = r; resolve(); }]);
+});
+const MeshV2Service = req.c['../scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js'].exports;
+window.__MeshV2Service = MeshV2Service;
+
+// チェック:
+// 1. 全 mixin メソッドが MeshV2Service.prototype に存在するか
+// 2. constructor が落ちずに必須プロパティを初期化するか
+// 3. testWebSocket() が解決するか (boolean)
+// 4. createDomain() が成功するか (string が返る)
+// 5. listGroups() が空配列を返すか
+// 6. _generateOrderKey が `\d{14}-\d{7}` 形式 + 連番が単調増加するか
+// 7. shouldDisconnectOnError / isNetworkFilterError のマトリクス
+// 8. getRemoteVariable('any') が remoteData={} で null を返すか
+```
+
+### Step 3: WebSocket モード (group 時間 ~2 分消費)
+
+```javascript
+// 同じタブ内に host と node の 2 つの MeshV2Service を作る (2 タブを開く必要なし)
+const ts = Date.now();
+const domain = `ws-test-${ts}`;
+const blocks = {
+    runtime: window.smalruby.vm.runtime,
+    opcodeFunctions: { event_broadcast: () => {} },
+};
+
+const host = new MeshV2Service(blocks, `host-${ts}`, domain);
+host.testWebSocket = () => Promise.resolve(true);
+await host.createGroup(`ws-grp-${ts}`);
+
+const node = new MeshV2Service(blocks, `node-${ts}`, domain);
+node.testWebSocket = () => Promise.resolve(true);
+await node.joinGroup(host.groupId, host.domain, `ws-grp-${ts}`);
+
+// 検証 (assertions):
+// - host.useWebSocket === true && node.useWebSocket === true
+// - host.subscriptions.length > 0 && node.subscriptions.length > 0
+// - node.dataSyncTimer (15s periodic-sync 起動)
+// - node.pollingTimer === null
+
+// データ同期: host が REPORT_DATA mutate → node.remoteData[hostId] に反映 (subscription 経由)
+// 期待: 4 秒以内に node.remoteData[hostId].score?.value === '42'
+
+// イベント配信: node.broadcastEvent をフックしてから host.fireEvent('a', '1') ×3
+// 期待: broadcastCalls の長さ 3、name/payload/orderKey が送信順と一致
+
+host.cleanup(); node.cleanup();
+```
+
+### Step 4: Polling モード (group 時間 ~2 分消費)
+
+```javascript
+// 同様の流れだが forcePolling = true
+const host = new MeshV2Service(blocks, `pl-host-${ts2}`, domain2);
+host.forcePolling = true;
+host.useWebSocket = false;
+await host.createGroup(`pl-grp-${ts2}`);
+
+const node = new MeshV2Service(blocks, `pl-node-${ts2}`, domain2);
+node.forcePolling = true;
+node.useWebSocket = false;
+await node.joinGroup(host.groupId, host.domain, `pl-grp-${ts2}`);
+
+// 検証:
+// - host.useWebSocket === false && node.useWebSocket === false
+// - host.subscriptions.length === 0 (polling は subscription 張らない)
+// - host.pollingTimer (2s pollEvents 起動)
+// - host.dataSyncTimer === null (issue #554: polling では periodic-sync 起動しない)
+
+// データ同期: host が REPORT_DATA mutate → node が pollGroupData で取得 (最大 2s 遅延)
+// 期待: 6 秒以内に node.remoteData[hostId].kp1?.value === '999'
+
+// イベント配信: node.broadcastEvent をフックしてから host.fireEvent('alpha', '11') ×3
+// fireEventsBatch は polling 時は RECORD_EVENTS を使う、node は pollGroupData の events で受け取る
+// 期待: broadcastCalls の長さ 3、順序が送信順と一致
+
+host.cleanup(); node.cleanup();
+```
+
+### 完了基準
+
+- Step 1: lint OK + 全 unit/integration test pass
+- Step 2: 全 prototype メソッド + プロパティ + helper メソッドが正常動作
+- Step 3: WebSocket でデータ + イベントが配信される、タイマー構成が正しい
+- Step 4: Polling でデータ + イベントが配信される、タイマー構成が正しい
+
+### よくある落とし穴
+
+- **dev server のマウント**: `docker compose run` する CWD が worktree の root と一致するか必ず確認 (`docker inspect ... --format '{{ range .Mounts }}{{ if eq .Destination "/app" }}{{ .Source }}{{ end }}{{ end }}'`)
+- **`bin/setup-worktree`**: 新しい worktree では `npm install` + `npm run build:dev` が必要 (詳細: `.claude/rules/git-workflow.md`)
+- **テスト失敗の本物 / 偽陽性**: `dist/` や per-package `node_modules` が無いと jest や tap が解決失敗する。本物のリグレッションと区別するため、まず setup の完了を確認する
+- **5 分タイマー**: createGroup から 5 分経過すると heartbeat 失効 → mutation が `GroupNotFound` で失敗する。新しい group を作り直す
+- **同一タブ host + node**: 同じ JS context で host と node を作ると subscription が 1 つの WebSocket 接続を共有するが、AppSync 側では別個の subscription として扱われる。テスト目的では問題ない
+
+## 参照
+
+- issue #554 (pollGroupData 統合) — PR #564
+- issue #555 (プロトコルロギング) — PR #557
+- issue #556 (orderKey によるイベント順序保証) — PR #563
+- issue #566 (mesh-service.js 責務分割) — PR #569

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/broadcast-receiver.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/broadcast-receiver.js
@@ -1,0 +1,175 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const BlockUtility = require('../../engine/block-utility');
+
+/**
+ * Incoming broadcast playback. 受信した batchEvent / pollGroupData の events を
+ * タイムスタンプ順 (同一タイムスタンプ内では orderKey 順, issue #556) にソート
+ * して `pendingBroadcasts` にキューイングし、フレームごとに 33ms ウィンドウで
+ * Scratch の `event_broadcast` ハンドラに渡す。
+ *
+ * `processNextBroadcast` は constructor で runtime の `BEFORE_STEP` にバインド
+ * されており、毎フレーム呼ばれる。
+ *
+ * Mixed into MeshV2Service.prototype.
+ */
+const BroadcastReceiverMixin = {
+    /**
+     * Internal method to queue events for playback with relative timing.
+     * @param {Array} events - Array of events to queue.
+     * @private
+     */
+    _queueEventsForPlayback(events) {
+        if (!events || events.length === 0) return;
+
+        // タイムスタンプでソート（副作用を避けるためコピーを作成）。
+        // issue #556: 同一タイムスタンプ内では orderKey の辞書順で安定ソートする。
+        // どちらか一方でも orderKey がない場合は元の順序を維持（タイムスタンプ比較のみ）。
+        const sortedEvents = [...events].sort((a, b) => {
+            const tDiff = new Date(a.timestamp) - new Date(b.timestamp);
+            if (tDiff !== 0) return tDiff;
+            if (a.orderKey && b.orderKey) {
+                if (a.orderKey < b.orderKey) return -1;
+                if (a.orderKey > b.orderKey) return 1;
+            }
+            return 0;
+        });
+
+        // 最初のイベントを基準にオフセットを計算
+        const baseTime = new Date(sortedEvents[0].timestamp).getTime();
+
+        // キューに追加
+        sortedEvents.forEach(event => {
+            const eventTime = new Date(event.timestamp).getTime();
+            const offsetMs = eventTime - baseTime;
+
+            this.pendingBroadcasts.push({
+                event: event,
+                offsetMs: offsetMs,
+            });
+            debug(
+                () =>
+                    `Mesh V2: Queued event: ${event.name} ` +
+                    `(offset: ${offsetMs}ms, original timestamp: ${event.timestamp})`,
+            );
+        });
+
+        // バッチ処理開始時刻を記録（未開始の場合のみ）
+        if (this.batchStartTime === null && this.pendingBroadcasts.length > 0) {
+            this.batchStartTime = Date.now();
+            this.lastBroadcastOffset = 0;
+        }
+
+        debug(() => `Mesh V2: Total pending broadcasts: ${this.pendingBroadcasts.length}`);
+    },
+
+    /**
+     * Process pending broadcast events that should fire based on elapsed real time.
+     * Called once per frame via BEFORE_STEP event.
+     *
+     * Strategy:
+     * - Process events whose timing has arrived (offsetMs <= elapsedMs)
+     * - Limit processing to a 33ms window of event time per frame to avoid spikes
+     * - Execute them in order (maintains event sequence)
+     * - Different event types don't cause RESTART (different handlers)
+     */
+    processNextBroadcast() {
+        if (!this.groupId) {
+            // 切断されている場合はなにもしない
+            return;
+        }
+
+        if (this.pendingBroadcasts.length === 0) {
+            // キューが空になったらリセット
+            this.batchStartTime = null;
+            this.lastBroadcastOffset = 0;
+            return;
+        }
+
+        const now = Date.now();
+        const elapsedMs = this.batchStartTime ? now - this.batchStartTime : 0;
+
+        // 処理すべきイベントを収集（タイミングが来ているもの）
+        const eventsToProcess = [];
+        let windowBase = null;
+
+        while (this.pendingBroadcasts.length > 0) {
+            const { event, offsetMs } = this.pendingBroadcasts[0];
+
+            // まだタイミングが来ていない場合は待機
+            if (offsetMs > elapsedMs) {
+                debug(
+                    () =>
+                        `Mesh V2: Waiting for event ${event.name} ` +
+                        `(needs ${offsetMs}ms, elapsed ${elapsedMs}ms)`,
+                );
+                break;
+            }
+
+            // 1フレーム(33ms)のウィンドウ制限を適用
+            // （バックログがある場合でも1フレームで大量のブロードキャストを避ける）
+            if (windowBase === null) {
+                windowBase = offsetMs;
+            } else if (offsetMs >= windowBase + 33) {
+                debug(
+                    () =>
+                        `Mesh V2: Window limit reached (33ms). ` +
+                        `Remaining events will be processed in next frames.`,
+                );
+                break;
+            }
+
+            // タイミングが来たイベントをキューから取り出し
+            const item = this.pendingBroadcasts.shift();
+            eventsToProcess.push(item);
+        }
+
+        // 収集したイベントを処理
+        if (eventsToProcess.length > 0) {
+            debug(
+                () =>
+                    `Mesh V2: Broadcasting ${eventsToProcess.length} events ` +
+                    `(${this.pendingBroadcasts.length} remaining in queue)`,
+            );
+
+            eventsToProcess.forEach(({ event, offsetMs }) => {
+                debug(
+                    () =>
+                        `Mesh V2: Broadcasting event: ${event.name} ` +
+                        `(offset: ${offsetMs}ms, elapsed: ${elapsedMs}ms)`,
+                );
+
+                this.broadcastEvent(event);
+                this.lastBroadcastOffset = offsetMs;
+            });
+        }
+    },
+
+    broadcastEvent(event) {
+        debug(() => `Mesh V2: Executing broadcastEvent for: ${event.name}`);
+        try {
+            const args = {
+                BROADCAST_OPTION: {
+                    id: null,
+                    name: event.name,
+                },
+            };
+            const util = BlockUtility.lastInstance();
+            if (util) {
+                if (!util.sequencer) {
+                    util.sequencer = this.runtime.sequencer;
+                }
+                debug(() => `Mesh V2: Triggering event_broadcast: ${event.name}`);
+                this.blocks.opcodeFunctions.event_broadcast(args, util);
+            } else {
+                log.warn(`Mesh V2: No BlockUtility instance available for broadcast: ${event.name}`);
+            }
+        } catch (error) {
+            log.error(`Mesh V2: Failed to broadcast event: ${error}`);
+        }
+    },
+};
+
+module.exports = { BroadcastReceiverMixin };

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/data-sender.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/data-sender.js
@@ -1,0 +1,178 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const Variable = require('../../engine/variable');
+const { REPORT_DATA } = require('./gql-operations');
+
+/**
+ * Outgoing data sender. Scratch のグローバル変数を `reportDataByNode`
+ * mutation で他ノードに伝播する。
+ *
+ * 二段デルタ送信:
+ *   - sendData → latestQueuedData による「キュー時点のデルタ」フィルタ
+ *   - _reportData → lastSentData による「サーバー反映済みのデルタ」フィルタ
+ * これにより、値が短時間で行ったり来たりしても重複 mutation を抑える。
+ *
+ * `getRemoteVariable` は他ノードから受信した値を最新タイムスタンプで読む。
+ *
+ * Mixed into MeshV2Service.prototype.
+ */
+const DataSenderMixin = {
+    async sendData(dataArray) {
+        if (!this.groupId || !this.client) return;
+
+        // Delta transmission: Filter out items that haven't changed since they were LAST QUEUED.
+        // This avoids redundant mutations if values change back within the rate-limit interval.
+        const filteredData = dataArray.filter(item => this.latestQueuedData[item.key] !== item.value);
+
+        debug(
+            () =>
+                `Mesh V2: sendData called with ${dataArray.length} items, ` +
+                `${filteredData.length} items changed: ${JSON.stringify(filteredData)}`,
+        );
+
+        if (filteredData.length === 0) {
+            return;
+        }
+
+        // Update latestQueuedData IMMEDIATELY before sending to RateLimiter
+        filteredData.forEach(item => {
+            this.latestQueuedData[item.key] = item.value;
+        });
+
+        try {
+            // Save Promise to track completion (including queue time)
+            this.lastDataSendPromise = this.dataRateLimiter.send(filteredData, this._reportDataBound);
+            await this.lastDataSendPromise;
+        } catch (error) {
+            log.error(`Mesh V2: Failed to send data: ${error}`);
+            const reason = this.shouldDisconnectOnError(error);
+            if (reason) {
+                this.cleanupAndDisconnect(reason);
+            }
+        }
+    },
+
+    /**
+     * Internal method to send data to the server.
+     * Used as sendFunction in dataRateLimiter.
+     * @param {Array} payload - Array of {key, value} objects.
+     * @returns {Promise} - Resolves with the mutation result.
+     * @private
+     */
+    async _reportData(payload) {
+        if (!this.groupId || !this.client) return;
+
+        // Final delta check: Filter out items that haven't changed since the LAST SUCCESSFUL transmission.
+        // This handles cases where values changed back while an earlier mutation was in flight.
+        const finalPayload = payload.filter(item => this.lastSentData[item.key] !== item.value);
+
+        if (finalPayload.length === 0) {
+            debug(() => 'Mesh V2: Skipping mutation as all data is already up-to-date on server');
+            return {
+                data: {
+                    reportDataByNode: {
+                        nodeStatus: {
+                            data: payload, // Return original payload to satisfy caller expectation
+                        },
+                    },
+                },
+            };
+        }
+
+        try {
+            this.costTracking.mutationCount++;
+            this.costTracking.reportDataCount++;
+
+            log.info(`Mesh V2: Sending ${finalPayload.length} data items to group ${this.groupId}`);
+
+            // Save Promise to track completion
+            this.lastDataSendPromise = this.client.mutate({
+                mutation: REPORT_DATA,
+                variables: {
+                    groupId: this.groupId,
+                    domain: this.domain,
+                    nodeId: this.meshId,
+                    data: finalPayload,
+                },
+            });
+
+            const result = await this.lastDataSendPromise;
+
+            // Update last sent data on success
+            finalPayload.forEach(item => {
+                this.lastSentData[item.key] = item.value;
+            });
+
+            return result;
+        } catch (error) {
+            log.error(`Mesh V2: Failed to report data: ${error}`);
+            const reason = this.shouldDisconnectOnError(error);
+            if (reason) {
+                this.cleanupAndDisconnect(reason);
+                // Do not re-throw: sendData will catch this and would call
+                // cleanupAndDisconnect again, causing duplicate cost summaries.
+                return;
+            }
+            throw error;
+        }
+    },
+
+    /**
+     * Get all global scalar variables.
+     * @returns {Array} Array of {key, value} objects.
+     */
+    getGlobalVariables() {
+        const stage = this.runtime.getTargetForStage();
+        if (!stage || !stage.variables) return [];
+
+        const variables = [];
+        for (const varId in stage.variables) {
+            const currVar = stage.variables[varId];
+            if (currVar.type === Variable.SCALAR_TYPE) {
+                variables.push({
+                    key: currVar.name,
+                    value: String(currVar.value),
+                });
+            }
+        }
+        return variables;
+    },
+
+    /**
+     * Send all global variables to other nodes in the group.
+     * @returns {Promise<void>} A promise that resolves when variables are queued for sending.
+     */
+    async sendAllGlobalVariables() {
+        if (!this.groupId || !this.client) return;
+
+        const allVariables = this.getGlobalVariables();
+        if (allVariables.length === 0) {
+            debug(() => 'Mesh V2: No global variables to send');
+            return;
+        }
+
+        await this.sendData(allVariables);
+        debug(() => `Mesh V2: Sent ${allVariables.length} global variables`);
+    },
+
+    getRemoteVariable(name) {
+        let latestValue = null;
+        let latestTimestamp = 0;
+
+        // Search across all nodes for the variable name
+        for (const nodeId in this.remoteData) {
+            if (Object.prototype.hasOwnProperty.call(this.remoteData[nodeId], name)) {
+                const data = this.remoteData[nodeId][name];
+                if (data.timestamp > latestTimestamp) {
+                    latestTimestamp = data.timestamp;
+                    latestValue = data.value;
+                }
+            }
+        }
+        return latestValue;
+    },
+};
+
+module.exports = { DataSenderMixin };

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/event-sender.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/event-sender.js
@@ -1,0 +1,217 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const { FIRE_EVENTS, RECORD_EVENTS } = require('./gql-operations');
+
+/**
+ * Outgoing event sender. Scratch の broadcast を mesh 経由で他ノードへ送る。
+ * fireEvent でキューイングし、eventBatchTimer (デフォルト 1 秒) ごとに
+ * 1 mutation でまとめて送信する。
+ *
+ * 重複/オーバーフロー保護:
+ *   - 同じ eventName + payload はキュー内に重複させない
+ *   - キューが MAX_EVENT_QUEUE_SIZE (100) に達したら FIFO で古い方を破棄
+ *
+ * issue #556: orderKey を `YYYYMMDDHHMMSS-<7桁連番>` で付与し、サーバー側 SK
+ * の安定ソートに使う。同一クライアントが連続送信した複数イベントの順序を
+ * 受信側でも保証する。
+ *
+ * Mixed into MeshV2Service.prototype.
+ */
+const EventSenderMixin = {
+    startEventBatchTimer() {
+        this.stopEventBatchTimer();
+        debug(() => `Mesh V2: Starting event batch timer (Interval: ${this.eventBatchInterval}ms)`);
+        this.eventBatchTimer = setInterval(() => {
+            this.processBatchEvents();
+        }, this.eventBatchInterval);
+    },
+
+    stopEventBatchTimer() {
+        if (this.eventBatchTimer) {
+            clearInterval(this.eventBatchTimer);
+            this.eventBatchTimer = null;
+        }
+    },
+
+    async processBatchEvents() {
+        if (this.eventQueue.length === 0) return;
+
+        // キューから全イベントを取り出す
+        const events = this.eventQueue.splice(0);
+        debug(() => `Mesh V2: Processing ${events.length} queued events for sending`);
+
+        try {
+            // ペイロードサイズ制限を考慮して分割送信（約1,000イベントごと）
+            const MAX_BATCH_SIZE = 1000;
+            while (events.length > 0) {
+                const batch = events.splice(0, MAX_BATCH_SIZE);
+                await this.fireEventsBatch(batch);
+            }
+        } catch (error) {
+            log.error(`Mesh V2: Failed to process batch events: ${error}`);
+        }
+    },
+
+    async fireEventsBatch(events) {
+        if (!this.groupId || !this.client || events.length === 0) return;
+
+        try {
+            // Wait for last data send to complete
+            await this.lastDataSendPromise;
+
+            this.costTracking.mutationCount++;
+            this.costTracking.fireEventsCount++;
+            log.info(
+                `Mesh V2: Sending batch of ${events.length} events to group ${this.groupId} ` +
+                    `(Protocol: ${this.useWebSocket ? 'WebSocket' : 'Polling'})`,
+            );
+
+            if (this.useWebSocket) {
+                await this.client.mutate({
+                    mutation: FIRE_EVENTS,
+                    variables: {
+                        groupId: this.groupId,
+                        domain: this.domain,
+                        nodeId: this.meshId,
+                        events: events,
+                    },
+                });
+            } else {
+                const result = await this.client.mutate({
+                    mutation: RECORD_EVENTS,
+                    variables: {
+                        groupId: this.groupId,
+                        domain: this.domain,
+                        nodeId: this.meshId,
+                        events: events,
+                    },
+                });
+                if (result.data && result.data.recordEventsByNode && result.data.recordEventsByNode.nextSince) {
+                    this.lastFetchTime = result.data.recordEventsByNode.nextSince;
+                }
+            }
+        } catch (error) {
+            log.error(`Mesh V2: Failed to fire batch events: ${error}`);
+            const reason = this.shouldDisconnectOnError(error);
+            if (reason) {
+                this.cleanupAndDisconnect(reason);
+            }
+        }
+    },
+
+    fireEvent(eventName, payload = '') {
+        if (!this.groupId || !this.client) {
+            if (this.groupId) {
+                log.warn(`Mesh V2: Cannot fire event ${eventName} - client not available`);
+            } else {
+                debug(() => `Mesh V2: Cannot fire event ${eventName} - not connected`);
+            }
+            return;
+        }
+
+        // ステップ1: 重複チェック
+        const isDuplicate = this.eventQueue.some(
+            item => item.eventName === eventName && item.payload === payload,
+        );
+
+        if (isDuplicate) {
+            this.eventQueueStats.duplicatesSkipped++;
+            this.reportEventStatsIfNeeded();
+
+            debug(() => `Mesh V2: Event already in queue, skipping: ${eventName}`);
+            return;
+        }
+
+        // ステップ2: サイズ制限チェック（保険）
+        if (this.eventQueue.length >= this.MAX_EVENT_QUEUE_SIZE) {
+            const dropped = this.eventQueue.shift(); // 古いイベントを破棄（FIFO）
+            this.eventQueueStats.dropped++;
+
+            if (this.eventQueueStats.dropped % 10 === 1) {
+                // 10イベントごとに警告
+                log.warn(
+                    `Mesh V2: Event queue full (${this.MAX_EVENT_QUEUE_SIZE}). ` +
+                        `Dropped ${this.eventQueueStats.dropped} events. ` +
+                        `Latest: ${dropped.eventName}`,
+                );
+            }
+        }
+
+        debug(
+            () =>
+                `Mesh V2: Queuing event for sending: ${eventName} ` +
+                `(queue size: ${this.eventQueue.length})`,
+        );
+
+        // キューに追加（発火日時と orderKey を記録）
+        const firedAt = new Date();
+        this.eventQueue.push({
+            eventName: eventName,
+            payload: payload,
+            firedAt: firedAt.toISOString(),
+            // issue #556: 同一バッチ内のイベント順序保証用
+            orderKey: this._generateOrderKey(firedAt),
+        });
+    },
+
+    /**
+     * Generate a sortable order key for an event.
+     * Format: `<YYYYMMDDHHMMSS>-<NNNNNNN>` where NNNNNNN is a 7-digit
+     * 0-padded sequence counter incremented per call (resets on group
+     * create/join).
+     *
+     * Same client guarantees lexicographic order = send order across batches.
+     * Cross-client collisions are possible but extremely unlikely; the server
+     * appends a short UUID to the SK to ensure uniqueness.
+     *
+     * Why 7 digits: connection cap is 35 min = 2100s. Worst-case throughput
+     * is bounded by MAX_EVENT_QUEUE_SIZE (100) draining every
+     * eventBatchInterval (min 100ms) → 1000 events/s max → ~2.1M per
+     * session. 7 digits (max 9,999,999) gives ~4.7x margin even at the
+     * minimum interval. 3 digits would overflow at the 1000th event,
+     * silently breaking lexicographic order ("1000" < "999").
+     * @param {Date} firedAt - The event fire time.
+     * @returns {string} Sortable order key.
+     * @private
+     */
+    _generateOrderKey(firedAt) {
+        const yyyy = firedAt.getFullYear().toString();
+        const mm = String(firedAt.getMonth() + 1).padStart(2, '0');
+        const dd = String(firedAt.getDate()).padStart(2, '0');
+        const hh = String(firedAt.getHours()).padStart(2, '0');
+        const mi = String(firedAt.getMinutes()).padStart(2, '0');
+        const ss = String(firedAt.getSeconds()).padStart(2, '0');
+        this.eventSequence += 1;
+        const seq = String(this.eventSequence).padStart(7, '0');
+        return `${yyyy}${mm}${dd}${hh}${mi}${ss}-${seq}`;
+    },
+
+    /**
+     * Report event queue statistics if needed (every 10 seconds).
+     */
+    reportEventStatsIfNeeded() {
+        const now = Date.now();
+        const elapsed = now - this.eventQueueStats.lastReportTime;
+
+        if (
+            elapsed >= 10000 &&
+            (this.eventQueueStats.duplicatesSkipped > 0 || this.eventQueueStats.dropped > 0)
+        ) {
+            debug(
+                () =>
+                    `Mesh V2: Event Queue Stats (last ${(elapsed / 1000).toFixed(1)}s): ` +
+                    `duplicates skipped=${this.eventQueueStats.duplicatesSkipped}, ` +
+                    `dropped=${this.eventQueueStats.dropped}, ` +
+                    `current queue size=${this.eventQueue.length}`,
+            );
+
+            this.eventQueueStats.duplicatesSkipped = 0;
+            this.eventQueueStats.dropped = 0;
+            this.eventQueueStats.lastReportTime = now;
+        }
+    },
+};
+
+module.exports = { EventSenderMixin };

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/group-lifecycle.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/group-lifecycle.js
@@ -1,0 +1,231 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const {
+    CREATE_DOMAIN,
+    CREATE_GROUP,
+    JOIN_GROUP,
+    LEAVE_GROUP,
+    DISSOLVE_GROUP,
+} = require('./gql-operations');
+
+/**
+ * Group lifecycle. グループの作成 (host) / 参加 (member) / 解散 (host) /
+ * 離脱 (member) を扱う。プロトコル選択 (WebSocket / Polling)、各種タイマー
+ * の起動、初期データ送信もここでオーケストレーションする。
+ *
+ * `createDomain` は IP ベースのドメイン文字列を AppSync 側で生成し、その後の
+ * 全 mutation/query 呼び出しの分離キーとして使う。
+ *
+ * Mixed into MeshV2Service.prototype.
+ */
+const GroupLifecycleMixin = {
+    async createDomain() {
+        if (!this.client) throw new Error('Client not initialized');
+
+        try {
+            this.costTracking.mutationCount++;
+            const result = await this.client.mutate({
+                mutation: CREATE_DOMAIN,
+            });
+
+            this.domain = result.data.createDomain;
+            debug(() => `Mesh V2: Created domain ${this.domain} from source IP`);
+            return this.domain;
+        } catch (error) {
+            log.error(`Mesh V2: Failed to create domain: ${error}`);
+            throw error;
+        }
+    },
+
+    async createGroup(groupName) {
+        if (!this.client) throw new Error('Client not initialized');
+
+        try {
+            // Simulate network filter (503) for testing when MESH_NETWORK_FILTER=true
+            this._checkSimulateNetworkFilter();
+
+            if (!this.domain) {
+                await this.createDomain();
+            }
+
+            // Test WebSocket availability
+            if (this.forcePolling) {
+                this.useWebSocket = false;
+            } else {
+                this.useWebSocket = await this.testWebSocket();
+            }
+            log.info(`Mesh V2: WebSocket available: ${this.useWebSocket}`);
+
+            this.costTracking.mutationCount++;
+            this.lastFetchTime = new Date().toISOString();
+            // issue #556: orderKey の連番をリセット
+            this.eventSequence = 0;
+            debug(() => `Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before createGroup)`);
+            const result = await this.client.mutate({
+                mutation: CREATE_GROUP,
+                variables: {
+                    name: groupName,
+                    hostId: this.meshId,
+                    domain: this.domain,
+                    useWebSocket: this.useWebSocket,
+                },
+            });
+
+            const group = result.data.createGroup;
+            this.groupId = group.id;
+            this.groupName = group.name;
+            this.domain = group.domain; // Update domain from server
+            this.expiresAt = group.expiresAt;
+            this.useWebSocket = group.useWebSocket;
+            if (group.pollingIntervalSeconds) {
+                this.pollingIntervalSeconds = group.pollingIntervalSeconds;
+            }
+            this.isHost = true;
+            if (group.heartbeatIntervalSeconds) {
+                this.hostHeartbeatInterval = group.heartbeatIntervalSeconds;
+            }
+
+            this.costTracking.connectionStartTime = Date.now();
+            if (this.useWebSocket) {
+                this.startSubscriptions();
+                // WebSocket モードは subscription でデータ更新をリアルタイム取得し、
+                // 念のため 15 秒ごとの fallback 同期を実行
+                this.startPeriodicDataSync();
+            } else {
+                // Polling モードは pollGroupData が events + nodeStatuses を
+                // 同時取得するため、startPeriodicDataSync は不要 (issue #554)
+                this.startPolling();
+            }
+            this.startHeartbeat();
+            this.startEventBatchTimer();
+            this.startConnectionTimer();
+
+            await this.sendAllGlobalVariables();
+
+            log.info(
+                `Mesh V2: Created group ${this.groupName} (${this.groupId}) in domain ${this.domain} ` +
+                    `(Protocol: ${this.useWebSocket ? 'WebSocket' : 'Polling'})`,
+            );
+            return group;
+        } catch (error) {
+            log.error(`Mesh V2: Failed to create group: ${error}`);
+            // Store error for network filter detection
+            this.lastError = error;
+            throw error;
+        }
+    },
+
+    async joinGroup(groupId, domain, groupName) {
+        if (!this.client) throw new Error('Client not initialized');
+
+        try {
+            // Simulate network filter (503) for testing when MESH_NETWORK_FILTER=true
+            this._checkSimulateNetworkFilter();
+
+            this.costTracking.mutationCount++;
+            this.lastFetchTime = new Date().toISOString();
+            // issue #556: orderKey の連番をリセット
+            this.eventSequence = 0;
+            debug(() => `Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before joinGroup)`);
+            const result = await this.client.mutate({
+                mutation: JOIN_GROUP,
+                variables: {
+                    groupId: groupId,
+                    domain: domain || this.domain,
+                    nodeId: this.meshId,
+                    useWebSocket: this.useWebSocket,
+                },
+            });
+
+            const node = result.data.joinGroup;
+            this.groupId = groupId;
+            this.groupName = groupName || groupId;
+            this.domain = node.domain; // Update domain from server
+            this.expiresAt = node.expiresAt;
+            this.useWebSocket = this.forcePolling ? false : node.useWebSocket;
+            if (node.pollingIntervalSeconds) {
+                this.pollingIntervalSeconds = node.pollingIntervalSeconds;
+            }
+            this.isHost = false;
+            if (node.heartbeatIntervalSeconds) {
+                this.memberHeartbeatInterval = node.heartbeatIntervalSeconds;
+            }
+
+            this.costTracking.connectionStartTime = Date.now();
+            if (this.useWebSocket) {
+                this.startSubscriptions();
+                // WebSocket モードは 15 秒ごとの fallback 同期を実行
+                this.startPeriodicDataSync();
+            } else {
+                // Polling モードは pollGroupData が events + nodeStatuses を
+                // 同時取得するため、startPeriodicDataSync は不要 (issue #554)
+                this.startPolling();
+            }
+            this.startHeartbeat(); // Start heartbeat for member too
+            this.startEventBatchTimer();
+            this.startConnectionTimer();
+
+            await this.sendAllGlobalVariables();
+            await this.fetchAllNodesData();
+
+            log.info(
+                `Mesh V2: Joined group ${this.groupId} in domain ${this.domain} ` +
+                    `(Protocol: ${this.useWebSocket ? 'WebSocket' : 'Polling'})`,
+            );
+            return node;
+        } catch (error) {
+            log.error(`Mesh V2: Failed to join group: ${error}`);
+            // Store error for network filter detection
+            this.lastError = error;
+            throw error;
+        }
+    },
+
+    async leaveGroup() {
+        if (!this.groupId) return;
+
+        const groupId = this.groupId;
+        const domain = this.domain;
+        const isHost = this.isHost;
+        const hostId = this.meshId;
+        const nodeId = this.meshId;
+
+        // Count the leave/dissolve mutation before cleanup() outputs the cost summary
+        this.costTracking.mutationCount++;
+        this.costTracking.leaveCount++;
+
+        this.cleanupAndDisconnect();
+
+        if (!this.client) return;
+
+        try {
+            if (isHost) {
+                await this.client.mutate({
+                    mutation: DISSOLVE_GROUP,
+                    variables: {
+                        groupId: groupId,
+                        domain: domain,
+                        hostId: hostId,
+                    },
+                });
+                debug(() => `Mesh V2: Dissolved group ${groupId}`);
+            } else {
+                await this.client.mutate({
+                    mutation: LEAVE_GROUP,
+                    variables: {
+                        groupId: groupId,
+                        domain: domain,
+                        nodeId: nodeId,
+                    },
+                });
+                debug(() => `Mesh V2: Left group ${groupId}`);
+            }
+        } catch (error) {
+            log.error(`Mesh V2: Error during leave/dissolve (background): ${error}`);
+        }
+    },
+};
+
+module.exports = { GroupLifecycleMixin };

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/heartbeat-manager.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/heartbeat-manager.js
@@ -1,0 +1,138 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const { RENEW_HEARTBEAT, SEND_MEMBER_HEARTBEAT } = require('./gql-operations');
+
+/**
+ * Heartbeat manager. Host は renewHeartbeat、Member は sendMemberHeartbeat を
+ * 一定間隔で送信し、グループ/ノードの TTL を延長する。サーバーが新しい間隔を
+ * 返した場合はそれに追従する。
+ *
+ * Connection timer は heartbeat の `expiresAt` を見て、グループが
+ * 失効する直前に leaveGroup を呼んで自動切断する。
+ *
+ * Mixed into MeshV2Service.prototype.
+ */
+const HeartbeatManagerMixin = {
+    startHeartbeat() {
+        this.stopHeartbeat();
+        if (!this.groupId) return;
+
+        debug(
+            () =>
+                `Mesh V2: Starting heartbeat timer (Role: ${this.isHost ? 'Host' : 'Member'}, ` +
+                `Interval: ${this.isHost ? this.hostHeartbeatInterval : this.memberHeartbeatInterval}s)`,
+        );
+        const interval = (this.isHost ? this.hostHeartbeatInterval : this.memberHeartbeatInterval) * 1000;
+
+        this.heartbeatTimer = setInterval(() => {
+            if (this.isHost) {
+                this.renewHeartbeat();
+            } else {
+                this.sendMemberHeartbeat();
+            }
+        }, interval);
+    },
+
+    stopHeartbeat() {
+        if (this.heartbeatTimer) {
+            debug(() => 'Mesh V2: Stopping heartbeat timer');
+            clearInterval(this.heartbeatTimer);
+            this.heartbeatTimer = null;
+        }
+    },
+
+    async renewHeartbeat() {
+        if (!this.groupId || !this.client || !this.isHost) return;
+
+        try {
+            this.costTracking.mutationCount++;
+            this.costTracking.heartbeatCount++;
+            const result = await this.client.mutate({
+                mutation: RENEW_HEARTBEAT,
+                variables: {
+                    groupId: this.groupId,
+                    domain: this.domain,
+                    hostId: this.meshId,
+                },
+            });
+
+            this.expiresAt = result.data.renewHeartbeat.expiresAt;
+            debug(() => `Mesh V2: Heartbeat renewed. Expires at: ${this.expiresAt}`);
+
+            if (result.data.renewHeartbeat.heartbeatIntervalSeconds) {
+                const newInterval = result.data.renewHeartbeat.heartbeatIntervalSeconds;
+                if (newInterval !== this.hostHeartbeatInterval) {
+                    this.hostHeartbeatInterval = newInterval;
+                    this.startHeartbeat(); // Restart with new interval
+                }
+            }
+            this.startConnectionTimer();
+            return result.data.renewHeartbeat;
+        } catch (error) {
+            log.error(`Mesh V2: Heartbeat renewal failed: ${error}`);
+            const reason = this.shouldDisconnectOnError(error);
+            if (reason) {
+                this.cleanupAndDisconnect(reason);
+            }
+        }
+    },
+
+    async sendMemberHeartbeat() {
+        if (!this.groupId || !this.client || this.isHost) return;
+
+        try {
+            this.costTracking.mutationCount++;
+            this.costTracking.heartbeatCount++;
+            const result = await this.client.mutate({
+                mutation: SEND_MEMBER_HEARTBEAT,
+                variables: {
+                    groupId: this.groupId,
+                    domain: this.domain,
+                    nodeId: this.meshId,
+                },
+            });
+
+            debug(() => 'Mesh V2: Member heartbeat sent');
+            if (result.data.sendMemberHeartbeat.expiresAt) {
+                this.expiresAt = result.data.sendMemberHeartbeat.expiresAt;
+            }
+
+            return result.data.sendMemberHeartbeat;
+        } catch (error) {
+            log.error(`Mesh V2: Member heartbeat failed: ${error}`);
+            const reason = this.shouldDisconnectOnError(error);
+            if (reason) {
+                this.cleanupAndDisconnect(reason);
+            }
+        }
+    },
+
+    startConnectionTimer() {
+        this.stopConnectionTimer();
+        if (!this.expiresAt) return;
+
+        const timeout = new Date(this.expiresAt).getTime() - Date.now();
+        if (timeout <= 0) {
+            log.warn('Mesh V2: Group is already expired');
+            this.leaveGroup();
+            return;
+        }
+
+        const timeoutMinutes = Math.round(timeout / 60000);
+        this.connectionTimer = setTimeout(() => {
+            log.warn(`Mesh V2: Connection timeout (${timeoutMinutes} minutes)`);
+            this.leaveGroup();
+        }, timeout);
+    },
+
+    stopConnectionTimer() {
+        if (this.connectionTimer) {
+            clearTimeout(this.connectionTimer);
+            this.connectionTimer = null;
+        }
+    },
+};
+
+module.exports = { HeartbeatManagerMixin };

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -18,7 +18,6 @@ const {
     REPORT_DATA,
     FIRE_EVENTS,
     RECORD_EVENTS,
-    ON_MESSAGE_IN_GROUP,
     SEARCH_GROUPS_BY_NAME_PREFIX
 } = require('./gql-operations');
 
@@ -27,6 +26,7 @@ const {getForcePollingFromUrl} = require('./utils');
 const {NetworkFilterMixin} = require('./network-filter');
 const {PeriodicSyncMixin} = require('./periodic-sync');
 const {PollingClientMixin} = require('./polling-client');
+const {SubscriptionManagerMixin} = require('./subscription-manager');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -509,84 +509,6 @@ class MeshV2Service {
         this.remoteData = {};
         this.lastSentData = {};
         this.latestQueuedData = {};
-    }
-
-    startSubscriptions () {
-        if (!this.groupId || !this.client) return;
-
-        const variables = {
-            groupId: this.groupId,
-            domain: this.domain
-        };
-
-        const messageSub = this.client.subscribe({
-            query: ON_MESSAGE_IN_GROUP,
-            variables
-        }).subscribe({
-            next: result => {
-                const message = result.data.onMessageInGroup;
-                if (!message) return;
-
-                // MeshMessage has three fields: nodeStatus, batchEvent, groupDissolve
-                // Only one field will be non-null per message
-                // Count all received messages for accurate cost estimation (AppSync delivers to sender too)
-                if (message.nodeStatus) {
-                    this.costTracking.dataUpdateReceived++;
-                    this.handleDataUpdate(message.nodeStatus);
-                } else if (message.batchEvent) {
-                    this.costTracking.batchEventReceived++;
-                    this.handleBatchEvent(message.batchEvent);
-                } else if (message.groupDissolve) {
-                    this.costTracking.dissolveReceived++;
-                    debug(() => 'Mesh V2: Group dissolved by host');
-                    this.cleanupAndDisconnect();
-                } else {
-                    log.warn('Mesh V2: Received message with all fields null');
-                }
-            },
-            error: err => log.error(`Mesh V2: Subscription error: ${err}`)
-        });
-
-        this.subscriptions.push(messageSub);
-    }
-
-    stopSubscriptions () {
-        this.subscriptions.forEach(sub => sub.unsubscribe());
-        this.subscriptions = [];
-    }
-
-    handleDataUpdate (nodeStatus) {
-        if (!nodeStatus || nodeStatus.nodeId === this.meshId) return;
-
-        const nodeId = nodeStatus.nodeId;
-        if (!this.remoteData[nodeId]) {
-            this.remoteData[nodeId] = {};
-        }
-
-        // Use server timestamp with fallback to current time
-        const serverTimestamp = nodeStatus.timestamp ?
-            new Date(nodeStatus.timestamp).getTime() :
-            (log.warn('Mesh V2: Missing server timestamp, using client time'), Date.now());
-
-        nodeStatus.data.forEach(item => {
-            this.remoteData[nodeId][item.key] = {
-                value: item.value,
-                timestamp: serverTimestamp
-            };
-        });
-    }
-
-    handleBatchEvent (batchEvent) {
-        if (!batchEvent || batchEvent.firedByNodeId === this.meshId) return;
-
-        const events = batchEvent.events ?
-            batchEvent.events.filter(event => event.firedByNodeId !== this.meshId) :
-            [];
-        if (events.length === 0) return;
-
-        debug(() => `Mesh V2: Received ${events.length} events from ${batchEvent.firedByNodeId}`);
-
-        this._queueEventsForPlayback(events);
     }
 
     /**
@@ -1184,5 +1106,6 @@ class MeshV2Service {
 Object.assign(MeshV2Service.prototype, NetworkFilterMixin);
 Object.assign(MeshV2Service.prototype, PeriodicSyncMixin);
 Object.assign(MeshV2Service.prototype, PollingClientMixin);
+Object.assign(MeshV2Service.prototype, SubscriptionManagerMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -5,7 +5,6 @@ const debug = debugLogger(process.env.DEBUG);
 const {getClient} = require('./mesh-client');
 const RateLimiter = require('./rate-limiter');
 const BlockUtility = require('../../engine/block-utility');
-const Variable = require('../../engine/variable');
 const {
     LIST_GROUPS_BY_DOMAIN,
     CREATE_DOMAIN,
@@ -13,7 +12,6 @@ const {
     JOIN_GROUP,
     LEAVE_GROUP,
     DISSOLVE_GROUP,
-    REPORT_DATA,
     FIRE_EVENTS,
     RECORD_EVENTS,
     SEARCH_GROUPS_BY_NAME_PREFIX
@@ -26,6 +24,7 @@ const {PeriodicSyncMixin} = require('./periodic-sync');
 const {PollingClientMixin} = require('./polling-client');
 const {SubscriptionManagerMixin} = require('./subscription-manager');
 const {HeartbeatManagerMixin} = require('./heartbeat-manager');
+const {DataSenderMixin} = require('./data-sender');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -729,103 +728,6 @@ class MeshV2Service {
         }
     }
 
-    async sendData (dataArray) {
-        if (!this.groupId || !this.client) return;
-
-        // Delta transmission: Filter out items that haven't changed since they were LAST QUEUED.
-        // This avoids redundant mutations if values change back within the rate-limit interval.
-        const filteredData = dataArray.filter(item => this.latestQueuedData[item.key] !== item.value);
-
-        debug(() => `Mesh V2: sendData called with ${dataArray.length} items, ` +
-            `${filteredData.length} items changed: ${JSON.stringify(filteredData)}`);
-
-        if (filteredData.length === 0) {
-            return;
-        }
-
-        // Update latestQueuedData IMMEDIATELY before sending to RateLimiter
-        filteredData.forEach(item => {
-            this.latestQueuedData[item.key] = item.value;
-        });
-
-        try {
-            // Save Promise to track completion (including queue time)
-            this.lastDataSendPromise = this.dataRateLimiter.send(filteredData, this._reportDataBound);
-            await this.lastDataSendPromise;
-        } catch (error) {
-            log.error(`Mesh V2: Failed to send data: ${error}`);
-            const reason = this.shouldDisconnectOnError(error);
-            if (reason) {
-                this.cleanupAndDisconnect(reason);
-            }
-        }
-    }
-
-    /**
-     * Internal method to send data to the server.
-     * Used as sendFunction in dataRateLimiter.
-     * @param {Array} payload - Array of {key, value} objects.
-     * @returns {Promise} - Resolves with the mutation result.
-     * @private
-     */
-    async _reportData (payload) {
-        if (!this.groupId || !this.client) return;
-
-        // Final delta check: Filter out items that haven't changed since the LAST SUCCESSFUL transmission.
-        // This handles cases where values changed back while an earlier mutation was in flight.
-        const finalPayload = payload.filter(item => this.lastSentData[item.key] !== item.value);
-
-        if (finalPayload.length === 0) {
-            debug(() => 'Mesh V2: Skipping mutation as all data is already up-to-date on server');
-            return {
-                data: {
-                    reportDataByNode: {
-                        nodeStatus: {
-                            data: payload // Return original payload to satisfy caller expectation
-                        }
-                    }
-                }
-            };
-        }
-
-        try {
-            this.costTracking.mutationCount++;
-            this.costTracking.reportDataCount++;
-
-            log.info(`Mesh V2: Sending ${finalPayload.length} data items to group ${this.groupId}`);
-
-            // Save Promise to track completion
-            this.lastDataSendPromise = this.client.mutate({
-                mutation: REPORT_DATA,
-                variables: {
-                    groupId: this.groupId,
-                    domain: this.domain,
-                    nodeId: this.meshId,
-                    data: finalPayload
-                }
-            });
-
-            const result = await this.lastDataSendPromise;
-
-            // Update last sent data on success
-            finalPayload.forEach(item => {
-                this.lastSentData[item.key] = item.value;
-            });
-
-            return result;
-        } catch (error) {
-            log.error(`Mesh V2: Failed to report data: ${error}`);
-            const reason = this.shouldDisconnectOnError(error);
-            if (reason) {
-                this.cleanupAndDisconnect(reason);
-                // Do not re-throw: sendData will catch this and would call
-                // cleanupAndDisconnect again, causing duplicate cost summaries.
-                return;
-            }
-            throw error;
-        }
-    }
-
     fireEvent (eventName, payload = '') {
         if (!this.groupId || !this.client) {
             if (this.groupId) {
@@ -927,60 +829,6 @@ class MeshV2Service {
         }
     }
 
-    /**
-     * Get all global scalar variables.
-     * @returns {Array} Array of {key, value} objects.
-     */
-    getGlobalVariables () {
-        const stage = this.runtime.getTargetForStage();
-        if (!stage || !stage.variables) return [];
-
-        const variables = [];
-        for (const varId in stage.variables) {
-            const currVar = stage.variables[varId];
-            if (currVar.type === Variable.SCALAR_TYPE) {
-                variables.push({
-                    key: currVar.name,
-                    value: String(currVar.value)
-                });
-            }
-        }
-        return variables;
-    }
-
-    /**
-     * Send all global variables to other nodes in the group.
-     * @returns {Promise<void>} A promise that resolves when variables are queued for sending.
-     */
-    async sendAllGlobalVariables () {
-        if (!this.groupId || !this.client) return;
-
-        const allVariables = this.getGlobalVariables();
-        if (allVariables.length === 0) {
-            debug(() => 'Mesh V2: No global variables to send');
-            return;
-        }
-
-        await this.sendData(allVariables);
-        debug(() => `Mesh V2: Sent ${allVariables.length} global variables`);
-    }
-
-    getRemoteVariable (name) {
-        let latestValue = null;
-        let latestTimestamp = 0;
-
-        // Search across all nodes for the variable name
-        for (const nodeId in this.remoteData) {
-            if (Object.prototype.hasOwnProperty.call(this.remoteData[nodeId], name)) {
-                const data = this.remoteData[nodeId][name];
-                if (data.timestamp > latestTimestamp) {
-                    latestTimestamp = data.timestamp;
-                    latestValue = data.value;
-                }
-            }
-        }
-        return latestValue;
-    }
 }
 
 // Mixins: split responsibilities into separate files for maintainability.
@@ -991,5 +839,6 @@ Object.assign(MeshV2Service.prototype, PeriodicSyncMixin);
 Object.assign(MeshV2Service.prototype, PollingClientMixin);
 Object.assign(MeshV2Service.prototype, SubscriptionManagerMixin);
 Object.assign(MeshV2Service.prototype, HeartbeatManagerMixin);
+Object.assign(MeshV2Service.prototype, DataSenderMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -13,8 +13,6 @@ const {
     JOIN_GROUP,
     LEAVE_GROUP,
     DISSOLVE_GROUP,
-    RENEW_HEARTBEAT,
-    SEND_MEMBER_HEARTBEAT,
     REPORT_DATA,
     FIRE_EVENTS,
     RECORD_EVENTS,
@@ -27,6 +25,7 @@ const {NetworkFilterMixin} = require('./network-filter');
 const {PeriodicSyncMixin} = require('./periodic-sync');
 const {PollingClientMixin} = require('./polling-client');
 const {SubscriptionManagerMixin} = require('./subscription-manager');
+const {HeartbeatManagerMixin} = require('./heartbeat-manager');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -730,122 +729,6 @@ class MeshV2Service {
         }
     }
 
-    startHeartbeat () {
-        this.stopHeartbeat();
-        if (!this.groupId) return;
-
-        debug(() => `Mesh V2: Starting heartbeat timer (Role: ${this.isHost ? 'Host' : 'Member'}, ` +
-            `Interval: ${this.isHost ? this.hostHeartbeatInterval : this.memberHeartbeatInterval}s)`);
-        const interval = (this.isHost ? this.hostHeartbeatInterval : this.memberHeartbeatInterval) * 1000;
-
-        this.heartbeatTimer = setInterval(() => {
-            if (this.isHost) {
-                this.renewHeartbeat();
-            } else {
-                this.sendMemberHeartbeat();
-            }
-        }, interval);
-    }
-
-    stopHeartbeat () {
-        if (this.heartbeatTimer) {
-            debug(() => 'Mesh V2: Stopping heartbeat timer');
-            clearInterval(this.heartbeatTimer);
-            this.heartbeatTimer = null;
-        }
-    }
-
-    async renewHeartbeat () {
-        if (!this.groupId || !this.client || !this.isHost) return;
-
-        try {
-            this.costTracking.mutationCount++;
-            this.costTracking.heartbeatCount++;
-            const result = await this.client.mutate({
-                mutation: RENEW_HEARTBEAT,
-                variables: {
-                    groupId: this.groupId,
-                    domain: this.domain,
-                    hostId: this.meshId
-                }
-            });
-
-            this.expiresAt = result.data.renewHeartbeat.expiresAt;
-            debug(() => `Mesh V2: Heartbeat renewed. Expires at: ${this.expiresAt}`);
-
-            if (result.data.renewHeartbeat.heartbeatIntervalSeconds) {
-                const newInterval = result.data.renewHeartbeat.heartbeatIntervalSeconds;
-                if (newInterval !== this.hostHeartbeatInterval) {
-                    this.hostHeartbeatInterval = newInterval;
-                    this.startHeartbeat(); // Restart with new interval
-                }
-            }
-            this.startConnectionTimer();
-            return result.data.renewHeartbeat;
-        } catch (error) {
-            log.error(`Mesh V2: Heartbeat renewal failed: ${error}`);
-            const reason = this.shouldDisconnectOnError(error);
-            if (reason) {
-                this.cleanupAndDisconnect(reason);
-            }
-        }
-    }
-
-    async sendMemberHeartbeat () {
-        if (!this.groupId || !this.client || this.isHost) return;
-
-        try {
-            this.costTracking.mutationCount++;
-            this.costTracking.heartbeatCount++;
-            const result = await this.client.mutate({
-                mutation: SEND_MEMBER_HEARTBEAT,
-                variables: {
-                    groupId: this.groupId,
-                    domain: this.domain,
-                    nodeId: this.meshId
-                }
-            });
-
-            debug(() => 'Mesh V2: Member heartbeat sent');
-            if (result.data.sendMemberHeartbeat.expiresAt) {
-                this.expiresAt = result.data.sendMemberHeartbeat.expiresAt;
-            }
-
-            return result.data.sendMemberHeartbeat;
-        } catch (error) {
-            log.error(`Mesh V2: Member heartbeat failed: ${error}`);
-            const reason = this.shouldDisconnectOnError(error);
-            if (reason) {
-                this.cleanupAndDisconnect(reason);
-            }
-        }
-    }
-
-    startConnectionTimer () {
-        this.stopConnectionTimer();
-        if (!this.expiresAt) return;
-
-        const timeout = new Date(this.expiresAt).getTime() - Date.now();
-        if (timeout <= 0) {
-            log.warn('Mesh V2: Group is already expired');
-            this.leaveGroup();
-            return;
-        }
-
-        const timeoutMinutes = Math.round(timeout / 60000);
-        this.connectionTimer = setTimeout(() => {
-            log.warn(`Mesh V2: Connection timeout (${timeoutMinutes} minutes)`);
-            this.leaveGroup();
-        }, timeout);
-    }
-
-    stopConnectionTimer () {
-        if (this.connectionTimer) {
-            clearTimeout(this.connectionTimer);
-            this.connectionTimer = null;
-        }
-    }
-
     async sendData (dataArray) {
         if (!this.groupId || !this.client) return;
 
@@ -1107,5 +990,6 @@ Object.assign(MeshV2Service.prototype, NetworkFilterMixin);
 Object.assign(MeshV2Service.prototype, PeriodicSyncMixin);
 Object.assign(MeshV2Service.prototype, PollingClientMixin);
 Object.assign(MeshV2Service.prototype, SubscriptionManagerMixin);
+Object.assign(MeshV2Service.prototype, HeartbeatManagerMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -11,8 +11,6 @@ const {
     JOIN_GROUP,
     LEAVE_GROUP,
     DISSOLVE_GROUP,
-    FIRE_EVENTS,
-    RECORD_EVENTS,
     SEARCH_GROUPS_BY_NAME_PREFIX
 } = require('./gql-operations');
 
@@ -25,6 +23,7 @@ const {SubscriptionManagerMixin} = require('./subscription-manager');
 const {HeartbeatManagerMixin} = require('./heartbeat-manager');
 const {DataSenderMixin} = require('./data-sender');
 const {BroadcastReceiverMixin} = require('./broadcast-receiver');
+const {EventSenderMixin} = require('./event-sender');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -509,186 +508,6 @@ class MeshV2Service {
         this.latestQueuedData = {};
     }
 
-    startEventBatchTimer () {
-        this.stopEventBatchTimer();
-        debug(() => `Mesh V2: Starting event batch timer (Interval: ${this.eventBatchInterval}ms)`);
-        this.eventBatchTimer = setInterval(() => {
-            this.processBatchEvents();
-        }, this.eventBatchInterval);
-    }
-
-    stopEventBatchTimer () {
-        if (this.eventBatchTimer) {
-            clearInterval(this.eventBatchTimer);
-            this.eventBatchTimer = null;
-        }
-    }
-
-    async processBatchEvents () {
-        if (this.eventQueue.length === 0) return;
-
-        // キューから全イベントを取り出す
-        const events = this.eventQueue.splice(0);
-        debug(() => `Mesh V2: Processing ${events.length} queued events for sending`);
-
-        try {
-            // ペイロードサイズ制限を考慮して分割送信（約1,000イベントごと）
-            const MAX_BATCH_SIZE = 1000;
-            while (events.length > 0) {
-                const batch = events.splice(0, MAX_BATCH_SIZE);
-                await this.fireEventsBatch(batch);
-            }
-        } catch (error) {
-            log.error(`Mesh V2: Failed to process batch events: ${error}`);
-        }
-    }
-
-    async fireEventsBatch (events) {
-        if (!this.groupId || !this.client || events.length === 0) return;
-
-        try {
-            // Wait for last data send to complete
-            await this.lastDataSendPromise;
-
-            this.costTracking.mutationCount++;
-            this.costTracking.fireEventsCount++;
-            log.info(`Mesh V2: Sending batch of ${events.length} events to group ${this.groupId} ` +
-                `(Protocol: ${this.useWebSocket ? 'WebSocket' : 'Polling'})`);
-
-            if (this.useWebSocket) {
-                await this.client.mutate({
-                    mutation: FIRE_EVENTS,
-                    variables: {
-                        groupId: this.groupId,
-                        domain: this.domain,
-                        nodeId: this.meshId,
-                        events: events
-                    }
-                });
-            } else {
-                const result = await this.client.mutate({
-                    mutation: RECORD_EVENTS,
-                    variables: {
-                        groupId: this.groupId,
-                        domain: this.domain,
-                        nodeId: this.meshId,
-                        events: events
-                    }
-                });
-                if (result.data && result.data.recordEventsByNode && result.data.recordEventsByNode.nextSince) {
-                    this.lastFetchTime = result.data.recordEventsByNode.nextSince;
-                }
-            }
-        } catch (error) {
-            log.error(`Mesh V2: Failed to fire batch events: ${error}`);
-            const reason = this.shouldDisconnectOnError(error);
-            if (reason) {
-                this.cleanupAndDisconnect(reason);
-            }
-        }
-    }
-
-    fireEvent (eventName, payload = '') {
-        if (!this.groupId || !this.client) {
-            if (this.groupId) {
-                log.warn(`Mesh V2: Cannot fire event ${eventName} - client not available`);
-            } else {
-                debug(() => `Mesh V2: Cannot fire event ${eventName} - not connected`);
-            }
-            return;
-        }
-
-        // ステップ1: 重複チェック
-        const isDuplicate = this.eventQueue.some(item =>
-            item.eventName === eventName && item.payload === payload
-        );
-
-        if (isDuplicate) {
-            this.eventQueueStats.duplicatesSkipped++;
-            this.reportEventStatsIfNeeded();
-
-            debug(() => `Mesh V2: Event already in queue, skipping: ${eventName}`);
-            return;
-        }
-
-        // ステップ2: サイズ制限チェック（保険）
-        if (this.eventQueue.length >= this.MAX_EVENT_QUEUE_SIZE) {
-            const dropped = this.eventQueue.shift(); // 古いイベントを破棄（FIFO）
-            this.eventQueueStats.dropped++;
-
-            if (this.eventQueueStats.dropped % 10 === 1) { // 10イベントごとに警告
-                log.warn(`Mesh V2: Event queue full (${this.MAX_EVENT_QUEUE_SIZE}). ` +
-                    `Dropped ${this.eventQueueStats.dropped} events. ` +
-                    `Latest: ${dropped.eventName}`);
-            }
-        }
-
-        debug(() => `Mesh V2: Queuing event for sending: ${eventName} ` +
-            `(queue size: ${this.eventQueue.length})`);
-
-        // キューに追加（発火日時と orderKey を記録）
-        const firedAt = new Date();
-        this.eventQueue.push({
-            eventName: eventName,
-            payload: payload,
-            firedAt: firedAt.toISOString(),
-            // issue #556: 同一バッチ内のイベント順序保証用
-            orderKey: this._generateOrderKey(firedAt)
-        });
-    }
-
-    /**
-     * Generate a sortable order key for an event.
-     * Format: `<YYYYMMDDHHMMSS>-<NNNNNNN>` where NNNNNNN is a 7-digit
-     * 0-padded sequence counter incremented per call (resets on group
-     * create/join).
-     *
-     * Same client guarantees lexicographic order = send order across batches.
-     * Cross-client collisions are possible but extremely unlikely; the server
-     * appends a short UUID to the SK to ensure uniqueness.
-     *
-     * Why 7 digits: connection cap is 35 min = 2100s. Worst-case throughput
-     * is bounded by MAX_EVENT_QUEUE_SIZE (100) draining every
-     * eventBatchInterval (min 100ms) → 1000 events/s max → ~2.1M per
-     * session. 7 digits (max 9,999,999) gives ~4.7x margin even at the
-     * minimum interval. 3 digits would overflow at the 1000th event,
-     * silently breaking lexicographic order ("1000" < "999").
-     * @param {Date} firedAt - The event fire time.
-     * @returns {string} Sortable order key.
-     * @private
-     */
-    _generateOrderKey (firedAt) {
-        const yyyy = firedAt.getFullYear().toString();
-        const mm = String(firedAt.getMonth() + 1).padStart(2, '0');
-        const dd = String(firedAt.getDate()).padStart(2, '0');
-        const hh = String(firedAt.getHours()).padStart(2, '0');
-        const mi = String(firedAt.getMinutes()).padStart(2, '0');
-        const ss = String(firedAt.getSeconds()).padStart(2, '0');
-        this.eventSequence += 1;
-        const seq = String(this.eventSequence).padStart(7, '0');
-        return `${yyyy}${mm}${dd}${hh}${mi}${ss}-${seq}`;
-    }
-
-    /**
-     * Report event queue statistics if needed (every 10 seconds).
-     */
-    reportEventStatsIfNeeded () {
-        const now = Date.now();
-        const elapsed = now - this.eventQueueStats.lastReportTime;
-
-        if (elapsed >= 10000 &&
-            (this.eventQueueStats.duplicatesSkipped > 0 || this.eventQueueStats.dropped > 0)) {
-            debug(() => `Mesh V2: Event Queue Stats (last ${(elapsed / 1000).toFixed(1)}s): ` +
-                `duplicates skipped=${this.eventQueueStats.duplicatesSkipped}, ` +
-                `dropped=${this.eventQueueStats.dropped}, ` +
-                `current queue size=${this.eventQueue.length}`);
-
-            this.eventQueueStats.duplicatesSkipped = 0;
-            this.eventQueueStats.dropped = 0;
-            this.eventQueueStats.lastReportTime = now;
-        }
-    }
-
 }
 
 // Mixins: split responsibilities into separate files for maintainability.
@@ -701,5 +520,6 @@ Object.assign(MeshV2Service.prototype, SubscriptionManagerMixin);
 Object.assign(MeshV2Service.prototype, HeartbeatManagerMixin);
 Object.assign(MeshV2Service.prototype, DataSenderMixin);
 Object.assign(MeshV2Service.prototype, BroadcastReceiverMixin);
+Object.assign(MeshV2Service.prototype, EventSenderMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -6,11 +6,6 @@ const {getClient} = require('./mesh-client');
 const RateLimiter = require('./rate-limiter');
 const {
     LIST_GROUPS_BY_DOMAIN,
-    CREATE_DOMAIN,
-    CREATE_GROUP,
-    JOIN_GROUP,
-    LEAVE_GROUP,
-    DISSOLVE_GROUP,
     SEARCH_GROUPS_BY_NAME_PREFIX
 } = require('./gql-operations');
 
@@ -24,6 +19,7 @@ const {HeartbeatManagerMixin} = require('./heartbeat-manager');
 const {DataSenderMixin} = require('./data-sender');
 const {BroadcastReceiverMixin} = require('./broadcast-receiver');
 const {EventSenderMixin} = require('./event-sender');
+const {GroupLifecycleMixin} = require('./group-lifecycle');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -186,100 +182,6 @@ class MeshV2Service {
         }
     }
 
-    async createDomain () {
-        if (!this.client) throw new Error('Client not initialized');
-
-        try {
-            this.costTracking.mutationCount++;
-            const result = await this.client.mutate({
-                mutation: CREATE_DOMAIN
-            });
-
-            this.domain = result.data.createDomain;
-            debug(() => `Mesh V2: Created domain ${this.domain} from source IP`);
-            return this.domain;
-        } catch (error) {
-            log.error(`Mesh V2: Failed to create domain: ${error}`);
-            throw error;
-        }
-    }
-
-    async createGroup (groupName) {
-        if (!this.client) throw new Error('Client not initialized');
-
-        try {
-            // Simulate network filter (503) for testing when MESH_NETWORK_FILTER=true
-            this._checkSimulateNetworkFilter();
-
-            if (!this.domain) {
-                await this.createDomain();
-            }
-
-            // Test WebSocket availability
-            if (this.forcePolling) {
-                this.useWebSocket = false;
-            } else {
-                this.useWebSocket = await this.testWebSocket();
-            }
-            log.info(`Mesh V2: WebSocket available: ${this.useWebSocket}`);
-
-            this.costTracking.mutationCount++;
-            this.lastFetchTime = new Date().toISOString();
-            // issue #556: orderKey の連番をリセット
-            this.eventSequence = 0;
-            debug(() => `Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before createGroup)`);
-            const result = await this.client.mutate({
-                mutation: CREATE_GROUP,
-                variables: {
-                    name: groupName,
-                    hostId: this.meshId,
-                    domain: this.domain,
-                    useWebSocket: this.useWebSocket
-                }
-            });
-
-            const group = result.data.createGroup;
-            this.groupId = group.id;
-            this.groupName = group.name;
-            this.domain = group.domain; // Update domain from server
-            this.expiresAt = group.expiresAt;
-            this.useWebSocket = group.useWebSocket;
-            if (group.pollingIntervalSeconds) {
-                this.pollingIntervalSeconds = group.pollingIntervalSeconds;
-            }
-            this.isHost = true;
-            if (group.heartbeatIntervalSeconds) {
-                this.hostHeartbeatInterval = group.heartbeatIntervalSeconds;
-            }
-
-            this.costTracking.connectionStartTime = Date.now();
-            if (this.useWebSocket) {
-                this.startSubscriptions();
-                // WebSocket モードは subscription でデータ更新をリアルタイム取得し、
-                // 念のため 15 秒ごとの fallback 同期を実行
-                this.startPeriodicDataSync();
-            } else {
-                // Polling モードは pollGroupData が events + nodeStatuses を
-                // 同時取得するため、startPeriodicDataSync は不要 (issue #554)
-                this.startPolling();
-            }
-            this.startHeartbeat();
-            this.startEventBatchTimer();
-            this.startConnectionTimer();
-
-            await this.sendAllGlobalVariables();
-
-            log.info(`Mesh V2: Created group ${this.groupName} (${this.groupId}) in domain ${this.domain} ` +
-                `(Protocol: ${this.useWebSocket ? 'WebSocket' : 'Polling'})`);
-            return group;
-        } catch (error) {
-            log.error(`Mesh V2: Failed to create group: ${error}`);
-            // Store error for network filter detection
-            this.lastError = error;
-            throw error;
-        }
-    }
-
     async listGroups () {
         if (!this.client) throw new Error('Client not initialized');
 
@@ -325,114 +227,6 @@ class MeshV2Service {
         } catch (error) {
             log.error(`Mesh V2: Failed to search groups by name: ${error}`);
             throw error;
-        }
-    }
-
-    async joinGroup (groupId, domain, groupName) {
-        if (!this.client) throw new Error('Client not initialized');
-
-        try {
-            // Simulate network filter (503) for testing when MESH_NETWORK_FILTER=true
-            this._checkSimulateNetworkFilter();
-
-            this.costTracking.mutationCount++;
-            this.lastFetchTime = new Date().toISOString();
-            // issue #556: orderKey の連番をリセット
-            this.eventSequence = 0;
-            debug(() => `Mesh V2: Initialized lastFetchTime to ${this.lastFetchTime} (before joinGroup)`);
-            const result = await this.client.mutate({
-                mutation: JOIN_GROUP,
-                variables: {
-                    groupId: groupId,
-                    domain: domain || this.domain,
-                    nodeId: this.meshId,
-                    useWebSocket: this.useWebSocket
-                }
-            });
-
-            const node = result.data.joinGroup;
-            this.groupId = groupId;
-            this.groupName = groupName || groupId;
-            this.domain = node.domain; // Update domain from server
-            this.expiresAt = node.expiresAt;
-            this.useWebSocket = this.forcePolling ? false : node.useWebSocket;
-            if (node.pollingIntervalSeconds) {
-                this.pollingIntervalSeconds = node.pollingIntervalSeconds;
-            }
-            this.isHost = false;
-            if (node.heartbeatIntervalSeconds) {
-                this.memberHeartbeatInterval = node.heartbeatIntervalSeconds;
-            }
-
-            this.costTracking.connectionStartTime = Date.now();
-            if (this.useWebSocket) {
-                this.startSubscriptions();
-                // WebSocket モードは 15 秒ごとの fallback 同期を実行
-                this.startPeriodicDataSync();
-            } else {
-                // Polling モードは pollGroupData が events + nodeStatuses を
-                // 同時取得するため、startPeriodicDataSync は不要 (issue #554)
-                this.startPolling();
-            }
-            this.startHeartbeat(); // Start heartbeat for member too
-            this.startEventBatchTimer();
-            this.startConnectionTimer();
-
-            await this.sendAllGlobalVariables();
-            await this.fetchAllNodesData();
-
-            log.info(`Mesh V2: Joined group ${this.groupId} in domain ${this.domain} ` +
-                `(Protocol: ${this.useWebSocket ? 'WebSocket' : 'Polling'})`);
-            return node;
-        } catch (error) {
-            log.error(`Mesh V2: Failed to join group: ${error}`);
-            // Store error for network filter detection
-            this.lastError = error;
-            throw error;
-        }
-    }
-
-    async leaveGroup () {
-        if (!this.groupId) return;
-
-        const groupId = this.groupId;
-        const domain = this.domain;
-        const isHost = this.isHost;
-        const hostId = this.meshId;
-        const nodeId = this.meshId;
-
-        // Count the leave/dissolve mutation before cleanup() outputs the cost summary
-        this.costTracking.mutationCount++;
-        this.costTracking.leaveCount++;
-
-        this.cleanupAndDisconnect();
-
-        if (!this.client) return;
-
-        try {
-            if (isHost) {
-                await this.client.mutate({
-                    mutation: DISSOLVE_GROUP,
-                    variables: {
-                        groupId: groupId,
-                        domain: domain,
-                        hostId: hostId
-                    }
-                });
-                debug(() => `Mesh V2: Dissolved group ${groupId}`);
-            } else {
-                await this.client.mutate({
-                    mutation: LEAVE_GROUP,
-                    variables: {
-                        groupId: groupId,
-                        domain: domain,
-                        nodeId: nodeId
-                    }
-                });
-                debug(() => `Mesh V2: Left group ${groupId}`);
-            }
-        } catch (error) {
-            log.error(`Mesh V2: Error during leave/dissolve (background): ${error}`);
         }
     }
 
@@ -521,5 +315,6 @@ Object.assign(MeshV2Service.prototype, HeartbeatManagerMixin);
 Object.assign(MeshV2Service.prototype, DataSenderMixin);
 Object.assign(MeshV2Service.prototype, BroadcastReceiverMixin);
 Object.assign(MeshV2Service.prototype, EventSenderMixin);
+Object.assign(MeshV2Service.prototype, GroupLifecycleMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -26,7 +26,7 @@ const {
 
 const {getForcePollingFromUrl} = require('./utils');
 
-const {GRAPHQL_ENDPOINT} = require('./mesh-client');
+const {NetworkFilterMixin} = require('./network-filter');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -44,16 +44,6 @@ const parseEnvInt = (envVar, defaultValue, min = 0, max = Infinity) => {
 };
 
 // Mesh v2 configuration parameters
-
-/**
- * GraphQL error types that indicate the connection is no longer valid.
- * These are defined in infra/mesh-v2/js/functions/*.js
- */
-const DISCONNECT_ERROR_TYPES = new Set([
-    'GroupNotFound', // Group doesn't exist, expired, or heartbeat expired
-    'Unauthorized', // Not authorized for this operation
-    'NodeNotFound' // Node doesn't exist
-]);
 
 /* istanbul ignore next */
 class MeshV2Service {
@@ -188,105 +178,6 @@ class MeshV2Service {
         };
     }
 
-    /**
-     * Check if the error indicates the group/node is no longer valid.
-     * Uses errorType from GraphQL response for robust error detection.
-     * @param {Error} error - The error to check.
-     * @returns {string|null} The error reason if should disconnect, null otherwise.
-     */
-    shouldDisconnectOnError (error) {
-        if (!error) return null;
-
-        // Primary check: GraphQL errorType (most reliable)
-        if (error.graphQLErrors && error.graphQLErrors.length > 0) {
-            const errorType = error.graphQLErrors[0].errorType;
-            if (DISCONNECT_ERROR_TYPES.has(errorType)) {
-                debug(() => `Mesh V2: Disconnecting due to errorType: ${errorType}`);
-                return errorType;
-            }
-        }
-
-        // Fallback: check message string (backward compatibility)
-        // This ensures old behavior is preserved if errorType is missing
-        if (error.message) {
-            const message = error.message.toLowerCase();
-            if (message.includes('not found') ||
-                message.includes('expired') ||
-                message.includes('unauthorized')) {
-                log.warn('Mesh V2: Disconnecting based on error message (fallback). Consider checking errorType.');
-                return 'expired';
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Check if the error is caused by network filtering (503 Service Unavailable).
-     * Network filters (e.g., i-Filter proxy) block requests before reaching AppSync
-     * and return HTTP 503. The error payload content is undefined and depends on
-     * the proxy implementation, so we can ONLY rely on the HTTP status code.
-     * @param {Error} error - The error to check.
-     * @returns {boolean} True if the error is caused by network filtering.
-     */
-    isNetworkFilterError (error) {
-        if (!error) {
-            debug(() => 'Mesh V2: isNetworkFilterError called with null/undefined error');
-            return false;
-        }
-
-        debug(() => `Mesh V2: Checking if error is network filter error: ` +
-            `hasNetworkError=${!!error.networkError}, ` +
-            `statusCode=${error.networkError?.statusCode}, ` +
-            `message=${error.message}`);
-
-        // Primary check: HTTP status code 503 from network error
-        // This is the ONLY reliable indicator when blocked by proxy (e.g., i-Filter)
-        if (error.networkError && error.networkError.statusCode === 503) {
-            debug(() => 'Mesh V2: Detected network filter error (HTTP 503)');
-            return true;
-        }
-
-        // Fallback: Check for 503 in error message (less reliable)
-        // Some GraphQL clients may include status code in message
-        if (error.message && error.message.includes('503')) {
-            debug(() => 'Mesh V2: Detected network filter error (503 in message)');
-            return true;
-        }
-
-        debug(() => 'Mesh V2: Error is NOT a network filter error');
-        return false;
-    }
-
-    /**
-     * Create a simulated HTTP 503 error for testing network filter detection.
-     * This simulates the error structure returned by i-Filter or similar proxies.
-     * @returns {Error} Error object with HTTP 503 structure.
-     * @private
-     */
-    _createSimulated503Error () {
-        const error = new Error('Network error: Service Unavailable');
-        error.networkError = {
-            statusCode: 503,
-            bodyText: 'Simulated network filter block (MESH_NETWORK_FILTER=true)'
-        };
-        error.graphQLErrors = [];
-        return error;
-    }
-
-    /**
-     * Check if network filter test mode is enabled and throw 503 error if so.
-     * @throws {Error} HTTP 503 error if MESH_NETWORK_FILTER=true.
-     * @private
-     */
-    _checkSimulateNetworkFilter () {
-        if (this.simulateNetworkFilter) {
-            const error = this._createSimulated503Error();
-            this.lastError = error;
-            throw error;
-        }
-    }
-
     setDisconnectCallback (callback) {
         this.disconnectCallback = callback;
     }
@@ -296,49 +187,6 @@ class MeshV2Service {
         if (this.disconnectCallback) {
             this.disconnectCallback(reason);
         }
-    }
-
-    /**
-     * Test if WebSocket connection is possible in the current environment.
-     * @returns {Promise<boolean>} True if WebSocket is available.
-     */
-    testWebSocket () {
-        return new Promise(resolve => {
-            try {
-                // Derived from https://xxx.appsync-api.region.amazonaws.com/graphql
-                // to wss://xxx.appsync-realtime-api.region.amazonaws.com/graphql
-                // or for custom domains, to wss://api.example.com/graphql/realtime
-                let wsUrl = GRAPHQL_ENDPOINT.replace('https://', 'wss://');
-                if (wsUrl.includes('appsync-api')) {
-                    wsUrl = wsUrl.replace('appsync-api', 'appsync-realtime-api');
-                } else {
-                    wsUrl = wsUrl.replace(/\/graphql$/, '/graphql/realtime');
-                }
-
-                const socket = new WebSocket(wsUrl, 'graphql-ws');
-                const timeout = setTimeout(() => {
-                    debug(() => 'Mesh V2: WebSocket test timed out');
-                    socket.close();
-                    resolve(false);
-                }, 3000); // 3 seconds timeout for test
-
-                socket.onopen = () => {
-                    debug(() => 'Mesh V2: WebSocket test successful');
-                    clearTimeout(timeout);
-                    socket.close();
-                    resolve(true);
-                };
-
-                socket.onerror = err => {
-                    debug(() => `Mesh V2: WebSocket test failed: ${err}`);
-                    clearTimeout(timeout);
-                    resolve(false);
-                };
-            } catch (error) {
-                debug(() => `Mesh V2: WebSocket not supported or failed to initialize: ${error}`);
-                resolve(false);
-            }
-        });
     }
 
     async createDomain () {
@@ -1475,5 +1323,10 @@ class MeshV2Service {
         return latestValue;
     }
 }
+
+// Mixins: split responsibilities into separate files for maintainability.
+// Each mixin attaches its methods to MeshV2Service.prototype so `this`
+// references continue to work unchanged.
+Object.assign(MeshV2Service.prototype, NetworkFilterMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -18,7 +18,6 @@ const {
     REPORT_DATA,
     FIRE_EVENTS,
     RECORD_EVENTS,
-    POLL_GROUP_DATA,
     ON_MESSAGE_IN_GROUP,
     SEARCH_GROUPS_BY_NAME_PREFIX
 } = require('./gql-operations');
@@ -27,6 +26,7 @@ const {getForcePollingFromUrl} = require('./utils');
 
 const {NetworkFilterMixin} = require('./network-filter');
 const {PeriodicSyncMixin} = require('./periodic-sync');
+const {PollingClientMixin} = require('./polling-client');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -553,97 +553,6 @@ class MeshV2Service {
     stopSubscriptions () {
         this.subscriptions.forEach(sub => sub.unsubscribe());
         this.subscriptions = [];
-    }
-
-    /**
-     * Start polling for events when WebSocket is not available.
-     */
-    startPolling () {
-        this.stopPolling();
-        if (!this.groupId) return;
-
-        debug(() => `Mesh V2: Starting event polling (Interval: ${this.pollingIntervalSeconds}s)`);
-
-        this.pollingTimer = setInterval(() => {
-            this.pollEvents();
-        }, this.pollingIntervalSeconds * 1000);
-    }
-
-    /**
-     * Stop event polling.
-     */
-    stopPolling () {
-        if (this.pollingTimer) {
-            debug(() => 'Mesh V2: Stopping event polling');
-            clearInterval(this.pollingTimer);
-            this.pollingTimer = null;
-        }
-        this.lastFetchTime = '';
-    }
-
-    /**
-     * Fetch new events and node statuses from the server since the last fetch time.
-     *
-     * issue #554: ポーリングモードでは pollGroupData クエリを使い、
-     * イベントとノードステータスを 1 リクエストで取得する。これにより:
-     *   - 旧: getEventsSince (2s) + listGroupStatuses (15s, startPeriodicDataSync)
-     *         → 34 query/min (events 30 + status 4)
-     *   - 新: pollGroupData (2s)
-     *         → 30 query/min (12% 削減 + データ同期遅延 15s → 2s に短縮)
-     * AppSync の課金単位は 1 リクエスト = 1 op なので、Pipeline Resolver
-     * 内で複数 DynamoDB アクセスをしても 1 op として課金される。
-     */
-    async pollEvents () {
-        if (!this.groupId || !this.client || this.useWebSocket) return;
-
-        if (!this.lastFetchTime) {
-            log.warn('Mesh V2: pollEvents called but lastFetchTime is empty. Falling back to current time.');
-            this.lastFetchTime = new Date().toISOString();
-        }
-
-        debug(() => `Mesh V2: pollGroupData for group ${this.groupId}. since=${this.lastFetchTime}`);
-
-        try {
-            this.costTracking.queryCount++;
-            const result = await this.client.query({
-                query: POLL_GROUP_DATA,
-                variables: {
-                    groupId: this.groupId,
-                    domain: this.domain,
-                    since: this.lastFetchTime
-                },
-                fetchPolicy: 'network-only'
-            });
-
-            if (result.data && result.data.pollGroupData) {
-                const {events, nodeStatuses} = result.data.pollGroupData;
-
-                // ノードステータスは fetchAllNodesData と同じ処理に流す
-                if (nodeStatuses && nodeStatuses.length > 0) {
-                    nodeStatuses.forEach(status => this.handleDataUpdate(status));
-                }
-
-                if (events && events.length > 0) {
-                    debug(() => `Mesh V2: Polled ${events.length} events`);
-
-                    // Filter out events from self and sort by timestamp to preserve order
-                    const otherEvents = events.filter(event => event.firedByNodeId !== this.meshId);
-
-                    if (otherEvents.length > 0) {
-                        this._queueEventsForPlayback(otherEvents);
-                    }
-
-                    // ALWAYS update lastFetchTime from the LAST event in the result (including our own)
-                    // to ensure we don't fetch the same events again.
-                    const lastEvent = events[events.length - 1];
-                    if (lastEvent.cursor) {
-                        this.lastFetchTime = lastEvent.cursor;
-                    }
-                }
-            }
-        } catch (error) {
-            log.error(`Mesh V2: Event polling failed: ${error}`);
-        }
     }
 
     handleDataUpdate (nodeStatus) {
@@ -1274,5 +1183,6 @@ class MeshV2Service {
 // references continue to work unchanged.
 Object.assign(MeshV2Service.prototype, NetworkFilterMixin);
 Object.assign(MeshV2Service.prototype, PeriodicSyncMixin);
+Object.assign(MeshV2Service.prototype, PollingClientMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -4,7 +4,6 @@ const debugLogger = require('../../util/debug-logger');
 const debug = debugLogger(process.env.DEBUG);
 const {getClient} = require('./mesh-client');
 const RateLimiter = require('./rate-limiter');
-const BlockUtility = require('../../engine/block-utility');
 const {
     LIST_GROUPS_BY_DOMAIN,
     CREATE_DOMAIN,
@@ -25,6 +24,7 @@ const {PollingClientMixin} = require('./polling-client');
 const {SubscriptionManagerMixin} = require('./subscription-manager');
 const {HeartbeatManagerMixin} = require('./heartbeat-manager');
 const {DataSenderMixin} = require('./data-sender');
+const {BroadcastReceiverMixin} = require('./broadcast-receiver');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -509,146 +509,6 @@ class MeshV2Service {
         this.latestQueuedData = {};
     }
 
-    /**
-     * Internal method to queue events for playback with relative timing.
-     * @param {Array} events - Array of events to queue.
-     * @private
-     */
-    _queueEventsForPlayback (events) {
-        if (!events || events.length === 0) return;
-
-        // タイムスタンプでソート（副作用を避けるためコピーを作成）。
-        // issue #556: 同一タイムスタンプ内では orderKey の辞書順で安定ソートする。
-        // どちらか一方でも orderKey がない場合は元の順序を維持（タイムスタンプ比較のみ）。
-        const sortedEvents = [...events].sort((a, b) => {
-            const tDiff = new Date(a.timestamp) - new Date(b.timestamp);
-            if (tDiff !== 0) return tDiff;
-            if (a.orderKey && b.orderKey) {
-                if (a.orderKey < b.orderKey) return -1;
-                if (a.orderKey > b.orderKey) return 1;
-            }
-            return 0;
-        });
-
-        // 最初のイベントを基準にオフセットを計算
-        const baseTime = new Date(sortedEvents[0].timestamp).getTime();
-
-        // キューに追加
-        sortedEvents.forEach(event => {
-            const eventTime = new Date(event.timestamp).getTime();
-            const offsetMs = eventTime - baseTime;
-
-            this.pendingBroadcasts.push({
-                event: event,
-                offsetMs: offsetMs
-            });
-            debug(() => `Mesh V2: Queued event: ${event.name} ` +
-                `(offset: ${offsetMs}ms, original timestamp: ${event.timestamp})`);
-        });
-
-        // バッチ処理開始時刻を記録（未開始の場合のみ）
-        if (this.batchStartTime === null && this.pendingBroadcasts.length > 0) {
-            this.batchStartTime = Date.now();
-            this.lastBroadcastOffset = 0;
-        }
-
-        debug(() => `Mesh V2: Total pending broadcasts: ${this.pendingBroadcasts.length}`);
-    }
-
-    /**
-     * Process pending broadcast events that should fire based on elapsed real time.
-     * Called once per frame via BEFORE_STEP event.
-     *
-     * Strategy:
-     * - Process events whose timing has arrived (offsetMs <= elapsedMs)
-     * - Limit processing to a 33ms window of event time per frame to avoid spikes
-     * - Execute them in order (maintains event sequence)
-     * - Different event types don't cause RESTART (different handlers)
-     */
-    processNextBroadcast () {
-        if (!this.groupId) {
-            // 切断されている場合はなにもしない
-            return;
-        }
-
-        if (this.pendingBroadcasts.length === 0) {
-            // キューが空になったらリセット
-            this.batchStartTime = null;
-            this.lastBroadcastOffset = 0;
-            return;
-        }
-
-        const now = Date.now();
-        const elapsedMs = this.batchStartTime ? now - this.batchStartTime : 0;
-
-        // 処理すべきイベントを収集（タイミングが来ているもの）
-        const eventsToProcess = [];
-        let windowBase = null;
-
-        while (this.pendingBroadcasts.length > 0) {
-            const {event, offsetMs} = this.pendingBroadcasts[0];
-
-            // まだタイミングが来ていない場合は待機
-            if (offsetMs > elapsedMs) {
-                debug(() => `Mesh V2: Waiting for event ${event.name} ` +
-                    `(needs ${offsetMs}ms, elapsed ${elapsedMs}ms)`);
-                break;
-            }
-
-            // 1フレーム(33ms)のウィンドウ制限を適用
-            // （バックログがある場合でも1フレームで大量のブロードキャストを避ける）
-            if (windowBase === null) {
-                windowBase = offsetMs;
-            } else if (offsetMs >= windowBase + 33) {
-                debug(() => `Mesh V2: Window limit reached (33ms). ` +
-                    `Remaining events will be processed in next frames.`);
-                break;
-            }
-
-            // タイミングが来たイベントをキューから取り出し
-            const item = this.pendingBroadcasts.shift();
-            eventsToProcess.push(item);
-        }
-
-        // 収集したイベントを処理
-        if (eventsToProcess.length > 0) {
-            debug(() => `Mesh V2: Broadcasting ${eventsToProcess.length} events ` +
-                `(${this.pendingBroadcasts.length} remaining in queue)`);
-
-            eventsToProcess.forEach(({event, offsetMs}) => {
-                debug(() => `Mesh V2: Broadcasting event: ${event.name} ` +
-                    `(offset: ${offsetMs}ms, elapsed: ${elapsedMs}ms)`);
-
-                this.broadcastEvent(event);
-                this.lastBroadcastOffset = offsetMs;
-            });
-        }
-    }
-
-    broadcastEvent (event) {
-        debug(() => `Mesh V2: Executing broadcastEvent for: ${event.name}`);
-        try {
-            const args = {
-                BROADCAST_OPTION: {
-                    id: null,
-                    name: event.name
-                }
-            };
-            const util = BlockUtility.lastInstance();
-            if (util) {
-                if (!util.sequencer) {
-                    util.sequencer = this.runtime.sequencer;
-                }
-                debug(() => `Mesh V2: Triggering event_broadcast: ${event.name}`);
-                this.blocks.opcodeFunctions.event_broadcast(args, util);
-            } else {
-                log.warn(`Mesh V2: No BlockUtility instance available for broadcast: ${event.name}`);
-            }
-        } catch (error) {
-            log.error(`Mesh V2: Failed to broadcast event: ${error}`);
-        }
-    }
-
     startEventBatchTimer () {
         this.stopEventBatchTimer();
         debug(() => `Mesh V2: Starting event batch timer (Interval: ${this.eventBatchInterval}ms)`);
@@ -840,5 +700,6 @@ Object.assign(MeshV2Service.prototype, PollingClientMixin);
 Object.assign(MeshV2Service.prototype, SubscriptionManagerMixin);
 Object.assign(MeshV2Service.prototype, HeartbeatManagerMixin);
 Object.assign(MeshV2Service.prototype, DataSenderMixin);
+Object.assign(MeshV2Service.prototype, BroadcastReceiverMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/mesh-service.js
@@ -20,13 +20,13 @@ const {
     RECORD_EVENTS,
     POLL_GROUP_DATA,
     ON_MESSAGE_IN_GROUP,
-    LIST_GROUP_STATUSES,
     SEARCH_GROUPS_BY_NAME_PREFIX
 } = require('./gql-operations');
 
 const {getForcePollingFromUrl} = require('./utils');
 
 const {NetworkFilterMixin} = require('./network-filter');
+const {PeriodicSyncMixin} = require('./periodic-sync');
 
 /**
  * Parses an environment variable as an integer with validation.
@@ -1214,61 +1214,6 @@ class MeshV2Service {
     }
 
     /**
-     * Fetch data from all nodes in the group.
-     * @returns {Promise<void>} A promise that resolves when data is fetched and updated.
-     */
-    async fetchAllNodesData () {
-        if (!this.groupId || !this.client) return;
-
-        try {
-            this.costTracking.queryCount++;
-            const result = await this.client.query({
-                query: LIST_GROUP_STATUSES,
-                variables: {
-                    groupId: this.groupId,
-                    domain: this.domain
-                },
-                fetchPolicy: 'network-only'
-            });
-
-            const nodeStatuses = result.data.listGroupStatuses;
-
-            // Reuse handleDataUpdate so polling/subscription/periodic-sync
-            // share a single ingestion path.
-            nodeStatuses.forEach(status => this.handleDataUpdate(status));
-
-            debug(() => `Mesh V2: Fetched data from ${nodeStatuses.length} nodes`);
-        } catch (error) {
-            log.error(`Mesh V2: Failed to fetch group data: ${error}`);
-        }
-    }
-
-    /**
-     * Start periodic data synchronization to ensure data consistency.
-     */
-    startPeriodicDataSync () {
-        this.stopPeriodicDataSync();
-
-        const interval = this.periodicDataSyncInterval;
-        debug(() => `Mesh V2: Starting periodic data sync timer (Interval: ${interval / 1000}s)`);
-        this.dataSyncTimer = setInterval(() => {
-            debug(() => 'Mesh V2: Periodic data sync');
-            this.fetchAllNodesData();
-        }, interval);
-    }
-
-    /**
-     * Stop periodic data synchronization.
-     */
-    stopPeriodicDataSync () {
-        if (this.dataSyncTimer) {
-            debug(() => 'Mesh V2: Stopping periodic data sync timer');
-            clearInterval(this.dataSyncTimer);
-            this.dataSyncTimer = null;
-        }
-    }
-
-    /**
      * Get all global scalar variables.
      * @returns {Array} Array of {key, value} objects.
      */
@@ -1328,5 +1273,6 @@ class MeshV2Service {
 // Each mixin attaches its methods to MeshV2Service.prototype so `this`
 // references continue to work unchanged.
 Object.assign(MeshV2Service.prototype, NetworkFilterMixin);
+Object.assign(MeshV2Service.prototype, PeriodicSyncMixin);
 
 module.exports = MeshV2Service;

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/network-filter.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/network-filter.js
@@ -1,0 +1,173 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const { GRAPHQL_ENDPOINT } = require('./mesh-client');
+
+/**
+ * GraphQL error types that indicate the connection is no longer valid.
+ * These are defined in infra/mesh-v2/js/functions/*.js
+ */
+const DISCONNECT_ERROR_TYPES = new Set([
+    'GroupNotFound', // Group doesn't exist, expired, or heartbeat expired
+    'Unauthorized', // Not authorized for this operation
+    'NodeNotFound', // Node doesn't exist
+]);
+
+/**
+ * Methods related to network error classification, network filter (proxy)
+ * detection, simulated test mode, and WebSocket availability probing.
+ *
+ * Mixed into MeshV2Service.prototype. All `this` references resolve to the
+ * MeshV2Service instance.
+ */
+const NetworkFilterMixin = {
+    /**
+     * Check if the error indicates the group/node is no longer valid.
+     * Uses errorType from GraphQL response for robust error detection.
+     * @param {Error} error - The error to check.
+     * @returns {string|null} The error reason if should disconnect, null otherwise.
+     */
+    shouldDisconnectOnError(error) {
+        if (!error) return null;
+
+        // Primary check: GraphQL errorType (most reliable)
+        if (error.graphQLErrors && error.graphQLErrors.length > 0) {
+            const errorType = error.graphQLErrors[0].errorType;
+            if (DISCONNECT_ERROR_TYPES.has(errorType)) {
+                debug(() => `Mesh V2: Disconnecting due to errorType: ${errorType}`);
+                return errorType;
+            }
+        }
+
+        // Fallback: check message string (backward compatibility)
+        // This ensures old behavior is preserved if errorType is missing
+        if (error.message) {
+            const message = error.message.toLowerCase();
+            if (
+                message.includes('not found') ||
+                message.includes('expired') ||
+                message.includes('unauthorized')
+            ) {
+                log.warn('Mesh V2: Disconnecting based on error message (fallback). Consider checking errorType.');
+                return 'expired';
+            }
+        }
+
+        return null;
+    },
+
+    /**
+     * Check if the error is caused by network filtering (503 Service Unavailable).
+     * Network filters (e.g., i-Filter proxy) block requests before reaching AppSync
+     * and return HTTP 503. The error payload content is undefined and depends on
+     * the proxy implementation, so we can ONLY rely on the HTTP status code.
+     * @param {Error} error - The error to check.
+     * @returns {boolean} True if the error is caused by network filtering.
+     */
+    isNetworkFilterError(error) {
+        if (!error) {
+            debug(() => 'Mesh V2: isNetworkFilterError called with null/undefined error');
+            return false;
+        }
+
+        debug(
+            () =>
+                `Mesh V2: Checking if error is network filter error: ` +
+                `hasNetworkError=${!!error.networkError}, ` +
+                `statusCode=${error.networkError?.statusCode}, ` +
+                `message=${error.message}`,
+        );
+
+        // Primary check: HTTP status code 503 from network error
+        // This is the ONLY reliable indicator when blocked by proxy (e.g., i-Filter)
+        if (error.networkError && error.networkError.statusCode === 503) {
+            debug(() => 'Mesh V2: Detected network filter error (HTTP 503)');
+            return true;
+        }
+
+        // Fallback: Check for 503 in error message (less reliable)
+        // Some GraphQL clients may include status code in message
+        if (error.message && error.message.includes('503')) {
+            debug(() => 'Mesh V2: Detected network filter error (503 in message)');
+            return true;
+        }
+
+        debug(() => 'Mesh V2: Error is NOT a network filter error');
+        return false;
+    },
+
+    /**
+     * Create a simulated HTTP 503 error for testing network filter detection.
+     * This simulates the error structure returned by i-Filter or similar proxies.
+     * @returns {Error} Error object with HTTP 503 structure.
+     * @private
+     */
+    _createSimulated503Error() {
+        const error = new Error('Network error: Service Unavailable');
+        error.networkError = {
+            statusCode: 503,
+            bodyText: 'Simulated network filter block (MESH_NETWORK_FILTER=true)',
+        };
+        error.graphQLErrors = [];
+        return error;
+    },
+
+    /**
+     * Check if network filter test mode is enabled and throw 503 error if so.
+     * @throws {Error} HTTP 503 error if MESH_NETWORK_FILTER=true.
+     * @private
+     */
+    _checkSimulateNetworkFilter() {
+        if (this.simulateNetworkFilter) {
+            const error = this._createSimulated503Error();
+            this.lastError = error;
+            throw error;
+        }
+    },
+
+    /**
+     * Test if WebSocket connection is possible in the current environment.
+     * @returns {Promise<boolean>} True if WebSocket is available.
+     */
+    testWebSocket() {
+        return new Promise(resolve => {
+            try {
+                // Derived from https://xxx.appsync-api.region.amazonaws.com/graphql
+                // to wss://xxx.appsync-realtime-api.region.amazonaws.com/graphql
+                // or for custom domains, to wss://api.example.com/graphql/realtime
+                let wsUrl = GRAPHQL_ENDPOINT.replace('https://', 'wss://');
+                if (wsUrl.includes('appsync-api')) {
+                    wsUrl = wsUrl.replace('appsync-api', 'appsync-realtime-api');
+                } else {
+                    wsUrl = wsUrl.replace(/\/graphql$/, '/graphql/realtime');
+                }
+
+                const socket = new WebSocket(wsUrl, 'graphql-ws');
+                const timeout = setTimeout(() => {
+                    debug(() => 'Mesh V2: WebSocket test timed out');
+                    socket.close();
+                    resolve(false);
+                }, 3000); // 3 seconds timeout for test
+
+                socket.onopen = () => {
+                    debug(() => 'Mesh V2: WebSocket test successful');
+                    clearTimeout(timeout);
+                    socket.close();
+                    resolve(true);
+                };
+
+                socket.onerror = err => {
+                    debug(() => `Mesh V2: WebSocket test failed: ${err}`);
+                    clearTimeout(timeout);
+                    resolve(false);
+                };
+            } catch (error) {
+                debug(() => `Mesh V2: WebSocket not supported or failed to initialize: ${error}`);
+                resolve(false);
+            }
+        });
+    },
+};
+
+module.exports = { NetworkFilterMixin, DISCONNECT_ERROR_TYPES };

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/periodic-sync.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/periodic-sync.js
@@ -1,0 +1,73 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const { LIST_GROUP_STATUSES } = require('./gql-operations');
+
+/**
+ * Periodic data sync. WebSocket モードで subscription の取りこぼしを補う
+ * ためのフォールバック (15 秒周期で全ノードのステータスをフェッチ)。
+ *
+ * Polling モードでは pollGroupData が events と nodeStatuses を一括で取る
+ * ため、こちらは起動しない (issue #554 参照)。
+ *
+ * Mixed into MeshV2Service.prototype.
+ */
+const PeriodicSyncMixin = {
+    /**
+     * Fetch data from all nodes in the group.
+     * @returns {Promise<void>} A promise that resolves when data is fetched and updated.
+     */
+    async fetchAllNodesData() {
+        if (!this.groupId || !this.client) return;
+
+        try {
+            this.costTracking.queryCount++;
+            const result = await this.client.query({
+                query: LIST_GROUP_STATUSES,
+                variables: {
+                    groupId: this.groupId,
+                    domain: this.domain,
+                },
+                fetchPolicy: 'network-only',
+            });
+
+            const nodeStatuses = result.data.listGroupStatuses;
+
+            // Reuse handleDataUpdate so polling/subscription/periodic-sync
+            // share a single ingestion path.
+            nodeStatuses.forEach(status => this.handleDataUpdate(status));
+
+            debug(() => `Mesh V2: Fetched data from ${nodeStatuses.length} nodes`);
+        } catch (error) {
+            log.error(`Mesh V2: Failed to fetch group data: ${error}`);
+        }
+    },
+
+    /**
+     * Start periodic data synchronization to ensure data consistency.
+     */
+    startPeriodicDataSync() {
+        this.stopPeriodicDataSync();
+
+        const interval = this.periodicDataSyncInterval;
+        debug(() => `Mesh V2: Starting periodic data sync timer (Interval: ${interval / 1000}s)`);
+        this.dataSyncTimer = setInterval(() => {
+            debug(() => 'Mesh V2: Periodic data sync');
+            this.fetchAllNodesData();
+        }, interval);
+    },
+
+    /**
+     * Stop periodic data synchronization.
+     */
+    stopPeriodicDataSync() {
+        if (this.dataSyncTimer) {
+            debug(() => 'Mesh V2: Stopping periodic data sync timer');
+            clearInterval(this.dataSyncTimer);
+            this.dataSyncTimer = null;
+        }
+    },
+};
+
+module.exports = { PeriodicSyncMixin };

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/polling-client.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/polling-client.js
@@ -1,0 +1,106 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const { POLL_GROUP_DATA } = require('./gql-operations');
+
+/**
+ * Polling client. WebSocket が使えない環境向けに、`pollGroupData` (issue #554)
+ * を 2 秒周期で呼び、events と nodeStatuses を一括取得する。
+ *
+ * Mixed into MeshV2Service.prototype.
+ */
+const PollingClientMixin = {
+    /**
+     * Start polling for events when WebSocket is not available.
+     */
+    startPolling() {
+        this.stopPolling();
+        if (!this.groupId) return;
+
+        debug(() => `Mesh V2: Starting event polling (Interval: ${this.pollingIntervalSeconds}s)`);
+
+        this.pollingTimer = setInterval(() => {
+            this.pollEvents();
+        }, this.pollingIntervalSeconds * 1000);
+    },
+
+    /**
+     * Stop event polling.
+     */
+    stopPolling() {
+        if (this.pollingTimer) {
+            debug(() => 'Mesh V2: Stopping event polling');
+            clearInterval(this.pollingTimer);
+            this.pollingTimer = null;
+        }
+        this.lastFetchTime = '';
+    },
+
+    /**
+     * Fetch new events and node statuses from the server since the last fetch time.
+     *
+     * issue #554: ポーリングモードでは pollGroupData クエリを使い、
+     * イベントとノードステータスを 1 リクエストで取得する。これにより:
+     *   - 旧: getEventsSince (2s) + listGroupStatuses (15s, startPeriodicDataSync)
+     *         → 34 query/min (events 30 + status 4)
+     *   - 新: pollGroupData (2s)
+     *         → 30 query/min (12% 削減 + データ同期遅延 15s → 2s に短縮)
+     * AppSync の課金単位は 1 リクエスト = 1 op なので、Pipeline Resolver
+     * 内で複数 DynamoDB アクセスをしても 1 op として課金される。
+     */
+    async pollEvents() {
+        if (!this.groupId || !this.client || this.useWebSocket) return;
+
+        if (!this.lastFetchTime) {
+            log.warn('Mesh V2: pollEvents called but lastFetchTime is empty. Falling back to current time.');
+            this.lastFetchTime = new Date().toISOString();
+        }
+
+        debug(() => `Mesh V2: pollGroupData for group ${this.groupId}. since=${this.lastFetchTime}`);
+
+        try {
+            this.costTracking.queryCount++;
+            const result = await this.client.query({
+                query: POLL_GROUP_DATA,
+                variables: {
+                    groupId: this.groupId,
+                    domain: this.domain,
+                    since: this.lastFetchTime,
+                },
+                fetchPolicy: 'network-only',
+            });
+
+            if (result.data && result.data.pollGroupData) {
+                const { events, nodeStatuses } = result.data.pollGroupData;
+
+                // ノードステータスは fetchAllNodesData と同じ処理に流す
+                if (nodeStatuses && nodeStatuses.length > 0) {
+                    nodeStatuses.forEach(status => this.handleDataUpdate(status));
+                }
+
+                if (events && events.length > 0) {
+                    debug(() => `Mesh V2: Polled ${events.length} events`);
+
+                    // Filter out events from self and sort by timestamp to preserve order
+                    const otherEvents = events.filter(event => event.firedByNodeId !== this.meshId);
+
+                    if (otherEvents.length > 0) {
+                        this._queueEventsForPlayback(otherEvents);
+                    }
+
+                    // ALWAYS update lastFetchTime from the LAST event in the result (including our own)
+                    // to ensure we don't fetch the same events again.
+                    const lastEvent = events[events.length - 1];
+                    if (lastEvent.cursor) {
+                        this.lastFetchTime = lastEvent.cursor;
+                    }
+                }
+            }
+        } catch (error) {
+            log.error(`Mesh V2: Event polling failed: ${error}`);
+        }
+    },
+};
+
+module.exports = { PollingClientMixin };

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/subscription-manager.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/subscription-manager.js
@@ -1,0 +1,98 @@
+/* global process */
+const log = require('../../util/log');
+const debugLogger = require('../../util/debug-logger');
+const debug = debugLogger(process.env.DEBUG);
+const { ON_MESSAGE_IN_GROUP } = require('./gql-operations');
+
+/**
+ * WebSocket subscription manager. AppSync の onMessageInGroup を購読し、
+ * 受信した nodeStatus / batchEvent / groupDissolve をディスパッチする。
+ *
+ * `handleDataUpdate` は subscription / pollGroupData / fetchAllNodesData の
+ * 3 経路から呼ばれる共通の取り込み口。
+ *
+ * Mixed into MeshV2Service.prototype.
+ */
+const SubscriptionManagerMixin = {
+    startSubscriptions() {
+        if (!this.groupId || !this.client) return;
+
+        const variables = {
+            groupId: this.groupId,
+            domain: this.domain,
+        };
+
+        const messageSub = this.client
+            .subscribe({
+                query: ON_MESSAGE_IN_GROUP,
+                variables,
+            })
+            .subscribe({
+                next: result => {
+                    const message = result.data.onMessageInGroup;
+                    if (!message) return;
+
+                    // MeshMessage has three fields: nodeStatus, batchEvent, groupDissolve
+                    // Only one field will be non-null per message
+                    // Count all received messages for accurate cost estimation (AppSync delivers to sender too)
+                    if (message.nodeStatus) {
+                        this.costTracking.dataUpdateReceived++;
+                        this.handleDataUpdate(message.nodeStatus);
+                    } else if (message.batchEvent) {
+                        this.costTracking.batchEventReceived++;
+                        this.handleBatchEvent(message.batchEvent);
+                    } else if (message.groupDissolve) {
+                        this.costTracking.dissolveReceived++;
+                        debug(() => 'Mesh V2: Group dissolved by host');
+                        this.cleanupAndDisconnect();
+                    } else {
+                        log.warn('Mesh V2: Received message with all fields null');
+                    }
+                },
+                error: err => log.error(`Mesh V2: Subscription error: ${err}`),
+            });
+
+        this.subscriptions.push(messageSub);
+    },
+
+    stopSubscriptions() {
+        this.subscriptions.forEach(sub => sub.unsubscribe());
+        this.subscriptions = [];
+    },
+
+    handleDataUpdate(nodeStatus) {
+        if (!nodeStatus || nodeStatus.nodeId === this.meshId) return;
+
+        const nodeId = nodeStatus.nodeId;
+        if (!this.remoteData[nodeId]) {
+            this.remoteData[nodeId] = {};
+        }
+
+        // Use server timestamp with fallback to current time
+        const serverTimestamp = nodeStatus.timestamp
+            ? new Date(nodeStatus.timestamp).getTime()
+            : (log.warn('Mesh V2: Missing server timestamp, using client time'), Date.now());
+
+        nodeStatus.data.forEach(item => {
+            this.remoteData[nodeId][item.key] = {
+                value: item.value,
+                timestamp: serverTimestamp,
+            };
+        });
+    },
+
+    handleBatchEvent(batchEvent) {
+        if (!batchEvent || batchEvent.firedByNodeId === this.meshId) return;
+
+        const events = batchEvent.events
+            ? batchEvent.events.filter(event => event.firedByNodeId !== this.meshId)
+            : [];
+        if (events.length === 0) return;
+
+        debug(() => `Mesh V2: Received ${events.length} events from ${batchEvent.firedByNodeId}`);
+
+        this._queueEventsForPlayback(events);
+    },
+};
+
+module.exports = { SubscriptionManagerMixin };


### PR DESCRIPTION
## Summary

issue #566 の対応。`mesh-service.js` (1479 行) を責務ごとに 9 つのミックスインに分割し、各ファイル ~250 行以下に収める。

ミックスインパターンを採用したため、すべての `this` 参照は変更なし、public API 不変、既存テストは無修正で全てパス。

Closes #566

## Changes

### 9 commits, each extracting one responsibility

| # | Mixin file | 行数 | 切り出し対象 |
|---|------------|------|-------------|
| 1 | `network-filter.js` | 173 | shouldDisconnectOnError, isNetworkFilterError, _createSimulated503Error, _checkSimulateNetworkFilter, testWebSocket |
| 2 | `periodic-sync.js` | 73 | fetchAllNodesData, startPeriodicDataSync, stopPeriodicDataSync |
| 3 | `polling-client.js` | 106 | startPolling, stopPolling, pollEvents |
| 4 | `subscription-manager.js` | 98 | startSubscriptions, stopSubscriptions, handleDataUpdate, handleBatchEvent |
| 5 | `heartbeat-manager.js` | 138 | startHeartbeat, stopHeartbeat, renewHeartbeat, sendMemberHeartbeat, startConnectionTimer, stopConnectionTimer |
| 6 | `data-sender.js` | 178 | sendData, _reportData, getGlobalVariables, sendAllGlobalVariables, getRemoteVariable |
| 7 | `broadcast-receiver.js` | 175 | _queueEventsForPlayback, processNextBroadcast, broadcastEvent |
| 8 | `event-sender.js` | 217 | startEventBatchTimer, stopEventBatchTimer, processBatchEvents, fireEventsBatch, fireEvent, _generateOrderKey, reportEventStatsIfNeeded |
| 9 | `group-lifecycle.js` | 231 | createDomain, createGroup, joinGroup, leaveGroup |

### `mesh-service.js` の最終形 (320 行)

ファサードのみ残す:

- constructor (~150 行) — 全インスタンスプロパティの初期化
- cleanup / cleanupAndDisconnect / setDisconnectCallback (~80 行)
- listGroups / searchGroupsByNamePrefix (~50 行) — 軽量な検索系
- 9 ミックスインの `Object.assign(MeshV2Service.prototype, ...)` (~25 行)

## Why mixin pattern (not composition)

Issue #566 で当初 composition (`this.heartbeatManager.renew()`) を提案していたが、実装過程で以下の理由でミックスインに切り替えた:

- すべての `this` 参照 (`this.groupId`, `this.client`, `this.costTracking`, ...) がそのまま動くため、ロジックの動作変更ゼロ
- public API (`createGroup`, `joinGroup`, `pollEvents`, ...) も完全不変
- 既存テスト (`mesh_service_v2_*.js` 系列、約 300 件) を無修正で全パス
- 各責務がファイル単位で閲覧可能になり、コードナビゲーションが向上

将来、より厳密なテスト分離が必要になった場合は composition に再リファクタリングできる。今回はサイズ目標と動作不変の両立を優先。

## File sizes (after / target)

| File | After | Target | 状態 |
|------|-------|--------|-----|
| mesh-service.js (facade) | 320 | ~250 | ⚠️ 70 行オーバー (constructor が大半) |
| group-lifecycle.js | 231 | 250 | ✅ |
| event-sender.js | 217 | 250 | ✅ |
| data-sender.js | 178 | 250 | ✅ |
| broadcast-receiver.js | 175 | 250 | ✅ |
| network-filter.js | 173 | 250 | ✅ |
| heartbeat-manager.js | 138 | 250 | ✅ |
| polling-client.js | 106 | 250 | ✅ |
| subscription-manager.js | 98 | 250 | ✅ |
| periodic-sync.js | 73 | 250 | ✅ |

facade の 320 行はほぼ constructor (約 150 行のプロパティ初期化) と cleanup() の集約コスト計算 (約 80 行) で構成されており、これ以上分割すると凝集度が下がる。受け入れ条件「~250 行」をかなり改善 (1479 → 320 = -78%) した状態でファサード責務として妥当な範囲。

## Test Coverage

- `npm run lint` ✅
- 関連ユニットテスト 317 件全てパス:
  - `mesh_service_v2.js`, `_polling`, `_subscription`, `_order`, `_order_key`, `_poll_group_data`, `_global_vars`, `_cost`, `_timestamp`, `_integration`
  - `extension_mesh_v2.js`, `_service`, `_domain`
- public API は変更していないので、テスト・呼び出し元の修正は **不要**

## Backward Compatibility

完全に後方互換。`packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js` の `new MeshV2Service(...)` 呼び出しは無修正で動作する。
