### PR TITLE
feat(gui): add mobile sprite management panel (Phase 2-F)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -60,6 +60,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/playground/render-gui.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui.jsx` | no_beforeunload URL param | beforeunload 無効化 |
 | `src/playground/render-gui.jsx` | MobileGui dispatcher | ResponsiveGui import + GUI を ResponsiveGui に差し替え (issue #572 Phase 2-A) |
+| `src/components/target-pane/target-pane.jsx` | mobile-sprite-panel suppress-library | MobileSpritePanel が同一ツリーで TargetPane を再描画する際の SpriteLibrary 二重表示を `hideSpriteLibrary` prop で抑止 (issue #572 Phase 2-F) |
 | `src/playground/render-gui-standalone.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui-standalone.jsx` | no_beforeunload URL param | beforeunload 無効化 |
 | `src/playground/player.jsx` | URL params for Playwright | URL パラメーター import |

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -25,6 +25,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/components/mobile-drawer/`
 - `src/components/mobile-gui/`
 - `src/components/mobile-palette-auto-closer/`
+- `src/components/mobile-sprite-panel/`
 - `src/components/mobile-top-bar/`
 - `src/components/narrow-screen-warning/`
 - `src/components/palette-toggle/`
@@ -192,6 +193,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/components/mobile-bottom-tabs.test.jsx`
 - `test/unit/components/mobile-drawer.test.jsx`
 - `test/unit/components/mobile-palette-auto-closer.test.jsx`
+- `test/unit/components/mobile-sprite-panel.test.jsx`
 - `test/unit/components/mobile-top-bar.test.jsx`
 - `test/unit/components/narrow-screen-warning.test.jsx`
 - `test/unit/components/palette-toggle.test.jsx`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -42,6 +42,7 @@ src/components/*
 !src/components/mobile-drawer/
 !src/components/mobile-gui/
 !src/components/mobile-palette-auto-closer/
+!src/components/mobile-sprite-panel/
 !src/components/mobile-top-bar/
 !src/components/narrow-screen-warning/
 !src/components/palette-toggle/
@@ -255,6 +256,7 @@ test/unit/components/*
 !test/unit/components/mobile-bottom-tabs.test.jsx
 !test/unit/components/mobile-drawer.test.jsx
 !test/unit/components/mobile-palette-auto-closer.test.jsx
+!test/unit/components/mobile-sprite-panel.test.jsx
 !test/unit/components/mobile-top-bar.test.jsx
 !test/unit/components/narrow-screen-warning.test.jsx
 !test/unit/components/palette-toggle.test.jsx

--- a/packages/scratch-gui/src/components/mobile-bottom-tabs/mobile-bottom-tabs.jsx
+++ b/packages/scratch-gui/src/components/mobile-bottom-tabs/mobile-bottom-tabs.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -70,16 +70,26 @@ const SPRITE_KEY = 'sprite';
  * ボトムタブを隠す (PR-2C で追加)。
  *
  * 表示位置は `position: fixed` + `visualViewport` API で viewport 下端に追従。
+ *
+ * Phase 2-F: スプライトタブの active state を親 (MobileGui) に持ち上げ、
+ * `<MobileSpritePanel>` の表示制御と共有する。
  * @param {object} props - props
  * @param {number} props.activeTabIndex - 現在の editorTab Redux 値
  * @param {boolean} props.isFullScreen - upstream の fullscreen mode フラグ
+ * @param {boolean} props.spriteTabActive - スプライトタブが選択中か (親管理)
+ * @param {Function} props.onSpriteTabActiveChange - スプライトタブの active 切替
  * @param {Function} props.onActivateTab - editorTab を切替えるディスパッチャ
  * @returns {JSX.Element|null} Portal でレンダリングされる固定ボトムバー
  */
-const MobileBottomTabsComponent = ({ activeTabIndex, isFullScreen, onActivateTab }) => {
+const MobileBottomTabsComponent = ({
+    activeTabIndex,
+    isFullScreen,
+    spriteTabActive,
+    onSpriteTabActiveChange,
+    onActivateTab,
+}) => {
     const ref = useRef(null);
     usePositionAtVisualViewportBottom(ref, !isFullScreen);
-    const [spriteActive, setSpriteActive] = useState(false);
 
     const tabs = [
         {
@@ -148,10 +158,10 @@ const MobileBottomTabsComponent = ({ activeTabIndex, isFullScreen, onActivateTab
         event => {
             const key = event.currentTarget.dataset.tabKey;
             if (key === SPRITE_KEY) {
-                setSpriteActive(true);
+                onSpriteTabActiveChange(true);
                 return;
             }
-            setSpriteActive(false);
+            onSpriteTabActiveChange(false);
             const tab = tabs.find(t => t.key === key);
             if (tab && typeof tab.tabIndex === 'number') {
                 onActivateTab(tab.tabIndex);
@@ -159,12 +169,12 @@ const MobileBottomTabsComponent = ({ activeTabIndex, isFullScreen, onActivateTab
         },
         // tabs is recreated each render (new FormattedMessage children) but the
         // `tabIndex` lookup by key is stable, so we don't depend on `tabs` here.
-        [onActivateTab],
+        [onActivateTab, onSpriteTabActiveChange],
     );
 
     const isActive = tab => {
-        if (tab.key === SPRITE_KEY) return spriteActive;
-        if (spriteActive) return false;
+        if (tab.key === SPRITE_KEY) return spriteTabActive;
+        if (spriteTabActive) return false;
         return activeTabIndex === tab.tabIndex;
     };
 
@@ -204,6 +214,8 @@ const MobileBottomTabsComponent = ({ activeTabIndex, isFullScreen, onActivateTab
 MobileBottomTabsComponent.propTypes = {
     activeTabIndex: PropTypes.number.isRequired,
     isFullScreen: PropTypes.bool.isRequired,
+    spriteTabActive: PropTypes.bool.isRequired,
+    onSpriteTabActiveChange: PropTypes.func.isRequired,
     onActivateTab: PropTypes.func.isRequired,
 };
 

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
@@ -5,6 +5,7 @@ import ConnectedIntlProvider from '../../lib/connected-intl-provider.jsx';
 import MobileBottomTabs from '../mobile-bottom-tabs/mobile-bottom-tabs.jsx';
 import MobileDrawer from '../mobile-drawer/mobile-drawer.jsx';
 import MobilePaletteAutoCloser from '../mobile-palette-auto-closer/mobile-palette-auto-closer.jsx';
+import MobileSpritePanel from '../mobile-sprite-panel/mobile-sprite-panel.jsx';
 import MobileTopBar from '../mobile-top-bar/mobile-top-bar.jsx';
 
 /**
@@ -23,15 +24,16 @@ import MobileTopBar from '../mobile-top-bar/mobile-top-bar.jsx';
  *   - PR-2C: ステージ全画面プレビュー (<MobileTopBar /> の ▶ で
  *     upstream の isFullScreen mode に入る)
  *   - PR-2D: ブロックパレットドロワー (<MobilePaletteAutoCloser /> で
- *     ブロックドラッグ開始時にパレットを自動クローズ。手動切替は
- *     upstream の <PaletteToggle> を共有 — モバイル時のみ CSS でハンドルを
- *     大きくする)
- *   - PR-2E: ハンバーガーメニュー (本 PR、<MobileDrawer /> + <MobileTopBar />
- *     左端の ☰ ボタン + プロジェクトタイトル表示。新しいプロジェクト /
- *     パソコンから開く / パソコンに保存 / 言語切替 (en/ja/ja-Hira) を提供)
+ *     ブロックドラッグ開始時にパレットを自動クローズ)
+ *   - PR-2E: ハンバーガーメニュー (<MobileDrawer /> + <MobileTopBar /> 左の ☰)
+ *   - PR-2F: スプライト管理 (本 PR、<MobileSpritePanel />)。スプライトタブを
+ *     active にすると upstream <TargetPane> を全画面オーバーレイで表示し、
+ *     スプライト追加 / 削除 / 選択 + ステージ背景管理ができるようにする。
+ *     issue #572 の元症状「I can't add sprites nor costumes on safari on iOS」の解消。
  *
- * ドロワーの開閉状態は React の useState で MobileGui がローカルに保持する。
- * 外部 (URL や永続化) との連携が必要になったときに Redux 化する想定。
+ * 状態管理:
+ * - drawer (ハンバーガー) の open: useState
+ * - sprite tab active: useState (Redux 化していないが、必要になったら検討)
  *
  * 受け取る props は <GUI> と同一 (AppStateHOC / HashParserHOC からの全 props)。
  * @param {object} props - <GUI> と同じ props
@@ -39,24 +41,30 @@ import MobileTopBar from '../mobile-top-bar/mobile-top-bar.jsx';
  */
 const MobileGui = props => {
     const [drawerOpen, setDrawerOpen] = useState(false);
+    const [spriteTabActive, setSpriteTabActive] = useState(false);
     const handleOpenDrawer = useCallback(() => setDrawerOpen(true), []);
     const handleCloseDrawer = useCallback(() => setDrawerOpen(false), []);
+    const handleSpriteTabActiveChange = useCallback(active => setSpriteTabActive(active), []);
     return (
         <>
             <GUI {...props} />
             {/*
-             * MobileTopBar / MobileBottomTabs / MobileDrawer は body 直下に
-             * Portal で出すため、<GUI> 内側の IntlProvider context を使えない。
-             * 別途 ConnectedIntlProvider で包んで FormattedMessage を有効化する。
+             * MobileTopBar / MobileBottomTabs / MobileDrawer / MobileSpritePanel
+             * は body 直下に Portal で出すため、<GUI> 内側の IntlProvider
+             * context を使えない。別途 ConnectedIntlProvider で包む。
              * MobilePaletteAutoCloser は描画しないが、connect でディスパッチを
              * 受け取るため同じ Provider 配下に置く。
              */}
             <ConnectedIntlProvider>
                 <>
                     <MobileTopBar onOpenDrawer={handleOpenDrawer} />
-                    <MobileBottomTabs />
+                    <MobileBottomTabs
+                        spriteTabActive={spriteTabActive}
+                        onSpriteTabActiveChange={handleSpriteTabActiveChange}
+                    />
                     <MobilePaletteAutoCloser />
                     <MobileDrawer open={drawerOpen} onClose={handleCloseDrawer} />
+                    <MobileSpritePanel active={spriteTabActive} />
                 </>
             </ConnectedIntlProvider>
         </>

--- a/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.css
+++ b/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.css
@@ -1,0 +1,73 @@
+.panel {
+    position: fixed;
+    /* top / left / width / height は JS (visualViewport) で MobileTopBar の
+       高さと MobileBottomTabs の高さを差し引いて設定する。 */
+    top: 0;
+    left: 0;
+    background: white;
+    /* MobileTopBar / MobileBottomTabs (z-index: 9000) より下に置き、
+       両者は常に visible にする。drawer (9501) よりは下。 */
+    z-index: 8500;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    box-sizing: border-box;
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/*
+ * upstream の TargetPane は元々 right-rail (272px 幅) 用にデザインされており、
+ * 内部は flex-direction: row でスプライトリスト (横並び) + 72px の
+ * stage-selector-wrapper という構造。モバイルの全画面幅に流し込むと
+ * sprite-selector のグリッドがちょうど良く広がるが、stage-selector が
+ * 右端に縦に張り付いて違和感があるので、column 方向に並び替える。
+ *
+ * 内部構造を class セレクタで掴むため :global([class*="..."]) で upstream の
+ * CSS module 出力をマッチさせる (class 名にハッシュサフィックスが付くので
+ * 部分一致)。
+ */
+.panel :global([class*="target-pane_target-pane"]) {
+    flex-direction: column !important;
+    flex-grow: 1;
+    height: 100%;
+}
+
+/* スプライト一覧側を可能な限り広く取る */
+.panel :global([class*="sprite-selector_sprite-selector"]) {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.panel :global([class*="target-pane_stage-selector-wrapper"]) {
+    flex: 0 0 auto;
+    flex-basis: auto !important;
+    /* 横並びにして「ステージ背景」を一行で見せる */
+    flex-direction: row;
+    align-items: stretch;
+    margin: 0.5rem 0 0 0 !important;
+    gap: 0.5rem;
+}
+
+/*
+ * stage-selector はデフォルトで上下に縦長 (about 72x100px)。モバイルでは
+ * 横一列に並べる Mobile-only セクションヘッダ + スワイプ対応にしたいので、
+ * 個別カードのレイアウトはそのまま使い、ラッパだけ row 方向にする。
+ */
+
+/*
+ * upstream のスプライトライブラリモーダル (`<SpriteLibrary>`) は
+ * react-modal の Overlay z-index がデフォルト 510。Smalruby のモバイル UI
+ * (MobileTopBar / MobileBottomTabs = 9000, MobileDrawer = 9501) より下にあり、
+ * モーダルを開いてもモバイル UI で隠れて操作できないので、Smalruby 側で
+ * 上書きする。スプライトライブラリ・背景ライブラリ両方のモーダルが対象。
+ *
+ * 9999 まで上げてしまうとデスクトップでも他の要素より高くなるが、upstream
+ * モーダル間の優先順位は同じ 9999 のままなので問題ない (もともと 510 同士で
+ * 順位なし)。
+ */
+:global(.ReactModal__Overlay) {
+    z-index: 9999 !important;
+}
+

--- a/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.jsx
+++ b/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.jsx
@@ -110,9 +110,16 @@ const MobileSpritePanelComponent = ({ active, vm, onNewBackdropClick }) => {
                  * 抑止する (詳細は target-pane.jsx の Smalruby マーカー参照)。
                  * 上流の右ペインの <TargetPane> がモーダルを担当する。
                  */}
+                {/*
+                 * stageSize="middle" を渡すと <SpriteInfo> がフルセット
+                 * (name / x / y / 表示・非表示 / 大きさ / 向き) で描画される。
+                 * "small" にすると name / x / y のみに省略されるが、モバイルで
+                 * もすべての項目を編集できた方が良いので "middle" を採用
+                 * (270px 右ペインと違いモバイルでは 390px+ あるため十分収まる)。
+                 */}
                 <TargetPane
                     vm={vm}
-                    stageSize="small"
+                    stageSize="middle"
                     hideSpriteLibrary
                     onNewBackdropClick={onNewBackdropClick}
                 />

--- a/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.jsx
+++ b/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.jsx
@@ -1,0 +1,144 @@
+import PropTypes from 'prop-types';
+import React, { useLayoutEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { connect } from 'react-redux';
+
+import TargetPane from '../../containers/target-pane.jsx';
+import { ModalFocusProvider } from '../../contexts/modal-focus-context.jsx';
+import { openBackdropLibrary } from '../../reducers/modals.js';
+import styles from './mobile-sprite-panel.css';
+
+/**
+ * パネルを top-bar と bottom-tabs の間に正確に配置する layout effect。
+ *
+ * - top: visualViewport.offsetTop + MobileTopBar の高さ (CSS 変数 `--smalruby-mobile-top-bar-height`)
+ * - bottom (= top + height): visualViewport.offsetTop + visualViewport.height - MobileBottomTabs の高さ (固定値)
+ *
+ * MobileTopBar の高さは JS で documentElement に CSS 変数として設定済み
+ * (PR-2C / mobile-top-bar.jsx 参照)。MobileBottomTabs は環境変数化されて
+ * いないので 64px 固定で計算する (mobile-bottom-tabs.css の min-height)。
+ *
+ * 表示されている (active=true) ときだけ計算し、隠れているときは何もしない。
+ * @param {object} ref - パネル要素の React ref
+ * @param {boolean} active - 描画中か
+ */
+const usePositionBetweenBars = (ref, active) => {
+    useLayoutEffect(() => {
+        if (!active || !ref.current || typeof window === 'undefined') return () => {};
+        const el = ref.current;
+        const vv = window.visualViewport;
+        const update = () => {
+            const cs = getComputedStyle(document.documentElement);
+            const topBarHeight = parseFloat(cs.getPropertyValue('--smalruby-mobile-top-bar-height')) || 0;
+            // MobileBottomTabs は 64px (mobile-bottom-tabs.css) 固定。CSS 変数化
+            // した方が綺麗だが、現状は他の場所で参照していないのでハードコード。
+            const bottomTabsHeight = 64;
+            if (vv) {
+                el.style.top = `${vv.offsetTop + topBarHeight}px`;
+                el.style.left = `${vv.offsetLeft}px`;
+                el.style.width = `${vv.width}px`;
+                el.style.height = `${vv.height - topBarHeight - bottomTabsHeight}px`;
+            } else {
+                el.style.top = `${topBarHeight}px`;
+                el.style.left = '0px';
+                el.style.width = `${window.innerWidth}px`;
+                el.style.height = `${window.innerHeight - topBarHeight - bottomTabsHeight}px`;
+            }
+        };
+        update();
+        const targets = vv ? [vv, window] : [window];
+        const events = ['resize', 'scroll'];
+        for (const t of targets) {
+            for (const ev of events) t.addEventListener(ev, update, { passive: true });
+        }
+        return () => {
+            for (const t of targets) {
+                for (const ev of events) t.removeEventListener(ev, update);
+            }
+        };
+    }, [active, ref]);
+};
+
+/**
+ * モバイル用スプライト管理パネル (issue #572 Phase 2-F)。
+ *
+ * MobileBottomTabs の「スプライト」タブが active のときだけ overlay として
+ * 表示される。upstream の <TargetPane> をそのまま流用し、CSS で flex-direction
+ * を column 方向に上書きすることで、狭幅でもスプライト一覧 + ステージ背景が
+ * 縦に並ぶレイアウトに変える。
+ *
+ * <TargetPane> 自体はスプライト追加 (Choose / Paint / Surprise / Upload),
+ * スプライト削除 / 複製 / 名前変更 / 位置変更などの全機能を内蔵しているため、
+ * モバイルでも基本機能はすべて使える。スプライトライブラリモーダル
+ * (Choose) は upstream の <SpriteLibrary> がそのまま開くので、モバイルで
+ * 操作性が悪い場合は別 PR で改善する。
+ *
+ * 注意: upstream の <GUI> 内の右ペインにも <TargetPane> が描画されている。
+ * 本コンポーネントが描画する <TargetPane> はそれとは別インスタンスだが、
+ * Redux 状態を共有しているため操作の整合性は保たれる (両方のリストが
+ * 同じスプライトを表示し、同じ editingTarget をハイライトする)。
+ *
+ * `onNewBackdropClick` (背景ライブラリを開く) は upstream gui.jsx と同じく
+ * `openBackdropLibrary()` を dispatch する。
+ *
+ * `onNewSpriteClick` は <TargetPane> コンテナ内部で `openSpriteLibrary()` を
+ * dispatch するため明示的に渡さない (mergeProps の defaults が効く)。
+ * @param {object} props - props
+ * @param {boolean} props.active - スプライトタブが active か
+ * @param {object} props.vm - scratch-vm
+ * @param {Function} props.onNewBackdropClick - 背景ライブラリを開く
+ * @returns {JSX.Element|null} portal で body 直下にレンダリング
+ */
+const MobileSpritePanelComponent = ({ active, vm, onNewBackdropClick }) => {
+    const ref = useRef(null);
+    usePositionBetweenBars(ref, active);
+
+    if (typeof document === 'undefined') return null;
+    if (!active) return null;
+
+    return createPortal(
+        <div ref={ref} className={styles.panel} data-testid="mobile-sprite-panel">
+            {/*
+             * upstream <TargetPane> は ModalFocusContext を必須にしている
+             * (Choose Sprite クリック時に context.captureFocus() を呼ぶ)。
+             * upstream <GUI> 内の <ModalFocusProvider> 配下の TargetPane と
+             * 別ツリーになるので、ここで独立した Provider を立てる。
+             */}
+            <ModalFocusProvider>
+                {/*
+                 * hideSpriteLibrary=true で <SpriteLibrary> モーダルの二重描画を
+                 * 抑止する (詳細は target-pane.jsx の Smalruby マーカー参照)。
+                 * 上流の右ペインの <TargetPane> がモーダルを担当する。
+                 */}
+                <TargetPane
+                    vm={vm}
+                    stageSize="small"
+                    hideSpriteLibrary
+                    onNewBackdropClick={onNewBackdropClick}
+                />
+            </ModalFocusProvider>
+        </div>,
+        document.body,
+    );
+};
+
+MobileSpritePanelComponent.propTypes = {
+    active: PropTypes.bool.isRequired,
+    // upstream の <TargetPane> に丸ごと渡す。型は Scratch VM だが、ここでは
+    // 単純に object として扱う (テストでモックしやすくするため)。
+    vm: PropTypes.object.isRequired,
+    onNewBackdropClick: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => ({
+    vm: state.scratchGui.vm,
+});
+
+const mapDispatchToProps = dispatch => ({
+    onNewBackdropClick: () => dispatch(openBackdropLibrary()),
+});
+
+const MobileSpritePanel = connect(mapStateToProps, mapDispatchToProps)(MobileSpritePanelComponent);
+
+export default MobileSpritePanel;
+export { MobileSpritePanelComponent };

--- a/packages/scratch-gui/src/components/target-pane/target-pane.jsx
+++ b/packages/scratch-gui/src/components/target-pane/target-pane.jsx
@@ -19,6 +19,9 @@ import styles from './target-pane.css';
 const TargetPane = ({
     editingTarget,
     fileInputRef,
+    // === Smalruby: Start of mobile-sprite-panel suppress-library ===
+    hideSpriteLibrary,
+    // === Smalruby: End of mobile-sprite-panel suppress-library ===
     hoveredTarget,
     spriteLibraryVisible,
     onActivateBlocksTab,
@@ -93,7 +96,15 @@ const TargetPane = ({
                 onNewBackdropClick={onNewBackdropClick}
             />}
             <div>
-                {spriteLibraryVisible ? (
+                {/*
+                 * === Smalruby: Start of mobile-sprite-panel suppress-library ===
+                 * MobileSpritePanel (issue #572 Phase 2-F) は upstream <GUI> 配下と
+                 * 別ツリーで <TargetPane> を再描画する。両方で <SpriteLibrary>
+                 * モーダルを描画するとモバイルで二重モーダルになるため、
+                 * mobile copy 側だけ hideSpriteLibrary=true で描画を抑止する。
+                 * === Smalruby: End of mobile-sprite-panel suppress-library ===
+                 */}
+                {spriteLibraryVisible && !hideSpriteLibrary ? (
                     <SpriteLibrary
                         vm={vm}
                         onActivateBlocksTab={onActivateBlocksTab}
@@ -131,6 +142,9 @@ TargetPane.propTypes = {
     editingTarget: PropTypes.string,
     extensionLibraryVisible: PropTypes.bool,
     fileInputRef: PropTypes.func,
+    // === Smalruby: Start of mobile-sprite-panel suppress-library ===
+    hideSpriteLibrary: PropTypes.bool,
+    // === Smalruby: End of mobile-sprite-panel suppress-library ===
     hoveredTarget: PropTypes.shape({
         receivedBlocks: PropTypes.bool,
         sprite: PropTypes.oneOfType([PropTypes.string, PropTypes.number])

--- a/packages/scratch-gui/test/unit/components/mobile-bottom-tabs.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mobile-bottom-tabs.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import React from 'react';
+import React, { useState } from 'react';
 import { IntlProvider } from 'react-intl';
 import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
@@ -18,15 +18,36 @@ const renderWithIntl = ui =>
         </IntlProvider>,
     );
 
+const baseProps = override => ({
+    isFullScreen: false,
+    activeTabIndex: BLOCKS_TAB_INDEX,
+    spriteTabActive: false,
+    onSpriteTabActiveChange: () => {},
+    onActivateTab: () => {},
+    ...override,
+});
+
+/**
+ * 親コンポーネントが持つ spriteTabActive を useState で再現する controlled
+ * wrapper。Phase 2-F でこの状態が MobileGui に持ち上がったため、テストでも
+ * 親側で保持して挙動を検証する。
+ * @param {object} props - test props
+ * @returns {JSX.Element} controlled wrapper
+ */
+const ControlledTabs = props => {
+    const [spriteTabActive, setSpriteTabActive] = useState(false);
+    return (
+        <MobileBottomTabsComponent
+            {...props}
+            spriteTabActive={spriteTabActive}
+            onSpriteTabActiveChange={setSpriteTabActive}
+        />
+    );
+};
+
 describe('MobileBottomTabs', () => {
     test('renders 5 tabs', () => {
-        const { getByTestId } = renderWithIntl(
-            <MobileBottomTabsComponent
-                isFullScreen={false}
-                activeTabIndex={BLOCKS_TAB_INDEX}
-                onActivateTab={() => {}}
-            />,
-        );
+        const { getByTestId } = renderWithIntl(<MobileBottomTabsComponent {...baseProps()} />);
         expect(getByTestId('mobile-bottom-tabs-code')).toBeInTheDocument();
         expect(getByTestId('mobile-bottom-tabs-ruby')).toBeInTheDocument();
         expect(getByTestId('mobile-bottom-tabs-sprite')).toBeInTheDocument();
@@ -35,13 +56,7 @@ describe('MobileBottomTabs', () => {
     });
 
     test('marks the block tab active when activeTabIndex is BLOCKS', () => {
-        const { getByTestId } = renderWithIntl(
-            <MobileBottomTabsComponent
-                isFullScreen={false}
-                activeTabIndex={BLOCKS_TAB_INDEX}
-                onActivateTab={() => {}}
-            />,
-        );
+        const { getByTestId } = renderWithIntl(<MobileBottomTabsComponent {...baseProps()} />);
         expect(getByTestId('mobile-bottom-tabs-code')).toHaveAttribute('data-active', 'true');
         expect(getByTestId('mobile-bottom-tabs-ruby')).toHaveAttribute('data-active', 'false');
     });
@@ -53,11 +68,7 @@ describe('MobileBottomTabs', () => {
     ])('dispatches activateTab(%s) for the matching tab', (key, expectedIndex) => {
         const onActivate = jest.fn();
         const { getByTestId } = renderWithIntl(
-            <MobileBottomTabsComponent
-                isFullScreen={false}
-                activeTabIndex={BLOCKS_TAB_INDEX}
-                onActivateTab={onActivate}
-            />,
+            <MobileBottomTabsComponent {...baseProps({ onActivateTab: onActivate })} />,
         );
         fireEvent.click(getByTestId(`mobile-bottom-tabs-${key}`));
         expect(onActivate).toHaveBeenCalledWith(expectedIndex);
@@ -67,48 +78,55 @@ describe('MobileBottomTabs', () => {
         const onActivate = jest.fn();
         const { getByTestId } = renderWithIntl(
             <MobileBottomTabsComponent
-                isFullScreen={false}
-                activeTabIndex={RUBY_TAB_INDEX}
-                onActivateTab={onActivate}
+                {...baseProps({ onActivateTab: onActivate, activeTabIndex: RUBY_TAB_INDEX })}
             />,
         );
         fireEvent.click(getByTestId('mobile-bottom-tabs-code'));
         expect(onActivate).toHaveBeenCalledWith(BLOCKS_TAB_INDEX);
     });
 
-    test('sprite tab does NOT dispatch activateTab and shows local active state', () => {
+    test('clicking sprite tab calls onSpriteTabActiveChange(true) and does NOT dispatch activateTab', () => {
         const onActivate = jest.fn();
+        const onSpriteTabActiveChange = jest.fn();
+        const { getByTestId } = renderWithIntl(
+            <MobileBottomTabsComponent {...baseProps({ onActivateTab: onActivate, onSpriteTabActiveChange })} />,
+        );
+        fireEvent.click(getByTestId('mobile-bottom-tabs-sprite'));
+        expect(onSpriteTabActiveChange).toHaveBeenCalledWith(true);
+        expect(onActivate).not.toHaveBeenCalled();
+    });
+
+    test('clicking another tab calls onSpriteTabActiveChange(false)', () => {
+        const onActivate = jest.fn();
+        const onSpriteTabActiveChange = jest.fn();
         const { getByTestId } = renderWithIntl(
             <MobileBottomTabsComponent
-                isFullScreen={false}
-                activeTabIndex={BLOCKS_TAB_INDEX}
-                onActivateTab={onActivate}
+                {...baseProps({
+                    onActivateTab: onActivate,
+                    onSpriteTabActiveChange,
+                    spriteTabActive: true,
+                })}
             />,
         );
-        // pre: block tab active
-        expect(getByTestId('mobile-bottom-tabs-code')).toHaveAttribute('data-active', 'true');
-        fireEvent.click(getByTestId('mobile-bottom-tabs-sprite'));
-        expect(onActivate).not.toHaveBeenCalled();
+        fireEvent.click(getByTestId('mobile-bottom-tabs-ruby'));
+        expect(onSpriteTabActiveChange).toHaveBeenCalledWith(false);
+        expect(onActivate).toHaveBeenCalledWith(RUBY_TAB_INDEX);
+    });
+
+    test('sprite tab is data-active=true when spriteTabActive prop is true', () => {
+        const { getByTestId } = renderWithIntl(
+            <MobileBottomTabsComponent {...baseProps({ spriteTabActive: true })} />,
+        );
         expect(getByTestId('mobile-bottom-tabs-sprite')).toHaveAttribute('data-active', 'true');
-        // block is no longer "active" in the bottom-tabs UI while sprite is selected
+        // editorTab-driven tabs are visually inactive while sprite is the focus
         expect(getByTestId('mobile-bottom-tabs-code')).toHaveAttribute('data-active', 'false');
     });
 
-    test('clicking another tab clears the sprite local active state', () => {
-        const onActivate = jest.fn();
-        const { getByTestId } = renderWithIntl(
-            <MobileBottomTabsComponent
-                isFullScreen={false}
-                activeTabIndex={BLOCKS_TAB_INDEX}
-                onActivateTab={onActivate}
-            />,
-        );
+    test('controlled wrapper toggles sprite tab on click and clears on other tab click', () => {
+        const { getByTestId } = renderWithIntl(<ControlledTabs {...baseProps()} />);
         fireEvent.click(getByTestId('mobile-bottom-tabs-sprite'));
         expect(getByTestId('mobile-bottom-tabs-sprite')).toHaveAttribute('data-active', 'true');
         fireEvent.click(getByTestId('mobile-bottom-tabs-ruby'));
         expect(getByTestId('mobile-bottom-tabs-sprite')).toHaveAttribute('data-active', 'false');
-        // ruby tab is now active per the activeTabIndex prop... but our prop is still BLOCKS,
-        // so visually the ruby tab is NOT active either (until parent re-renders with RUBY_TAB_INDEX).
-        // Re-render with RUBY_TAB_INDEX to simulate Redux state having changed.
     });
 });

--- a/packages/scratch-gui/test/unit/components/mobile-sprite-panel.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mobile-sprite-panel.test.jsx
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { MobileSpritePanelComponent } from '../../../src/components/mobile-sprite-panel/mobile-sprite-panel.jsx';
+
+// upstream <TargetPane> は VM や Redux store / IntlProvider に依存する
+// 重いコンテナなので、unit test ではモックして「active=true のとき
+// MobileSpritePanel の portal にレンダリングされる」だけを確認する。
+jest.mock('../../../src/containers/target-pane.jsx', () => ({
+    __esModule: true,
+    default: () => <div data-testid="target-pane-stub" />,
+}));
+
+const fakeVm = {};
+
+describe('MobileSpritePanel', () => {
+    test('renders nothing when active=false', () => {
+        const { queryByTestId } = render(
+            <MobileSpritePanelComponent active={false} vm={fakeVm} onNewBackdropClick={() => {}} />,
+        );
+        expect(queryByTestId('mobile-sprite-panel')).not.toBeInTheDocument();
+        expect(queryByTestId('target-pane-stub')).not.toBeInTheDocument();
+    });
+
+    test('renders panel + TargetPane when active=true', () => {
+        const { getByTestId } = render(
+            <MobileSpritePanelComponent active={true} vm={fakeVm} onNewBackdropClick={() => {}} />,
+        );
+        expect(getByTestId('mobile-sprite-panel')).toBeInTheDocument();
+        expect(getByTestId('target-pane-stub')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary

issue #572 Phase 2-F: モバイル用スプライト管理パネルを追加します。元の Issue 報告 ([smalruby/smalruby3-develop#80](https://github.com/smalruby/smalruby3-develop/discussions/80) "I can't add sprites nor costumes on safari on iOS") の核心症状の解消です。

bottom-tabs の「スプライト」タブをタップすると、上部バーと下部タブの間に full-width のオーバーレイが立ち上がり、upstream の `<TargetPane>` がそのまま使えるレイアウトでスプライト追加 / 削除 / 名前変更 / ステージ背景管理が可能になります。

## 実装

- **`MobileSpritePanel`** (新規): スプライトタブが active のときだけ表示する portal オーバーレイ。upstream `<TargetPane>` を再利用して全機能 (Choose / Paint / Surprise / Upload + 削除 + 複製 + 名前変更 + ステージ背景) を流用。
- **`MobileGui`**: `spriteTabActive` を useState で保持し、子コンポーネントに共有。
- **`MobileBottomTabs`**: スプライトタブの active 状態を親管理に変更 (controlled component 化)。
- **`MobileSpritePanel` CSS**:
  - upstream `<TargetPane>` の flex-direction を column に上書き (270px 右ペイン前提の row レイアウトを mobile 全幅に流すと stage-selector が右に張り付いて違和感があるため)
  - `ReactModal__Overlay` の z-index を 9999 に引き上げ (upstream の 510 だとモバイル UI 9000+ に隠れて操作不能)

## upstream への影響 (Smalruby マーカー)

`src/components/target-pane/target-pane.jsx` に `hideSpriteLibrary` prop を追加。

- 同じツリーで `<TargetPane>` を 2 つ描画すると `<SpriteLibrary>` モーダルが 2 重に portal されるため、mobile copy 側だけ抑止
- 上流右ペインの `<TargetPane>` がモーダル描画を担当 (single instance)

`.claude/rules/scratch-gui/smalruby-markers.md` 一覧に追加済み。

## Test plan

- [x] Unit tests: `npm exec jest test/unit/components/mobile-{sprite-panel,bottom-tabs}.test.jsx` → 12 件 pass
- [x] Lint + format check pass
- [x] dev server (`?mobile_gui=1` + 390x844 viewport) で:
  - スプライトタブをタップ → パネルが正しい位置に表示される (top-bar と bottom-tabs の間)
  - 「スプライトを選ぶ」(`+` FAB) → SpriteLibrary モーダルが全画面で開く (二重表示なし)
  - スプライトを選択 → モーダルが閉じてリストに追加される
- [ ] iOS Safari 実機で操作性確認

## 残タスク

PR-2F でブロッカー #1 (スプライト管理) は解消しますが、残タスクとして直前の整理に挙げた:

1. ✅ ~~スプライト管理 (← issue #572 の元の症状)~~
2. コードタブの編集レイアウト (通常画面)
3. ルビータブ (Monaco editor) のタッチ操作確認
4. コスチューム / 音タブのモバイル最適化
5. 拡張機能の追加メニュー
…

… が残っています。次は #2 を予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
