### PR TITLE
chore(infra): bump smalruby-api Lambda runtime to Node.js 22.x

### DIFF
--- a/infra/smalruby-api/lib/smalruby-api-stack.ts
+++ b/infra/smalruby-api/lib/smalruby-api-stack.ts
@@ -57,7 +57,7 @@ export class SmalrubyApiStack extends cdk.Stack {
 
             return new lambdaNodejs.NodejsFunction(this, constructId, {
                 functionName,
-                runtime: lambda.Runtime.NODEJS_20_X,
+                runtime: lambda.Runtime.NODEJS_22_X,
                 entry: path.join(__dirname, `../lambda/${entry}`),
                 handler: 'handler',
                 timeout: cdk.Duration.seconds(timeoutSec),


### PR DESCRIPTION
## Summary
Bump the Lambda runtime for `infra/smalruby-api` from Node.js 20.x to 22.x ahead of the AWS Lambda Node.js 20.x EOL on 2026-04-30.

## Why
- AWS は 2026-04-30 から Node.js 20.x のセキュリティパッチ提供を停止
- 2026-09-30 以降は既存関数のコード/設定の更新もブロックされる
- 移行先に Node.js 22.x (Active LTS, deprecation 2027-04-30) を採用

## Changes
- `lib/smalruby-api-stack.ts`: `Runtime.NODEJS_20_X` → `Runtime.NODEJS_22_X` の 1 行のみ

## Verification

### Local
- ✅ `npm test`: 23 passed (unit tests)
- ✅ `npx cdk synth`: CFN テンプレートの `Runtime` フィールドが `nodejs22.x` になることを確認

### Stg deploy
- ✅ `npx cdk diff`: Runtime 以外の差分なし（4 関数すべて `nodejs20.x` → `nodejs22.x`）
- ✅ `npx cdk deploy`: SmalrubyApiStack-stg が UPDATE_COMPLETE（53.96s）
- ✅ `npm run test:integration`: 18/18 passed against `https://stg.api.smalruby.app`

## Affected Lambda Functions (4 functions)
- `smalruby-api-cors-proxy-stg` / `smalruby-api-cors-proxy` (prod)
- `smalruby-api-mesh-zone-stg` / `smalruby-api-mesh-zone` (prod)
- `smalruby-api-scratch-projects-stg` / `smalruby-api-scratch-projects` (prod)
- `smalruby-api-scratch-translate-stg` / `smalruby-api-scratch-translate` (prod)

## Related Issue
Refs #578
