### PR TITLE
feat(gui): add mobile hamburger menu drawer (Phase 2-E)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -22,6 +22,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/components/google-drive-save-dialog/`
 - `src/components/koshien-test-modal/`
 - `src/components/mobile-bottom-tabs/`
+- `src/components/mobile-drawer/`
 - `src/components/mobile-gui/`
 - `src/components/mobile-palette-auto-closer/`
 - `src/components/mobile-top-bar/`
@@ -189,6 +190,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/components/action-menu.test.jsx`
 - `test/unit/components/connected-step.test.jsx`
 - `test/unit/components/mobile-bottom-tabs.test.jsx`
+- `test/unit/components/mobile-drawer.test.jsx`
 - `test/unit/components/mobile-palette-auto-closer.test.jsx`
 - `test/unit/components/mobile-top-bar.test.jsx`
 - `test/unit/components/narrow-screen-warning.test.jsx`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -39,6 +39,7 @@ src/components/*
 !src/components/google-drive-save-dialog/
 !src/components/koshien-test-modal/
 !src/components/mobile-bottom-tabs/
+!src/components/mobile-drawer/
 !src/components/mobile-gui/
 !src/components/mobile-palette-auto-closer/
 !src/components/mobile-top-bar/
@@ -252,6 +253,7 @@ test/unit/components/*
 !test/unit/components/action-menu.test.jsx
 !test/unit/components/connected-step.test.jsx
 !test/unit/components/mobile-bottom-tabs.test.jsx
+!test/unit/components/mobile-drawer.test.jsx
 !test/unit/components/mobile-palette-auto-closer.test.jsx
 !test/unit/components/mobile-top-bar.test.jsx
 !test/unit/components/narrow-screen-warning.test.jsx

--- a/packages/scratch-gui/src/components/mobile-drawer/icon--close.svg
+++ b/packages/scratch-gui/src/components/mobile-drawer/icon--close.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="6" y1="6" x2="18" y2="18" />
+  <line x1="18" y1="6" x2="6" y2="18" />
+</svg>

--- a/packages/scratch-gui/src/components/mobile-drawer/icon--hamburger.svg
+++ b/packages/scratch-gui/src/components/mobile-drawer/icon--hamburger.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="4" y1="7" x2="20" y2="7" />
+  <line x1="4" y1="12" x2="20" y2="12" />
+  <line x1="4" y1="17" x2="20" y2="17" />
+</svg>

--- a/packages/scratch-gui/src/components/mobile-drawer/mobile-drawer.css
+++ b/packages/scratch-gui/src/components/mobile-drawer/mobile-drawer.css
@@ -1,0 +1,142 @@
+.backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    /*
+     * MobileTopBar / MobileBottomTabs (z-index: 9000) より上に乗せて、
+     * メニューを開いたときに下のレイヤーを完全に隠す。
+     */
+    z-index: 9500;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 200ms ease;
+}
+
+.backdrop.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.drawer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(80vw, 320px);
+    background-color: #ffffff;
+    box-shadow: 2px 0 10px rgba(0, 0, 0, 0.2);
+    z-index: 9501;
+    transform: translateX(-100%);
+    transition: transform 200ms ease;
+    display: flex;
+    flex-direction: column;
+}
+
+.drawer.open {
+    transform: translateX(0);
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 0.5rem 0 1rem;
+    height: 3rem;
+    background-color: #855cd6;
+    color: white;
+    flex: 0 0 auto;
+}
+
+.header-title {
+    font-size: 1rem;
+    font-weight: bold;
+}
+
+.close-button {
+    width: 2.75rem;
+    height: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    color: white;
+    padding: 0;
+}
+
+.close-icon {
+    width: 24px;
+    height: 24px;
+}
+
+.menu-list {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 0.5rem 0;
+    margin: 0;
+    list-style: none;
+    -webkit-overflow-scrolling: touch;
+}
+
+.menu-item {
+    display: block;
+    width: 100%;
+    padding: 0.875rem 1rem;
+    background: transparent;
+    border: 0;
+    text-align: left;
+    font-size: 0.95rem;
+    color: #333;
+    cursor: pointer;
+    box-sizing: border-box;
+}
+
+.menu-item:active {
+    background-color: rgba(133, 92, 214, 0.12);
+}
+
+.section-title {
+    padding: 0.625rem 1rem 0.25rem;
+    color: #855cd6;
+    font-size: 0.75rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+    margin-top: 0.25rem;
+}
+
+.section-title:first-child {
+    border-top: 0;
+    margin-top: 0;
+}
+
+.locale-item {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    background: transparent;
+    border: 0;
+    text-align: left;
+    font-size: 0.95rem;
+    color: #333;
+    cursor: pointer;
+    box-sizing: border-box;
+}
+
+.locale-item.selected {
+    color: #855cd6;
+    font-weight: bold;
+}
+
+.locale-check {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #855cd6;
+}

--- a/packages/scratch-gui/src/components/mobile-drawer/mobile-drawer.jsx
+++ b/packages/scratch-gui/src/components/mobile-drawer/mobile-drawer.jsx
@@ -1,0 +1,248 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import SB3Downloader from '../../containers/sb3-downloader.jsx';
+import intlShape from '../../lib/intlShape';
+import SBFileUploaderHOC from '../../lib/sb-file-uploader-hoc.jsx';
+import sharedMessages from '../../lib/shared-messages';
+import { selectLocale } from '../../reducers/locales.js';
+import { requestNewProject } from '../../reducers/project-state.js';
+import closeIcon from './icon--close.svg';
+import styles from './mobile-drawer.css';
+
+const messages = defineMessages({
+    drawerTitle: {
+        defaultMessage: 'Menu',
+        description: 'Title of the mobile drawer (hamburger menu)',
+        id: 'gui.mobile.drawer.title',
+    },
+    sectionFile: {
+        defaultMessage: 'File',
+        description: 'Section header for file operations in mobile drawer',
+        id: 'gui.mobile.drawer.section.file',
+    },
+    sectionLanguage: {
+        defaultMessage: 'Language',
+        description: 'Section header for language switcher in mobile drawer',
+        id: 'gui.mobile.drawer.section.language',
+    },
+    closeAriaLabel: {
+        defaultMessage: 'Close menu',
+        description: 'Aria label for the mobile drawer close button',
+        id: 'gui.mobile.drawer.close',
+    },
+});
+
+/**
+ * Smalruby のモバイルで表示する 3 言語のみ。upstream の LanguageMenu は
+ * scratch-l10n の 50+ ロケールをすべて出すが、Smalruby が翻訳を持つのは
+ * en / ja / ja-Hira のみで、モバイル UI ではリストが長すぎても扱いに困るため
+ * 短いリストに固定する。
+ */
+const SUPPORTED_LOCALES = [
+    { code: 'ja', label: '日本語' },
+    { code: 'ja-Hira', label: 'にほんご' },
+    { code: 'en', label: 'English' },
+];
+
+/**
+ * Mobile 用ドロワー (ハンバーガーメニュー本体, issue #572 Phase 2-E)。
+ *
+ * MobileTopBar の ☰ から開閉し、最低限の File 操作と言語切替を提供する。
+ * - 新しいプロジェクト
+ * - パソコンから開く (upstream <SBFileUploaderHOC> の機能を再利用)
+ * - パソコンに保存する (upstream <SB3Downloader> を render-prop で利用)
+ * - 言語切替 (en / ja / ja-Hira の 3 つに固定)
+ *
+ * クラスルーム / ルビティー / mesh / Google Drive など Smalruby 固有の機能は、
+ * モバイルでは画面が狭すぎて操作しにくいため Phase 2-E では搭載しない (要望:
+ * 「画面がさますぎて動作しないくらいなら表示しない」)。
+ *
+ * createPortal で document.body 直下に出すため、`<GUI>` の overflow に
+ * クリップされない。SSR 時は document が無いので null を返す。
+ * @param {object} props - props
+ * @param {boolean} props.open - ドロワーが開いているか
+ * @param {Function} props.onClose - ドロワーを閉じるコールバック
+ * @param {string} props.currentLocale - 現在の locale コード
+ * @param {Function} props.onClickNew - 新しいプロジェクト
+ * @param {Function} props.onSelectLocale - 言語切替
+ * @param {Function} props.onStartSelectingFileUpload - SBFileUploaderHOC からの注入
+ * @param {object} props.intl - react-intl
+ * @returns {JSX.Element|null} portal 経由で body 直下にレンダリング
+ */
+const MobileDrawerComponent = ({
+    open,
+    onClose,
+    currentLocale,
+    onClickNew,
+    onSelectLocale,
+    onStartSelectingFileUpload,
+    intl,
+}) => {
+    const handleClickNew = useCallback(() => {
+        onClickNew();
+        onClose();
+    }, [onClickNew, onClose]);
+
+    const handleClickLoad = useCallback(() => {
+        onStartSelectingFileUpload();
+        onClose();
+    }, [onStartSelectingFileUpload, onClose]);
+
+    const handleClickLocale = useCallback(
+        event => {
+            const code = event.currentTarget.dataset.localeCode;
+            if (code) {
+                onSelectLocale(code);
+                onClose();
+            }
+        },
+        [onSelectLocale, onClose],
+    );
+
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    return createPortal(
+        <>
+            <div
+                className={classNames(styles.backdrop, { [styles.open]: open })}
+                onClick={onClose}
+                data-testid="mobile-drawer-backdrop"
+                data-state={open ? 'open' : 'closed'}
+                aria-hidden="true"
+            />
+            <aside
+                className={classNames(styles.drawer, { [styles.open]: open })}
+                role="dialog"
+                aria-modal="true"
+                aria-label={intl.formatMessage(messages.drawerTitle)}
+                data-testid="mobile-drawer"
+                data-state={open ? 'open' : 'closed'}
+            >
+                <header className={styles.header}>
+                    <span className={styles.headerTitle}>
+                        <FormattedMessage {...messages.drawerTitle} />
+                    </span>
+                    <button
+                        type="button"
+                        className={styles.closeButton}
+                        onClick={onClose}
+                        aria-label={intl.formatMessage(messages.closeAriaLabel)}
+                        data-testid="mobile-drawer-close"
+                    >
+                        <img className={styles.closeIcon} src={closeIcon} alt="" aria-hidden="true" />
+                    </button>
+                </header>
+                <ul className={styles.menuList}>
+                    <li className={styles.sectionTitle}>
+                        <FormattedMessage {...messages.sectionFile} />
+                    </li>
+                    <li>
+                        <button
+                            type="button"
+                            className={styles.menuItem}
+                            onClick={handleClickNew}
+                            data-testid="mobile-drawer-new"
+                        >
+                            <FormattedMessage
+                                defaultMessage="New"
+                                description="Menu bar item for creating a new project"
+                                id="gui.menuBar.new"
+                            />
+                        </button>
+                    </li>
+                    <li>
+                        <button
+                            type="button"
+                            className={styles.menuItem}
+                            onClick={handleClickLoad}
+                            data-testid="mobile-drawer-load"
+                        >
+                            <FormattedMessage {...sharedMessages.loadFromComputerTitle} />
+                        </button>
+                    </li>
+                    <li>
+                        <SB3Downloader>
+                            {(_className, downloadProjectCallback) => (
+                                <button
+                                    type="button"
+                                    className={styles.menuItem}
+                                    // eslint-disable-next-line react/jsx-no-bind
+                                    onClick={() => {
+                                        downloadProjectCallback();
+                                        onClose();
+                                    }}
+                                    data-testid="mobile-drawer-save"
+                                >
+                                    <FormattedMessage
+                                        defaultMessage="Save to your computer"
+                                        description="Menu bar item for downloading a project to your computer"
+                                        id="gui.menuBar.downloadToComputer"
+                                    />
+                                </button>
+                            )}
+                        </SB3Downloader>
+                    </li>
+                    <li className={styles.sectionTitle}>
+                        <FormattedMessage {...messages.sectionLanguage} />
+                    </li>
+                    {SUPPORTED_LOCALES.map(({ code, label }) => (
+                        <li key={code}>
+                            <button
+                                type="button"
+                                className={classNames(styles.localeItem, {
+                                    [styles.selected]: currentLocale === code,
+                                })}
+                                onClick={handleClickLocale}
+                                data-locale-code={code}
+                                data-selected={currentLocale === code ? 'true' : 'false'}
+                                data-testid={`mobile-drawer-locale-${code}`}
+                            >
+                                <span className={styles.localeCheck} aria-hidden="true">
+                                    {currentLocale === code ? '✓' : ''}
+                                </span>
+                                {label}
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            </aside>
+        </>,
+        document.body,
+    );
+};
+
+MobileDrawerComponent.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    currentLocale: PropTypes.string,
+    onClickNew: PropTypes.func.isRequired,
+    onSelectLocale: PropTypes.func.isRequired,
+    onStartSelectingFileUpload: PropTypes.func,
+    intl: intlShape.isRequired,
+};
+
+const mapStateToProps = state => ({
+    currentLocale: state.locales.locale,
+});
+
+const mapDispatchToProps = dispatch => ({
+    onClickNew: () => dispatch(requestNewProject(false)),
+    onSelectLocale: locale => dispatch(selectLocale(locale)),
+});
+
+const MobileDrawer = compose(
+    injectIntl,
+    SBFileUploaderHOC,
+    connect(mapStateToProps, mapDispatchToProps),
+)(MobileDrawerComponent);
+
+export default MobileDrawer;
+export { MobileDrawerComponent };

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import GUI from '../../containers/gui.jsx';
 import ConnectedIntlProvider from '../../lib/connected-intl-provider.jsx';
 import MobileBottomTabs from '../mobile-bottom-tabs/mobile-bottom-tabs.jsx';
+import MobileDrawer from '../mobile-drawer/mobile-drawer.jsx';
 import MobilePaletteAutoCloser from '../mobile-palette-auto-closer/mobile-palette-auto-closer.jsx';
 import MobileTopBar from '../mobile-top-bar/mobile-top-bar.jsx';
 
@@ -21,35 +22,45 @@ import MobileTopBar from '../mobile-top-bar/mobile-top-bar.jsx';
  *   - PR-2B: ボトムタブ × 5 (<MobileBottomTabs /> を追加)
  *   - PR-2C: ステージ全画面プレビュー (<MobileTopBar /> の ▶ で
  *     upstream の isFullScreen mode に入る)
- *   - PR-2D: ブロックパレットドロワー (本 PR、<MobilePaletteAutoCloser /> で
- *     初回エントリー時とブロックドラッグ開始時にパレットを自動クローズ。
- *     パレット表示・非表示の手動切替は upstream の <PaletteToggle> を
- *     共有 — モバイル時のみ CSS でハンドルを大きくする)
- *   - PR-2E: ハンバーガーメニュー (予定)
+ *   - PR-2D: ブロックパレットドロワー (<MobilePaletteAutoCloser /> で
+ *     ブロックドラッグ開始時にパレットを自動クローズ。手動切替は
+ *     upstream の <PaletteToggle> を共有 — モバイル時のみ CSS でハンドルを
+ *     大きくする)
+ *   - PR-2E: ハンバーガーメニュー (本 PR、<MobileDrawer /> + <MobileTopBar />
+ *     左端の ☰ ボタン + プロジェクトタイトル表示。新しいプロジェクト /
+ *     パソコンから開く / パソコンに保存 / 言語切替 (en/ja/ja-Hira) を提供)
+ *
+ * ドロワーの開閉状態は React の useState で MobileGui がローカルに保持する。
+ * 外部 (URL や永続化) との連携が必要になったときに Redux 化する想定。
  *
  * 受け取る props は <GUI> と同一 (AppStateHOC / HashParserHOC からの全 props)。
  * @param {object} props - <GUI> と同じ props
- * @returns {JSX.Element} <GUI> + <MobileTopBar /> + <MobileBottomTabs /> +
- *   <MobilePaletteAutoCloser />
+ * @returns {JSX.Element} <GUI> + 各種 mobile-only コンポーネント
  */
-const MobileGui = props => (
-    <>
-        <GUI {...props} />
-        {/*
-         * MobileTopBar / MobileBottomTabs は body 直下に Portal で出すため、
-         * <GUI> 内側の IntlProvider context を使えない。
-         * 別途 ConnectedIntlProvider で包んで FormattedMessage を有効化する。
-         * MobilePaletteAutoCloser は描画しないが、connect でディスパッチを
-         * 受け取るため同じ Provider 配下に置く。
-         */}
-        <ConnectedIntlProvider>
-            <>
-                <MobileTopBar />
-                <MobileBottomTabs />
-                <MobilePaletteAutoCloser />
-            </>
-        </ConnectedIntlProvider>
-    </>
-);
+const MobileGui = props => {
+    const [drawerOpen, setDrawerOpen] = useState(false);
+    const handleOpenDrawer = useCallback(() => setDrawerOpen(true), []);
+    const handleCloseDrawer = useCallback(() => setDrawerOpen(false), []);
+    return (
+        <>
+            <GUI {...props} />
+            {/*
+             * MobileTopBar / MobileBottomTabs / MobileDrawer は body 直下に
+             * Portal で出すため、<GUI> 内側の IntlProvider context を使えない。
+             * 別途 ConnectedIntlProvider で包んで FormattedMessage を有効化する。
+             * MobilePaletteAutoCloser は描画しないが、connect でディスパッチを
+             * 受け取るため同じ Provider 配下に置く。
+             */}
+            <ConnectedIntlProvider>
+                <>
+                    <MobileTopBar onOpenDrawer={handleOpenDrawer} />
+                    <MobileBottomTabs />
+                    <MobilePaletteAutoCloser />
+                    <MobileDrawer open={drawerOpen} onClose={handleCloseDrawer} />
+                </>
+            </ConnectedIntlProvider>
+        </>
+    );
+};
 
 export default MobileGui;

--- a/packages/scratch-gui/src/components/mobile-top-bar/mobile-top-bar.css
+++ b/packages/scratch-gui/src/components/mobile-top-bar/mobile-top-bar.css
@@ -21,6 +21,43 @@
     flex: 1 1 auto;
 }
 
+.menu-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: 0;
+    padding: 4px;
+    margin-right: 8px;
+    cursor: pointer;
+    color: #575e75;
+    -webkit-tap-highlight-color: transparent;
+    flex: 0 0 auto;
+}
+
+.menu-button:focus {
+    outline: 2px solid rgba(76, 151, 255, 0.4);
+    outline-offset: -2px;
+    border-radius: 4px;
+}
+
+.menu-icon {
+    width: 28px;
+    height: 28px;
+}
+
+.project-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 0.95rem;
+    font-weight: bold;
+    color: #575e75;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    margin-right: 8px;
+}
+
 .play-button {
     display: inline-flex;
     align-items: center;
@@ -29,6 +66,7 @@
     border: 0;
     padding: 4px;
     cursor: pointer;
+    flex: 0 0 auto;
     -webkit-tap-highlight-color: transparent;
 }
 

--- a/packages/scratch-gui/src/components/mobile-top-bar/mobile-top-bar.jsx
+++ b/packages/scratch-gui/src/components/mobile-top-bar/mobile-top-bar.jsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { connect } from 'react-redux';
 
 import { setFullScreen } from '../../reducers/mode.js';
+import hamburgerIcon from '../mobile-drawer/icon--hamburger.svg';
 import playIcon from './icon--play.svg';
 import stopIcon from './icon--stop.svg';
 import styles from './mobile-top-bar.css';
@@ -56,17 +57,28 @@ const usePositionAtVisualViewportTop = (ref, enabled) => {
  * - 編集中 (isFullScreen=false): ▶ → setFullScreen(true) + vm.start() + vm.greenFlag()
  * - プレビュー中 (isFullScreen=true): ⏹ → setFullScreen(false) + vm.stopAll()
  *
- * Phase 2-E でハンバーガーメニュー / プロジェクトタイトルを左側に追加する予定。
+ * Phase 2-E: 左端に ☰ ハンバーガー、中央にプロジェクトタイトル表示を追加。
+ * - ☰ タップ → onOpenDrawer() で <MobileDrawer> を開く
+ * - プロジェクトタイトルは表示のみ。編集はモバイルでは省略する。
  *
  * 全画面でも上部バーは表示し続ける (要望)。
  * @param {object} props - props
  * @param {object} props.vm - scratch-vm インスタンス
  * @param {boolean} props.isFullScreen - 既に全画面モードか
  * @param {boolean} props.isStarted - VM がすでに start 済みか
+ * @param {string} props.projectTitle - プロジェクトタイトル
  * @param {Function} props.onSetFullScreen - setFullScreen ディスパッチャ
+ * @param {Function} props.onOpenDrawer - ☰ クリックで呼ぶ
  * @returns {JSX.Element|null} Portal でレンダリングされる上部バー
  */
-const MobileTopBarComponent = ({ vm, isFullScreen, isStarted, onSetFullScreen }) => {
+const MobileTopBarComponent = ({
+    vm,
+    isFullScreen,
+    isStarted,
+    projectTitle,
+    onSetFullScreen,
+    onOpenDrawer,
+}) => {
     const ref = useRef(null);
     usePositionAtVisualViewportTop(ref, true);
 
@@ -88,13 +100,39 @@ const MobileTopBarComponent = ({ vm, isFullScreen, isStarted, onSetFullScreen })
         [vm, isFullScreen, isStarted, onSetFullScreen],
     );
 
+    const handleMenuClick = useCallback(
+        e => {
+            onOpenDrawer();
+            const target = e?.currentTarget;
+            if (target) target.blur();
+        },
+        [onOpenDrawer],
+    );
+
     if (typeof document === 'undefined') {
         return null;
     }
 
     return createPortal(
         <div ref={ref} className={styles.topBar} data-testid="mobile-top-bar">
-            <div className={styles.spacer} />
+            <button
+                type="button"
+                className={styles.menuButton}
+                onClick={handleMenuClick}
+                data-testid="mobile-top-bar-menu"
+                aria-label="menu"
+            >
+                <img
+                    alt=""
+                    aria-hidden="true"
+                    className={styles.menuIcon}
+                    draggable={false}
+                    src={hamburgerIcon}
+                />
+            </button>
+            <span className={styles.projectTitle} data-testid="mobile-top-bar-title">
+                {projectTitle}
+            </span>
             <button
                 type="button"
                 className={styles.playButton}
@@ -123,13 +161,16 @@ MobileTopBarComponent.propTypes = {
     }).isRequired,
     isFullScreen: PropTypes.bool.isRequired,
     isStarted: PropTypes.bool.isRequired,
+    projectTitle: PropTypes.string,
     onSetFullScreen: PropTypes.func.isRequired,
+    onOpenDrawer: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
     vm: state.scratchGui.vm,
     isFullScreen: state.scratchGui.mode.isFullScreen,
     isStarted: state.scratchGui.vmStatus.started,
+    projectTitle: state.scratchGui.projectTitle,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/scratch-gui/src/lib/log-suppression.js
+++ b/packages/scratch-gui/src/lib/log-suppression.js
@@ -18,6 +18,12 @@ const ignoredWarnings = [
     'The AudioContext was not allowed to start',
     'apple-mobile-web-app-capable',
     'GenerateSW has been called multiple times',
+    // Monaco editor (editor.api-*.js) のタッチハンドラが start を取り逃した
+    // touch の move / end を受け取ると警告を吐く。モバイル UI で blockly や
+    // ステージにタッチを始めて Monaco エリアに指が乗ったまま離す等で発生
+    // するが実害は無く、画面サイズが小さい環境では繰り返し発生して
+    // ノイズになるため抑止する。
+    'of an UNKNOWN touch',
 ];
 
 /**

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -637,4 +637,8 @@ export default {
         'This code contains constructs not supported in Japanese mode.\nPlease use only supported instructions before switching modes.',
     'gui.narrowScreenWarning.message': '📱 For full editing, a PC or tablet is recommended.',
     'gui.narrowScreenWarning.close': 'Close',
+    'gui.mobile.drawer.title': 'Menu',
+    'gui.mobile.drawer.section.file': 'File',
+    'gui.mobile.drawer.section.language': 'Language',
+    'gui.mobile.drawer.close': 'Close menu',
 };

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -943,4 +943,8 @@ export default {
         'にほんごモードではたいおうしていないきじゅつです。\nたいおうしているめいれいのみにしてから、モードきりかえをおこなってください。',
     'gui.narrowScreenWarning.message': '📱 ほんかくてきな へんしゅうは PC・タブレットが おすすめです。',
     'gui.narrowScreenWarning.close': 'とじる',
+    'gui.mobile.drawer.title': 'メニュー',
+    'gui.mobile.drawer.section.file': 'ファイル',
+    'gui.mobile.drawer.section.language': 'げんご',
+    'gui.mobile.drawer.close': 'メニューをとじる',
 };

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -918,4 +918,8 @@ export default {
         '日本語モードでは対応していない記述です。\n対応している命令のみにしてから、モード切り替えを行ってください。',
     'gui.narrowScreenWarning.message': '📱 本格的な編集は PC・タブレットを推奨します。',
     'gui.narrowScreenWarning.close': '閉じる',
+    'gui.mobile.drawer.title': 'メニュー',
+    'gui.mobile.drawer.section.file': 'ファイル',
+    'gui.mobile.drawer.section.language': '言語',
+    'gui.mobile.drawer.close': 'メニューを閉じる',
 };

--- a/packages/scratch-gui/test/unit/components/mobile-drawer.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mobile-drawer.test.jsx
@@ -1,0 +1,102 @@
+/* eslint-env jest */
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import { MobileDrawerComponent } from '../../../src/components/mobile-drawer/mobile-drawer.jsx';
+
+// SB3Downloader は connect(state.scratchGui.vm.saveProjectSb3) を使うため、
+// 単体テストでは Redux Provider 無しで描画すると store エラーになる。
+// 保存メニューの「クリックで onClose する」挙動はクリック先のコールバックを
+// fakeDownloader として渡して検証する。
+jest.mock('../../../src/containers/sb3-downloader.jsx', () => ({
+    __esModule: true,
+    default: ({ children }) => children('', () => {}),
+}));
+
+const fakeIntl = {
+    locale: 'en',
+    formatMessage: descriptor => descriptor.defaultMessage,
+};
+
+const baseProps = () => ({
+    open: true,
+    onClose: jest.fn(),
+    currentLocale: 'en',
+    onClickNew: jest.fn(),
+    onSelectLocale: jest.fn(),
+    onStartSelectingFileUpload: jest.fn(),
+    intl: fakeIntl,
+});
+
+const renderWithIntl = props => {
+    const merged = { ...baseProps(), ...props };
+    return {
+        ...render(
+            <IntlProvider locale="en" messages={{}}>
+                <MobileDrawerComponent {...merged} />
+            </IntlProvider>,
+        ),
+        props: merged,
+    };
+};
+
+describe('MobileDrawer', () => {
+    test('does not mark backdrop as open when open=false', () => {
+        const { queryByTestId } = renderWithIntl({ open: false });
+        const backdrop = queryByTestId('mobile-drawer-backdrop');
+        expect(backdrop).toBeInTheDocument();
+        expect(backdrop).toHaveAttribute('data-state', 'closed');
+    });
+
+    test('marks backdrop / drawer as open when open=true', () => {
+        const { getByTestId } = renderWithIntl();
+        expect(getByTestId('mobile-drawer-backdrop')).toHaveAttribute('data-state', 'open');
+        expect(getByTestId('mobile-drawer')).toHaveAttribute('data-state', 'open');
+    });
+
+    test('clicking backdrop calls onClose', () => {
+        const { getByTestId, props } = renderWithIntl();
+        fireEvent.click(getByTestId('mobile-drawer-backdrop'));
+        expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('clicking close button calls onClose', () => {
+        const { getByTestId, props } = renderWithIntl();
+        fireEvent.click(getByTestId('mobile-drawer-close'));
+        expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('clicking "New" calls onClickNew + onClose', () => {
+        const { getByTestId, props } = renderWithIntl();
+        fireEvent.click(getByTestId('mobile-drawer-new'));
+        expect(props.onClickNew).toHaveBeenCalledTimes(1);
+        expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('clicking "Load from computer" triggers SBFileUploader + onClose', () => {
+        const { getByTestId, props } = renderWithIntl();
+        fireEvent.click(getByTestId('mobile-drawer-load'));
+        expect(props.onStartSelectingFileUpload).toHaveBeenCalledTimes(1);
+        expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('clicking "Save" calls onClose (download is wired via SB3Downloader)', () => {
+        const { getByTestId, props } = renderWithIntl();
+        fireEvent.click(getByTestId('mobile-drawer-save'));
+        expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('clicking a locale calls onSelectLocale with code + onClose', () => {
+        const { getByTestId, props } = renderWithIntl();
+        fireEvent.click(getByTestId('mobile-drawer-locale-ja'));
+        expect(props.onSelectLocale).toHaveBeenCalledWith('ja');
+        expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('selected locale gets the selected attribute', () => {
+        const { getByTestId } = renderWithIntl({ currentLocale: 'ja' });
+        expect(getByTestId('mobile-drawer-locale-ja')).toHaveAttribute('data-selected', 'true');
+        expect(getByTestId('mobile-drawer-locale-en')).toHaveAttribute('data-selected', 'false');
+    });
+});

--- a/packages/scratch-gui/test/unit/components/mobile-top-bar.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mobile-top-bar.test.jsx
@@ -10,71 +10,69 @@ const makeFakeVm = () => ({
     stopAll: jest.fn(),
 });
 
+const baseProps = () => ({
+    vm: makeFakeVm(),
+    isFullScreen: false,
+    isStarted: false,
+    projectTitle: '',
+    onSetFullScreen: jest.fn(),
+    onOpenDrawer: jest.fn(),
+});
+
 describe('MobileTopBar', () => {
     test('renders the play button when not fullscreen', () => {
-        const { getByTestId } = render(
-            <MobileTopBarComponent
-                vm={makeFakeVm()}
-                isFullScreen={false}
-                isStarted={false}
-                onSetFullScreen={() => {}}
-            />,
-        );
+        const props = baseProps();
+        const { getByTestId } = render(<MobileTopBarComponent {...props} />);
         expect(getByTestId('mobile-top-bar')).toBeInTheDocument();
         expect(getByTestId('mobile-top-bar-play')).toBeInTheDocument();
         expect(getByTestId('mobile-top-bar-play')).toHaveAttribute('aria-label', 'play');
     });
 
     test('still renders in fullscreen mode (button toggles to stop)', () => {
-        const { getByTestId } = render(
-            <MobileTopBarComponent
-                vm={makeFakeVm()}
-                isFullScreen={true}
-                isStarted={true}
-                onSetFullScreen={() => {}}
-            />,
-        );
+        const props = { ...baseProps(), isFullScreen: true, isStarted: true };
+        const { getByTestId } = render(<MobileTopBarComponent {...props} />);
         expect(getByTestId('mobile-top-bar')).toBeInTheDocument();
         expect(getByTestId('mobile-top-bar-play')).toHaveAttribute('aria-label', 'stop');
     });
 
     test('clicking play activates fullscreen + vm.start + vm.greenFlag (when not started)', () => {
-        const vm = makeFakeVm();
-        const onSetFullScreen = jest.fn();
-        const { getByTestId } = render(
-            <MobileTopBarComponent
-                vm={vm}
-                isFullScreen={false}
-                isStarted={false}
-                onSetFullScreen={onSetFullScreen}
-            />,
-        );
+        const props = baseProps();
+        const { getByTestId } = render(<MobileTopBarComponent {...props} />);
         fireEvent.click(getByTestId('mobile-top-bar-play'));
-        expect(onSetFullScreen).toHaveBeenCalledWith(true);
-        expect(vm.start).toHaveBeenCalledTimes(1);
-        expect(vm.greenFlag).toHaveBeenCalledTimes(1);
-        expect(vm.stopAll).not.toHaveBeenCalled();
+        expect(props.onSetFullScreen).toHaveBeenCalledWith(true);
+        expect(props.vm.start).toHaveBeenCalledTimes(1);
+        expect(props.vm.greenFlag).toHaveBeenCalledTimes(1);
+        expect(props.vm.stopAll).not.toHaveBeenCalled();
     });
 
     test('clicking play skips vm.start when isStarted is true', () => {
-        const vm = makeFakeVm();
-        const { getByTestId } = render(
-            <MobileTopBarComponent vm={vm} isFullScreen={false} isStarted={true} onSetFullScreen={jest.fn()} />,
-        );
+        const props = { ...baseProps(), isStarted: true };
+        const { getByTestId } = render(<MobileTopBarComponent {...props} />);
         fireEvent.click(getByTestId('mobile-top-bar-play'));
-        expect(vm.start).not.toHaveBeenCalled();
-        expect(vm.greenFlag).toHaveBeenCalledTimes(1);
+        expect(props.vm.start).not.toHaveBeenCalled();
+        expect(props.vm.greenFlag).toHaveBeenCalledTimes(1);
     });
 
     test('clicking stop (in fullscreen) calls vm.stopAll + setFullScreen(false)', () => {
-        const vm = makeFakeVm();
-        const onSetFullScreen = jest.fn();
-        const { getByTestId } = render(
-            <MobileTopBarComponent vm={vm} isFullScreen={true} isStarted={true} onSetFullScreen={onSetFullScreen} />,
-        );
+        const props = { ...baseProps(), isFullScreen: true, isStarted: true };
+        const { getByTestId } = render(<MobileTopBarComponent {...props} />);
         fireEvent.click(getByTestId('mobile-top-bar-play'));
-        expect(vm.stopAll).toHaveBeenCalledTimes(1);
-        expect(onSetFullScreen).toHaveBeenCalledWith(false);
-        expect(vm.greenFlag).not.toHaveBeenCalled();
+        expect(props.vm.stopAll).toHaveBeenCalledTimes(1);
+        expect(props.onSetFullScreen).toHaveBeenCalledWith(false);
+        expect(props.vm.greenFlag).not.toHaveBeenCalled();
+    });
+
+    test('renders the hamburger menu button and project title', () => {
+        const props = { ...baseProps(), projectTitle: 'My Cool Project' };
+        const { getByTestId } = render(<MobileTopBarComponent {...props} />);
+        expect(getByTestId('mobile-top-bar-menu')).toBeInTheDocument();
+        expect(getByTestId('mobile-top-bar-title')).toHaveTextContent('My Cool Project');
+    });
+
+    test('clicking hamburger calls onOpenDrawer', () => {
+        const props = baseProps();
+        const { getByTestId } = render(<MobileTopBarComponent {...props} />);
+        fireEvent.click(getByTestId('mobile-top-bar-menu'));
+        expect(props.onOpenDrawer).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Summary
issue #572 Phase 2-E: モバイル用上部ハンバーガーメニューを追加します。

- MobileTopBar 左端に ☰ ボタン、中央にプロジェクトタイトル表示
- 左から slide-out する MobileDrawer (新規 / 開く / 保存 / 言語) を新設
- ドロワー開閉は MobileGui の useState で保持

## 設計判断
- スコープ: クラスルーム / ルビティー / mesh / Google Drive 等の Smalruby 固有機能は、モバイルでは画面が狭くて操作しにくいため Phase 2-E では意図的に省略しました (「画面がさますぎて動作しないくらいなら表示しない」要望)。後続 PR で必要に応じて追加していきます。
- プロジェクトタイトルは表示のみ。編集 (rename) は未対応。
- 言語は en / ja / ja-Hira の 3 つに固定 (Smalruby が翻訳を持つもの)。

## Files
- `src/components/mobile-drawer/mobile-drawer.{jsx,css}` (新規) — drawer 本体。`SBFileUploaderHOC` で読み込み、`SB3Downloader` の render-prop で保存、`requestNewProject` / `selectLocale` を直接 dispatch。
- `src/components/mobile-drawer/icon--{hamburger,close}.svg` — シンプルな SVG アイコン
- `src/components/mobile-top-bar/mobile-top-bar.{jsx,css}` — ☰ ボタンとタイトル表示を追加
- `src/components/mobile-gui/mobile-gui.jsx` — drawer 開閉 state と props 配線
- `src/locales/{en,ja,ja-Hira}.js` — 4 つの新規 i18n string (`gui.mobile.drawer.*`)
- `test/unit/components/mobile-drawer.test.jsx` (新規) — 8 件
- `test/unit/components/mobile-top-bar.test.jsx` — `onOpenDrawer` prop と ☰ クリック動作のテストを追加

## Test plan
- [x] Unit tests: `npm exec jest test/unit/components/mobile-{drawer,top-bar}.test.jsx` → 16 件 pass
- [x] Lint + format check pass
- [x] dev server (`?mobile_gui=1` + 390x844 viewport) で目視確認: ☰ → drawer open / × → close / 各メニューが描画される / 現在の locale が ✓ で示される
- [ ] 実機 / Chrome DevTools でドロワー操作と各メニュー機能の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
