### PR TITLE
feat(gui): lock mobile to landscape orientation (Phase 2-I)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -24,6 +24,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/components/mobile-bottom-tabs/`
 - `src/components/mobile-drawer/`
 - `src/components/mobile-gui/`
+- `src/components/mobile-orientation-gate/`
 - `src/components/mobile-palette-auto-closer/`
 - `src/components/mobile-sprite-panel/`
 - `src/components/mobile-top-bar/`
@@ -192,6 +193,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/components/connected-step.test.jsx`
 - `test/unit/components/mobile-bottom-tabs.test.jsx`
 - `test/unit/components/mobile-drawer.test.jsx`
+- `test/unit/components/mobile-orientation-gate.test.jsx`
 - `test/unit/components/mobile-palette-auto-closer.test.jsx`
 - `test/unit/components/mobile-sprite-panel.test.jsx`
 - `test/unit/components/mobile-top-bar.test.jsx`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -41,6 +41,7 @@ src/components/*
 !src/components/mobile-bottom-tabs/
 !src/components/mobile-drawer/
 !src/components/mobile-gui/
+!src/components/mobile-orientation-gate/
 !src/components/mobile-palette-auto-closer/
 !src/components/mobile-sprite-panel/
 !src/components/mobile-top-bar/
@@ -255,6 +256,7 @@ test/unit/components/*
 !test/unit/components/connected-step.test.jsx
 !test/unit/components/mobile-bottom-tabs.test.jsx
 !test/unit/components/mobile-drawer.test.jsx
+!test/unit/components/mobile-orientation-gate.test.jsx
 !test/unit/components/mobile-palette-auto-closer.test.jsx
 !test/unit/components/mobile-sprite-panel.test.jsx
 !test/unit/components/mobile-top-bar.test.jsx

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
@@ -4,6 +4,7 @@ import GUI from '../../containers/gui.jsx';
 import ConnectedIntlProvider from '../../lib/connected-intl-provider.jsx';
 import MobileBottomTabs from '../mobile-bottom-tabs/mobile-bottom-tabs.jsx';
 import MobileDrawer from '../mobile-drawer/mobile-drawer.jsx';
+import MobileOrientationGate from '../mobile-orientation-gate/mobile-orientation-gate.jsx';
 import MobilePaletteAutoCloser from '../mobile-palette-auto-closer/mobile-palette-auto-closer.jsx';
 import MobileSpritePanel from '../mobile-sprite-panel/mobile-sprite-panel.jsx';
 import MobileTopBar from '../mobile-top-bar/mobile-top-bar.jsx';
@@ -104,6 +105,12 @@ const MobileGui = props => {
                     <MobilePaletteAutoCloser />
                     <MobileDrawer open={drawerOpen} onClose={handleCloseDrawer} />
                     <MobileSpritePanel active={spriteTabActive} />
+                    {/*
+                     * Phase 2-I: 縦向き時にオーバーレイを出して横にしてもらう。
+                     * 上流の paint editor / sound editor の min-width 群が
+                     * 390px に収まらないため、横固定運用に倒す。
+                     */}
+                    <MobileOrientationGate />
                 </>
             </ConnectedIntlProvider>
         </>

--- a/packages/scratch-gui/src/components/mobile-orientation-gate/mobile-orientation-gate.css
+++ b/packages/scratch-gui/src/components/mobile-orientation-gate/mobile-orientation-gate.css
@@ -1,0 +1,68 @@
+.overlay {
+    position: fixed;
+    inset: 0;
+    /*
+     * MobileTopBar / MobileBottomTabs (z-index: 9000) や、ドロワー (9501) より
+     * も上に重ねて操作不能にする (横向きにするまで先に進めない)。
+     */
+    z-index: 10000;
+    background: linear-gradient(180deg, #855cd6 0%, #5b3a99 100%);
+    color: white;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    text-align: center;
+    user-select: none;
+    -webkit-user-select: none;
+    /* iOS の safe-area-inset を尊重 */
+    padding-top: max(1.5rem, env(safe-area-inset-top, 1.5rem));
+    padding-bottom: max(1.5rem, env(safe-area-inset-bottom, 1.5rem));
+    padding-left: max(1.5rem, env(safe-area-inset-left, 1.5rem));
+    padding-right: max(1.5rem, env(safe-area-inset-right, 1.5rem));
+}
+
+.icon-row {
+    font-size: 3rem;
+    line-height: 1;
+    margin-bottom: 1.25rem;
+    /* 端末を回しているのを示すアニメーション */
+    animation: rotate-hint 2.5s ease-in-out infinite;
+    transform-origin: center center;
+}
+
+@keyframes rotate-hint {
+    0%,
+    20% {
+        transform: rotate(0deg);
+    }
+    50%,
+    70% {
+        transform: rotate(90deg);
+    }
+    100% {
+        transform: rotate(0deg);
+    }
+}
+
+.title {
+    font-size: 1.25rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+}
+
+.message {
+    font-size: 0.95rem;
+    line-height: 1.5;
+    max-width: 320px;
+}
+
+.note {
+    margin-top: 1.5rem;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.85);
+    max-width: 320px;
+}

--- a/packages/scratch-gui/src/components/mobile-orientation-gate/mobile-orientation-gate.jsx
+++ b/packages/scratch-gui/src/components/mobile-orientation-gate/mobile-orientation-gate.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import styles from './mobile-orientation-gate.css';
+
+const PORTRAIT_QUERY = '(orientation: portrait)';
+
+const messages = defineMessages({
+    title: {
+        defaultMessage: 'Please rotate your device',
+        description: 'Mobile orientation gate title shown when user holds the device in portrait',
+        id: 'gui.mobile.orientation.title',
+    },
+    body: {
+        defaultMessage: 'Smalruby works best in landscape mode on phones.',
+        description: 'Mobile orientation gate body explaining landscape requirement',
+        id: 'gui.mobile.orientation.body',
+    },
+    iosNote: {
+        defaultMessage: 'On iOS, make sure orientation lock is OFF (Control Center).',
+        description: 'Mobile orientation gate note for iOS users about orientation lock',
+        id: 'gui.mobile.orientation.iosNote',
+    },
+});
+
+/**
+ * `(orientation: portrait)` メディアクエリを購読する hook。
+ *
+ * SSR / matchMedia 非対応環境では false を返す。
+ * @returns {boolean} 縦向き (portrait) の時 true
+ */
+const usePortraitOrientation = () => {
+    const [isPortrait, setIsPortrait] = useState(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+        return window.matchMedia(PORTRAIT_QUERY).matches;
+    });
+    useEffect(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
+        const mql = window.matchMedia(PORTRAIT_QUERY);
+        const handler = event => setIsPortrait(event.matches);
+        if (typeof mql.addEventListener === 'function') {
+            mql.addEventListener('change', handler);
+            return () => mql.removeEventListener('change', handler);
+        }
+        // Safari < 14 fallback
+        mql.addListener(handler);
+        return () => mql.removeListener(handler);
+    }, []);
+    return isPortrait;
+};
+
+/**
+ * 縦向き (portrait) の時だけフルスクリーンオーバーレイを表示して、
+ * 横向きにするよう案内するゲート (issue #572 Phase 2-I)。
+ *
+ * 背景:
+ * - upstream の <PaintEditor> や <SoundEditor> は密度が高く、390px 縦持ちでは
+ *   どうしてもボタンが画面外にはみ出してしまう (524px / 600px+ の min-width
+ *   群が編集機能の核なので削れない)
+ * - スマホは横向き運用に割り切ることで開発コストを抑える
+ *
+ * 動作:
+ * - `(orientation: portrait)` メディアクエリで横向き / 縦向きをリアルタイム検出
+ * - 縦向き → オーバーレイ表示、横向き → オーバーレイ消失
+ * - 自動回転: PWA (manifest `orientation: landscape-primary`) ホーム画面起動時のみ
+ *   有効 (Android Chrome / iOS の home screen)。通常の Safari タブでは
+ *   ユーザーが手動で回転する必要がある。
+ *
+ * iOS Safari では JS の `screen.orientation.lock()` が無効化されているため
+ * 自動回転は不可能。ユーザーには「コントロールセンターで画面の向きロックを
+ * 解除してから横にしてね」と案内する。
+ *
+ * 子要素は描画しつづけて、Blockly 等の重い state を回転で失わないようにする
+ * (オーバーレイは上に重ねるだけ)。
+ * @returns {JSX.Element|null} portal でレンダリングされる縦向き案内オーバーレイ
+ */
+const MobileOrientationGate = () => {
+    const isPortrait = usePortraitOrientation();
+    if (typeof document === 'undefined') return null;
+    if (!isPortrait) return null;
+    return createPortal(
+        <div className={styles.overlay} role="alert" data-testid="mobile-orientation-gate">
+            <div className={styles.iconRow} aria-hidden="true">
+                📱
+            </div>
+            <div className={styles.title}>
+                <FormattedMessage {...messages.title} />
+            </div>
+            <div className={styles.message}>
+                <FormattedMessage {...messages.body} />
+            </div>
+            <div className={styles.note}>
+                <FormattedMessage {...messages.iosNote} />
+            </div>
+        </div>,
+        document.body,
+    );
+};
+
+export default MobileOrientationGate;
+export { usePortraitOrientation };

--- a/packages/scratch-gui/src/lib/use-is-narrow-screen.js
+++ b/packages/scratch-gui/src/lib/use-is-narrow-screen.js
@@ -1,17 +1,29 @@
 import { useEffect, useState } from 'react';
 
 /**
- * 「狭幅画面 (= スマホ縦持ち相当、< 768px)」を検知する React hook。
+ * 「スマホ相当の小さい画面」を検知する React hook。
  *
  * issue #572 のレスポンシブ対応で、PC レイアウトと別 UI を出し分ける際の
  * 共通ブレークポイントとして使用する。
  *
+ * 検出条件: viewport の幅 ≤ 767px または高さ ≤ 500px。
+ * これにより、スマホ縦持ち (例 390x844) も横持ち (例 844x390) も同じ
+ * mobile UI が出る (Phase 2-I で横固定運用に切り替えたため)。
+ *
+ * - スマホ縦持ち (390x844): width 390 ≤ 767 → match
+ * - スマホ横持ち (844x390): height 390 ≤ 500 → match
+ * - タブレット (820x1180 / 1180x820): 両方 > 閾値 → no match (desktop UI)
+ * - PC (1920x1080): 両方 > 閾値 → no match (desktop UI)
+ *
+ * 高さの閾値は 500 で iPhone 14 Pro Max (横 430) 等を含むが、デスクトップで
+ * ウィンドウを縦に縮めても 500 を下回らない範囲としてバランスを取る。
+ *
  * 同じ matchMedia インスタンスを各コンポーネントが個別に購読すると、
  * リスナー数 = コンポーネント数になるが、それぞれ独立に最新値を持つので
  * 整合性は保たれる。
- * @returns {boolean} viewport が 767px 以下なら true
+ * @returns {boolean} スマホ相当のサイズなら true
  */
-const NARROW_SCREEN_QUERY = '(max-width: 767px)';
+const NARROW_SCREEN_QUERY = '(max-width: 767px), (max-height: 500px)';
 
 const useIsNarrowScreen = () => {
     const [isNarrow, setIsNarrow] = useState(() => {

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -642,4 +642,7 @@ export default {
     'gui.mobile.drawer.section.language': 'Language',
     'gui.mobile.drawer.close': 'Close menu',
     'gui.mobile.drawer.reload': 'Reload',
+    'gui.mobile.orientation.title': 'Please rotate your device',
+    'gui.mobile.orientation.body': 'Smalruby works best in landscape mode on phones.',
+    'gui.mobile.orientation.iosNote': 'On iOS, make sure orientation lock is OFF (Control Center).',
 };

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -948,4 +948,8 @@ export default {
     'gui.mobile.drawer.section.language': 'げんご',
     'gui.mobile.drawer.close': 'メニューをとじる',
     'gui.mobile.drawer.reload': 'さいよみこみ',
+    'gui.mobile.orientation.title': 'よこむきにしてください',
+    'gui.mobile.orientation.body': 'スマホでは よこむきで つかってください。',
+    'gui.mobile.orientation.iosNote':
+        'iPhone のばあいは、コントロールセンターから「がめんのむきロック」を かいじょしてから よこにしてください。',
 };

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -923,4 +923,8 @@ export default {
     'gui.mobile.drawer.section.language': '言語',
     'gui.mobile.drawer.close': 'メニューを閉じる',
     'gui.mobile.drawer.reload': '再読み込み',
+    'gui.mobile.orientation.title': '横向きにしてください',
+    'gui.mobile.orientation.body': 'スマホでは横向きでお使いください。',
+    'gui.mobile.orientation.iosNote':
+        'iPhone の場合は、コントロールセンターから「画面の向きロック」を解除してから横にしてください。',
 };

--- a/packages/scratch-gui/test/unit/components/mobile-orientation-gate.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mobile-orientation-gate.test.jsx
@@ -1,0 +1,85 @@
+/* eslint-env jest */
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import '@testing-library/jest-dom';
+import { act, render } from '@testing-library/react';
+import MobileOrientationGate from '../../../src/components/mobile-orientation-gate/mobile-orientation-gate.jsx';
+
+/**
+ * `(orientation: portrait)` の `matchMedia` をテスト用に差し替えるヘルパ。
+ * 戻り値の `setMatches(bool)` で動的に切り替え可能。
+ * @returns {{setMatches: Function, restore: Function}} 切替/復元 API
+ */
+const installMatchMedia = () => {
+    const original = window.matchMedia;
+    let listeners = [];
+    let matches = false;
+    window.matchMedia = jest.fn().mockImplementation(query => {
+        if (query !== '(orientation: portrait)') {
+            // 他のクエリは default false を返す
+            return { matches: false, addEventListener: () => {}, removeEventListener: () => {} };
+        }
+        return {
+            matches,
+            addEventListener: (_event, handler) => listeners.push(handler),
+            removeEventListener: (_event, handler) => {
+                listeners = listeners.filter(h => h !== handler);
+            },
+        };
+    });
+    return {
+        setMatches: next => {
+            matches = next;
+            listeners.forEach(h => h({ matches: next }));
+        },
+        restore: () => {
+            window.matchMedia = original;
+        },
+    };
+};
+
+const renderWithIntl = ui =>
+    render(
+        <IntlProvider locale="en" messages={{}}>
+            {ui}
+        </IntlProvider>,
+    );
+
+describe('MobileOrientationGate', () => {
+    test('does not render the overlay when in landscape', () => {
+        const mm = installMatchMedia();
+        try {
+            const { queryByTestId } = renderWithIntl(<MobileOrientationGate />);
+            expect(queryByTestId('mobile-orientation-gate')).not.toBeInTheDocument();
+        } finally {
+            mm.restore();
+        }
+    });
+
+    test('renders the overlay when in portrait', () => {
+        const mm = installMatchMedia();
+        mm.setMatches(true);
+        try {
+            const { getByTestId } = renderWithIntl(<MobileOrientationGate />);
+            expect(getByTestId('mobile-orientation-gate')).toBeInTheDocument();
+        } finally {
+            mm.restore();
+        }
+    });
+
+    test('shows / hides the overlay when orientation changes', () => {
+        const mm = installMatchMedia();
+        try {
+            const { queryByTestId } = renderWithIntl(<MobileOrientationGate />);
+            expect(queryByTestId('mobile-orientation-gate')).not.toBeInTheDocument();
+            // rotate to portrait
+            act(() => mm.setMatches(true));
+            expect(queryByTestId('mobile-orientation-gate')).toBeInTheDocument();
+            // rotate back to landscape
+            act(() => mm.setMatches(false));
+            expect(queryByTestId('mobile-orientation-gate')).not.toBeInTheDocument();
+        } finally {
+            mm.restore();
+        }
+    });
+});

--- a/packages/scratch-gui/webpack.config.js
+++ b/packages/scratch-gui/webpack.config.js
@@ -325,7 +325,13 @@ const buildWithPwaConfig = buildConfig.clone()
             short_name: 'Smalruby',
             description: 'GraphicaL User Interface for creating and running Smalruby 3.0 projects',
             background_color: '#ffffff',
-            orientation: 'any',
+            // ホーム画面に追加された PWA を「横向き」で起動させる (issue #572 Phase 2-I)。
+            // スマホのコスチューム/サウンドエディタは upstream の min-width 制約で
+            // 縦持ちでは見切れるため、横画面前提で運用する。デスクトップやタブレットの
+            // PWA インストール時もこのヒントが入るが、デスクトップブラウザは
+            // orientation ヒントを無視するので影響なし。タブレットはサポートしている
+            // 場合のみ landscape で起動する。
+            orientation: 'landscape',
             crossorigin: 'use-credentials',
             inject: true,
             ios: {
@@ -387,7 +393,13 @@ const distWithHtmlConfig = buildConfig.clone()
             short_name: 'Smalruby',
             description: 'GraphicaL User Interface for creating and running Smalruby 3.0 projects',
             background_color: '#ffffff',
-            orientation: 'any',
+            // ホーム画面に追加された PWA を「横向き」で起動させる (issue #572 Phase 2-I)。
+            // スマホのコスチューム/サウンドエディタは upstream の min-width 制約で
+            // 縦持ちでは見切れるため、横画面前提で運用する。デスクトップやタブレットの
+            // PWA インストール時もこのヒントが入るが、デスクトップブラウザは
+            // orientation ヒントを無視するので影響なし。タブレットはサポートしている
+            // 場合のみ landscape で起動する。
+            orientation: 'landscape',
             crossorigin: 'use-credentials',
             inject: true,
             ios: {


### PR DESCRIPTION
## Summary

issue #572 Phase 2-I: スマホは **横向き運用** に割り切ります (PR #589 PR-2H をクローズした上で。portrait に詰め込む方針はやめ)。

upstream `<PaintEditor>` / `<SoundEditor>` は密度が高く、min-width 524px / 600px+ の制約が編集機能の核なので削れません。390px 縦持ちではボタン群が画面外にはみ出してしまうため、横向きにしてもらう前提に切り、開発コストを抑えます。

## 実装

1. **`MobileOrientationGate`** (新規): 縦向き時にフルスクリーンオーバーレイ ("📱 横にしてください") を Portal で表示。
   - `(orientation: portrait)` メディアクエリでリアルタイム検出
   - 子要素は描画し続けるので Blockly 等の重い state は維持される
   - iOS の画面の向きロック注意書きを併記

2. **PWA manifest** (`webpack.config.js` の 2 箇所): `orientation: 'any'` → `'landscape'`
   - ホーム画面起動時は自動横固定 (Android Chrome / iOS home-screen mode)
   - 通常 Safari タブはユーザーが手動で回転する

3. **`useIsNarrowScreen`** の検出条件を拡張
   - 旧: `(max-width: 767px)` のみ → スマホ横持ち (844x390) で発火しない
   - 新: `(max-width: 767px), (max-height: 500px)` → 縦持ちも横持ちも発火
   - タブレット (820x1180 / 1180x820) は両方とも閾値超えなので desktop UI

## UX

| 端末状態 | 表示 |
|---|---|
| スマホ縦持ち (`mobile_gui=1`) | MobileGui + 「横にしてください」オーバーレイ |
| スマホ横持ち (`mobile_gui=1`) | MobileGui (オーバーレイ無し) |
| タブレット | desktop GUI |
| PWA (ホーム画面) | manifest により自動横固定 |

## Test plan

- [x] Lint + format check pass
- [x] Unit tests (6 mobile suites / 34 tests)
- [x] dev server で目視確認:
  - 390x844 (portrait): オーバーレイ表示 ✓
  - 844x390 (landscape): MobileGui 表示、コスチュームエディタが収まる ✓
  - viewport 切替で overlay が動的に show/hide ✓
- [ ] iOS Safari 実機での確認
- [ ] PWA install (Add to Home Screen) で自動横固定する確認

## 関連: PR #589 (PR-2H) クローズ

PR-2H で portrait 用の min-width 0 上書きを試みましたが、上流のボタン群が大量にあって 390px に収まらないことが判明。PR-2I で抜本的に landscape 運用に切り替えるためクローズしました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
