### PR TITLE
chore(infra): bump smalruby-classroom Lambda runtime to Node.js 22.x

### DIFF
--- a/infra/smalruby-classroom/lib/classroom-stack.ts
+++ b/infra/smalruby-classroom/lib/classroom-stack.ts
@@ -191,7 +191,7 @@ export class ClassroomStack extends cdk.Stack {
 
     const handlerFn = new lambdaNodejs.NodejsFunction(this, 'ClassroomHandler', {
       functionName: `ClassroomHandler${stageSuffix}`,
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       entry: path.join(__dirname, '../lambda/handler.ts'),
       handler: 'handler',
       timeout: cdk.Duration.seconds(30),


### PR DESCRIPTION
## Summary
Bump the Lambda runtime for `infra/smalruby-classroom` from Node.js 20.x to 22.x ahead of the AWS Lambda Node.js 20.x EOL on 2026-04-30.

## Why
- AWS は 2026-04-30 から Node.js 20.x のセキュリティパッチ提供を停止
- 2026-09-30 以降は既存関数のコード/設定の更新もブロックされる
- 移行先に Node.js 22.x (Active LTS, deprecation 2027-04-30) を採用

## Changes
- `lib/classroom-stack.ts`: `Runtime.NODEJS_20_X` → `Runtime.NODEJS_22_X` の 1 行のみ

## Verification

### Local
- ✅ `npm test`: 63 passed (unit tests)
- ✅ `npx cdk diff`: Runtime 以外の差分なし（`nodejs20.x` → `nodejs22.x`）

### Stg deploy
- ✅ `npx cdk deploy`: ClassroomStack-stg が UPDATE_COMPLETE
- ✅ `aws lambda get-function-configuration ClassroomHandler-stg --query Runtime`: `nodejs22.x`
- ✅ `npm run test:integration`: 18 passed / 16 skipped (skipped は Google OAuth トークンが必要なテスト)

## Affected Lambda Functions
- `ClassroomHandler-stg` (stg) / `ClassroomHandler` (prod)

## Related Issue
Refs #578
