### PR TITLE
feat(gui): add MobileGui skeleton + opt-in dispatcher (Phase 2-A of #572)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -59,6 +59,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/lib/blocks.js` | gesture recovery | ジェスチャー復旧ハンドラーのインストール |
 | `src/playground/render-gui.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui.jsx` | no_beforeunload URL param | beforeunload 無効化 |
+| `src/playground/render-gui.jsx` | MobileGui dispatcher | ResponsiveGui import + GUI を ResponsiveGui に差し替え (issue #572 Phase 2-A) |
 | `src/playground/render-gui-standalone.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui-standalone.jsx` | no_beforeunload URL param | beforeunload 無効化 |
 | `src/playground/player.jsx` | URL params for Playwright | URL パラメーター import |

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -21,6 +21,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/components/blocks-screenshot-button/`
 - `src/components/google-drive-save-dialog/`
 - `src/components/koshien-test-modal/`
+- `src/components/mobile-gui/`
 - `src/components/narrow-screen-warning/`
 - `src/components/palette-toggle/`
 - `src/components/ruby-script-preview/`
@@ -111,6 +112,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/lib/prism-parser.js`
 - `src/lib/project-loader-utils.js`
 - `src/lib/radix-ui-context-menu.js`
+- `src/lib/responsive-gui.jsx`
 - `src/lib/ruby-parser.js`
 - `src/lib/ruby-screenshot.js`
 - `src/lib/smalrubot-firmware-flasher.js`
@@ -123,6 +125,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/lib/url-loader.js`
 - `src/lib/url-params.js`
 - `src/lib/url-parser.js`
+- `src/lib/use-is-narrow-screen.js`
 - `src/lib/version-checker.js`
 
 ### src/locales/
@@ -206,7 +209,9 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/lib/furigana-annotator-perf.test.js`
 - `test/unit/lib/furigana-annotator.test.js`
 - `test/unit/lib/google-drive-api.test.js`
+- `test/unit/lib/responsive-gui.test.jsx`
 - `test/unit/lib/url-loader.test.js`
+- `test/unit/lib/use-is-narrow-screen.test.js`
 - `test/unit/lib/insert-class.test.js`
 - `test/unit/lib/join-code-history.test.js`
 - `test/unit/lib/layout-constants.test.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -38,6 +38,7 @@ src/components/*
 !src/components/blocks-screenshot-button/
 !src/components/google-drive-save-dialog/
 !src/components/koshien-test-modal/
+!src/components/mobile-gui/
 !src/components/narrow-screen-warning/
 !src/components/palette-toggle/
 !src/components/ruby-script-preview/
@@ -134,6 +135,7 @@ src/lib/*
 !src/lib/prism-parser.js
 !src/lib/project-loader-utils.js
 !src/lib/radix-ui-context-menu.js
+!src/lib/responsive-gui.jsx
 !src/lib/ruby-parser.js
 !src/lib/ruby-screenshot.js
 !src/lib/smalrubot-firmware-flasher.js
@@ -146,6 +148,7 @@ src/lib/*
 !src/lib/url-loader.js
 !src/lib/url-params.js
 !src/lib/url-parser.js
+!src/lib/use-is-narrow-screen.js
 !src/lib/version-checker.js
 
 # Level 3: src/lib/libraries/*
@@ -289,6 +292,8 @@ test/unit/lib/*
 !test/unit/lib/layout-constants.test.js
 !test/unit/lib/legacy-storage.test.js
 !test/unit/lib/make-toolbox-xml.test.js
+!test/unit/lib/responsive-gui.test.jsx
+!test/unit/lib/use-is-narrow-screen.test.js
 !test/unit/lib/module-sync.test.js
 !test/unit/lib/prism-parser.test.js
 !test/unit/lib/removed-trademarks.test.js

--- a/packages/scratch-gui/src/components/mobile-gui/index.js
+++ b/packages/scratch-gui/src/components/mobile-gui/index.js
@@ -1,0 +1,1 @@
+export { default } from './mobile-gui.jsx';

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import GUI from '../../containers/gui.jsx';
+
+/**
+ * 狭幅 viewport 用の独立 GUI シェル (issue #572 Phase 2)。
+ *
+ * 設計方針:
+ * - upstream の <GUI> には手を入れず、別コンポーネントとして並走する
+ * - Phase 2-A の段階では中身は <GUI> を素通し (機能・見た目に変化なし)
+ * - 後続の PR で順次:
+ *   - PR-2B: ボトムタブ × 5 (ブロック / Ruby / スプライト / コスチューム / 音)
+ *   - PR-2C: ステージ全画面プレビュー (▶ 起動 + 自動実行、⏹ 停止 + 戻る)
+ *   - PR-2D: ブロックパレットドロワー
+ *   - PR-2E: ハンバーガーメニュー
+ *   をこのコンポーネント内に実装し、徐々に <GUI> から切り離していく。
+ *
+ * 受け取る props は <GUI> と同一 (AppStateHOC / HashParserHOC からの全 props)。
+ * @param {object} props - <GUI> と同じ props
+ * @returns {JSX.Element} 現状は <GUI> を素通しでレンダリング
+ */
+const MobileGui = props => <GUI {...props} />;
+
+export default MobileGui;

--- a/packages/scratch-gui/src/components/narrow-screen-warning/narrow-screen-warning.jsx
+++ b/packages/scratch-gui/src/components/narrow-screen-warning/narrow-screen-warning.jsx
@@ -1,36 +1,9 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { FormattedMessage } from 'react-intl';
 
+import useIsNarrowScreen from '../../lib/use-is-narrow-screen.js';
 import styles from './narrow-screen-warning.css';
-
-const NARROW_SCREEN_QUERY = '(max-width: 767px)';
-
-const useIsNarrowScreen = () => {
-    const [isNarrow, setIsNarrow] = useState(() => {
-        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-            return false;
-        }
-        return window.matchMedia(NARROW_SCREEN_QUERY).matches;
-    });
-
-    useEffect(() => {
-        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-            return () => {};
-        }
-        const mql = window.matchMedia(NARROW_SCREEN_QUERY);
-        const handler = event => setIsNarrow(event.matches);
-        if (typeof mql.addEventListener === 'function') {
-            mql.addEventListener('change', handler);
-            return () => mql.removeEventListener('change', handler);
-        }
-        // Safari < 14 fallback
-        mql.addListener(handler);
-        return () => mql.removeListener(handler);
-    }, []);
-
-    return isNarrow;
-};
 
 /**
  * バナーを visual viewport の下端に追従させる (position: fixed 前提)。

--- a/packages/scratch-gui/src/lib/responsive-gui.jsx
+++ b/packages/scratch-gui/src/lib/responsive-gui.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import MobileGui from '../components/mobile-gui/mobile-gui.jsx';
+import GUI from '../containers/gui.jsx';
+import getUrlParams from './url-params.js';
+import useIsNarrowScreen from './use-is-narrow-screen.js';
+
+/**
+ * 狭幅 viewport で MobileGui を、それ以外で <GUI> を出し分けるラッパー
+ * (issue #572 Phase 2)。
+ *
+ * MobileGui は **URL パラメーター `mobile_gui=1` が指定されたときのみ** 採用される。
+ * オプトインなので Phase 2 が未完成でも develop にマージしても影響しない。
+ *
+ * 切替条件:
+ * 1. URL に `?mobile_gui=1` が付いている
+ * 2. かつ viewport 幅が 768px 未満 (matchMedia で実時間判定)
+ *
+ * 上記が両方 true → <MobileGui>
+ * いずれか false → <GUI> (既存挙動)
+ *
+ * URL パラメーターは初回読み込み時に評価される (キャッシュされる)。
+ * viewport 変化 (resize / 端末回転) はリアルタイムで反映される。
+ * @param {object} props - <GUI> に渡される全 props
+ * @returns {JSX.Element} <GUI> または <MobileGui>
+ */
+const ResponsiveGui = props => {
+    const isNarrow = useIsNarrowScreen();
+    const { mobileGui: optedIn } = getUrlParams();
+    if (optedIn && isNarrow) {
+        return <MobileGui {...props} />;
+    }
+    return <GUI {...props} />;
+};
+
+export default ResponsiveGui;

--- a/packages/scratch-gui/src/lib/url-params.js
+++ b/packages/scratch-gui/src/lib/url-params.js
@@ -22,6 +22,9 @@ const RUBY_ALIASES = ['ruby'];
  * - ruby_version=2     — set the Ruby version (1 or 2); invalid values are ignored
  * - rubyMode=dncl      — activate DNCL mode (aliases: dnclv2, case-insensitive)
  * - rubyMode=rubi      — activate furigana mode (aliases: furigana, case-insensitive)
+ * - mobile_gui=1       — opt-in to the experimental MobileGui (issue #572 Phase 2,
+ *                        narrow viewport only). Off by default; only takes effect when
+ *                        viewport <768px.
  * @returns {object} parsed parameters
  */
 const parseUrlParams = () => {
@@ -34,6 +37,7 @@ const parseUrlParams = () => {
             features: [],
             classcode: null,
             devlogin: false,
+            mobileGui: false,
         };
     }
 
@@ -49,6 +53,7 @@ const parseUrlParams = () => {
             features: [],
             classcode: null,
             devlogin: false,
+            mobileGui: false,
         };
     }
 
@@ -89,7 +94,10 @@ const parseUrlParams = () => {
     // devlogin: bypass Google auth with a secret token (stg/local only)
     const devlogin = params.get('devlogin') || null;
 
-    return { noBeforeUnload, initialTab, rubyVersion, rubyMode, features, classcode, devlogin };
+    // mobile_gui: experimental opt-in for the narrow-viewport MobileGui shell (issue #572)
+    const mobileGui = params.get('mobile_gui') === '1' || params.get('mobile_gui') === 'true';
+
+    return { noBeforeUnload, initialTab, rubyVersion, rubyMode, features, classcode, devlogin, mobileGui };
 };
 
 // Cache the result so it's only parsed once

--- a/packages/scratch-gui/src/lib/use-is-narrow-screen.js
+++ b/packages/scratch-gui/src/lib/use-is-narrow-screen.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * 「狭幅画面 (= スマホ縦持ち相当、< 768px)」を検知する React hook。
+ *
+ * issue #572 のレスポンシブ対応で、PC レイアウトと別 UI を出し分ける際の
+ * 共通ブレークポイントとして使用する。
+ *
+ * 同じ matchMedia インスタンスを各コンポーネントが個別に購読すると、
+ * リスナー数 = コンポーネント数になるが、それぞれ独立に最新値を持つので
+ * 整合性は保たれる。
+ * @returns {boolean} viewport が 767px 以下なら true
+ */
+const NARROW_SCREEN_QUERY = '(max-width: 767px)';
+
+const useIsNarrowScreen = () => {
+    const [isNarrow, setIsNarrow] = useState(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return false;
+        }
+        return window.matchMedia(NARROW_SCREEN_QUERY).matches;
+    });
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return () => {};
+        }
+        const mql = window.matchMedia(NARROW_SCREEN_QUERY);
+        const handler = event => setIsNarrow(event.matches);
+        if (typeof mql.addEventListener === 'function') {
+            mql.addEventListener('change', handler);
+            return () => mql.removeEventListener('change', handler);
+        }
+        // Safari < 14 fallback
+        mql.addListener(handler);
+        return () => mql.removeListener(handler);
+    }, []);
+
+    return isNarrow;
+};
+
+export default useIsNarrowScreen;
+export { NARROW_SCREEN_QUERY };

--- a/packages/scratch-gui/src/playground/render-gui.jsx
+++ b/packages/scratch-gui/src/playground/render-gui.jsx
@@ -10,6 +10,9 @@ import {PLATFORM} from '../lib/platform.js';
 // === Smalruby: Start of URL params for Playwright ===
 import {getUrlParams} from '../lib/url-params.js';
 // === Smalruby: End of URL params for Playwright ===
+// === Smalruby: Start of MobileGui dispatcher ===
+import ResponsiveGui from '../lib/responsive-gui.jsx';
+// === Smalruby: End of MobileGui dispatcher ===
 
 const onClickLogo = () => {
     window.location = 'https://smalruby.jp';
@@ -41,7 +44,11 @@ export default appTarget => {
     const WrappedGui = compose(
         AppStateHOC,
         HashParserHOC
-    )(GUI);
+        // === Smalruby: Start of MobileGui dispatcher ===
+        // ResponsiveGui forwards all HOC-injected props and switches between
+        // <GUI> and <MobileGui> based on the `mobile_gui=1` URL flag + viewport width.
+        // === Smalruby: End of MobileGui dispatcher ===
+    )(ResponsiveGui);
 
     // TODO a hack for testing the backpack, allow backpack host to be set by url param
     const backpackHostMatches = window.location.href.match(/[?&]backpack_host=([^&]*)&?/);

--- a/packages/scratch-gui/test/unit/lib/responsive-gui.test.jsx
+++ b/packages/scratch-gui/test/unit/lib/responsive-gui.test.jsx
@@ -1,0 +1,78 @@
+/* eslint-env jest */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import ResponsiveGui from '../../../src/lib/responsive-gui.jsx';
+
+// Mock GUI / MobileGui as cheap stand-ins so we don't need the full Redux + VM tree.
+jest.mock('../../../src/containers/gui.jsx', () => {
+    const MockGui = props => <div data-testid="mock-gui" data-prop={props.marker || ''} />;
+    return MockGui;
+});
+jest.mock('../../../src/components/mobile-gui/mobile-gui.jsx', () => {
+    const MockMobileGui = props => <div data-testid="mock-mobile-gui" data-prop={props.marker || ''} />;
+    return MockMobileGui;
+});
+
+// Mock getUrlParams so tests can swap the mobile_gui flag without resetting modules
+// (which would create duplicate React instances and break hooks).
+const mockGetUrlParams = jest.fn();
+jest.mock('../../../src/lib/url-params.js', () => ({
+    __esModule: true,
+    default: () => mockGetUrlParams(),
+    getUrlParams: () => mockGetUrlParams(),
+    clearClasscode: jest.fn(),
+}));
+
+// Mock the matchMedia hook similarly so we control narrow-screen state.
+const mockUseIsNarrowScreen = jest.fn();
+jest.mock('../../../src/lib/use-is-narrow-screen.js', () => ({
+    __esModule: true,
+    default: () => mockUseIsNarrowScreen(),
+}));
+
+const setEnv = ({ flag, narrow }) => {
+    mockGetUrlParams.mockReturnValue({ mobileGui: flag });
+    mockUseIsNarrowScreen.mockReturnValue(narrow);
+};
+
+beforeEach(() => {
+    mockGetUrlParams.mockReset();
+    mockUseIsNarrowScreen.mockReset();
+});
+
+describe('ResponsiveGui', () => {
+    test('renders <GUI> by default (no flag, wide viewport)', () => {
+        setEnv({ flag: false, narrow: false });
+        const { queryByTestId } = render(<ResponsiveGui marker="X" />);
+        expect(queryByTestId('mock-gui')).toBeInTheDocument();
+        expect(queryByTestId('mock-mobile-gui')).not.toBeInTheDocument();
+    });
+
+    test('renders <GUI> when flag is set but viewport is wide', () => {
+        setEnv({ flag: true, narrow: false });
+        const { queryByTestId } = render(<ResponsiveGui marker="X" />);
+        expect(queryByTestId('mock-gui')).toBeInTheDocument();
+        expect(queryByTestId('mock-mobile-gui')).not.toBeInTheDocument();
+    });
+
+    test('renders <GUI> when viewport is narrow but flag is missing', () => {
+        setEnv({ flag: false, narrow: true });
+        const { queryByTestId } = render(<ResponsiveGui marker="X" />);
+        expect(queryByTestId('mock-gui')).toBeInTheDocument();
+        expect(queryByTestId('mock-mobile-gui')).not.toBeInTheDocument();
+    });
+
+    test('renders <MobileGui> only when flag + narrow viewport both apply', () => {
+        setEnv({ flag: true, narrow: true });
+        const { queryByTestId } = render(<ResponsiveGui marker="X" />);
+        expect(queryByTestId('mock-mobile-gui')).toBeInTheDocument();
+        expect(queryByTestId('mock-gui')).not.toBeInTheDocument();
+    });
+
+    test('forwards props to the chosen child', () => {
+        setEnv({ flag: true, narrow: true });
+        const { getByTestId } = render(<ResponsiveGui marker="passed-through" />);
+        expect(getByTestId('mock-mobile-gui')).toHaveAttribute('data-prop', 'passed-through');
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/use-is-narrow-screen.test.js
+++ b/packages/scratch-gui/test/unit/lib/use-is-narrow-screen.test.js
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { act, render } from '@testing-library/react';
+import useIsNarrowScreen from '../../../src/lib/use-is-narrow-screen.js';
+
+const setMatchMedia = matches => {
+    const listeners = new Set();
+    const mql = {
+        matches,
+        media: '',
+        onchange: null,
+        addEventListener: (_event, listener) => listeners.add(listener),
+        removeEventListener: (_event, listener) => listeners.delete(listener),
+        addListener: listener => listeners.add(listener),
+        removeListener: listener => listeners.delete(listener),
+        dispatchEvent: () => false,
+    };
+    window.matchMedia = jest.fn(() => mql);
+    return { mql, listeners };
+};
+
+const ProbeComponent = ({ onValue }) => {
+    const value = useIsNarrowScreen();
+    onValue(value);
+    return null;
+};
+
+describe('useIsNarrowScreen', () => {
+    test('returns true when matchMedia matches', () => {
+        setMatchMedia(true);
+        let observed = null;
+        render(<ProbeComponent onValue={v => (observed = v)} />);
+        expect(observed).toBe(true);
+    });
+
+    test('returns false when matchMedia does not match', () => {
+        setMatchMedia(false);
+        let observed = null;
+        render(<ProbeComponent onValue={v => (observed = v)} />);
+        expect(observed).toBe(false);
+    });
+
+    test('updates when viewport changes', () => {
+        const { listeners } = setMatchMedia(false);
+        const observations = [];
+        render(<ProbeComponent onValue={v => observations.push(v)} />);
+        expect(observations[observations.length - 1]).toBe(false);
+        act(() => {
+            listeners.forEach(listener => listener({ matches: true }));
+        });
+        expect(observations[observations.length - 1]).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

iPhone 等の狭幅画面向けレスポンシブ対応 (issue #572 Phase 2) の基礎となる **MobileGui スケルトン + オプトイン切替** を導入。

## 採用戦略

B 案 (MobileGui 並走) + URL フラグでオプトイン (Phase 2 が未完成のまま develop にマージしても影響ゼロ):

- upstream の `<GUI>` には手を入れず、別コンポーネント `<MobileGui>` を並走させる
- Phase 2-A (本 PR) ではスケルトン: `<MobileGui>` の中身は `<GUI>` 素通し
- 後続 PR で `<MobileGui>` 内のレイアウトを徐々に置き換える:
  - PR-2B: ボトムタブ × 5 (ブロック / Ruby / スプライト / コスチューム / 音)
  - PR-2C: ステージ全画面プレビュー (▶ 起動 + 自動実行、⏹ 停止 + 戻る)
  - PR-2D: ブロックパレットドロワー
  - PR-2E: ハンバーガーメニュー

## URL フラグ

| URL | viewport | レンダリング |
|---|---|---|
| `?mobile_gui` 未指定 (デフォルト) | 任意 | `<GUI>` (既存挙動、変更なし) |
| `?mobile_gui=1` 指定 | < 768px | `<MobileGui>` (現状は `<GUI>` 素通し) |
| `?mobile_gui=1` 指定 | ≥ 768px | `<GUI>` (PC レイアウト維持) |

## 変更ファイル

### 新規 (Smalruby 固有)

- `src/lib/use-is-narrow-screen.js` — `matchMedia('(max-width: 767px)')` を購読する共有 hook (旧 `narrow-screen-warning.jsx` から抽出)
- `src/lib/responsive-gui.jsx` — 切替ロジック。フラグ + viewport を見て `<GUI>` か `<MobileGui>` を返す
- `src/components/mobile-gui/{mobile-gui.jsx,index.js}` — スケルトンコンポーネント
- `test/unit/lib/use-is-narrow-screen.test.js` — hook 3 ケース
- `test/unit/lib/responsive-gui.test.jsx` — 切替 5 ケース (フラグ × viewport の全組合せ)

### 変更

- `src/lib/url-params.js` — `mobile_gui` パラメーターの解釈を追加 (既存 Smalruby 専用ファイル)
- `src/components/narrow-screen-warning/narrow-screen-warning.jsx` — `useIsNarrowScreen` を共有 hook に置き換え
- `src/playground/render-gui.jsx` — **upstream ファイル**。Smalruby マーカーで囲んだ 4 行追加 (import 1 行 + ResponsiveGui への差し替え + コメント 2 行)。インデント変更・条件分岐追加なし

### メタファイル

- `.prettierignore` / `smalruby-prettier-files.md` (scratch-gui) — 新規ファイルをホワイトリストに追加
- `smalruby-markers.md` — `render-gui.jsx` の MobileGui dispatcher マーカーを追加

## 検証

### ユニットテスト (jest, 13 件)

- `useIsNarrowScreen`: 3 ケース (狭幅 true / 広幅 false / viewport 変化で切替)
- `ResponsiveGui`: 5 ケース (フラグ × viewport の全組合せ + props 透過)
- `NarrowScreenWarning` (既存、共有 hook 利用): 5 ケース (リグレッションなし)

### Playwright (Chromium、390×844 設定)

| URL | 結果 |
|---|---|
| `?no_beforeunload=1` | GUI 描画 + Phase 1 バナー / overflow-y: clip 維持 ✓ |
| `?no_beforeunload=1&mobile_gui=1` | MobileGui (中身は GUI) 描画 + Phase 1 機能維持 ✓ |

## Test plan

- [x] ユニットテスト 13/13 緑
- [x] ESLint / Prettier クリーン
- [x] Playwright で 2 つの URL で動作確認
- [x] フラグ未指定時に既存挙動 (デフォルト GUI) が壊れていないこと
- [ ] CI green (push 後)

## Related

- 設計: `notes/issue-572-responsive-ux-design.md` (本リポジトリ、git 管理外)
- Issue: #572 (Phase 1 = #577 でマージ済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
