### PR TITLE
fix(gui): Ruby tab で stage 列が viewport 外にはみ出す bug 修正 (#602)

### DIFF
--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css
@@ -101,7 +101,14 @@
 
 .commandWrapper {
     position: relative;
-    min-width: 300px;
+    /*
+     * 旧 min-width: 300px は narrow desktop (iPad landscape 1024×768) で
+     * ruby-toolbar の min-content 幅を ~860px に押し上げ、editor-wrapper が
+     * 必要以上に grow して stage 列が viewport 外にはみ出す原因だった
+     * (issue #602)。min-width を緩めて flex で shrink できるようにする。
+     */
+    min-width: 0;
+    flex: 1 1 auto;
     max-width: 500px;
 }
 


### PR DESCRIPTION
## Summary

issue #602 — iPad landscape (1024×768) など narrow desktop の Ruby タブで、stage 列が極端に狭くなり sprite-info pane が viewport 外にはみ出していたバグを修正。

## 原因

`packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.css` の `.commandWrapper` (スプライト検索入力) に `min-width: 300px` が設定されていた。これにより:

```
ruby-toolbar の min-content 幅: 41 + 109 + 43 + 372 + 161 + 32 = ~860px
```

editor-wrapper (`flex-grow: 1, flex-shrink: 0, min-width: auto`) は内側コンテンツの min-content 幅に引っ張られて広がり、結果 stage 列が圧縮された。

```
[1024px viewport]
| editor 861.5 ← min-content の引力で広がる
                 | stage 列 162.5 (natural 378 が overflow)
                                   stage 列右端 = 1239.5 (viewport を 215.5 超過)
```

sprite-info pane (280px) は stage 列内に収まりきらず、`向き` ラベル + 入力欄が viewport 外に。

## 修正

`commandWrapper` に flex shrink を許可:

```diff
 .commandWrapper {
     position: relative;
-    min-width: 300px;
+    min-width: 0;
+    flex: 1 1 auto;
     max-width: 500px;
 }
```

- `min-width: 0` で flex container 内で shrink 可能に
- `flex: 1 1 auto` で余裕があれば伸び、足りなければ縮む

これで ruby-toolbar の min-content 幅は editor-wrapper の flex-basis (~598px) と同程度まで縮められる。

## 検証 (Playwright MCP)

| viewport | tab | editor-wrapper | stage 列 | sprite-info 表示 |
|---------|------|----------------|---------|------------------|
| 1024×768 (iPad landscape) | Ruby | 861.5 → **646** ✅ | 162 → **378** ✅ | 切れ → **全表示** ✅ |
| 1024×768 | Code | 646 → 646 (変化なし) | 378 → 378 | 全表示 |
| 1280×800 (desktop) | Ruby | 元のまま | 元のまま | 全表示 |
| 768×1024 (iPad portrait) | Ruby | small stage と組み合わせて正常 | 290 | 仕様通り compact |

ruby-tab integration test (7/7 pass)、lint + prettier pass。

## Related

- Closes #602
- 関連: #572 Phase 3 系列、#599 / #600 / #601 / #603
