### PR TITLE
feat(gui): mobile editor layout for code tab (Phase 2-G)

### DIFF
--- a/packages/scratch-gui/src/components/mobile-drawer/mobile-drawer.jsx
+++ b/packages/scratch-gui/src/components/mobile-drawer/mobile-drawer.jsx
@@ -36,6 +36,11 @@ const messages = defineMessages({
         description: 'Aria label for the mobile drawer close button',
         id: 'gui.mobile.drawer.close',
     },
+    reload: {
+        defaultMessage: 'Reload',
+        description: 'Mobile drawer item to force a page reload',
+        id: 'gui.mobile.drawer.reload',
+    },
 });
 
 /**
@@ -104,6 +109,13 @@ const MobileDrawerComponent = ({
         },
         [onSelectLocale, onClose],
     );
+
+    const handleClickReload = useCallback(() => {
+        if (typeof window !== 'undefined' && window.location) {
+            window.location.reload();
+        }
+        onClose();
+    }, [onClose]);
 
     if (typeof document === 'undefined') {
         return null;
@@ -189,6 +201,20 @@ const MobileDrawerComponent = ({
                                 </button>
                             )}
                         </SB3Downloader>
+                    </li>
+                    <li>
+                        {/*
+                         * 「下にひっぱってリロード」を mobile-mode で無効化したので、
+                         * 代わりにここから手動でページをリロードできるようにする。
+                         */}
+                        <button
+                            type="button"
+                            className={styles.menuItem}
+                            onClick={handleClickReload}
+                            data-testid="mobile-drawer-reload"
+                        >
+                            <FormattedMessage {...messages.reload} />
+                        </button>
                     </li>
                     <li className={styles.sectionTitle}>
                         <FormattedMessage {...messages.sectionLanguage} />

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
@@ -47,11 +47,35 @@
 }
 
 /* ------------------------------------------------------------ */
-/* 3. upstream の右ペイン全体 (ステージ + sprite selector) を非表示 */
-/* MobileTopBar の ▶ で全画面ステージ、MobileSpritePanel で       */
-/* スプライト管理を提供しているので、右ペインは不要。              */
+/* 3. upstream の右ペインを「ほぼ」非表示にする                    */
+/*                                                                */
+/* ▶ ボタンで全画面 (isFullScreen=true) のときだけ <Stage> は      */
+/* upstream の CSS で `position: fixed` になるので、親 wrapper を   */
+/* `display: none` にすると fullscreen でも render されない。      */
+/* そこで wrapper 自体は残し、flex-basis を 0 / overflow hidden で  */
+/* 編集中は実質非表示にする。`stage-wrapper_full-screen` を持つ    */
+/* 子孫がいる時 (fullscreen) は `display: flex` で復活させる。     */
+/*                                                                */
+/* `gui_target-wrapper` (sprite selector / stage selector) は      */
+/* MobileSpritePanel が同じ役割を担うため常に隠す。                */
 /* ------------------------------------------------------------ */
 :global(body.smalruby-mobile-mode [class*="gui_stage-and-target-wrapper"]) {
+    flex: 0 0 0 !important;
+    width: 0 !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+}
+
+:global(
+        body.smalruby-mobile-mode
+            [class*="gui_stage-and-target-wrapper"]:has([class*="stage-wrapper_full-screen"])
+    ) {
+    flex: 0 0 auto !important;
+    width: auto !important;
+    overflow: visible !important;
+}
+
+:global(body.smalruby-mobile-mode [class*="gui_target-wrapper"]) {
     display: none !important;
 }
 

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
@@ -21,6 +21,13 @@
     min-width: 100% !important;
     width: 100% !important;
     overflow-x: hidden;
+    /*
+     * iOS Safari / Android Chrome の「下にひっぱってリロード (pull-to-refresh)」
+     * を無効化する。スクロール可能な要素が画面に多く存在するため誤発動
+     * しやすく、編集中の状態が失われるストレスが大きい。
+     * 代替の手動リロードは MobileDrawer の「再読み込み」メニュー項目で提供する。
+     */
+    overscroll-behavior-y: none;
 }
 
 /*

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
@@ -1,0 +1,118 @@
+/*
+ * MobileGui がマウントされている間だけ documentElement (= <html>) または
+ * <body> に `smalruby-mobile-mode` クラスを付与する想定で、その class を
+ * 起点として upstream <GUI> の幅・配置を mobile viewport (390px+) 用に
+ * 上書きする。
+ *
+ * ポリシー:
+ * - upstream のソースには触らない (Smalruby マーカーを増やさない)
+ * - すべて :global() 経由で documentElement のクラス + 上流 CSS Module の
+ *   ハッシュ済みクラスを部分一致で掴む
+ * - desktop (mobile-mode クラス無し) には何の影響もない
+ */
+
+/* ------------------------------------------------------------ */
+/* 1. body 全体の幅制限を解除                                     */
+/* upstream playground/index.css の `min-width: 1024px` で body が */
+/* 横スクロールするのを mobile-mode のときだけ無効化する。         */
+/* ------------------------------------------------------------ */
+:global(body.smalruby-mobile-mode),
+:global(html.smalruby-mobile-mode) {
+    min-width: 100% !important;
+    width: 100% !important;
+    overflow-x: hidden;
+}
+
+/*
+ * upstream playground/index.css の `.app { min-width: 1024px }` は CSS Modules
+ * 経由で `.index_app_<hash>` に変換される。webpack 側でハッシュは変わるが、
+ * `index_app` プレフィックスは安定しているので部分一致で掴む。
+ *
+ * gui_page-wrapper も height/width 100% を継承するので一緒に押さえる。
+ */
+:global(body.smalruby-mobile-mode [class*="index_app"]),
+:global(body.smalruby-mobile-mode [class*="gui_page-wrapper"]) {
+    min-width: 100% !important;
+    max-width: 100vw !important;
+    width: 100% !important;
+}
+
+/* ------------------------------------------------------------ */
+/* 2. upstream のタブナビゲーション (コード/コスチューム/音/ルビー) */
+/* を非表示                                                       */
+/* MobileBottomTabs が同じ役割を担う。                            */
+/* ------------------------------------------------------------ */
+:global(body.smalruby-mobile-mode [class*="gui_tab-list-container"]) {
+    display: none !important;
+}
+
+/* ------------------------------------------------------------ */
+/* 3. upstream の右ペイン全体 (ステージ + sprite selector) を非表示 */
+/* MobileTopBar の ▶ で全画面ステージ、MobileSpritePanel で       */
+/* スプライト管理を提供しているので、右ペインは不要。              */
+/* ------------------------------------------------------------ */
+:global(body.smalruby-mobile-mode [class*="gui_stage-and-target-wrapper"]) {
+    display: none !important;
+}
+
+/* ------------------------------------------------------------ */
+/* 3b. upstream の <MenuBar> も非表示                              */
+/* MobileTopBar (☰ + プロジェクトタイトル + ▶) が同等の役割を果たす。 */
+/* MenuBar はデスクトップ前提で密度が高く、モバイルでは破綻する。  */
+/* ------------------------------------------------------------ */
+:global(body.smalruby-mobile-mode [class*="menu-bar_menu-bar_"]) {
+    display: none !important;
+}
+
+/* ------------------------------------------------------------ */
+/* 3c. upstream の <Backpack> も非表示                              */
+/* バックパックは画面下部に常駐する横長エリアで縦サイズを 50px 取る */
+/* が、モバイルではブロック作業エリアを優先する。                   */
+/* ------------------------------------------------------------ */
+:global(body.smalruby-mobile-mode [class*="backpack_backpack-container"]) {
+    display: none !important;
+}
+
+/* ------------------------------------------------------------ */
+/* 4. body-wrapper / editor-wrapper を mobile 全幅で使う          */
+/* upstream は body-wrapper を 1024px 想定で flex で並べているが、 */
+/* 右ペインを display:none にしただけでは flex-basis が残るので   */
+/* width も明示的に上書きする。                                    */
+/* ------------------------------------------------------------ */
+:global(body.smalruby-mobile-mode [class*="gui_body-wrapper"]) {
+    width: 100% !important;
+    min-width: 100% !important;
+}
+
+:global(body.smalruby-mobile-mode [class*="gui_editor-wrapper"]) {
+    width: 100% !important;
+    max-width: 100% !important;
+    flex: 1 1 100% !important;
+}
+
+/* ------------------------------------------------------------ */
+/* 5. MobileTopBar / MobileBottomTabs の高さぶん本体に余白を取る  */
+/*                                                                */
+/* upstream <MenuBar> を非表示にしたので body-wrapper は y=0 から  */
+/* 始まる。MobileTopBar (top, fixed) と MobileBottomTabs (bottom,  */
+/* fixed) を overlay 表示しているので、その高さぶん body-wrapper の */
+/* 上下にパディングを追加してコンテンツが両者に隠れないようにする。 */
+/*                                                                */
+/* MobileTopBar の高さは CSS 変数 --smalruby-mobile-top-bar-height */
+/* に保存される (mobile-top-bar.jsx)。MobileBottomTabs は今のところ */
+/* 固定値 64px (mobile-bottom-tabs.css の min-height)。            */
+/* ------------------------------------------------------------ */
+:global(body.smalruby-mobile-mode [class*="gui_body-wrapper"]) {
+    padding-top: var(--smalruby-mobile-top-bar-height, 0px);
+    padding-bottom: 64px;
+    box-sizing: border-box;
+    height: 100vh;
+}
+
+/*
+ * upstream の `.body-wrapper` は元々 `height: calc(100% - $menu-bar-height)`
+ * (menu-bar 分を引いている)。その body-wrapper の親は page-wrapper で
+ * height: 100%。MenuBar を非表示にしたので body-wrapper の高さも 100% に
+ * したいのだが、CSS Modules 経由で書かれた親側の calc を上書きする方が
+ * 早い。height: 100vh で固定するのが確実。
+ */

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
@@ -57,10 +57,28 @@ const MobileGui = props => {
     // :global ルールがこの class を起点として upstream <GUI> の layout を
     // 上書きする)。MobileGui がアンマウントされたら class を取り除いて
     // デスクトップ挙動に戻す。
+    //
+    // また、Blockly のワークスペース SVG はマウント直後に injectionDiv の
+    // サイズを基にレイアウトを決めるため、その時点でまだ desktop 幅 (~646px) で
+    // 計算済みになっている。後から CSS 経由で 390px に縮めても再計算は走らず、
+    // ズームコントロールが viewport 外に取り残される。class を付けた直後に
+    // window の resize を発火して Blockly に再計測を促す。
     useEffect(() => {
         if (typeof document === 'undefined') return () => {};
         document.documentElement.classList.add(MOBILE_MODE_CLASS);
         document.body.classList.add(MOBILE_MODE_CLASS);
+        if (typeof window !== 'undefined') {
+            // CSS が適用された後の rAF で resize を投げる (同一フレーム内では
+            // class 適用前の幅で測ってしまうため)。
+            const raf = window.requestAnimationFrame(() => {
+                window.dispatchEvent(new Event('resize'));
+            });
+            return () => {
+                window.cancelAnimationFrame(raf);
+                document.documentElement.classList.remove(MOBILE_MODE_CLASS);
+                document.body.classList.remove(MOBILE_MODE_CLASS);
+            };
+        }
         return () => {
             document.documentElement.classList.remove(MOBILE_MODE_CLASS);
             document.body.classList.remove(MOBILE_MODE_CLASS);

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import GUI from '../../containers/gui.jsx';
 import ConnectedIntlProvider from '../../lib/connected-intl-provider.jsx';
@@ -7,6 +7,11 @@ import MobileDrawer from '../mobile-drawer/mobile-drawer.jsx';
 import MobilePaletteAutoCloser from '../mobile-palette-auto-closer/mobile-palette-auto-closer.jsx';
 import MobileSpritePanel from '../mobile-sprite-panel/mobile-sprite-panel.jsx';
 import MobileTopBar from '../mobile-top-bar/mobile-top-bar.jsx';
+
+// Side-effect import: グローバル CSS で upstream <GUI> の layout を上書きする。
+// `body.smalruby-mobile-mode` を起点にしたセレクタなので、MobileGui が
+// マウントされていない (= class が無い) 時はデスクトップに何も影響しない。
+import './mobile-gui.css';
 
 /**
  * 狭幅 viewport 用の独立 GUI シェル (issue #572 Phase 2)。
@@ -39,12 +44,28 @@ import MobileTopBar from '../mobile-top-bar/mobile-top-bar.jsx';
  * @param {object} props - <GUI> と同じ props
  * @returns {JSX.Element} <GUI> + 各種 mobile-only コンポーネント
  */
+const MOBILE_MODE_CLASS = 'smalruby-mobile-mode';
+
 const MobileGui = props => {
     const [drawerOpen, setDrawerOpen] = useState(false);
     const [spriteTabActive, setSpriteTabActive] = useState(false);
     const handleOpenDrawer = useCallback(() => setDrawerOpen(true), []);
     const handleCloseDrawer = useCallback(() => setDrawerOpen(false), []);
     const handleSpriteTabActiveChange = useCallback(active => setSpriteTabActive(active), []);
+
+    // マウント中だけ <html>/<body> に mobile-mode class を付ける (mobile-gui.css の
+    // :global ルールがこの class を起点として upstream <GUI> の layout を
+    // 上書きする)。MobileGui がアンマウントされたら class を取り除いて
+    // デスクトップ挙動に戻す。
+    useEffect(() => {
+        if (typeof document === 'undefined') return () => {};
+        document.documentElement.classList.add(MOBILE_MODE_CLASS);
+        document.body.classList.add(MOBILE_MODE_CLASS);
+        return () => {
+            document.documentElement.classList.remove(MOBILE_MODE_CLASS);
+            document.body.classList.remove(MOBILE_MODE_CLASS);
+        };
+    }, []);
     return (
         <>
             <GUI {...props} />

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -641,4 +641,5 @@ export default {
     'gui.mobile.drawer.section.file': 'File',
     'gui.mobile.drawer.section.language': 'Language',
     'gui.mobile.drawer.close': 'Close menu',
+    'gui.mobile.drawer.reload': 'Reload',
 };

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -947,4 +947,5 @@ export default {
     'gui.mobile.drawer.section.file': 'ファイル',
     'gui.mobile.drawer.section.language': 'げんご',
     'gui.mobile.drawer.close': 'メニューをとじる',
+    'gui.mobile.drawer.reload': 'さいよみこみ',
 };

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -922,4 +922,5 @@ export default {
     'gui.mobile.drawer.section.file': 'ファイル',
     'gui.mobile.drawer.section.language': '言語',
     'gui.mobile.drawer.close': 'メニューを閉じる',
+    'gui.mobile.drawer.reload': '再読み込み',
 };

--- a/packages/scratch-gui/test/unit/components/mobile-drawer.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mobile-drawer.test.jsx
@@ -87,6 +87,22 @@ describe('MobileDrawer', () => {
         expect(props.onClose).toHaveBeenCalledTimes(1);
     });
 
+    test('clicking "Reload" calls window.location.reload + onClose', () => {
+        const reload = jest.fn();
+        const originalLocation = window.location;
+        // jsdom の window.location は writable: false なので一時的に置換する。
+        delete window.location;
+        window.location = { ...originalLocation, reload };
+        try {
+            const { getByTestId, props } = renderWithIntl();
+            fireEvent.click(getByTestId('mobile-drawer-reload'));
+            expect(reload).toHaveBeenCalledTimes(1);
+            expect(props.onClose).toHaveBeenCalledTimes(1);
+        } finally {
+            window.location = originalLocation;
+        }
+    });
+
     test('clicking a locale calls onSelectLocale with code + onClose', () => {
         const { getByTestId, props } = renderWithIntl();
         fireEvent.click(getByTestId('mobile-drawer-locale-ja'));


### PR DESCRIPTION
## Summary

issue #572 Phase 2-G: モバイル幅でコードタブを使えるようにします。upstream `<GUI>` の右ペイン (ステージ + sprite selector)・<MenuBar>・タブナビゲーションを非表示にし、ブロックパレット + ワークスペースを viewport 全幅に伸ばします。

## 実装

`MobileGui` がマウントされている間だけ `<html>` / `<body>` に `smalruby-mobile-mode` class を付け、`mobile-gui.css` (新規) の `:global()` ルールが起点として upstream layout を mobile viewport (390px+) 用に上書きします。**upstream のソースには触りません** — Smalruby マーカーを増やさずに完結。

mobile-mode で上書きする箇所:

1. `body` / `html` / `.app` の `min-width: 1024px` → `100%` (upstream `playground/index.css`)
2. upstream の TabList (コード/コスチューム/音/ルビー) → 非表示 (MobileBottomTabs が代替)
3. upstream の右ペイン (`gui_stage-and-target-wrapper`) → 非表示 (▶ で全画面ステージ + MobileSpritePanel で sprite 管理)
4. upstream の `<MenuBar>` → 非表示 (MobileTopBar が ☰ + プロジェクト名 + ▶ を提供)
5. upstream の `<Backpack>` → 非表示 (モバイルではブロック作業エリアを優先)
6. `body-wrapper` / `editor-wrapper` → `width: 100%` (右ペイン display:none だけでは flex-basis が残るため明示)
7. `body-wrapper` に MobileTopBar 高さぶんの `padding-top` と MobileBottomTabs ぶんの `padding-bottom` (= 64px) を追加

## UX

- パレット + ワークスペースが viewport 全幅 (390px) を使う
- 既存の `<PaletteToggle>` (PR-2D でモバイル用に大きくしたハンドル) でパレットを閉じれば、ワークスペースを 390px 全幅で確保できる
- ▶ で全画面ステージプレビュー、▶ → ⏹ で編集に戻る

## Test plan

- [x] Lint + format check pass
- [x] Unit tests pass (5 件 / 30 tests)
- [x] dev server (`?mobile_gui=1` + 390x844 viewport) で目視確認:
  - コードタブで viewport 全幅にパレット + ワークスペースが収まる
  - パレットトグル `<` でワークスペースが viewport 全幅 (390px) に拡張される
  - パレットトグル `>` で再度パレットが開く
- [ ] 実機でブロックドラッグ操作の感触

## Known limitations

- upstream `<MenuBar>` を hide したことで、Smalrubot S1 ファームウェア / クラスルームなど Smalruby 固有メニューがモバイルから一時的に到達不能になる
  → 後続 PR で MobileDrawer に項目を追加する予定 (issue #572 Phase 2 残課題リストの「Drawer の拡充」)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
