### PR TITLE
feat(gui): iPad landscape (1024x768) touch comfort polish (Phase 1)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -49,7 +49,9 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/components/gui/gui.jsx` | Redux action props prevention | Redux action props の伝播防止 |
 | `src/components/gui/gui.jsx` | iPad portrait narrow desktop stage size | 768〜1023px viewport で stage を small に強制 (issue #572 Phase 3-C) |
 | `src/components/gui/gui.css` | iPad portrait narrow desktop layout | 768〜1023px viewport で editor-wrapper の flex-basis を緩める (issue #572 Phase 3-C) |
-| `src/components/gui/gui.css` | narrow desktop legal links cleanup | 768〜1279px viewport でフィードバックリンク + セパレータを非表示 (issue #600) |
+| `src/components/gui/gui.css` | iPad portrait legal links cleanup | 768〜1023px viewport でフィードバックリンク + セパレータを非表示 (issue #600) |
+| `src/components/gui/gui.css` | narrow-height vertical chrome compression | max-height: 800px で body-wrapper / tab-list の高さを圧縮 (issue #600) |
+| `src/components/menu-bar/menu-bar.css` | narrow-height menu bar compression | max-height: 800px で menu-bar 48→40px に圧縮 (issue #600) |
 | `src/components/stage-header/stage-header.css` | touch-friendly stage controls | < 1280px viewport でステージサイズボタンを 40×40 に拡大 (issue #600) |
 | `src/components/green-flag/green-flag.css` | touch-friendly green flag | < 1280px viewport で実行ボタンを 40×40 に拡大 (issue #600) |
 | `src/components/stop-all/stop-all.css` | touch-friendly stop button | < 1280px viewport で停止ボタンを 40×40 に拡大 (issue #600) |

--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -49,6 +49,8 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/components/gui/gui.jsx` | Redux action props prevention | Redux action props の伝播防止 |
 | `src/components/gui/gui.jsx` | iPad portrait narrow desktop stage size | 768〜1023px viewport で stage を small に強制 (issue #572 Phase 3-C) |
 | `src/components/gui/gui.css` | iPad portrait narrow desktop layout | 768〜1023px viewport で editor-wrapper の flex-basis を緩める (issue #572 Phase 3-C) |
+| `src/components/gui/gui.css` | narrow desktop legal links cleanup | 768〜1279px viewport でフィードバックリンク + セパレータを非表示 (issue #600) |
+| `src/components/stage-header/stage-header.css` | touch-friendly stage controls | < 1280px viewport でステージサイズボタンを 40×40 に拡大 (issue #600) |
 | `src/playground/index.css` | narrow viewport vertical scroll lock | 狭幅画面で縦スクロールを overflow-y: clip で抑止 (issue #572 Phase 1) |
 | `src/playground/index.css` | iPad portrait min-width relax | 768〜1023px viewport の min-width: 1024px を緩めて横スクロールを抑止 (issue #572 Phase 3-C) |
 | `src/containers/gui.jsx` | smalrubot firmware modal | SmalrubotS1 ファームウェアモーダル state マッピング |

--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -51,6 +51,8 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/components/gui/gui.css` | iPad portrait narrow desktop layout | 768〜1023px viewport で editor-wrapper の flex-basis を緩める (issue #572 Phase 3-C) |
 | `src/components/gui/gui.css` | narrow desktop legal links cleanup | 768〜1279px viewport でフィードバックリンク + セパレータを非表示 (issue #600) |
 | `src/components/stage-header/stage-header.css` | touch-friendly stage controls | < 1280px viewport でステージサイズボタンを 40×40 に拡大 (issue #600) |
+| `src/components/green-flag/green-flag.css` | touch-friendly green flag | < 1280px viewport で実行ボタンを 40×40 に拡大 (issue #600) |
+| `src/components/stop-all/stop-all.css` | touch-friendly stop button | < 1280px viewport で停止ボタンを 40×40 に拡大 (issue #600) |
 | `src/playground/index.css` | narrow viewport vertical scroll lock | 狭幅画面で縦スクロールを overflow-y: clip で抑止 (issue #572 Phase 1) |
 | `src/playground/index.css` | iPad portrait min-width relax | 768〜1023px viewport の min-width: 1024px を緩めて横スクロールを抑止 (issue #572 Phase 3-C) |
 | `src/containers/gui.jsx` | smalrubot firmware modal | SmalrubotS1 ファームウェアモーダル state マッピング |

--- a/packages/scratch-gui/src/components/green-flag/green-flag.css
+++ b/packages/scratch-gui/src/components/green-flag/green-flag.css
@@ -24,3 +24,15 @@
 .green-flag.is-active {
     background-color: $looks-transparent;
 }
+
+/*
+ * === Smalruby: Start of touch-friendly green flag ===
+ * < 1280px (iPad landscape など) ではタッチ向けに 32→40 に拡大 (issue #600)。
+ */
+@media (max-width: 1279px) {
+    .green-flag {
+        width: 2.5rem;
+        height: 2.5rem;
+    }
+}
+/* === Smalruby: End of touch-friendly green flag === */

--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -126,6 +126,22 @@
     }
 }
 
+/* === Smalruby: Start of narrow desktop legal links cleanup === */
+/*
+    iPad portrait/landscape など 768〜1279px の narrow desktop では、
+    フィードバックリンクとセパレータを隠してタブ列をすっきりさせる。
+    プライバシーポリシーはコンプライアンス上残し、フィードバックは
+    メニューバーや別経路から到達できるため省略しても影響は小さい
+    (issue #600)。
+*/
+@media (min-width: 768px) and (max-width: 1279px) {
+    .feedback-link,
+    .link-separator {
+        display: none;
+    }
+}
+/* === Smalruby: End of narrow desktop legal links cleanup === */
+
 .tab {
     flex-grow: 1;
     height: 80%;

--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -126,21 +126,21 @@
     }
 }
 
-/* === Smalruby: Start of narrow desktop legal links cleanup === */
+/* === Smalruby: Start of iPad portrait legal links cleanup === */
 /*
-    iPad portrait/landscape など 768〜1279px の narrow desktop では、
-    フィードバックリンクとセパレータを隠してタブ列をすっきりさせる。
-    プライバシーポリシーはコンプライアンス上残し、フィードバックは
-    メニューバーや別経路から到達できるため省略しても影響は小さい
+    iPad portrait (768〜1023px) ではタブ列が狭く、
+    フィードバックリンク + セパレータを隠してすっきりさせる。
+    プライバシーポリシーはコンプライアンス上残す。
+    iPad landscape (1024+) では両方表示する余裕があるためそのまま
     (issue #600)。
 */
-@media (min-width: 768px) and (max-width: 1279px) {
+@media (min-width: 768px) and (max-width: 1023px) {
     .feedback-link,
     .link-separator {
         display: none;
     }
 }
-/* === Smalruby: End of narrow desktop legal links cleanup === */
+/* === Smalruby: End of iPad portrait legal links cleanup === */
 
 .tab {
     flex-grow: 1;
@@ -405,3 +405,21 @@ body .alerts-container {
     }
 }
 /* === Smalruby: End of iPad portrait narrow desktop layout === */
+
+/* === Smalruby: Start of narrow-height vertical chrome compression === */
+/*
+    iPad landscape (1024×768) など縦が短い viewport では、
+    menu-bar (48 → 40) と tab-list (44 → 36) を圧縮して
+    workspace の縦スペースを 16px 余分に稼ぐ。menu-bar 側の
+    height は menu-bar.css で揃えている (issue #600)。
+*/
+@media (max-height: 800px) {
+    .body-wrapper {
+        height: calc(100% - 2.5rem);
+    }
+    .tab-list,
+    .tab-list-container {
+        height: 2.25rem;
+    }
+}
+/* === Smalruby: End of narrow-height vertical chrome compression === */

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.css
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.css
@@ -31,6 +31,25 @@
     color: $ui-white;
 }
 
+/* === Smalruby: Start of narrow-height menu bar compression === */
+/*
+    iPad landscape (1024×768) など縦が短い viewport では menu bar を
+    48px → 40px に圧縮して workspace 縦を稼ぐ。`.body-wrapper` の
+    height calc も同じ閾値で揃える (gui.css 側で) (issue #600)。
+*/
+@media (max-height: 800px) {
+    .menu-bar {
+        height: 2.5rem;
+    }
+    .menu-bar-item {
+        height: 2.5rem;
+    }
+    .menu-bar-menu {
+        margin-top: 2.5rem;
+    }
+}
+/* === Smalruby: End of narrow-height menu bar compression === */
+
 .main-menu {
     display: flex;
     flex-direction: row;

--- a/packages/scratch-gui/src/components/stage-header/stage-header.css
+++ b/packages/scratch-gui/src/components/stage-header/stage-header.css
@@ -98,3 +98,18 @@
         filter: brightness(90%);
     }
 }
+
+/*
+ * === Smalruby: Start of touch-friendly stage controls ===
+ * iPad landscape (1024×768) など、横幅が 1280px 未満の narrow desktop /
+ * tablet 範囲では、ステージサイズトグル・フルスクリーンボタンを少し大きく
+ * してタップしやすくする (issue #600)。
+ */
+@media (max-width: 1279px) {
+    .stage-button {
+        width: calc(2.5rem + 2px);
+        height: calc(2.5rem + 2px);
+        padding: 0.5rem;
+    }
+}
+/* === Smalruby: End of touch-friendly stage controls === */

--- a/packages/scratch-gui/src/components/stop-all/stop-all.css
+++ b/packages/scratch-gui/src/components/stop-all/stop-all.css
@@ -27,3 +27,15 @@
 .stop-all.is-active {
     opacity: 1;
 }
+
+/*
+ * === Smalruby: Start of touch-friendly stop button ===
+ * < 1280px (iPad landscape など) ではタッチ向けに 32→40 に拡大 (issue #600)。
+ */
+@media (max-width: 1279px) {
+    .stop-all {
+        width: 2.5rem;
+        height: 2.5rem;
+    }
+}
+/* === Smalruby: End of touch-friendly stop button === */


### PR DESCRIPTION
## Summary

issue #600 — iPad landscape (1024×768) でタッチ操作 + ワークスペース効率を上げるための UI 細部調整。デスクトップ (≥ 1280px) は変更なし。

## Phase 1: タッチ快適化 (< 1280px viewport)

| ファイル | 変更 |
|---------|------|
| `stage-header.css` | ステージサイズトグル + フルスクリーンボタン 32×32 → 40×40 |
| `green-flag.css` | 実行ボタン 32×32 → 40×40 |
| `stop-all.css` | 停止ボタン 32×32 → 40×40 |

タブレットの指で押しやすくする。1280px 以上は元の 32×32 のまま。

## Phase 2: 縦 chrome 圧縮 (max-height: 800px)

| ファイル | 変更 |
|---------|------|
| `menu-bar.css` | menu-bar 48 → 40px |
| `gui.css` | tab-list 44 → 36px、body-wrapper の calc も追従 |

iPad landscape (1024×768) など縦が短い viewport で workspace 縦に **+16px** 余裕を作る (637 → 653)。1280×900 など縦が大きい viewport は変更なし。

## Phase 3: iPad portrait の legal links 整理 (768〜1023px)

| ファイル | 変更 |
|---------|------|
| `gui.css` | iPad portrait (768〜1023px) のみフィードバックリンク + セパレータを非表示。iPad landscape (1024+) ではタブ列に両方表示する余裕があるため両方残す |

既存の `feedback-link.test.js` integration test (Selenium 1024px) も pass する。

## 動作確認 (Playwright MCP)

| viewport | 結果 |
|---------|------|
| 1024×768 (iPad landscape) | ✅ 全タッチボタン拡大、menu/tab 圧縮で workspace +16px、両方のリンク表示 |
| 768×1024 (iPad portrait) | ✅ Phase 3-C の small stage を維持、フィードバック非表示で整理 |
| 1280×900 (desktop) | ✅ 完全に元のまま (32×32 ボタン、48px menu、44px tab、両リンク表示) |

Code/Costumes/Sounds/Ruby タブすべて確認済み。lint pass、prettier pass。

## Markers

| ファイル | 機能名 |
|---------|--------|
| `stage-header.css` | touch-friendly stage controls |
| `green-flag.css` | touch-friendly green flag |
| `stop-all.css` | touch-friendly stop button |
| `gui.css` | iPad portrait legal links cleanup |
| `gui.css` | narrow-height vertical chrome compression |
| `menu-bar.css` | narrow-height menu bar compression |

## Related

- #600 (iPad landscape の細部調整 issue)
- 直前: PR #598 (iPad portrait Phase 3-C/3-D)
