### PR TITLE
fix(gui): add 5s timeout to FetchWorkerTool for iOS subdir sprite add (issue #572)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -60,6 +60,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/playground/render-gui.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui.jsx` | no_beforeunload URL param | beforeunload 無効化 |
 | `src/playground/render-gui.jsx` | MobileGui dispatcher | ResponsiveGui import + GUI を ResponsiveGui に差し替え (issue #572 Phase 2-A) |
+| `src/playground/render-gui.jsx` | storage worker timeout HOC | scratch-storage の FetchWorkerTool に 5s タイムアウトを当てる HOC import と compose 配置 (subdir deploy + iOS Safari の Worker hang 対策) |
 | `src/components/target-pane/target-pane.jsx` | mobile-sprite-panel suppress-library | MobileSpritePanel が同一ツリーで TargetPane を再描画する際の SpriteLibrary 二重表示を `hideSpriteLibrary` prop で抑止 (issue #572 Phase 2-F) |
 | `src/playground/render-gui-standalone.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui-standalone.jsx` | no_beforeunload URL param | beforeunload 無効化 |

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -124,6 +124,8 @@ upstream (Scratch) ファイルは対象外。
 - `src/lib/ruby-screenshot.js`
 - `src/lib/smalrubot-firmware-flasher.js`
 - `src/lib/smalrubot-firmware.hex.js`
+- `src/lib/storage-worker-timeout.js`
+- `src/lib/storage-worker-timeout-hoc.jsx`
 - `src/lib/ruby-script-preview.js`
 - `src/lib/ruby-to-blocks-converter-hoc.jsx`
 - `src/lib/rubytee-api.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -147,6 +147,8 @@ src/lib/*
 !src/lib/ruby-screenshot.js
 !src/lib/smalrubot-firmware-flasher.js
 !src/lib/smalrubot-firmware.hex.js
+!src/lib/storage-worker-timeout.js
+!src/lib/storage-worker-timeout-hoc.jsx
 !src/lib/ruby-script-preview.js
 !src/lib/ruby-to-blocks-converter-hoc.jsx
 !src/lib/rubytee-api.js

--- a/packages/scratch-gui/src/lib/storage-worker-timeout-hoc.jsx
+++ b/packages/scratch-gui/src/lib/storage-worker-timeout-hoc.jsx
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { applyStorageWorkerTimeout } from './storage-worker-timeout.js';
+
+/**
+ * `vm.runtime.storage` が用意できしだい、FetchWorkerTool への timeout patch
+ * を当てる HOC。サブディレクトリ deploy + iOS Safari で Web Worker 内
+ * `fetch()` が無限にハングする問題への対策 (詳細は storage-worker-timeout.js)。
+ *
+ * VM は AppStateHOC が Redux store にセットアップする。VM の constructor で
+ * すでに storage が作られているはずだが、安全のため 250ms 周期で 10 秒間
+ * polling し、storage が見えたら一度だけ patch する。
+ * @param {React.ComponentType} WrappedComponent - ラップ対象 (通常 ResponsiveGui)
+ * @returns {React.ComponentType} HOC でラップされたコンポーネント
+ */
+const StorageWorkerTimeoutHOC = WrappedComponent => {
+    const Wrapped = ({ vm, ...rest }) => {
+        useEffect(() => {
+            if (!vm) return () => {};
+            const tryApply = () => {
+                const storage = vm.runtime?.storage;
+                return Boolean(storage && applyStorageWorkerTimeout(storage));
+            };
+            if (tryApply()) return () => {};
+            let attempts = 0;
+            const interval = setInterval(() => {
+                if (tryApply() || ++attempts > 40) clearInterval(interval);
+            }, 250);
+            return () => clearInterval(interval);
+        }, [vm]);
+        return <WrappedComponent vm={vm} {...rest} />;
+    };
+    Wrapped.propTypes = {
+        vm: PropTypes.object,
+    };
+    Wrapped.displayName = `StorageWorkerTimeoutHOC(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+    return connect(state => ({ vm: state.scratchGui.vm }))(Wrapped);
+};
+
+export default StorageWorkerTimeoutHOC;

--- a/packages/scratch-gui/src/lib/storage-worker-timeout.js
+++ b/packages/scratch-gui/src/lib/storage-worker-timeout.js
@@ -1,0 +1,85 @@
+/**
+ * scratch-storage の `FetchWorkerTool` (Web Worker 内 fetch) がレスポンスを
+ * 返さず永久にハングする現象への対策。
+ *
+ * 既知の発生条件:
+ * - サブディレクトリ deploy (例: `https://smalruby.jp/smalruby3-editor/...`)
+ *   かつ iOS Safari (WebKit ベース)
+ * - root deploy (例: `https://smalruby.app/`) では再現しない
+ *
+ * 仕組み:
+ * - scratch-storage の `ProxyTool.get()` は
+ *   `tool.get(reqConfig).catch(nextTool)` で **REJECTION** が発生したときだけ
+ *   次の tool (FetchTool) にフォールバックする。HANG だと永久に pending
+ *   なので `.catch` ハンドラが発火せず、`storage.load` の Promise も無限に
+ *   pending → スプライト追加が完了しない症状になる。
+ * - 対策として FetchWorkerTool の `get` を `Promise.race` で 5 秒
+ *   タイムアウトし、応答が来なければ強制 reject する。これで ProxyTool が
+ *   FetchTool に切り替わり、main thread の `fetch()` で取得できる。
+ * - 一度タイムアウトが起きた場合、後続呼び出しでも Worker は壊れている
+ *   可能性が高いので、`isGetSupported` を false にして以降は ProxyTool が
+ *   即座に FetchTool に行くようにする。これで 5 秒×N 回の wait が回避できる。
+ *
+ * UA detection を使わない理由:
+ * - iOS でも root deploy (smalruby.app) では Worker が正常動作する。
+ * - 「iOS だから無条件に Worker を切る」のは過剰で、smalruby.app での
+ *   並列読み込みのメリットを失う。
+ * - timeout-based fallback は env 非依存なので、将来の別ブラウザ/別 deploy
+ *   形態の似た問題にも自動的に対応する。
+ */
+
+const FETCH_WORKER_TIMEOUT_MS = 5000;
+
+/**
+ * tool が `PublicFetchWorkerTool` インスタンスかを判定する。
+ *
+ * production バンドルでは terser が class 名を 1 文字に mangle するので
+ * `constructor.name === 'PublicFetchWorkerTool'` は使えない。
+ * `PublicFetchWorkerTool` のみが持つ `inner` プロパティ
+ * (`this.inner = PrivateFetchWorkerTool.instance`) の存在を見る。
+ * `inner` は string property name なので terser のデフォルト mangle で残る
+ * (production bundle の `'.inner=V.instance'` や `'this.inner.isGetSupported'`
+ * で実在することを確認済み)。
+ * @param {object} tool - assetTool.tools の要素
+ * @returns {boolean} FetchWorkerTool ならば true
+ */
+const isFetchWorkerTool = tool => Boolean(tool && tool.inner && typeof tool.inner === 'object');
+
+/**
+ * `vm.runtime.storage` に対し、FetchWorkerTool への timeout patch を当てる。
+ * 一度適用したら再適用しない (idempotent)。
+ * @param {object} storage - vm.runtime.storage インスタンス
+ * @returns {boolean} 適用したか (false = storage が無い / すでに patch 済み)
+ */
+const applyStorageWorkerTimeout = storage => {
+    const tools = storage?.webHelper?.assetTool?.tools;
+    if (!tools || !Array.isArray(tools)) return false;
+    let patchedAny = false;
+    for (const tool of tools) {
+        if (!isFetchWorkerTool(tool)) continue;
+        if (tool.__smalrubyWorkerTimeoutPatched) continue;
+        const origGet = tool.get.bind(tool);
+        let workerProvenBroken = false;
+        tool.get = function (reqConfig) {
+            // Worker が壊れていることが既に判明しているなら、即 reject して
+            // ProxyTool に FetchTool フォールバックさせる (5s 待ちを省略)。
+            if (workerProvenBroken) {
+                return Promise.reject(new Error('FetchWorkerTool disabled after first timeout'));
+            }
+            return Promise.race([
+                origGet(reqConfig),
+                new Promise((_, reject) =>
+                    setTimeout(() => {
+                        workerProvenBroken = true;
+                        reject(new Error(`FetchWorkerTool timeout after ${FETCH_WORKER_TIMEOUT_MS}ms`));
+                    }, FETCH_WORKER_TIMEOUT_MS),
+                ),
+            ]);
+        };
+        tool.__smalrubyWorkerTimeoutPatched = true;
+        patchedAny = true;
+    }
+    return patchedAny;
+};
+
+export { applyStorageWorkerTimeout, isFetchWorkerTool, FETCH_WORKER_TIMEOUT_MS };

--- a/packages/scratch-gui/src/playground/render-gui.jsx
+++ b/packages/scratch-gui/src/playground/render-gui.jsx
@@ -13,6 +13,9 @@ import {getUrlParams} from '../lib/url-params.js';
 // === Smalruby: Start of MobileGui dispatcher ===
 import ResponsiveGui from '../lib/responsive-gui.jsx';
 // === Smalruby: End of MobileGui dispatcher ===
+// === Smalruby: Start of storage worker timeout HOC ===
+import StorageWorkerTimeoutHOC from '../lib/storage-worker-timeout-hoc.jsx';
+// === Smalruby: End of storage worker timeout HOC ===
 
 const onClickLogo = () => {
     window.location = 'https://smalruby.jp';
@@ -43,7 +46,14 @@ export default appTarget => {
     // ability to compose reducers.
     const WrappedGui = compose(
         AppStateHOC,
-        HashParserHOC
+        HashParserHOC,
+        // === Smalruby: Start of storage worker timeout HOC ===
+        // VM がセットアップされたら scratch-storage の FetchWorkerTool に
+        // 5s タイムアウトを当て、ハング時に FetchTool フォールバックを発動させる。
+        // サブディレクトリ deploy + iOS Safari で Worker 内 fetch がハングする
+        // 問題への対策 (詳細は storage-worker-timeout.js)。
+        StorageWorkerTimeoutHOC,
+        // === Smalruby: End of storage worker timeout HOC ===
         // === Smalruby: Start of MobileGui dispatcher ===
         // ResponsiveGui forwards all HOC-injected props and switches between
         // <GUI> and <MobileGui> based on the `mobile_gui=1` URL flag + viewport width.


### PR DESCRIPTION
## Summary

issue #572 で報告されている **iOS Safari でスプライト/コスチュームが追加できない** 症状の根本原因に対応。

## 根本原因

scratch-storage の `FetchWorkerTool` (Web Worker 内 `fetch()`) が、**サブディレクトリ deploy** (`https://smalruby.jp/smalruby3-editor/...` 等) と **iOS Safari** の組み合わせで応答せず無限にハングする。`https://smalruby.app/` (root deploy) では同じ iOS Safari でも正常動作するため、これまで Phase 2 の MobileGui で隠していたが、本質的な問題ではなかった。

`ProxyTool.get()` は `tool.get(reqConfig).catch(nextTool)` で **REJECTION** 時のみ FetchTool にフォールバックするので、HANG だと永久に pending → `storage.load` も pending → スプライト追加完了しない。

iOS Safari 実機で取得したログ:

```
vm.addSprite called: string len=1080
load#1 ImageVector ... fmt=svg
tool#1 K GET pi/asset/...
worker.post id=...
load#1 HANG@3s
load#1 HANG@8s   ← Worker から応答が永久に来ない
```

## 対策

`FetchWorkerTool.get` を `Promise.race` で **5s タイムアウト** し、応答が無ければ強制 reject。これで ProxyTool が FetchTool に切り替わり、main thread の `fetch()` で取得できる。一度タイムアウトしたら以降は即 reject (`workerProvenBroken` フラグ) し、N 回の wait を回避する。

### UA detection を使わない理由

- iOS でも root deploy では Worker が正常動作する → 「iOS なら Worker を無効化」は過剰
- timeout-based fallback は環境非依存。将来の別ブラウザ/別 deploy の類似問題にも自動的に対応

### 実装

- `src/lib/storage-worker-timeout.js` — patch 関数本体。production の terser mangle に耐えるよう、FetchWorkerTool 判定は `inner` プロパティの存在で行う (class 名は mangle で `K` 等に変わるため `constructor.name` は使えない)
- `src/lib/storage-worker-timeout-hoc.jsx` — VM が用意できしだい patch を当てる Redux 接続 HOC
- `src/playground/render-gui.jsx` — compose チェーンに HOC を追加 (Smalruby マーカーで囲む)

## Test plan

- [x] `npm run test:lint` 通過
- [x] `prettier -c .` 通過
- [x] Playwright (Chrome desktop) で通常パス: 15ms で 6081 bytes 取得 (Worker 経由)
- [x] Playwright で Worker hang シミュレート (`inner.get = () => new Promise(()=>{})`):
  - 1 回目 6420ms (5s timeout + FetchTool fallback)
  - 2 回目以降 5ms (workerProvenBroken 短絡で即 FetchTool)
- [ ] iOS Safari (subdir deploy) でスプライト追加が完了することを実機確認 (CI deploy 後)
- [ ] iOS Safari (smalruby.app, root deploy) で従来通り Worker 経由で動作することを確認 (回帰テスト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
