### PR TITLE
revert(gui): remove touch-friendly button enlargements at < 1280px

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -52,9 +52,6 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/components/gui/gui.css` | iPad portrait legal links cleanup | 744〜1023px viewport でフィードバックリンク + セパレータを非表示 (issue #600, #599 で 768→744 拡張) |
 | `src/components/gui/gui.css` | narrow-height vertical chrome compression | max-height: 800px で body-wrapper / tab-list の高さを圧縮 (issue #600) |
 | `src/components/menu-bar/menu-bar.css` | narrow-height menu bar compression | max-height: 800px で menu-bar 48→40px に圧縮 (issue #600) |
-| `src/components/stage-header/stage-header.css` | touch-friendly stage controls | < 1280px viewport でステージサイズボタンを 40×40 に拡大 (issue #600) |
-| `src/components/green-flag/green-flag.css` | touch-friendly green flag | < 1280px viewport で実行ボタンを 40×40 に拡大 (issue #600) |
-| `src/components/stop-all/stop-all.css` | touch-friendly stop button | < 1280px viewport で停止ボタンを 40×40 に拡大 (issue #600) |
 | `src/playground/index.css` | narrow viewport vertical scroll lock | 狭幅画面で縦スクロールを overflow-y: clip で抑止 (issue #572 Phase 1) |
 | `src/playground/index.css` | iPad portrait min-width relax | 744〜1023px viewport の min-width: 1024px を緩めて横スクロールを抑止 (issue #572 Phase 3-C, #599 で 768→744 拡張) |
 | `src/containers/gui.jsx` | smalrubot firmware modal | SmalrubotS1 ファームウェアモーダル state マッピング |

--- a/packages/scratch-gui/src/components/green-flag/green-flag.css
+++ b/packages/scratch-gui/src/components/green-flag/green-flag.css
@@ -24,15 +24,3 @@
 .green-flag.is-active {
     background-color: $looks-transparent;
 }
-
-/*
- * === Smalruby: Start of touch-friendly green flag ===
- * < 1280px (iPad landscape など) ではタッチ向けに 32→40 に拡大 (issue #600)。
- */
-@media (max-width: 1279px) {
-    .green-flag {
-        width: 2.5rem;
-        height: 2.5rem;
-    }
-}
-/* === Smalruby: End of touch-friendly green flag === */

--- a/packages/scratch-gui/src/components/stage-header/stage-header.css
+++ b/packages/scratch-gui/src/components/stage-header/stage-header.css
@@ -98,18 +98,3 @@
         filter: brightness(90%);
     }
 }
-
-/*
- * === Smalruby: Start of touch-friendly stage controls ===
- * iPad landscape (1024×768) など、横幅が 1280px 未満の narrow desktop /
- * tablet 範囲では、ステージサイズトグル・フルスクリーンボタンを少し大きく
- * してタップしやすくする (issue #600)。
- */
-@media (max-width: 1279px) {
-    .stage-button {
-        width: calc(2.5rem + 2px);
-        height: calc(2.5rem + 2px);
-        padding: 0.5rem;
-    }
-}
-/* === Smalruby: End of touch-friendly stage controls === */

--- a/packages/scratch-gui/src/components/stop-all/stop-all.css
+++ b/packages/scratch-gui/src/components/stop-all/stop-all.css
@@ -27,15 +27,3 @@
 .stop-all.is-active {
     opacity: 1;
 }
-
-/*
- * === Smalruby: Start of touch-friendly stop button ===
- * < 1280px (iPad landscape など) ではタッチ向けに 32→40 に拡大 (issue #600)。
- */
-@media (max-width: 1279px) {
-    .stop-all {
-        width: 2.5rem;
-        height: 2.5rem;
-    }
-}
-/* === Smalruby: End of touch-friendly stop button === */


### PR DESCRIPTION
## Summary

PR #601 で追加した narrow desktop (< 1280px) 向けのボタン拡大 3 件を取り消します。

## 取り消し理由 (ユーザフィードバック)

1. 元のサイズでも十分押せる
2. upstream に追従するコストが上がる (CSS の divergence が増える)
3. PC で見たときに違和感がある (1280px 以下のラップトップで)

## 取り消した変更

| ファイル | 取り消した Smalruby マーカー |
|---------|------------------------------|
| `stage-header.css` | touch-friendly stage controls (40×40) |
| `green-flag.css` | touch-friendly green flag (40×40) |
| `stop-all.css` | touch-friendly stop button (40×40) |

すべて Smalruby マーカーで囲まれていたので削除のみ、upstream に完全に戻る。

## 残す変更 (#600 関連)

以下は引き続き有効:

- `gui.css` iPad portrait legal links cleanup (744〜1023px)
- `gui.css` narrow-height vertical chrome compression (max-height: 800px)
- `menu-bar.css` narrow-height menu bar compression (max-height: 800px)

## 動作確認

iPad landscape (1024×768) で全ボタンが upstream サイズ (32〜34px) に戻ったことを Playwright MCP で確認。lint pass。

## Related

- 取り消し対象: PR #601 (Phase 1 タッチ快適化)
- issue #600 (Phase 2/3 の調整は維持)
