### PR TITLE
fix(dncl): handle nested parens and user-defined function calls in DNCL→Ruby conversion

### DIFF
--- a/packages/scratch-gui/src/lib/dncl/dncl-to-ruby.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-to-ruby.js
@@ -340,64 +340,159 @@ const processSegments = (line) => {
 }
 
 /**
- * Convert DNCL built-in function calls to Ruby equivalents.
+ * Find the matching close paren for an open paren at `openParenPos`.
+ * Skips parens inside string literals.
+ * @param {string} text - The text to scan.
+ * @param {number} openParenPos - Position of the open paren `(`.
+ * @returns {number} Position of the matching close paren, or -1 if unmatched.
+ */
+const findMatchingClose = (text, openParenPos) => {
+  let depth = 1
+  let i = openParenPos + 1
+  while (i < text.length) {
+    const ch = text[i]
+    if (ch === '"' || ch === "'") {
+      i = skipString(text, i, ch)
+      continue
+    }
+    if (ch === '(') {
+      depth++
+    } else if (ch === ')') {
+      depth--
+      if (depth === 0) return i
+    }
+    i++
+  }
+  return -1
+}
+
+/**
+ * Replace `name(...)` calls with the result of `transform(args)`.
+ * Uses balanced-paren matching so nested function calls don't confuse the
+ * boundary. Skips occurrences inside string literals.
+ * @param {string} text - Source text.
+ * @param {string} name - Function name to match (e.g. `表示する`).
+ * @param {Function} transform - Receives the raw args string between the
+ *   matching parens and returns the full replacement text.
+ * @returns {string} Text with all occurrences of `name(...)` transformed.
+ */
+const replaceCall = (text, name, transform) => {
+  let result = ''
+  let i = 0
+  while (i < text.length) {
+    const ch = text[i]
+    if (ch === '"' || ch === "'") {
+      const end = skipString(text, i, ch)
+      result += text.substring(i, end)
+      i = end
+      continue
+    }
+    if (text.startsWith(name, i) && text[i + name.length] === '(') {
+      const openPos = i + name.length
+      const closePos = findMatchingClose(text, openPos)
+      if (closePos === -1) {
+        result += ch
+        i++
+        continue
+      }
+      const args = text.substring(openPos + 1, closePos)
+      result += transform(args)
+      i = closePos + 1
+      continue
+    }
+    result += ch
+    i++
+  }
+  return result
+}
+
+/**
+ * Split function args by top-level commas (depth 0). Skips commas inside
+ * nested parens or string literals.
+ * @param {string} args - The args string between the outer parens.
+ * @returns {Array<string>} Array of trimmed argument strings.
+ */
+const splitArgsAtTopLevel = (args) => {
+  const parts = []
+  let depth = 0
+  let current = ''
+  let i = 0
+  while (i < args.length) {
+    const ch = args[i]
+    if (ch === '"' || ch === "'") {
+      const end = skipString(args, i, ch)
+      current += args.substring(i, end)
+      i = end
+      continue
+    }
+    if (ch === '(') {
+      depth++
+      current += ch
+      i++
+      continue
+    }
+    if (ch === ')') {
+      depth--
+      current += ch
+      i++
+      continue
+    }
+    if (ch === ',' && depth === 0) {
+      parts.push(current.trim())
+      current = ''
+      i++
+      continue
+    }
+    current += ch
+    i++
+  }
+  if (current.length > 0 || parts.length > 0) {
+    parts.push(current.trim())
+  }
+  return parts
+}
+
+/**
+ * Convert DNCL built-in function calls to Ruby equivalents. Uses balanced
+ * paren matching so nested calls (e.g. `表示する(乱数(1..10))`) are
+ * correctly delimited.
  * @param {string} text - Text that may contain DNCL function calls.
  * @returns {string} Text with functions converted to Ruby.
  */
 const convertBuiltinFunctions = (text) => {
   let result = text
 
-  // Handle 表示する(...) → say(..., 1)
-  result = result.replace(
-    /表示する\(([^)]*)\)/g,
-    (_, args) => `say(${args}, 1)`,
-  )
+  // 表示する(...) → say(..., 1)
+  result = replaceCall(result, '表示する', (args) => `say(${args}, 1)`)
 
-  // Handle 含む(str, sub) → str.include?(sub)
-  result = result.replace(
-    /含む\(([^,]+),\s*([^)]+)\)/g,
-    (_, str, sub) => `${str}.include?(${sub})`,
-  )
+  // 含む(str, sub) → str.include?(sub) — only the 2-arg form is valid;
+  // any other arity is left unchanged so we don't emit malformed Ruby.
+  result = replaceCall(result, '含む', (args) => {
+    const parts = splitArgsAtTopLevel(args)
+    if (parts.length === 2) {
+      return `${parts[0]}.include?(${parts[1]})`
+    }
+    return `含む(${args})`
+  })
 
-  // Handle 要素数(Name) → Name.length
-  result = result.replace(
-    /要素数\(([^)]*)\)/g,
-    (_, name) => `${name}.length`,
-  )
+  // 要素数(Name) → Name.length
+  result = replaceCall(result, '要素数', (args) => `${args}.length`)
 
-  // Handle 整数(expr) → expr.to_i
-  result = result.replace(/整数\(([^)]*)\)/g, (_, expr) => `${expr}.to_i`)
+  // 整数(expr) → expr.to_i
+  result = replaceCall(result, '整数', (args) => `${args}.to_i`)
 
-  // Handle 文字列(expr) → expr.to_s
-  result = result.replace(
-    /文字列\(([^)]*)\)/g,
-    (_, expr) => `${expr}.to_s`,
-  )
+  // 文字列(expr) → expr.to_s
+  result = replaceCall(result, '文字列', (args) => `${args}.to_s`)
 
-  // Handle 乱数(n) → rand(n)
-  result = result.replace(/乱数\(([^)]*)\)/g, (_, n) => `rand(${n})`)
+  // 乱数(n) → rand(n)
+  result = replaceCall(result, '乱数', (args) => `rand(${args})`)
 
-  // Handle math functions
-  result = result.replace(
-    /四捨五入\(([^)]*)\)/g,
-    (_, expr) => `${expr}.round`,
-  )
-  result = result.replace(
-    /切り捨て\(([^)]*)\)/g,
-    (_, expr) => `${expr}.floor`,
-  )
-  result = result.replace(
-    /切り上げ\(([^)]*)\)/g,
-    (_, expr) => `${expr}.ceil`,
-  )
-  result = result.replace(
-    /絶対値\(([^)]*)\)/g,
-    (_, expr) => `${expr}.abs`,
-  )
-  result = result.replace(
-    /平方根\(([^)]*)\)/g,
-    (_, expr) => `Math.sqrt(${expr})`,
-  )
+  // Math functions
+  result = replaceCall(result, '四捨五入', (args) => `${args}.round`)
+  result = replaceCall(result, '切り捨て', (args) => `${args}.floor`)
+  result = replaceCall(result, '切り上げ', (args) => `${args}.ceil`)
+  result = replaceCall(result, '絶対値', (args) => `${args}.abs`)
+  result = replaceCall(result, '平方根', (args) => `Math.sqrt(${args})`)
 
   return result
 }

--- a/packages/scratch-gui/src/lib/dncl/dncl-to-ruby.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-to-ruby.js
@@ -110,6 +110,14 @@ const RUBY_LITERALS = new Set([
 let arrayNames = new Set()
 
 /**
+ * Track names of user-defined functions within a conversion. These should
+ * not be prefixed with `@` when referenced (they are method calls, not
+ * instance variables).
+ * @type {Set<string>}
+ */
+let functionNames = new Set()
+
+/**
  * Stack tracking for-loop state for increment insertion at `を繰り返す`.
  * Each entry: { varName, stepRuby, ascending, indent }
  * @type {Array<object>}
@@ -158,6 +166,24 @@ const detectArrayNames = (source) => {
 const isArrayName = (name) => arrayNames.has(name)
 
 /**
+ * Detect user-defined function names from `関数 name(...)` definitions.
+ * Runs before line-by-line conversion so calls (including forward
+ * references) can be recognized regardless of definition order.
+ * @param {string} source - The full DNCL source code.
+ */
+const detectFunctionNames = (source) => {
+  functionNames = new Set()
+  const lines = source.split('\n')
+  for (const line of lines) {
+    const trimmed = line.trim()
+    const m = trimmed.match(/^関数\s+(\w+)\s*\(/)
+    if (m) {
+      functionNames.add(m[1])
+    }
+  }
+}
+
+/**
  * Convert a single DNCL token/identifier to its Ruby equivalent.
  * @param {string} name - The identifier.
  * @returns {string} The Ruby variable reference.
@@ -165,6 +191,7 @@ const isArrayName = (name) => arrayNames.has(name)
 const convertIdentifier = (name) => {
   if (DNCL_KEYWORDS.has(name)) return name
   if (RUBY_LITERALS.has(name)) return name
+  if (functionNames.has(name)) return name
   if (/^\d/.test(name)) return name
   if (/^[A-Z]/.test(name)) {
     return mapVarName(name, isArrayName(name))
@@ -707,6 +734,7 @@ const dnclToRuby = (source) => {
   }
 
   detectArrayNames(source)
+  detectFunctionNames(source)
   forLoopStack = []
 
   const lines = source.split('\n')

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-roundtrip.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-roundtrip.test.js
@@ -129,6 +129,65 @@ describe('DNCL round-trip (DNCL → Ruby → DNCL)', () => {
     })
   })
 
+  describe('nested function calls', () => {
+    test('表示する(乱数(1..10)) round-trips', () => {
+      expect(roundtrip('表示する(乱数(1..10))')).toBe('表示する(乱数(1..10))')
+    })
+
+    test('表示する(整数(x)) round-trips', () => {
+      expect(roundtrip('表示する(整数(x))')).toBe('表示する(整数(x))')
+    })
+
+    test('表示する(絶対値(x)) round-trips', () => {
+      expect(roundtrip('表示する(絶対値(x))')).toBe('表示する(絶対値(x))')
+    })
+
+    test('表示する(乱数(1..10) + 5) round-trips', () => {
+      expect(roundtrip('表示する(乱数(1..10) + 5)')).toBe(
+        '表示する(乱数(1..10) + 5)',
+      )
+    })
+
+    test('a = 含む(s, 乱数(1..10)) round-trips', () => {
+      expect(roundtrip('a = 含む(s, 乱数(1..10))')).toBe(
+        'a = 含む(s, 乱数(1..10))',
+      )
+    })
+  })
+
+  describe('user-defined function calls', () => {
+    test('function definition + call round-trips', () => {
+      const dncl = '関数 myfunc(x)\n  返す 5\nと定義する\nmyfunc(3)'
+      expect(roundtrip(dncl)).toBe(dncl)
+    })
+
+    test('function call in assignment round-trips', () => {
+      const dncl = '関数 myfunc(x)\n  返す 5\nと定義する\na = myfunc(3)'
+      expect(roundtrip(dncl)).toBe(dncl)
+    })
+  })
+
+  describe('Ruby → DNCL → Ruby (regression for nested parens)', () => {
+    const rubyRoundtrip = (ruby) => {
+      const dncl = rubyToDncl(ruby).dncl
+      return dnclToRuby(dncl).ruby
+    }
+
+    test('say(rand(1..10), 1) survives both directions', () => {
+      expect(rubyRoundtrip('say(rand(1..10), 1)')).toBe('say(rand(1..10), 1)')
+    })
+
+    test('say(rand(1..10) + 5, 1) survives both directions', () => {
+      expect(rubyRoundtrip('say(rand(1..10) + 5, 1)')).toBe(
+        'say(rand(1..10) + 5, 1)',
+      )
+    })
+
+    test('say(@x.to_i, 1) survives both directions', () => {
+      expect(rubyRoundtrip('say(@x.to_i, 1)')).toBe('say(@x.to_i, 1)')
+    })
+  })
+
   describe('comments and blank lines', () => {
     test('preserves comments', () => {
       expect(roundtrip('# コメント')).toBe('# コメント')

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-to-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-to-ruby.test.js
@@ -209,6 +209,33 @@ describe('dnclToRuby', () => {
     })
   })
 
+  describe('user-defined function calls', () => {
+    test('bare function call after definition keeps name without @', () => {
+      const dncl = '関数 myfunc(x)\n  返す 5\nと定義する\nmyfunc(3)'
+      const ruby = 'def myfunc(x)\n  return 5\nend\nmyfunc(3)'
+      expect(convert(dncl)).toBe(ruby)
+    })
+
+    test('function call in assignment', () => {
+      expect(
+        convert('関数 myfunc(x)\n  返す 5\nと定義する\na = myfunc(3)'),
+      ).toBe('def myfunc(x)\n  return 5\nend\n@a = myfunc(3)')
+    })
+
+    test('function call inside 表示する', () => {
+      expect(
+        convert('関数 myfunc(x)\n  返す 5\nと定義する\n表示する(myfunc(3))'),
+      ).toBe('def myfunc(x)\n  return 5\nend\nsay(myfunc(3), 1)')
+    })
+
+    test('function called before definition (forward reference)', () => {
+      // detectFunctionNames runs before line conversion, so order should not matter.
+      expect(
+        convert('myfunc(3)\n関数 myfunc(x)\n  返す 5\nと定義する'),
+      ).toBe('myfunc(3)\ndef myfunc(x)\n  return 5\nend')
+    })
+  })
+
   describe('multiline', () => {
     test('multiple statements', () => {
       expect(convert('a = 1\nb = 2')).toBe('@a = 1\n@b = 2')

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-to-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-to-ruby.test.js
@@ -171,6 +171,44 @@ describe('dnclToRuby', () => {
     })
   })
 
+  describe('nested function calls', () => {
+    test('表示する(乱数(1..10)) keeps closing parens balanced', () => {
+      expect(convert('表示する(乱数(1..10))')).toBe('say(rand(1..10), 1)')
+    })
+
+    test('表示する(整数(x)) places .to_i inside say argument', () => {
+      expect(convert('表示する(整数(x))')).toBe('say(@x.to_i, 1)')
+    })
+
+    test('表示する(絶対値(x)) places .abs inside say argument', () => {
+      expect(convert('表示する(絶対値(x))')).toBe('say(@x.abs, 1)')
+    })
+
+    test('表示する(要素数(A)) keeps array conversion inside say', () => {
+      expect(convert('表示する(要素数(Kouka))')).toBe(
+        'say(@_array_Kouka_.length, 1)',
+      )
+    })
+
+    test('表示する with expression containing 乱数', () => {
+      expect(convert('表示する(乱数(1..10) + 5)')).toBe(
+        'say(rand(1..10) + 5, 1)',
+      )
+    })
+
+    test('含む with 乱数 as second argument', () => {
+      expect(convert('a = 含む(s, 乱数(1..10))')).toBe(
+        '@a = @s.include?(rand(1..10))',
+      )
+    })
+
+    test('含む with 3 args is left unchanged (only 2-arg form is valid)', () => {
+      // Identifier conversion still runs (a → @a, b → @b, s → @s),
+      // but 含む itself stays as-is to avoid generating malformed Ruby.
+      expect(convert('含む(s, a, b)')).toBe('含む(@s, @a, @b)')
+    })
+  })
+
   describe('multiline', () => {
     test('multiple statements', () => {
       expect(convert('a = 1\nb = 2')).toBe('@a = 1\n@b = 2')


### PR DESCRIPTION
## Summary

DNCL モードへの切り替え時、`say(rand(1..10), 1)` のようなネストした括弧を含むコードでエラーが出る不具合を修正。あわせてユーザー定義関数の呼び出し名に誤って `@` が付与される不具合も同 PR で修正する。

## Bug

ruby tab で `say(rand(1..10), 1)` を入力 → 「日本語」ボタン押下 → エラー「日本語モードでは対応していない記述です。」が表示され、DNCL モードに切り替わらない。

原因は `dnclToRuby` (`convertBuiltinFunctions`) が `[^)]*` 系正規表現で外側関数の閉じ括弧を取りこぼし、`表示する(乱数(1..10))` を `say(rand(1..10, 1))` のように `say` の duration が `rand` の引数に紛れ込んだ不正な Ruby に変換していたため。

## Implementation Steps

- [x] **Phase 1**: ネスト括弧対応 (`convertBuiltinFunctions` の括弧バランスマッチ化)
  - [x] **[RED]** `dncl-to-ruby.test.js` にネスト括弧テスト 7 ケース追加
  - [x] **[GREEN]** `findMatchingClose` / `replaceCall` / `splitArgsAtTopLevel` ヘルパー追加。`convertBuiltinFunctions` を全関数 `replaceCall` 経由に書き換え。`含む` は引数 2 個以外は変換せず原文保持
  - [x] **[PASS]** lint + 関連 jest テスト
  - [x] **[COMMIT & PUSH]**
- [x] **Phase 2**: 関数呼び出し名の `@` 誤付与修正
  - [x] **[RED]** `dncl-to-ruby.test.js` に user-defined function call テスト 4 ケース追加
  - [x] **[GREEN]** `functionNames` Set + `detectFunctionNames(source)` を追加。`convertIdentifier` で関数名は `@` を付けずに通す
  - [x] **[COMMIT & PUSH]**
- [x] **Phase 3**: ラウンドトリップ回帰テスト
  - [x] `dncl-roundtrip.test.js` にネスト括弧 + 関数定義 + Ruby↔DNCL 双方向テスト 10 ケース追加
  - [x] **[COMMIT & PUSH]**

## Definition of Done

- [x] `dncl-to-ruby.test.js` のネストケース新規テストが pass
- [x] `dncl-to-ruby.test.js` の関数呼び出しケース新規テストが pass
- [x] `dncl-roundtrip.test.js` のラウンドトリップ新規テストが pass
- [x] DNCL 系 jest テストすべて pass（6 ファイル / 194 tests）
- [x] lint pass（`scratch-gui --max-warnings 0`）
- [x] CI green
- [x] **Playwright MCP でブラウザ確認**:
  - [x] DNCL モード切替: `say(rand(1..10), 1)` → `表示する(乱数(1..10))` へエラー無く切替（marker なし、language=dncl）
  - [x] DNCL → コードタブ切替: `looks_sayforsecs` + `operator_random(1..10)` のブロック構造に正しく復元
  - [x] DNCL モードで関数定義+呼び出し: `関数 myfunc(x) ... myfunc(3)` が `def myfunc(x) ... myfunc(3)` に変換（`@myfunc` ではない）。エラーマーカー無し
  - [x] `表示する(整数(x))` → `say(@x.to_i, 1)`、`表示する(絶対値(x))` → `say(@x.abs, 1)`、`表示する(乱数(1..10) + 5)` → `say(rand(1..10) + 5, 1)`、`a = 含む(s, 乱数(1..10))` → `@a = @s.include?(rand(1..10))` のいずれもエラー無し

## Test Plan

- [x] Unit tests (Phase 1): ネスト括弧 7 ケース追加
- [x] Unit tests (Phase 2): 関数呼び出し 4 ケース追加（前方参照含む）
- [x] Roundtrip tests (Phase 3): DNCL→Ruby→DNCL 7 ケース + Ruby→DNCL→Ruby 3 ケース
- [x] Browser verification: Playwright MCP で DoD 全項目を実機確認済み

Fixes #570