### PR TITLE
feat: shut down legacy Mesh and force-migrate v1 to v2 (#592)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -73,8 +73,10 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/reducers/editor-tab.js` | initial tab from URL param | 初期タブ URL パラメーター |
 | `src/reducers/settings.js` | URL params for Playwright | URL パラメーター import |
 | `src/reducers/settings.js` | ruby_version URL param | Ruby バージョン URL パラメーター |
+| `src/containers/backpack.jsx` | mesh v1 backpack auto-migration | Skyway 停止 (Issue #592) に伴う localStorage バックパックの自動 v1→v2 マイグレーション |
 
 ## 関連ファイル
 
 マーカーで囲まれたコードが参照するファイル:
 - `src/reducers/smalruby-registry.ts` — gui.ts のマーカーから参照
+- `src/lib/backpack-mesh-v1-migration.js` — backpack.jsx のマーカーから参照

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -94,6 +94,7 @@ upstream (Scratch) ファイルは対象外。
 
 **個別ファイル:**
 - `src/lib/auto-correct.js`
+- `src/lib/backpack-mesh-v1-migration.js`
 - `src/lib/classroom-api.js`
 - `src/lib/google-classroom-auth.js`
 - `src/lib/block-utils.js`
@@ -218,6 +219,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/empty-block-selection.test.js`
 - `test/unit/lib/auto-correct.test.js`
 - `test/unit/lib/backpack-api.test.js`
+- `test/unit/lib/backpack-mesh-v1-migration.test.js`
 - `test/unit/lib/block-display-initialization.test.js`
 - `test/unit/lib/blocks-gesture-recovery.test.js`
 - `test/unit/lib/blocks-screenshot.test.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -117,6 +117,7 @@ src/lib/*
 !src/lib/libraries/
 # Individual Smalruby files
 !src/lib/auto-correct.js
+!src/lib/backpack-mesh-v1-migration.js
 !src/lib/classroom-api.js
 !src/lib/google-classroom-auth.js
 !src/lib/block-utils.js
@@ -295,6 +296,7 @@ test/unit/lib/*
 # Individual Smalruby files
 !test/unit/lib/auto-correct.test.js
 !test/unit/lib/backpack-api.test.js
+!test/unit/lib/backpack-mesh-v1-migration.test.js
 !test/unit/lib/block-display-initialization.test.js
 !test/unit/lib/blocks-gesture-recovery.test.js
 !test/unit/lib/blocks-screenshot.test.js

--- a/packages/scratch-gui/src/containers/backpack.jsx
+++ b/packages/scratch-gui/src/containers/backpack.jsx
@@ -18,6 +18,13 @@ import {GUIStoragePropType} from '../gui-config';
 import {connect} from 'react-redux';
 import VM from '@smalruby/scratch-vm';
 
+// === Smalruby: Start of mesh v1 backpack auto-migration ===
+import {injectIntl} from 'react-intl';
+import intlShape from '../lib/intlShape.js';
+import sharedMessages from '../lib/shared-messages';
+import {migrateMeshV1InLocalStorageBackpack} from '../lib/backpack-mesh-v1-migration';
+// === Smalruby: End of mesh v1 backpack auto-migration ===
+
 
 const dragTypes = [DragConstants.COSTUME, DragConstants.SOUND, DragConstants.SPRITE];
 const DroppableBackpack = DropAreaHOC(dragTypes)(BackpackComponent);
@@ -57,6 +64,22 @@ class Backpack extends React.Component {
     componentDidMount () {
         this.props.vm.addListener('BLOCK_DRAG_END', this.handleBlockDragEnd);
         this.props.vm.addListener('BLOCK_DRAG_UPDATE', this.handleBlockDragUpdate);
+        // === Smalruby: Start of mesh v1 backpack auto-migration ===
+        // Skyway shut down — eagerly rewrite any v1 mesh blocks/sprites in
+        // localStorage so users never restore them. One-shot per browser.
+        migrateMeshV1InLocalStorageBackpack(this.props.vm)
+            .then(count => {
+                if (count > 0) {
+                    // eslint-disable-next-line no-alert
+                    alert(this.props.intl.formatMessage(
+                        sharedMessages.meshV1BackpackAutoMigrated,
+                        {count}
+                    ));
+                }
+            })
+            // eslint-disable-next-line no-console
+            .catch(error => console.warn('[Smalruby] backpack mesh v1 migration failed', error));
+        // === Smalruby: End of mesh v1 backpack auto-migration ===
     }
     componentWillUnmount () {
         this.props.vm.removeListener('BLOCK_DRAG_END', this.handleBlockDragEnd);
@@ -244,7 +267,10 @@ Backpack.propTypes = {
     username: PropTypes.string,
     vm: PropTypes.instanceOf(VM),
     ariaRole: PropTypes.string,
-    ariaLabel: PropTypes.string
+    ariaLabel: PropTypes.string,
+    // === Smalruby: Start of mesh v1 backpack auto-migration ===
+    intl: intlShape
+    // === Smalruby: End of mesh v1 backpack auto-migration ===
 };
 
 const getTokenAndUsername = state => {
@@ -277,4 +303,7 @@ const mapStateToProps = state => Object.assign(
 
 const mapDispatchToProps = () => ({});
 
-export default connect(mapStateToProps, mapDispatchToProps)(Backpack);
+// === Smalruby: Start of mesh v1 backpack auto-migration ===
+// Wrap with injectIntl so the eager-migration alert can be localized.
+export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(Backpack));
+// === Smalruby: End of mesh v1 backpack auto-migration ===

--- a/packages/scratch-gui/src/lib/backpack-mesh-v1-migration.js
+++ b/packages/scratch-gui/src/lib/backpack-mesh-v1-migration.js
@@ -1,0 +1,102 @@
+// Eager mesh v1 → v2 migration for backpack contents stored in localStorage.
+// Skyway (the v1 backend) shut down — see Issue #592. We rewrite any v1 opcodes
+// inside scripts and sprite zips at app startup so users never restore v1 blocks
+// from the backpack. Once migrated for a given browser, a flag in localStorage
+// keeps subsequent runs as a no-op.
+
+const STORAGE_KEY = 'smalrubyBackpack';
+const MIGRATED_AT_KEY = 'smalruby:meshV1BackpackMigratedAt';
+
+const decodeBase64 = b64 => {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+};
+
+const encodeBase64 = bytes => {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    return btoa(binary);
+};
+
+const migrateScriptItem = (item, vm) => {
+    try {
+        const decoded = decodeBase64(item.body);
+        const json = JSON.parse(new TextDecoder().decode(decoded));
+        if (!vm.migrateMeshV1InBackpackBlocks(json)) return false;
+        const reEncoded = new TextEncoder().encode(JSON.stringify(json));
+        item.body = encodeBase64(reEncoded);
+        return true;
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('[Smalruby] failed to migrate backpack script item', item.id, e);
+        return false;
+    }
+};
+
+const migrateSpriteItem = async (item, vm) => {
+    try {
+        const buf = decodeBase64(item.body).buffer;
+        const { changed, buffer } = await vm.migrateMeshV1InBackpackSprite(buf);
+        if (!changed) return false;
+        // The local `item` reference is exclusively mutated here; suppress the
+        // false-positive race-condition warning from require-atomic-updates.
+        // eslint-disable-next-line require-atomic-updates
+        item.body = encodeBase64(new Uint8Array(buffer));
+        return true;
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('[Smalruby] failed to migrate backpack sprite item', item.id, e);
+        return false;
+    }
+};
+
+/**
+ * Scan localStorage backpack contents and rewrite any mesh v1 opcodes to mesh v2.
+ * Idempotent — sets a "migrated at" flag so subsequent calls are no-ops.
+ * @param {VirtualMachine} vm Scratch VM instance (provides the migration helpers).
+ * @returns {Promise<number>} Number of migrated items (0 if already migrated or empty).
+ */
+const migrateMeshV1InLocalStorageBackpack = async vm => {
+    if (typeof window === 'undefined' || !window.localStorage) return 0;
+    if (window.localStorage.getItem(MIGRATED_AT_KEY)) return 0;
+
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+        window.localStorage.setItem(MIGRATED_AT_KEY, new Date().toISOString());
+        return 0;
+    }
+    let backpack;
+    try {
+        backpack = JSON.parse(raw);
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('[Smalruby] backpack localStorage entry is not valid JSON; skipping migration', e);
+        window.localStorage.setItem(MIGRATED_AT_KEY, new Date().toISOString());
+        return 0;
+    }
+    if (!Array.isArray(backpack)) {
+        window.localStorage.setItem(MIGRATED_AT_KEY, new Date().toISOString());
+        return 0;
+    }
+
+    let count = 0;
+    for (const item of backpack) {
+        if (!item || typeof item !== 'object') continue;
+        let changed = false;
+        if (item.type === 'script') {
+            changed = migrateScriptItem(item, vm);
+        } else if (item.type === 'sprite') {
+            changed = await migrateSpriteItem(item, vm);
+        }
+        if (changed) count += 1;
+    }
+    if (count > 0) {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(backpack));
+    }
+    window.localStorage.setItem(MIGRATED_AT_KEY, new Date().toISOString());
+    return count;
+};
+
+export { migrateMeshV1InLocalStorageBackpack, STORAGE_KEY, MIGRATED_AT_KEY };

--- a/packages/scratch-gui/src/lib/libraries/extensions/index.jsx
+++ b/packages/scratch-gui/src/lib/libraries/extensions/index.jsx
@@ -49,10 +49,6 @@ import gdxforConnectionSmallIconURL from './gdxfor/gdxfor-small.svg';
 import faceSensingIconURL from './faceSensing/faceSensing.png';
 import faceSensingInsetIconURL from './faceSensing/faceSensing-small.svg';
 
-import meshIconURL from './mesh/mesh.png';
-import meshInsetIconURL from './mesh/mesh-small.png';
-import meshConnectionIconURL from './mesh/mesh-illustration.png';
-import meshConnectionSmallIconURL from './mesh/mesh-small.png';
 
 import smalrubotS1IconURL from './smalrubot-s1/smalrubot-s1.png';
 import smalrubotS1InsetIconURL from './smalrubot-s1/smalrubot-s1-small.png';
@@ -447,41 +443,9 @@ export default [
         ),
         helpLink: 'https://scratch.mit.edu/wedo'
     },
-    {
-        name: (
-            <FormattedMessage
-                defaultMessage="Old Mesh"
-                description="Name for the 'Mesh' extension"
-                id="gui.smalruby3.extension.mesh.name"
-            />
-        ),
-        extensionId: 'mesh',
-        iconURL: meshIconURL,
-        insetIconURL: meshInsetIconURL,
-        description: (
-            <FormattedMessage
-                defaultMessage="Allowing users to interact over a computer network."
-                description="Description for the 'Mesh' extension"
-                id="gui.smalruby3.extension.mesh.description"
-            />
-        ),
-        featured: true,
-        defaultHidden: true,
-        bluetoothRequired: false,
-        internetConnectionRequired: true,
-        launchPeripheralConnectionFlow: true,
-        useAutoScan: false,
-        connectionIconURL: meshConnectionIconURL,
-        connectionSmallIconURL: meshConnectionSmallIconURL,
-        connectingMessage: (
-            <FormattedMessage
-                defaultMessage="Connecting"
-                description="Message to help people connect to Mesh network."
-                id="gui.smalruby3.extension.mesh.connectingMessage"
-            />
-        ),
-        helpLink: 'https://github.com/smalruby/smalruby3-gui/wiki/Mesh'
-    },
+    // Mesh v1 (Skyway-backed) reached end of service. Removed from the picker so
+    // it can no longer be added to new projects. Existing v1 blocks (incl. those
+    // restored from the backpack) are auto-migrated to meshV2 — see Issue #592.
     {
         name: (
             <FormattedMessage

--- a/packages/scratch-gui/src/lib/project-loader-utils.js
+++ b/packages/scratch-gui/src/lib/project-loader-utils.js
@@ -13,12 +13,11 @@ const loadProjectWithChecks = (vm, intl, projectData, currentRubyVersion, onSetR
     vm
         .hasMeshV1Project(projectData)
         .then(hasMeshV1 => {
-            let migrateMeshV1ToV2 = false;
             if (hasMeshV1) {
                 // eslint-disable-next-line no-alert
-                migrateMeshV1ToV2 = !confirm(intl.formatMessage(sharedMessages.migrateMeshV1Warning));
+                alert(intl.formatMessage(sharedMessages.meshV1AutoMigrated));
             }
-            return vm.loadProject(projectData, { migrateMeshV1ToV2 });
+            return vm.loadProject(projectData, { migrateMeshV1ToV2: hasMeshV1 });
         })
         .then(() => vm.hasKoshienProject(projectData))
         .then(hasKoshien => {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/mesh.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/mesh.js
@@ -1,26 +1,26 @@
-const Mesh = 'mesh_v1';
+// `mesh_v1` is the legacy receiver name still emitted by `ruby-generator/mesh.js` for any
+// surviving v1 blocks. The Skyway service that backed v1 has shut down (Issue #592), so we
+// alias `mesh_v1.*` to mesh v2 blocks here — typing v1 Ruby never produces v1 blocks again.
+const LegacyMesh = 'mesh_v1';
 
-/**
- * Mesh extension converter
- */
 const MeshConverter = {
     register: function (converter) {
-        converter.registerOnSend('self', Mesh, 0, params => {
+        converter.registerOnSend('self', LegacyMesh, 0, params => {
             const {node} = params;
 
-            return converter.createRubyExpressionBlock(Mesh, node);
+            return converter.createRubyExpressionBlock(LegacyMesh, node);
         });
 
-        converter.registerOnSend(Mesh, 'sensor_value', 1, params => {
+        converter.registerOnSend(LegacyMesh, 'sensor_value', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
 
-            const block = converter.changeRubyExpressionBlock(receiver, 'mesh_getSensorValue', 'value');
-            converter.addFieldInput(block, 'NAME', 'mesh_menu_variableNames', 'variableNames', args[0], ' ');
+            const block = converter.changeRubyExpressionBlock(receiver, 'meshV2_getSensorValue', 'value');
+            converter.addFieldInput(block, 'NAME', 'meshV2_menu_variableNames', 'variableNames', args[0], ' ');
             return block;
         });
-    }
+    },
 };
 
 export default MeshConverter;

--- a/packages/scratch-gui/src/lib/shared-messages.ts
+++ b/packages/scratch-gui/src/lib/shared-messages.ts
@@ -34,7 +34,21 @@ const reactIntlMessages = defineMessages({
     migrateMeshV1Warning: {
         id: 'gui.sharedMessages.migrateMeshV1Warning',
         defaultMessage: 'This project contains old Mesh blocks. Would you like to migrate them to Mesh V2?',
-        description: 'Confirmation that user wants to migrate old Mesh blocks to Mesh V2'
+        description: 'Confirmation that user wants to migrate old Mesh blocks to Mesh V2',
+    },
+    meshV1AutoMigrated: {
+        id: 'gui.sharedMessages.meshV1AutoMigrated',
+        defaultMessage:
+            'The legacy Mesh service has ended. The blocks in this project have been ' +
+            'automatically replaced with the new Mesh blocks. Please verify that it works as expected.',
+        description: 'Alert shown after a project containing legacy Mesh blocks is auto-migrated on load',
+    },
+    meshV1BackpackAutoMigrated: {
+        id: 'gui.sharedMessages.meshV1BackpackAutoMigrated',
+        defaultMessage:
+            '{count, plural, one {# legacy Mesh item in your backpack was} other {# legacy Mesh items in your backpack were}} ' +
+            'automatically replaced with the new Mesh blocks.',
+        description: 'Alert shown when legacy Mesh blocks/sprites in the backpack are auto-migrated',
     },
     changedRubyVersionByKoshien: {
         id: 'gui.sharedMessages.changedRubyVersionByKoshien',

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -1,6 +1,10 @@
 export default {
     'gui.sharedMessages.migrateMeshV1Warning':
         'This project contains legacy Mesh extensions and can only be used until April 30th. Select OK to continue using the legacy Mesh extensions. Select Cancel to use the new Mesh extensions instead.',
+    'gui.sharedMessages.meshV1AutoMigrated':
+        'The legacy Mesh service has ended. The blocks in this project have been automatically replaced with the new Mesh blocks. Please verify that it works as expected.',
+    'gui.sharedMessages.meshV1BackpackAutoMigrated':
+        '{count, plural, one {# legacy Mesh item in your backpack was} other {# legacy Mesh items in your backpack were}} automatically replaced with the new Mesh blocks.',
     'gui.stageHeader.stageSizeMiddle': 'Switch to middle stage',
     'gui.sharedMessages.changedRubyVersionByKoshien':
         'This project contains the Smalruby Koshien extension, so the Ruby version has been changed to version 1.',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -208,6 +208,10 @@ export default {
     'gui.sharedMessages.loadFromComputerTitle': 'コンピューターからよみこむ',
     'gui.sharedMessages.migrateMeshV1Warning':
         'このプロジェクトにはじゅうらいのメッシュかくちょうきのうがふくまれていますので4がつ30にちまでしかつかえません。このままじゅうらいのメッシュかくちょうきのうをりようするばあいはOKをせんたくします。そうではなく、あたらしいメッシュかくちょうきのうをつかうばあいはキャンセルをせんたくします。',
+    'gui.sharedMessages.meshV1AutoMigrated':
+        'じゅうらいのメッシュかくちょうきのうのサービスはしゅうりょうしました。プロジェクトのなかのブロックをあたらしいメッシュかくちょうきのうにじどうでおきかえました。どうさをかくにんしてください。',
+    'gui.sharedMessages.meshV1BackpackAutoMigrated':
+        'バックパックのなかのじゅうらいのメッシュブロックを{count}けん、あたらしいメッシュブロックにじどうでおきかえました。',
     'gui.sharedMessages.changedRubyVersionByKoshien':
         'このプロジェクトにはスモウルビーこうしえんかくちょうきのうがふくまれていますのでルビーをバージョン1にへんこうしました',
     'gui.menuBar.loadFromGoogleDrive': 'Google ドライブからよみこむ',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -201,6 +201,10 @@ export default {
     'gui.sharedMessages.loadFromComputerTitle': 'コンピューターから読み込む',
     'gui.sharedMessages.migrateMeshV1Warning':
         'このプロジェクトには従来のメッシュ拡張機能が含まれていますので4月30日までしか使えません。このまま従来のメッシュ拡張機能を利用する場合はOKを選択します。そうではなく、あたらしいメッシュ拡張機能を使う場合はキャンセルを選択します。',
+    'gui.sharedMessages.meshV1AutoMigrated':
+        '従来のメッシュ拡張機能のサービスは終了しました。プロジェクト内のブロックを新しいメッシュ拡張機能に自動で置き換えました。動作を確認してください。',
+    'gui.sharedMessages.meshV1BackpackAutoMigrated':
+        'バックパックの中の従来のメッシュブロックを{count}件、新しいメッシュブロックに自動で置き換えました。',
     'gui.sharedMessages.changedRubyVersionByKoshien':
         'このプロジェクトにはスモウルビー甲子園拡張機能が含まれていますのでルビーをバージョン1に変更しました',
     'gui.menuBar.loadFromGoogleDrive': 'Google ドライブから読み込む',

--- a/packages/scratch-gui/test/unit/lib/backpack-mesh-v1-migration.test.js
+++ b/packages/scratch-gui/test/unit/lib/backpack-mesh-v1-migration.test.js
@@ -1,0 +1,159 @@
+import JSZip from 'jszip';
+import {
+    migrateMeshV1InLocalStorageBackpack,
+    STORAGE_KEY,
+    MIGRATED_AT_KEY,
+} from '../../../src/lib/backpack-mesh-v1-migration';
+
+const decodeB64 = b64 => {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+};
+
+const encodeB64 = bytes => {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    return btoa(binary);
+};
+
+const makeFakeVm = () => ({
+    migrateMeshV1InBackpackBlocks: jest.fn(blocks => {
+        let changed = false;
+        if (Array.isArray(blocks)) {
+            for (const b of blocks) {
+                if (b && typeof b.opcode === 'string' && b.opcode.startsWith('mesh_')) {
+                    b.opcode = `meshV2_${b.opcode.slice('mesh_'.length)}`;
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }),
+    migrateMeshV1InBackpackSprite: jest.fn(async buf => {
+        const zip = await JSZip.loadAsync(buf);
+        const json = JSON.parse(await zip.file('sprite.json').async('string'));
+        let changed = false;
+        if (json.blocks) {
+            for (const id in json.blocks) {
+                const b = json.blocks[id];
+                if (b.opcode && b.opcode.startsWith('mesh_')) {
+                    b.opcode = `meshV2_${b.opcode.slice('mesh_'.length)}`;
+                    changed = true;
+                }
+            }
+        }
+        if (!changed) return { changed: false, buffer: buf };
+        zip.file('sprite.json', JSON.stringify(json));
+        const newBuf = await zip.generateAsync({ type: 'arraybuffer' });
+        return { changed: true, buffer: newBuf };
+    }),
+});
+
+const makeScriptItem = (id, opcodes) => {
+    const blocks = opcodes.map((opcode, i) => ({ opcode, id: `b${i}` }));
+    return {
+        id,
+        type: 'script',
+        mime: 'application/json',
+        name: 'code',
+        body: encodeB64(new TextEncoder().encode(JSON.stringify(blocks))),
+        thumbnail: '',
+    };
+};
+
+const makeSpriteItem = async (id, opcodes) => {
+    const zip = new JSZip();
+    const blocks = {};
+    opcodes.forEach((opcode, i) => {
+        blocks[`b${i}`] = { opcode };
+    });
+    zip.file('sprite.json', JSON.stringify({ name: 'sprite1', blocks, extensions: ['mesh'] }));
+    const buf = await zip.generateAsync({ type: 'arraybuffer' });
+    return {
+        id,
+        type: 'sprite',
+        mime: 'application/zip',
+        name: 'sprite1',
+        body: encodeB64(new Uint8Array(buf)),
+        thumbnail: '',
+    };
+};
+
+describe('migrateMeshV1InLocalStorageBackpack', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    test('returns 0 and sets flag when backpack is empty', async () => {
+        const vm = makeFakeVm();
+        const count = await migrateMeshV1InLocalStorageBackpack(vm);
+        expect(count).toBe(0);
+        expect(localStorage.getItem(MIGRATED_AT_KEY)).toBeTruthy();
+        expect(vm.migrateMeshV1InBackpackBlocks).not.toHaveBeenCalled();
+    });
+
+    test('rewrites v1 opcodes inside script items', async () => {
+        const item = makeScriptItem('s1', ['mesh_getSensorValue', 'motion_movesteps']);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([item]));
+
+        const count = await migrateMeshV1InLocalStorageBackpack(makeFakeVm());
+        expect(count).toBe(1);
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        const blocks = JSON.parse(new TextDecoder().decode(decodeB64(stored[0].body)));
+        expect(blocks[0].opcode).toBe('meshV2_getSensorValue');
+        expect(blocks[1].opcode).toBe('motion_movesteps');
+        expect(localStorage.getItem(MIGRATED_AT_KEY)).toBeTruthy();
+    });
+
+    test('rewrites v1 opcodes inside sprite zip items', async () => {
+        const item = await makeSpriteItem('sp1', ['mesh_getSensorValue', 'motion_movesteps']);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([item]));
+
+        const count = await migrateMeshV1InLocalStorageBackpack(makeFakeVm());
+        expect(count).toBe(1);
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        const zip = await JSZip.loadAsync(decodeB64(stored[0].body).buffer);
+        const json = JSON.parse(await zip.file('sprite.json').async('string'));
+        expect(json.blocks.b0.opcode).toBe('meshV2_getSensorValue');
+        expect(json.blocks.b1.opcode).toBe('motion_movesteps');
+    });
+
+    test('skips items already migrated and reports correct count', async () => {
+        const v1 = makeScriptItem('s1', ['mesh_getSensorValue']);
+        const v2 = makeScriptItem('s2', ['meshV2_getSensorValue']);
+        const other = makeScriptItem('s3', ['motion_movesteps']);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([v1, v2, other]));
+
+        const count = await migrateMeshV1InLocalStorageBackpack(makeFakeVm());
+        expect(count).toBe(1);
+    });
+
+    test('is a no-op once the migrated-at flag is set', async () => {
+        const item = makeScriptItem('s1', ['mesh_getSensorValue']);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([item]));
+        localStorage.setItem(MIGRATED_AT_KEY, '2026-05-01T00:00:00.000Z');
+
+        const vm = makeFakeVm();
+        const count = await migrateMeshV1InLocalStorageBackpack(vm);
+        expect(count).toBe(0);
+        expect(vm.migrateMeshV1InBackpackBlocks).not.toHaveBeenCalled();
+
+        // Body left unchanged because we skipped the migration.
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        const blocks = JSON.parse(new TextDecoder().decode(decodeB64(stored[0].body)));
+        expect(blocks[0].opcode).toBe('mesh_getSensorValue');
+    });
+
+    test('sets flag and skips on malformed JSON in storage', async () => {
+        localStorage.setItem(STORAGE_KEY, 'not-json');
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const count = await migrateMeshV1InLocalStorageBackpack(makeFakeVm());
+        expect(count).toBe(0);
+        expect(localStorage.getItem(MIGRATED_AT_KEY)).toBeTruthy();
+        warn.mockRestore();
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/mesh.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/mesh.test.js
@@ -17,16 +17,16 @@ describe('RubyToBlocksConverter/Mesh', () => {
         expected = null;
     });
 
-    test('mesh_getSensorValue', async () => {
+    test('mesh_v1.sensor_value aliases to meshV2_getSensorValue (Issue #592)', async () => {
         code = 'mesh_v1.sensor_value(" ")';
         expected = [
             {
-                opcode: 'mesh_getSensorValue',
+                opcode: 'meshV2_getSensorValue',
                 inputs: [
                     {
                         name: 'NAME',
                         block: {
-                            opcode: 'mesh_menu_variableNames',
+                            opcode: 'meshV2_menu_variableNames',
                             fields: [
                                 {
                                     name: 'variableNames',

--- a/packages/scratch-vm/src/serialization/smalruby-migration.js
+++ b/packages/scratch-vm/src/serialization/smalruby-migration.js
@@ -3,6 +3,23 @@
  * Utilities for migrating projects from the legacy mesh extension to meshV2.
  */
 
+const JSZip = require('jszip');
+
+const MESH_V1_OPCODE_PREFIX = 'mesh_';
+const MESH_V2_OPCODE_PREFIX = 'meshV2_';
+
+/**
+ * Rewrite a single block's opcode in place if it belongs to legacy mesh.
+ * @param {object} block The block JSON.
+ * @returns {boolean} True if the block was modified.
+ */
+const migrateBlockOpcode = block => {
+    if (!block || typeof block.opcode !== 'string') return false;
+    if (!block.opcode.startsWith(MESH_V1_OPCODE_PREFIX)) return false;
+    block.opcode = MESH_V2_OPCODE_PREFIX + block.opcode.slice(MESH_V1_OPCODE_PREFIX.length);
+    return true;
+};
+
 /**
  * Detect if the project contains any legacy mesh blocks.
  * @param {object} projectJSON The project JSON to check.
@@ -13,7 +30,7 @@ const detectMeshV1Blocks = projectJSON => {
     for (const target of projectJSON.targets) {
         for (const blockId in target.blocks) {
             const block = target.blocks[blockId];
-            if (block.opcode && block.opcode.startsWith('mesh_')) {
+            if (block.opcode && block.opcode.startsWith(MESH_V1_OPCODE_PREFIX)) {
                 return true;
             }
         }
@@ -26,6 +43,35 @@ const detectKoshien = projectJSON => {
         return projectJSON.extensions.indexOf('koshien') !== -1;
     }
     return false;
+};
+
+/**
+ * Rewrite mesh v1 opcodes in place inside a sb3-style blocks object ({blockId: block}).
+ * @param {object} blocksObject The blocks object to mutate.
+ * @returns {boolean} True if any block was modified.
+ */
+const migrateMeshV1InBlocksObject = blocksObject => {
+    if (!blocksObject || typeof blocksObject !== 'object') return false;
+    let changed = false;
+    for (const blockId in blocksObject) {
+        if (migrateBlockOpcode(blocksObject[blockId])) changed = true;
+    }
+    return changed;
+};
+
+/**
+ * Rewrite mesh v1 opcodes in place inside an array of block JSON
+ * (backpack "code" payloads use this shape).
+ * @param {Array<object>} blockArray The array of block JSON to mutate.
+ * @returns {boolean} True if any block was modified.
+ */
+const migrateMeshV1InBlockArray = blockArray => {
+    if (!Array.isArray(blockArray)) return false;
+    let changed = false;
+    for (const block of blockArray) {
+        if (migrateBlockOpcode(block)) changed = true;
+    }
+    return changed;
 };
 
 /**
@@ -47,20 +93,57 @@ const migrateMeshV1Blocks = projectJSON => {
     }
 
     // Update opcodes
-    for (const target of newProjectJSON.targets) {
-        for (const blockId in target.blocks) {
-            const block = target.blocks[blockId];
-            if (block.opcode && block.opcode.startsWith('mesh_')) {
-                block.opcode = block.opcode.replace('mesh_', 'meshV2_');
-            }
+    if (Array.isArray(newProjectJSON.targets)) {
+        for (const target of newProjectJSON.targets) {
+            migrateMeshV1InBlocksObject(target.blocks);
         }
     }
 
     return newProjectJSON;
 };
 
+/**
+ * Migrate a sprite3 zip buffer (used by backpack sprite payloads). The zip's
+ * sprite.json `blocks` and `extensions` fields are rewritten if mesh v1 is found.
+ * @param {ArrayBuffer | Uint8Array} zipInput The sprite3 zip buffer.
+ * @returns {Promise<{changed: boolean, buffer: ArrayBuffer | Uint8Array}>}
+ *     Resolves with the new buffer (re-zipped only if changed). When unchanged,
+ *     the original buffer reference is returned to avoid wasted work.
+ */
+const migrateMeshV1InSprite3Zip = async zipInput => {
+    const zip = await JSZip.loadAsync(zipInput);
+    const spriteJsonFile = zip.file('sprite.json');
+    if (!spriteJsonFile) return { changed: false, buffer: zipInput };
+    const spriteJsonStr = await spriteJsonFile.async('string');
+    const spriteJson = JSON.parse(spriteJsonStr);
+
+    let changed = false;
+    if (spriteJson.blocks && migrateMeshV1InBlocksObject(spriteJson.blocks)) {
+        changed = true;
+    }
+    if (Array.isArray(spriteJson.extensions)) {
+        const replaced = spriteJson.extensions.map(ext => (ext === 'mesh' ? 'meshV2' : ext));
+        if (replaced.some((ext, i) => ext !== spriteJson.extensions[i])) {
+            spriteJson.extensions = replaced;
+            if (spriteJson.extensions.indexOf('meshV2') === -1) {
+                spriteJson.extensions.push('meshV2');
+            }
+            changed = true;
+        }
+    }
+
+    if (!changed) return { changed: false, buffer: zipInput };
+
+    zip.file('sprite.json', JSON.stringify(spriteJson));
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' });
+    return { changed: true, buffer };
+};
+
 module.exports = {
     detectMeshV1Blocks,
     detectKoshien,
     migrateMeshV1Blocks,
+    migrateMeshV1InBlockArray,
+    migrateMeshV1InBlocksObject,
+    migrateMeshV1InSprite3Zip,
 };

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -18,7 +18,13 @@ const formatMessage = require('format-message');
 
 const Variable = require('./engine/variable');
 const newBlockIds = require('./util/new-block-ids');
-const {detectMeshV1Blocks, detectKoshien, migrateMeshV1Blocks} = require('./serialization/smalruby-migration');
+const {
+    detectMeshV1Blocks,
+    detectKoshien,
+    migrateMeshV1Blocks,
+    migrateMeshV1InBlockArray,
+    migrateMeshV1InSprite3Zip,
+} = require('./serialization/smalruby-migration');
 
 const {loadCostume} = require('./import/load-costume.js');
 const {loadSound} = require('./import/load-sound.js');
@@ -420,6 +426,26 @@ class VirtualMachine extends EventEmitter {
         })
             .then(validatedInput => detectKoshien(validatedInput[0]))
             .catch(() => false);
+    }
+
+    /**
+     * Rewrite legacy mesh opcodes in a backpack "code" payload (array of block JSON)
+     * to mesh v2 opcodes. Mutates the array in place.
+     * @param {Array<object>} blockArray Backpack code payload.
+     * @returns {boolean} True if any block was modified.
+     */
+    migrateMeshV1InBackpackBlocks (blockArray) {
+        return migrateMeshV1InBlockArray(blockArray);
+    }
+
+    /**
+     * Rewrite legacy mesh opcodes inside a backpack sprite3 zip buffer.
+     * @param {ArrayBuffer | Uint8Array} zipBuffer Backpack sprite payload.
+     * @returns {Promise<{changed: boolean, buffer: ArrayBuffer | Uint8Array}>} The
+     *     possibly-rewritten buffer (original reference returned when unchanged).
+     */
+    migrateMeshV1InBackpackSprite (zipBuffer) {
+        return migrateMeshV1InSprite3Zip(zipBuffer);
     }
 
     /**
@@ -1312,6 +1338,8 @@ class VirtualMachine extends EventEmitter {
         const sb3 = require('./serialization/sb3');
 
         const copiedBlocks = JSON.parse(JSON.stringify(blocks));
+        // Mesh v1 service is gone; rewrite stray v1 opcodes so we never auto-load v1.
+        migrateMeshV1InBlockArray(copiedBlocks);
         newBlockIds(copiedBlocks);
         const target = this.runtime.getTargetById(targetId);
 

--- a/packages/scratch-vm/test/unit/smalruby_migration.js
+++ b/packages/scratch-vm/test/unit/smalruby_migration.js
@@ -1,10 +1,14 @@
 const test = require('tap').test;
 const path = require('path');
 const fs = require('fs');
+const JSZip = require('jszip');
 const {
     detectMeshV1Blocks,
     detectKoshien,
     migrateMeshV1Blocks,
+    migrateMeshV1InBlockArray,
+    migrateMeshV1InBlocksObject,
+    migrateMeshV1InSprite3Zip,
 } = require('../../src/serialization/smalruby-migration');
 
 const meshV1Project = JSON.parse(
@@ -52,4 +56,87 @@ test('migrateMeshV1Blocks', t => {
     t.ok(foundMeshV2, 'found at least one meshV2 block');
 
     t.end();
+});
+
+test('migrateMeshV1InBlockArray rewrites in place', t => {
+    const blocks = [
+        { opcode: 'mesh_getSensorValue', inputs: {}, fields: {} },
+        { opcode: 'mesh_menu_variableNames', inputs: {}, fields: {} },
+        { opcode: 'motion_movesteps', inputs: {}, fields: {} },
+    ];
+    const changed = migrateMeshV1InBlockArray(blocks);
+    t.equal(changed, true, 'reports changed');
+    t.equal(blocks[0].opcode, 'meshV2_getSensorValue', 'rewrites first opcode');
+    t.equal(blocks[1].opcode, 'meshV2_menu_variableNames', 'rewrites second opcode');
+    t.equal(blocks[2].opcode, 'motion_movesteps', 'leaves unrelated opcodes alone');
+    t.end();
+});
+
+test('migrateMeshV1InBlockArray returns false on no-op', t => {
+    const blocks = [{ opcode: 'meshV2_getSensorValue' }, { opcode: 'motion_movesteps' }];
+    t.equal(migrateMeshV1InBlockArray(blocks), false, 'no v1 opcodes -> no change');
+    t.equal(migrateMeshV1InBlockArray(null), false, 'null input -> no change');
+    t.equal(migrateMeshV1InBlockArray('not-an-array'), false, 'non-array input -> no change');
+    t.end();
+});
+
+test('migrateMeshV1InBlocksObject rewrites in place', t => {
+    const blocks = {
+        a: { opcode: 'mesh_getSensorValue' },
+        b: { opcode: 'mesh_menu_variableNames' },
+        c: { opcode: 'motion_movesteps' },
+    };
+    const changed = migrateMeshV1InBlocksObject(blocks);
+    t.equal(changed, true, 'reports changed');
+    t.equal(blocks.a.opcode, 'meshV2_getSensorValue', 'rewrites a');
+    t.equal(blocks.b.opcode, 'meshV2_menu_variableNames', 'rewrites b');
+    t.equal(blocks.c.opcode, 'motion_movesteps', 'leaves c alone');
+    t.end();
+});
+
+test('migrateMeshV1InSprite3Zip rewrites sprite.json', async t => {
+    const original = new JSZip();
+    original.file(
+        'sprite.json',
+        JSON.stringify({
+            name: 'スプライト1',
+            blocks: {
+                x: { opcode: 'mesh_getSensorValue' },
+                y: { opcode: 'mesh_menu_variableNames' },
+                z: { opcode: 'motion_movesteps' },
+            },
+            extensions: ['mesh'],
+        }),
+    );
+    original.file('asset/foo.svg', '<svg/>');
+    const buffer = await original.generateAsync({ type: 'arraybuffer' });
+
+    const { changed, buffer: newBuffer } = await migrateMeshV1InSprite3Zip(buffer);
+    t.equal(changed, true, 'reports changed');
+    t.not(newBuffer, buffer, 'returns a new buffer');
+
+    const reloaded = await JSZip.loadAsync(newBuffer);
+    const spriteJson = JSON.parse(await reloaded.file('sprite.json').async('string'));
+    t.equal(spriteJson.blocks.x.opcode, 'meshV2_getSensorValue', 'rewrites x');
+    t.equal(spriteJson.blocks.y.opcode, 'meshV2_menu_variableNames', 'rewrites y');
+    t.equal(spriteJson.blocks.z.opcode, 'motion_movesteps', 'leaves z alone');
+    t.ok(spriteJson.extensions.includes('meshV2'), 'extensions has meshV2');
+    t.notOk(spriteJson.extensions.includes('mesh'), 'extensions does not have mesh');
+    t.ok(reloaded.file('asset/foo.svg'), 'preserves other zip entries');
+});
+
+test('migrateMeshV1InSprite3Zip is no-op for v2 sprite', async t => {
+    const original = new JSZip();
+    original.file(
+        'sprite.json',
+        JSON.stringify({
+            blocks: { x: { opcode: 'meshV2_getSensorValue' } },
+            extensions: ['meshV2'],
+        }),
+    );
+    const buffer = await original.generateAsync({ type: 'arraybuffer' });
+
+    const { changed, buffer: newBuffer } = await migrateMeshV1InSprite3Zip(buffer);
+    t.equal(changed, false, 'reports unchanged');
+    t.equal(newBuffer, buffer, 'returns the same buffer reference');
 });


### PR DESCRIPTION
## Summary

Skyway（mesh v1 のバックエンド）のサービスが終了したため、以下を実装しました。

- **Phase 1**: 拡張機能ライブラリの一覧と検索から v1 を完全除外。VM 側の登録は保険として維持。`mesh_v1.*` Ruby を v2 ブロックに alias 化。
- **Phase 2**: プロジェクトロード時の `confirm()` を撤廃し、v1 検出時は強制マイグレーション + 事後 alert。
- **Phase 3**: バックパック（localStorage）を起動時に一度だけスキャンし、v1 を含む script / sprite を自動で v2 に書き換え。ブラウザ単位のフラグ管理で再実行を防止。`shareBlocksToTarget` に Lazy 保険を入れ、漏れた v1 opcode も即時書き換え。

詳細な設計と実装範囲は Issue #592 を参照。

## Changes Made

### scratch-vm
- `serialization/smalruby-migration.js` にヘルパー 3 関数追加: `migrateMeshV1InBlockArray`, `migrateMeshV1InBlocksObject`, `migrateMeshV1InSprite3Zip`
- `virtual-machine.js` で `vm.migrateMeshV1InBackpackBlocks` / `migrateMeshV1InBackpackSprite` を公開
- `shareBlocksToTarget` 冒頭に Lazy in-place migration を追加

### scratch-gui
- `lib/project-loader-utils.js`: `confirm()` 撤廃 → 強制マイグレーション + alert
- `lib/shared-messages.ts` + `locales/{en,ja,ja-Hira}.js`: `meshV1AutoMigrated` / `meshV1BackpackAutoMigrated` 翻訳追加
- `lib/libraries/extensions/index.jsx`: mesh v1 エントリ削除
- `lib/ruby-to-blocks-converter/mesh.js`: `mesh_v1.*` を v2 ブロックに alias
- `lib/backpack-mesh-v1-migration.js` (新規): localStorage バックパック eager 一括マイグレーション + フラグ管理
- `containers/backpack.jsx`: `componentDidMount` で eager 起動 (Smalruby マーカー付き)
- `.prettierignore` / `smalruby-prettier-files.md` / `smalruby-markers.md` 更新

## Test Coverage

- scratch-vm `smalruby_migration.js`: 既存 3 テスト + 新規 5 テスト = 33 アサーション
- scratch-gui `backpack-mesh-v1-migration.test.js` (新規): 6 テスト（script / sprite / 既マイグレーション / フラグ no-op / 不正 JSON）
- scratch-gui `ruby-to-blocks-converter/mesh.test.js`: 期待 opcode を v2 に更新
- 既存の `mesh-v1-migration` 統合テスト・`backpack.test.jsx`・`backpack-api.test.js` 全 pass

## Test Plan

- [ ] CI lint + unit + integration をすべて pass する
- [ ] 別 worktree で Playwright による手動検証（ユーザー側で実施）
  - [ ] 拡張機能チューザーから「Old Mesh」が消えていること（検索でもヒットしない）
  - [ ] v1 ブロックを含む `.sb3` をロードすると「自動で置き換えました」alert が出て、ブロックが v2 になっていること
  - [ ] Ruby タブで `mesh_v1.sensor_value("x")` と書くと `meshV2_getSensorValue` ブロックが生成されること
  - [ ] localStorage に v1 ブロックを含むバックパックエントリを仕込んで再読み込み → 件数 alert が出て v2 に書き換わっていること、フラグセット後は再走しないこと

## Related Issues

Fixes #592
