### PR TITLE
feat(gui): iPad mini portrait support + legal links cleanup (#599)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -47,16 +47,16 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/components/gui/gui.jsx` | classroom modal | クラスルームモーダルの import と配置 |
 | `src/components/gui/gui.jsx` | narrow screen warning | 狭幅画面警告バナーの import と配置 (issue #572 Phase 1) |
 | `src/components/gui/gui.jsx` | Redux action props prevention | Redux action props の伝播防止 |
-| `src/components/gui/gui.jsx` | iPad portrait narrow desktop stage size | 768〜1023px viewport で stage を small に強制 (issue #572 Phase 3-C) |
-| `src/components/gui/gui.css` | iPad portrait narrow desktop layout | 768〜1023px viewport で editor-wrapper の flex-basis を緩める (issue #572 Phase 3-C) |
-| `src/components/gui/gui.css` | iPad portrait legal links cleanup | 768〜1023px viewport でフィードバックリンク + セパレータを非表示 (issue #600) |
+| `src/components/gui/gui.jsx` | iPad portrait narrow desktop stage size | 744〜1023px viewport で stage を small に強制 (issue #572 Phase 3-C, #599 で 768→744 拡張) |
+| `src/components/gui/gui.css` | iPad portrait narrow desktop layout | 744〜1023px viewport で editor-wrapper の flex-basis を緩める (issue #572 Phase 3-C, #599 で 768→744 拡張) |
+| `src/components/gui/gui.css` | iPad portrait legal links cleanup | 744〜1023px viewport でフィードバックリンク + セパレータを非表示 (issue #600, #599 で 768→744 拡張) |
 | `src/components/gui/gui.css` | narrow-height vertical chrome compression | max-height: 800px で body-wrapper / tab-list の高さを圧縮 (issue #600) |
 | `src/components/menu-bar/menu-bar.css` | narrow-height menu bar compression | max-height: 800px で menu-bar 48→40px に圧縮 (issue #600) |
 | `src/components/stage-header/stage-header.css` | touch-friendly stage controls | < 1280px viewport でステージサイズボタンを 40×40 に拡大 (issue #600) |
 | `src/components/green-flag/green-flag.css` | touch-friendly green flag | < 1280px viewport で実行ボタンを 40×40 に拡大 (issue #600) |
 | `src/components/stop-all/stop-all.css` | touch-friendly stop button | < 1280px viewport で停止ボタンを 40×40 に拡大 (issue #600) |
 | `src/playground/index.css` | narrow viewport vertical scroll lock | 狭幅画面で縦スクロールを overflow-y: clip で抑止 (issue #572 Phase 1) |
-| `src/playground/index.css` | iPad portrait min-width relax | 768〜1023px viewport の min-width: 1024px を緩めて横スクロールを抑止 (issue #572 Phase 3-C) |
+| `src/playground/index.css` | iPad portrait min-width relax | 744〜1023px viewport の min-width: 1024px を緩めて横スクロールを抑止 (issue #572 Phase 3-C, #599 で 768→744 拡張) |
 | `src/containers/gui.jsx` | smalrubot firmware modal | SmalrubotS1 ファームウェアモーダル state マッピング |
 | `src/containers/gui.jsx` | classroom modal | クラスルームモーダル state マッピング |
 | `src/containers/gui.jsx` | classcode auto-open | クラスコード URL パラメーターによるモーダル自動オープン |

--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -119,7 +119,7 @@
     text-decoration: underline;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 743px) {
     .feedback-link,
     .link-separator {
         display: none;
@@ -128,15 +128,17 @@
 
 /* === Smalruby: Start of iPad portrait legal links cleanup === */
 /*
-    iPad portrait (768〜1023px) ではタブ列が狭く、
-    フィードバックリンク + セパレータを隠してすっきりさせる。
-    プライバシーポリシーはコンプライアンス上残す。
-    iPad landscape (1024+) では両方表示する余裕があるためそのまま
-    (issue #600)。
+    iPad mini / iPad portrait (744〜1023px) ではタブ列が狭く、
+    legal-links がタブ列に重なってプライバシーポリシーの先頭文字が
+    隠れる。すべてのリンク (privacy + separator + feedback) を非表示
+    にして整理する。これらは iPad landscape (1024+) や PC では引き続き
+    表示される。プライバシーポリシーは smalruby.app のフッターからも
+    アクセス可能 (issue #600, #599)。
 */
-@media (min-width: 768px) and (max-width: 1023px) {
-    .feedback-link,
-    .link-separator {
+@media (min-width: 744px) and (max-width: 1023px) {
+    .privacy-link,
+    .link-separator,
+    .feedback-link {
         display: none;
     }
 }
@@ -393,12 +395,13 @@ body .alerts-container {
 
 /* === Smalruby: Start of iPad portrait narrow desktop layout === */
 /*
-    iPad portrait (768x1024) などの narrow desktop 範囲では、
-    editor-wrapper の flex-basis を relax して stage 列の幅に応じて
-    縮められるようにする。stageSize 自体は gui.jsx 側で small に
-    強制するため、stage 列は ~250px に収まる (issue #572 Phase 3-C)。
+    iPad mini portrait (744x1133) / iPad portrait (768x1024) などの
+    narrow desktop 範囲では、editor-wrapper の flex-basis を relax して
+    stage 列の幅に応じて縮められるようにする。stageSize 自体は gui.jsx
+    側で small に強制するため、stage 列は ~250px に収まる
+    (issue #572 Phase 3-C, 閾値を issue #599 で 768→744 に拡張)。
 */
-@media (min-width: 768px) and (max-width: 1023px) {
+@media (min-width: 744px) and (max-width: 1023px) {
     .editor-wrapper {
         flex-basis: 0;
         flex-shrink: 1;

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -301,10 +301,11 @@ const GUIComponent = props => {
 
     return (<MediaQuery minWidth={layout.fullSizeMinWidth}>{isFullSize => (
         // === Smalruby: Start of iPad portrait narrow desktop stage size ===
-        // 768〜1023px (iPad portrait など) の narrow desktop では、
-        // 480px / 408px / 360px の stage を維持すると viewport に収まらないため、
-        // stage を 240x180 (small) に強制する。
-        <MediaQuery maxWidth={1023} minWidth={768}>{isNarrowDesktop => {
+        // 744〜1023px (iPad mini portrait / iPad portrait など) の narrow desktop
+        // では、480px / 408px / 360px の stage を維持すると viewport に収まらない
+        // ため、stage を 240x180 (small) に強制する。閾値は issue #599 で 768→744
+        // に拡張 (iPad mini portrait をカバー)。
+        <MediaQuery maxWidth={1023} minWidth={744}>{isNarrowDesktop => {
             const baseStageSize = resolveStageSize(stageSizeMode, isFullSize);
             const stageSize = isNarrowDesktop ? STAGE_DISPLAY_SIZES.small : baseStageSize;
             // === Smalruby: End of iPad portrait narrow desktop stage size ===

--- a/packages/scratch-gui/src/lib/use-is-narrow-screen.js
+++ b/packages/scratch-gui/src/lib/use-is-narrow-screen.js
@@ -6,12 +6,16 @@ import { useEffect, useState } from 'react';
  * issue #572 のレスポンシブ対応で、PC レイアウトと別 UI を出し分ける際の
  * 共通ブレークポイントとして使用する。
  *
- * 検出条件: viewport の幅 ≤ 767px または高さ ≤ 500px。
+ * 検出条件: viewport の幅 ≤ 743px または高さ ≤ 500px。
  * これにより、スマホ縦持ち (例 390x844) も横持ち (例 844x390) も同じ
  * mobile UI が出る (Phase 2-I で横固定運用に切り替えたため)。
+ * iPad mini portrait (744×1133) は閾値を上回って desktop UI を出す
+ * (issue #599)。
  *
- * - スマホ縦持ち (390x844): width 390 ≤ 767 → match
+ * - スマホ縦持ち (390x844): width 390 ≤ 743 → match
  * - スマホ横持ち (844x390): height 390 ≤ 500 → match
+ * - iPad mini portrait (744x1133): 両方 > 閾値 → no match (desktop UI)
+ * - iPad portrait (768x1024): 両方 > 閾値 → no match (desktop UI)
  * - タブレット (820x1180 / 1180x820): 両方 > 閾値 → no match (desktop UI)
  * - PC (1920x1080): 両方 > 閾値 → no match (desktop UI)
  *
@@ -23,7 +27,7 @@ import { useEffect, useState } from 'react';
  * 整合性は保たれる。
  * @returns {boolean} スマホ相当のサイズなら true
  */
-const NARROW_SCREEN_QUERY = '(max-width: 767px), (max-height: 500px)';
+const NARROW_SCREEN_QUERY = '(max-width: 743px), (max-height: 500px)';
 
 const useIsNarrowScreen = () => {
     const [isNarrow, setIsNarrow] = useState(() => {

--- a/packages/scratch-gui/src/playground/index.css
+++ b/packages/scratch-gui/src/playground/index.css
@@ -16,7 +16,7 @@ body,
 /* よって body が viewport より縦に伸びてしまい、ページ全体が縦スクロール */
 /* 可能になっていた。横スクロール (1024px min-width) は残したいので、 */
 /* overflow-y: clip だけ当てる (clip は overflow-x への副作用がない)。 */
-@media (max-width: 767px) {
+@media (max-width: 743px) {
     html,
     body {
         overflow-y: clip;
@@ -25,15 +25,16 @@ body,
 /* === Smalruby: End of narrow viewport vertical scroll lock === */
 
 /* === Smalruby: Start of iPad portrait min-width relax === */
-/* iPad portrait (768x1024) など、横幅が 1024px 未満で 768px 以上の */
-/* デスクトップレイアウト範囲では、min-width: 1024px を緩めて横スクロール */
-/* なしで GUI が表示されるようにする。レイアウト調整は gui.css と     */
-/* gui.jsx の Smalruby マーカーで行う (issue #572 Phase 3-C)。       */
-@media (min-width: 768px) and (max-width: 1023px) {
+/* iPad mini portrait (744x1133) / iPad portrait (768x1024) など、    */
+/* 横幅が 1024px 未満で 744px 以上のデスクトップレイアウト範囲では、 */
+/* min-width: 1024px を緩めて横スクロールなしで GUI が表示されるように  */
+/* する。レイアウト調整は gui.css と gui.jsx の Smalruby マーカーで    */
+/* 行う (issue #572 Phase 3-C, 閾値を issue #599 で 768→744 に拡張)。 */
+@media (min-width: 744px) and (max-width: 1023px) {
     html,
     body,
     .app {
-        min-width: 768px;
+        min-width: 744px;
     }
 }
 /* === Smalruby: End of iPad portrait min-width relax === */


### PR DESCRIPTION
## Summary

issue #599 — iPad portrait の細部調整。**iPad mini portrait (744×1133) を desktop layout 対象に拡張**しつつ、narrow desktop でタブと重なっていた legal links を整理。

## 変更内容

### 1. iPad mini portrait (744×1133) サポート — 閾値 768 → 744

iPad mini portrait は元々 `useIsNarrowScreen` (max-width: 767) に引っかかってモバイル警告バナーが出ていた。Phase 3-C の閾値も 768 だったため、レイアウト調整が適用されず、`min-width: 1024` で横スクロールが発生していた。

| ファイル | 変更 |
|---------|------|
| `use-is-narrow-screen.js` | `max-width: 767px` → `max-width: 743px` |
| `playground/index.css` | scroll lock / min-width relax を 744 から |
| `gui.css` | editor-wrapper flex / legal links cleanup を 744 から |
| `gui.jsx` | narrow desktop stage size MediaQuery を 744 から |

### 2. legal links のタブ重なり修正

iPad mini portrait (744×1133) で発見: tabs と legal-links が同じ flex 行に並んでおり、ルビータブの右端と「プライバシーポリシー」の左端が重なって "イバシーポリシー" のように先頭が隠れていた。

修正: 744〜1023px の narrow desktop では、`privacy-link` + `link-separator` + `feedback-link` の **3 つすべて** を非表示にしてタブ列を整理。プライバシーポリシーは smalruby.app のフッターからもアクセス可能。

## 動作確認 (Playwright MCP)

| viewport | 結果 |
|---------|------|
| 744×1133 (iPad mini portrait) | ✅ 警告バナーなし。stage 240×180、tabs 整理 (legal links 非表示)、横スクロールなし |
| 768×1024 (iPad portrait) | ✅ 既存の動作と同じ (legal links を全て非表示にする以外) |
| 1024×768 (iPad landscape) | ✅ プライバシー + フィードバック両方表示 (元のまま) |
| 720×1280 (閾値以下) | ✅ モバイル警告バナー表示、min-width: 1024 で fallback |

unit tests: `use-is-narrow-screen.test.js` 3/3, `narrow-screen-warning.test.jsx` 5/5 pass。lint pass。

## 残課題 (#599 で未対応)

- **sprite-info pane の 大きさ/向き 切れ** — Phase 3-C で stage を small に強制した結果、upstream の sprite-info が secondary row (visibility/大きさ/向き) を意図的に省略する仕様。これは "切れ" ではなく仕様。別 issue に切り出すか、後続 PR で iPad portrait 用の 3 行版 sprite-info を実装するかを検討予定。

## Related

- #599 (iPad portrait polish)
- #572 Phase 3-C / #600 を踏まえた拡張
- 直前: PR #598, PR #601
