### PR TITLE
chore(infra): bump smalruby-rubytee-relay Lambda runtime to Node.js 22.x

### DIFF
--- a/infra/smalruby-rubytee-relay/lib/rubytee-relay-stack.ts
+++ b/infra/smalruby-rubytee-relay/lib/rubytee-relay-stack.ts
@@ -79,7 +79,7 @@ export class RubyteeRelayStack extends cdk.Stack {
     // Lambda function (esbuild bundling)
     const handlerFn = new lambdaNodejs.NodejsFunction(this, 'RubyteeRelayHandler', {
       functionName: `RubyteeRelayHandler${stageSuffix}`,
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       entry: path.join(__dirname, '../lambda/handler.ts'),
       handler: 'handler',
       timeout: cdk.Duration.seconds(60),


### PR DESCRIPTION
## Summary
Bump the Lambda runtime for `infra/smalruby-rubytee-relay` from Node.js 20.x to 22.x ahead of the AWS Lambda Node.js 20.x EOL on 2026-04-30.

## Why
- AWS は 2026-04-30 から Node.js 20.x のセキュリティパッチ提供を停止
- 2026-09-30 以降は既存関数のコード/設定の更新もブロックされる
- 移行先に Node.js 22.x (Active LTS, deprecation 2027-04-30) を採用

## Changes
- `lib/rubytee-relay-stack.ts`: `Runtime.NODEJS_20_X` → `Runtime.NODEJS_22_X` の 1 行のみ

## Verification

### Local
- ✅ `npm test`: 43 passed (unit tests)

### Stg deploy
- ✅ `npx cdk deploy`: RubyteeRelayStack-stg が UPDATE_COMPLETE（38.45s）
- ✅ `aws lambda get-function-configuration RubyteeRelayHandler-stg --query Runtime`: `nodejs22.x`
- ✅ `npm run test:integration`: 8/8 passed against stg endpoint
- ✅ Anthropic Claude プロンプトキャッシュも正常動作（CloudWatch ログで確認）:
  - 初回: `cacheCreationTokens: 5841, cacheReadTokens: 0`
  - 2回目以降: `cacheCreationTokens: 0, cacheReadTokens: 5841` (hit)

## Affected Lambda Functions
- `RubyteeRelayHandler-stg` (stg) / `RubyteeRelayHandler` (prod)

## Related Issue
Refs #578
