### PR TITLE
refactor(gui): clean up SP/iPad code comments (remove phase markers + what-only)

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.css
+++ b/packages/scratch-gui/src/components/gui/gui.css
@@ -133,7 +133,7 @@
     隠れる。すべてのリンク (privacy + separator + feedback) を非表示
     にして整理する。これらは iPad landscape (1024+) や PC では引き続き
     表示される。プライバシーポリシーは smalruby.app のフッターからも
-    アクセス可能 (issue #600, #599)。
+    アクセス可能。
 */
 @media (min-width: 744px) and (max-width: 1023px) {
     .privacy-link,
@@ -398,8 +398,7 @@ body .alerts-container {
     iPad mini portrait (744x1133) / iPad portrait (768x1024) などの
     narrow desktop 範囲では、editor-wrapper の flex-basis を relax して
     stage 列の幅に応じて縮められるようにする。stageSize 自体は gui.jsx
-    側で small に強制するため、stage 列は ~250px に収まる
-    (issue #572 Phase 3-C, 閾値を issue #599 で 768→744 に拡張)。
+    側で small に強制するため、stage 列は ~250px に収まる。
 */
 @media (min-width: 744px) and (max-width: 1023px) {
     .editor-wrapper {
@@ -414,7 +413,7 @@ body .alerts-container {
     iPad landscape (1024×768) など縦が短い viewport では、
     menu-bar (48 → 40) と tab-list (44 → 36) を圧縮して
     workspace の縦スペースを 16px 余分に稼ぐ。menu-bar 側の
-    height は menu-bar.css で揃えている (issue #600)。
+    height は menu-bar.css で揃えている。
 */
 @media (max-height: 800px) {
     .body-wrapper {

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -300,8 +300,7 @@ const GUIComponent = props => {
         // === Smalruby: Start of iPad portrait narrow desktop stage size ===
         // 744〜1023px (iPad mini portrait / iPad portrait など) の narrow desktop
         // では、480px / 408px / 360px の stage を維持すると viewport に収まらない
-        // ため、stage を 240x180 (small) に強制する。閾値は issue #599 で 768→744
-        // に拡張 (iPad mini portrait をカバー)。
+        // ため、stage を 240x180 (small) に強制する。
         <MediaQuery maxWidth={1023} minWidth={744}>{isNarrowDesktop => {
             const baseStageSize = resolveStageSize(stageSizeMode, isFullSize);
             const stageSize = isNarrowDesktop ? STAGE_DISPLAY_SIZES.small : baseStageSize;

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.css
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.css
@@ -35,7 +35,7 @@
 /*
     iPad landscape (1024×768) など縦が短い viewport では menu bar を
     48px → 40px に圧縮して workspace 縦を稼ぐ。`.body-wrapper` の
-    height calc も同じ閾値で揃える (gui.css 側で) (issue #600)。
+    height calc も同じ閾値で揃える (gui.css 側で)。
 */
 @media (max-height: 800px) {
     .menu-bar {

--- a/packages/scratch-gui/src/components/mobile-bottom-tabs/mobile-bottom-tabs.jsx
+++ b/packages/scratch-gui/src/components/mobile-bottom-tabs/mobile-bottom-tabs.jsx
@@ -61,18 +61,12 @@ const SPRITE_KEY = 'sprite';
  * 5 つのモバイル用ボトムタブ:
  *   スプライト / コード / コスチューム / 音 / ルビー
  *
- * - コード / コスチューム / 音 / ルビー は upstream の `editorTab` Redux に
- *   ディスパッチして既存タブを切り替える。アイコン・ラベルは upstream の
- *   <Tab> と同じ SVG / 翻訳キーを再利用 (`gui.gui.codeTab` 等)
- * - スプライトタブは mobile 固有の placeholder
+ * コード / コスチューム / 音 / ルビー は upstream の `editorTab` Redux に
+ * ディスパッチして既存タブを切り替える。スプライトタブは mobile 固有で、
+ * active state は親 (MobileGui) で `<MobileSpritePanel>` と共有する。
  *
- * 全画面 (isFullScreen=true) のときはステージプレビューに専念するため
- * ボトムタブを隠す (PR-2C で追加)。
- *
+ * 全画面時はステージプレビューに専念するためボトムタブを隠す。
  * 表示位置は `position: fixed` + `visualViewport` API で viewport 下端に追従。
- *
- * Phase 2-F: スプライトタブの active state を親 (MobileGui) に持ち上げ、
- * `<MobileSpritePanel>` の表示制御と共有する。
  * @param {object} props - props
  * @param {number} props.activeTabIndex - 現在の editorTab Redux 値
  * @param {boolean} props.isFullScreen - upstream の fullscreen mode フラグ

--- a/packages/scratch-gui/src/components/mobile-drawer/mobile-drawer.jsx
+++ b/packages/scratch-gui/src/components/mobile-drawer/mobile-drawer.jsx
@@ -175,7 +175,7 @@ const hasV2Features = vm => {
 };
 
 /**
- * Mobile 用ドロワー (ハンバーガーメニュー本体, issue #572 Phase 3-A)。
+ * Mobile 用ドロワー (ハンバーガーメニュー本体)。
  *
  * MobileSideRail の ☰ から開閉する。Desktop メニューバーと同等の主要機能を
  * 折りたたみ可能なツリー形式で提供する:
@@ -537,9 +537,8 @@ const MobileDrawerComponent = ({
                      * これらは「セクション」ではなく単独のトップレベル項目なので、
                      * sectionTitle は付けず menuItem だけ並べる。
                      *
-                     * チュートリアル (Tips Library) は SP では非対応 (PR #595):
-                     * カードコンテンツの cards.jsx が SP のレイアウトに合わない
-                     * (固定幅、複数列、画像中心) ため。
+                     * チュートリアル (Tips Library) は SP 非対応:
+                     * cards.jsx が固定幅・複数列・画像中心で SP レイアウトに合わない。
                      */}
                     {classroomEnabled && (
                         <li>

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
@@ -147,9 +147,7 @@
 }
 
 /*
- * バックパックを開いた状態 (Phase 3-B):
- * - サイドレールの右側 (left: 56px) から右端まで横全幅
- * - 画面下部に固定 (position: fixed)
+ * バックパックを開いた状態:
  * - 高さは max 35vh + min 140px で、本文エリアを大きく削らない
  * - z-index は 200。各タブコンテンツ (paint canvas / sound waveform /
  *   Monaco など、それぞれ z-index ≦100) より確実に上に乗せる一方、
@@ -160,8 +158,8 @@
  */
 :global(body.smalruby-mobile-mode.smalruby-mobile-backpack-open [class*="backpack_backpack-container"]) {
     /*
-     * Phase 3-B fix: position: fixed をやめて editor-wrapper の flex column
-     * 内に正しく組み込む。これによって:
+     * editor-wrapper の flex column 内に組み込む (position: fixed ではなく
+     * relative)。これによって:
      * - Blockly workspace の injectionDiv が backpack の高さぶん縮む
      * - scratch-blocks の `areBlocksOverGui` 判定で backpack 領域は
      *   workspace 外と認識され、`BLOCK_DRAG_END` がブロック付きで発火する
@@ -229,7 +227,7 @@
 }
 
 /* ------------------------------------------------------------ */
-/* 4b. paint-editor の縦スクロール構成 (Phase 2-J Stage 1)         */
+/* 4b. paint-editor の縦スクロール構成                             */
 /*                                                                */
 /* 横向き iPhone の編集エリア縦 ~390px に対し、コスチュームエディタ */
 /* の最小要求は ~520px (上部 toolbar 104 + 中央 380 + 下部 36)。    */
@@ -321,18 +319,13 @@
 /* ------------------------------------------------------------ */
 /* 5. MobileSideRail (左 56px 固定) のぶん body-wrapper を左にずらす */
 /*                                                                */
-/* Phase 2-J で MobileTopBar / MobileBottomTabs を廃止し、左 56px  */
-/* の縦サイドレールに ☰ + ▶ + 5 タブを集約。これにより編集エリアは */
+/* 縦サイドレールに ☰ + ▶ + 5 タブを集約。これにより編集エリアは */
 /* 縦 100vh をフルに使える (上流 paint/sound エディタの縦最低高さに */
 /* 対応)。                                                          */
 /*                                                                */
 /* 56px は「スプライト」「コスチューム」のラベルが ... に省略され */
 /* ない最小幅 (label font-size: 7px 前提)。詳細は                  */
 /* mobile-side-rail.css のコメント参照。                            */
-/*                                                                */
-/* MobileMenuBar 非表示済みなので body-wrapper は y=0 から開始。    */
-/* 縦は 100vh を確保し、横はサイドレール 56px を padding-left で    */
-/* 空ける。                                                          */
 /* ------------------------------------------------------------ */
 :global(body.smalruby-mobile-mode [class*="gui_body-wrapper"]) {
     padding-left: 56px;
@@ -341,7 +334,7 @@
 }
 
 /* ------------------------------------------------------------ */
-/* 6. 各種モーダルを SP では全画面化 (Phase 3-A2)                  */
+/* 6. 各種モーダルを SP では全画面化                                */
 /*                                                                */
 /* スマホは画面の縦が 390-450px しか無いので、デフォルトの         */
 /* `margin: 100px auto` + `max-height: calc(100vh - 170px)` が    */
@@ -354,9 +347,9 @@
 /* 背景ライブラリなど。                                            */
 /*                                                                */
 /* SP では非対応 (ドロワーから削除済み):                            */
-/* - ブロック表示 (PR #594)                                        */
+/* - ブロック表示                                                  */
 /* - チュートリアル (Tips Library): カードコンテンツ自体が SP の  */
-/*   レイアウトに合わないため (PR #595)                            */
+/*   レイアウトに合わないため                                      */
 /* ------------------------------------------------------------ */
 
 /*

--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.jsx
@@ -20,33 +20,13 @@ import MobileSpritePanel from '../mobile-sprite-panel/mobile-sprite-panel.jsx';
 import './mobile-gui.css';
 
 /**
- * 狭幅 viewport 用の独立 GUI シェル (issue #572 Phase 2)。
+ * 狭幅 viewport 用の独立 GUI シェル。
  *
- * 設計方針:
- * - upstream の <GUI> には手を入れず、別コンポーネントとして並走する
- * - 段階的に <MobileGui> 配下の独自 UI を増やし、徐々に <GUI> 内部の
- *   レイアウトと役割を分担していく。
- * - 各 PR は機能を一つずつ追加するインクリメンタルな構成にして、
- *   develop に小さくマージできるようにする。
+ * 設計方針: upstream の <GUI> には手を入れず、本コンポーネントから
+ * `body.smalruby-mobile-mode` 起点の CSS とサイドレール / ドロワー /
+ * スプライトパネル等の mobile-only UI で覆い被せる。
  *
- * 進捗:
- *   - PR-2A: スケルトン (本コンポーネントの作成、<GUI> 素通し)
- *   - PR-2B: ボトムタブ × 5 (<MobileBottomTabs /> を追加)
- *   - PR-2C: ステージ全画面プレビュー (<MobileTopBar /> の ▶ で
- *     upstream の isFullScreen mode に入る)
- *   - PR-2D: ブロックパレットドロワーのドラッグ開始自動クローズ
- *     (Phase 2-J で横固定運用に切り替え、十分な横幅を確保できたため revert)
- *   - PR-2E: ハンバーガーメニュー (<MobileDrawer /> + <MobileTopBar /> 左の ☰)
- *   - PR-2F: スプライト管理 (本 PR、<MobileSpritePanel />)。スプライトタブを
- *     active にすると upstream <TargetPane> を全画面オーバーレイで表示し、
- *     スプライト追加 / 削除 / 選択 + ステージ背景管理ができるようにする。
- *     issue #572 の元症状「I can't add sprites nor costumes on safari on iOS」の解消。
- *
- * 状態管理:
- * - drawer (ハンバーガー) の open: useState
- * - sprite tab active: useState (Redux 化していないが、必要になったら検討)
- *
- * 受け取る props は <GUI> と同一 (AppStateHOC / HashParserHOC からの全 props)。
+ * iOS Safari 等の狭幅 viewport では自動的にこちらがマウントされる。
  * @param {object} props - <GUI> と同じ props
  * @returns {JSX.Element} <GUI> + 各種 mobile-only コンポーネント
  */
@@ -168,8 +148,7 @@ const MobileGui = ({ activeTabIndex, isFullScreen, vm, ...props }) => {
 
     /*
      * モバイル (狭幅 viewport で自動的に MobileGui がマウントされる) で
-     * コードブロックをバックパックに drop できるようにする補助レイヤー
-     * (Phase 3-B fix)。
+     * コードブロックをバックパックに drop できるようにする補助レイヤー。
      *
      * 背景:
      * upstream の `<Backpack>` (containers/backpack.jsx) はブロックドロップを
@@ -303,10 +282,9 @@ const MobileGui = ({ activeTabIndex, isFullScreen, vm, ...props }) => {
             <ConnectedIntlProvider>
                 <>
                     {/*
-                     * Phase 2-J: 上下のメニュー (MobileTopBar / MobileBottomTabs) を
-                     * 廃止し、左 48px サイドレールに ☰ + ▶ + 5 タブを集約。
-                     * 編集エリアが viewport 縦 100% を使えるようになり、上流の
-                     * paint editor / sound editor の縦最小サイズを満たせる。
+                     * 左 48px サイドレールに ☰ + ▶ + 5 タブを集約することで、
+                     * 編集エリアが viewport 縦 100% を使えるようにし、上流の
+                     * paint editor / sound editor の縦最小サイズを満たす。
                      */}
                     <MobileSideRail
                         onOpenDrawer={handleOpenDrawer}
@@ -318,10 +296,10 @@ const MobileGui = ({ activeTabIndex, isFullScreen, vm, ...props }) => {
                     <MobileDrawer open={drawerOpen} onClose={handleCloseDrawer} />
                     <MobileSpritePanel active={spriteTabActive} />
                     {/*
-                     * Phase 2-J: コスチュームタブで上部ツールバーを出し入れする
-                     * トグル。折りたたみ中は body class で paint-editor の上部
-                     * ツールバーを display: none にし、canvas + ツールが viewport
-                     * 縦 100% を使えるようにする。
+                     * コスチュームタブで上部ツールバーを出し入れするトグル。
+                     * 折りたたみ中は body class で paint-editor の上部ツールバーを
+                     * display: none にし、canvas + ツールが viewport 縦 100% を
+                     * 使えるようにする。
                      */}
                     <MobilePaintToolbarToggle
                         active={paintToolbarToggleActive}
@@ -329,7 +307,7 @@ const MobileGui = ({ activeTabIndex, isFullScreen, vm, ...props }) => {
                         onToggle={handleTogglePaintToolbar}
                     />
                     {/*
-                     * Phase 2-I: 縦向き時にオーバーレイを出して横にしてもらう。
+                     * 縦向き時にオーバーレイを出して横にしてもらう。
                      * 上流の paint editor / sound editor の min-width 群が
                      * 390px に収まらないため、横固定運用に倒す。
                      */}

--- a/packages/scratch-gui/src/components/mobile-orientation-gate/mobile-orientation-gate.jsx
+++ b/packages/scratch-gui/src/components/mobile-orientation-gate/mobile-orientation-gate.jsx
@@ -51,7 +51,7 @@ const usePortraitOrientation = () => {
 
 /**
  * 縦向き (portrait) の時だけフルスクリーンオーバーレイを表示して、
- * 横向きにするよう案内するゲート (issue #572 Phase 2-I)。
+ * 横向きにするよう案内するゲート。
  *
  * 背景:
  * - upstream の <PaintEditor> や <SoundEditor> は密度が高く、390px 縦持ちでは

--- a/packages/scratch-gui/src/components/mobile-paint-toolbar-toggle/mobile-paint-toolbar-toggle.jsx
+++ b/packages/scratch-gui/src/components/mobile-paint-toolbar-toggle/mobile-paint-toolbar-toggle.jsx
@@ -15,10 +15,10 @@ const TOOLBAR_HEIGHT = 104;
 
 /**
  * コスチュームタブの上部ツールバー (`paint-editor_editor-container-top`) を
- * 出し入れするトグルハンドル (issue #572 Phase 2-J)。
+ * 出し入れするトグルハンドル。
  *
- * 横向き iPhone で paint editor の上部ツールバーは sticky で常駐させる
- * (PR-2J Stage 1) が、それでも canvas の縦スペースを 104px ほど食う。
+ * 横向き iPhone で paint editor の上部ツールバーは sticky で常駐させるが、
+ * それでも canvas の縦スペースを 104px ほど食う。
  * このトグルで折りたたむと canvas + ツールが viewport 縦 100% を使え、
  * もう一度タップで戻せる。ブロックパレットの `<PaletteToggle>` と同じ
  * 「出し入れ」UX。

--- a/packages/scratch-gui/src/components/mobile-side-rail/mobile-side-rail.jsx
+++ b/packages/scratch-gui/src/components/mobile-side-rail/mobile-side-rail.jsx
@@ -26,7 +26,7 @@ import styles from './mobile-side-rail.css';
 const SPRITE_KEY = 'sprite';
 
 /**
- * 横向き専用 Mobile UI の左 48px サイドレール (issue #572 Phase 2-J)。
+ * 横向き専用 Mobile UI の左 48px サイドレール。
  *
  * 上下のメニューバーを廃止し、本コンポーネントに ☰ + ▶/⏹ + 5 タブ
  * (sprite/code/costume/sound/ruby) を集約することで、編集エリアが viewport
@@ -38,8 +38,7 @@ const SPRITE_KEY = 'sprite';
  * - middle: 5 タブ
  * - bottom: 余白 (将来的にプロジェクト保存ステータス等を入れる枠)
  *
- * 構成は MobileTopBar (PR-2C/2E) + MobileBottomTabs (PR-2B/2F) を縦に並べた
- * 等価物。スプライトタブの active state は親 (MobileGui) 管理を継続。
+ * スプライトタブの active state は親 (MobileGui) 管理。
  * @param {object} props - props
  * @param {object} props.vm - scratch-vm
  * @param {boolean} props.isFullScreen - 全画面ステージ中か
@@ -117,8 +116,7 @@ const MobileSideRailComponent = ({
 
     if (typeof document === 'undefined') return null;
 
-    // 順序: コード / コスチューム / 音 / ルビー / スプライト
-    // (PC 版とほぼ同じ並びにする)
+    // 順序は PC 版と揃える: コード / コスチューム / 音 / ルビー / スプライト
     const tabs = [
         {
             key: 'code',

--- a/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.css
+++ b/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.css
@@ -1,7 +1,6 @@
 .panel {
     position: fixed;
-    /* top / left / width / height は JS (visualViewport) で MobileTopBar の
-       高さと MobileBottomTabs の高さを差し引いて設定する。 */
+    /* top / left / width / height は JS (visualViewport) で動的に設定する。 */
     top: 0;
     left: 0;
     background: white;
@@ -9,14 +8,10 @@
      * z-index は 100。タブコンテンツ (Blockly toolbox 40 等) より上に乗せて
      * sprite tab 切替時に編集エリアを覆い隠す。
      *
-     * SideRail (9200) や backpack (200, mobile-gui.css の Phase 3-B) より下に
-     * 置くことで、sprite タブ中でも左サイドレールがタップ可能、かつ画面下端
-     * に開かれた backpack が前面に見える (drop ターゲットとして使える)。
+     * SideRail (9200) や backpack (200) より下に置くことで、sprite タブ中でも
+     * 左サイドレールがタップ可能、かつ画面下端に開かれた backpack が前面に
+     * 見える (drop ターゲットとして使える)。
      * drawer (9501) や modal overlay (10000) よりも当然下。
-     *
-     * 旧 Phase (MobileTopBar / MobileBottomTabs があった時代) では 8500 で
-     * 上下メニュー (9000) より下に置いていたが、それらは Phase 2-J で廃止
-     * されたので低い値に戻して問題ない。
      */
     z-index: 100;
     overflow: auto;
@@ -29,11 +24,10 @@
 }
 
 /*
- * upstream の TargetPane は元々 right-rail 用に flex-direction: row で
- * スプライトリスト (左) + 72px の stage-selector-wrapper (右) というレイアウト。
- * 横向きスマホ (Phase 2-I で横固定運用に切り替え済み) なら横幅が十分
- * (844 - 56 = 788px) あるので、デスクトップと同じ row レイアウトをそのまま
- * 使える。column 方向への並び替えは廃止。
+ * upstream の TargetPane は flex-direction: row で
+ * スプライトリスト (左) + 72px の stage-selector-wrapper (右) のレイアウト。
+ * 横向きスマホは横幅が十分 (844 - 56 = 788px) あるので、デスクトップと
+ * 同じ row レイアウトをそのまま使える。
  *
  * height: 100% でサイドレール右の利用可能高さを使い切る。
  */

--- a/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.jsx
+++ b/packages/scratch-gui/src/components/mobile-sprite-panel/mobile-sprite-panel.jsx
@@ -11,11 +11,8 @@ import styles from './mobile-sprite-panel.css';
 const SIDE_RAIL_WIDTH = 56;
 
 /**
- * パネルを左サイドレールの右側、viewport 縦 100% に配置する layout effect。
- *
- * Phase 2-J で MobileTopBar / MobileBottomTabs を廃止し、左 48px の縦
- * サイドレール (MobileSideRail) に UI を集約した。本パネルもサイドレール
- * の右隣からビューポート右端まで、縦は 100% で開く。
+ * パネルを左サイドレール (MobileSideRail) の右隣からビューポート右端まで、
+ * 縦は 100% で配置する layout effect。
  *
  * 表示されている (active=true) ときだけ計算し、隠れているときは何もしない。
  * @param {object} ref - パネル要素の React ref
@@ -54,12 +51,10 @@ const usePositionRightOfRail = (ref, active) => {
 };
 
 /**
- * モバイル用スプライト管理パネル (issue #572 Phase 2-F)。
+ * モバイル用スプライト管理パネル。
  *
- * MobileBottomTabs の「スプライト」タブが active のときだけ overlay として
- * 表示される。upstream の <TargetPane> をそのまま流用し、CSS で flex-direction
- * を column 方向に上書きすることで、狭幅でもスプライト一覧 + ステージ背景が
- * 縦に並ぶレイアウトに変える。
+ * MobileSideRail の「スプライト」タブが active のときだけ overlay として
+ * 表示される。upstream の <TargetPane> をそのまま流用する。
  *
  * <TargetPane> 自体はスプライト追加 (Choose / Paint / Surprise / Upload),
  * スプライト削除 / 複製 / 名前変更 / 位置変更などの全機能を内蔵しているため、

--- a/packages/scratch-gui/src/components/mobile-top-bar/mobile-top-bar.css
+++ b/packages/scratch-gui/src/components/mobile-top-bar/mobile-top-bar.css
@@ -104,7 +104,7 @@
 /*
  * upstream の getStageDimensions(isFullScreen=true) は width = window.innerWidth
  * (= viewport 幅) で計算するが、stage には 3px の border が content-box で付くため
- * 結果的に viewport 幅 + 6px の box になり左右がはみ出す (issue #572 検証で判明)。
+ * 結果的に viewport 幅 + 6px の box になり左右がはみ出す。
  * 全画面ステージのみ box-sizing を border-box に上書きして、border を box 幅に
  * 含める形にする。stage 内の canvas は影響を受けない (canvas は別の sizing JS で
  * 制御されている)。

--- a/packages/scratch-gui/src/components/mobile-top-bar/mobile-top-bar.jsx
+++ b/packages/scratch-gui/src/components/mobile-top-bar/mobile-top-bar.jsx
@@ -51,16 +51,13 @@ const usePositionAtVisualViewportTop = (ref, enabled) => {
 };
 
 /**
- * Mobile 用上部バー。
+ * Mobile 用上部バー。左端 ☰ + 中央プロジェクトタイトル + 右端 ▶/⏹ の構成。
  *
- * Phase 2-C: 右端に「▶ / ⏹ ボタン」を置く。
+ * - ☰ タップ → onOpenDrawer() で <MobileDrawer> を開く
  * - 編集中 (isFullScreen=false): ▶ → setFullScreen(true) + vm.start() + vm.greenFlag()
  * - プレビュー中 (isFullScreen=true): ⏹ → setFullScreen(false) + vm.stopAll()
  *
- * Phase 2-E: 左端に ☰ ハンバーガー、中央にプロジェクトタイトル表示を追加。
- * - ☰ タップ → onOpenDrawer() で <MobileDrawer> を開く
- * - プロジェクトタイトルは表示のみ。編集はモバイルでは省略する。
- *
+ * プロジェクトタイトルは表示のみ (モバイルでは編集を省略)。
  * 全画面でも上部バーは表示し続ける (要望)。
  * @param {object} props - props
  * @param {object} props.vm - scratch-vm インスタンス

--- a/packages/scratch-gui/src/components/palette-toggle/palette-toggle.css
+++ b/packages/scratch-gui/src/components/palette-toggle/palette-toggle.css
@@ -1,10 +1,8 @@
 @import "../../css/z-index.css";
 
 /*
- * パレットを出し入れするトグル。SP のコスチュームトグル
- * (mobile-paint-toolbar-toggle, 60×18) と同じ tap 領域 (1080px²) を
- * 確保するため、縦長 18×60 で固定。PC/SP 両方で同サイズ・同スタイル
- * (issue #572 Phase 3-D)。
+ * パレットを出し入れするトグル。指でも掴めるように縦長 18×60 の
+ * tap 領域を確保する。
  */
 .palette-toggle-button {
     position: absolute;

--- a/packages/scratch-gui/src/components/target-pane/target-pane.jsx
+++ b/packages/scratch-gui/src/components/target-pane/target-pane.jsx
@@ -98,10 +98,10 @@ const TargetPane = ({
             <div>
                 {/*
                  * === Smalruby: Start of mobile-sprite-panel suppress-library ===
-                 * MobileSpritePanel (issue #572 Phase 2-F) は upstream <GUI> 配下と
-                 * 別ツリーで <TargetPane> を再描画する。両方で <SpriteLibrary>
-                 * モーダルを描画するとモバイルで二重モーダルになるため、
-                 * mobile copy 側だけ hideSpriteLibrary=true で描画を抑止する。
+                 * MobileSpritePanel は upstream <GUI> 配下と別ツリーで
+                 * <TargetPane> を再描画する。両方で <SpriteLibrary> モーダルを
+                 * 描画するとモバイルで二重モーダルになるため、mobile copy 側
+                 * だけ hideSpriteLibrary=true で描画を抑止する。
                  * === Smalruby: End of mobile-sprite-panel suppress-library ===
                  */}
                 {spriteLibraryVisible && !hideSpriteLibrary ? (

--- a/packages/scratch-gui/src/lib/responsive-gui.jsx
+++ b/packages/scratch-gui/src/lib/responsive-gui.jsx
@@ -4,18 +4,10 @@ import GUI from '../containers/gui.jsx';
 import useIsNarrowScreen from './use-is-narrow-screen.js';
 
 /**
- * 狭幅 viewport で MobileGui を、それ以外で <GUI> を出し分けるラッパー
- * (issue #572 Phase 2)。
- *
- * 切替条件: viewport 幅 ≤ 743px または高さ ≤ 500px のとき MobileGui。
- * 判定は `useIsNarrowScreen` (matchMedia) でリアルタイムに反映するため、
- * resize / 端末回転に追従する。
- *
- * 旧実装は `?mobile_gui=1` URL パラメータでオプトインする方式だったが、
- * Phase 3 シリーズで MobileGui の完成度が上がったため、フラグなしで
- * viewport だけを根拠に自動判定する形へ移行した。
- * @param {object} props - <GUI> に渡される全 props
- * @returns {JSX.Element} viewport が狭ければ <MobileGui>、そうでなければ <GUI>
+ * 狭い viewport で <MobileGui>、そうでなければ <GUI> を出し分けるラッパー。
+ * matchMedia でリアルタイムに切り替わるので resize / 端末回転に追従する。
+ * @param {object} props - <GUI> / <MobileGui> に渡す props
+ * @returns {JSX.Element} 選択された GUI コンポーネント
  */
 const ResponsiveGui = props => {
     const isNarrow = useIsNarrowScreen();

--- a/packages/scratch-gui/src/lib/use-is-narrow-screen.js
+++ b/packages/scratch-gui/src/lib/use-is-narrow-screen.js
@@ -1,30 +1,13 @@
 import { useEffect, useState } from 'react';
 
 /**
- * 「スマホ相当の小さい画面」を検知する React hook。
+ * スマホ相当の狭い viewport を検知する hook。MobileGui と desktop GUI の
+ * 出し分けに使う共通ブレークポイント。
  *
- * issue #572 のレスポンシブ対応で、PC レイアウトと別 UI を出し分ける際の
- * 共通ブレークポイントとして使用する。
- *
- * 検出条件: viewport の幅 ≤ 743px または高さ ≤ 500px。
- * これにより、スマホ縦持ち (例 390x844) も横持ち (例 844x390) も同じ
- * mobile UI が出る (Phase 2-I で横固定運用に切り替えたため)。
- * iPad mini portrait (744×1133) は閾値を上回って desktop UI を出す
- * (issue #599)。
- *
- * - スマホ縦持ち (390x844): width 390 ≤ 743 → match
- * - スマホ横持ち (844x390): height 390 ≤ 500 → match
- * - iPad mini portrait (744x1133): 両方 > 閾値 → no match (desktop UI)
- * - iPad portrait (768x1024): 両方 > 閾値 → no match (desktop UI)
- * - タブレット (820x1180 / 1180x820): 両方 > 閾値 → no match (desktop UI)
- * - PC (1920x1080): 両方 > 閾値 → no match (desktop UI)
- *
- * 高さの閾値は 500 で iPhone 14 Pro Max (横 430) 等を含むが、デスクトップで
- * ウィンドウを縦に縮めても 500 を下回らない範囲としてバランスを取る。
- *
- * 同じ matchMedia インスタンスを各コンポーネントが個別に購読すると、
- * リスナー数 = コンポーネント数になるが、それぞれ独立に最新値を持つので
- * 整合性は保たれる。
+ * 閾値の根拠:
+ * - 幅 743px は iPad mini portrait (744) を除外する境界値
+ * - 高さ 500px はスマホ横持ち (844×390 等) を拾う保険
+ *   (デスクトップで 500 以下に縮めても他の min-height 制約に引っかかる範囲)
  * @returns {boolean} スマホ相当のサイズなら true
  */
 const NARROW_SCREEN_QUERY = '(max-width: 743px), (max-height: 500px)';

--- a/packages/scratch-gui/src/playground/index.css
+++ b/packages/scratch-gui/src/playground/index.css
@@ -29,7 +29,7 @@ body,
 /* 横幅が 1024px 未満で 744px 以上のデスクトップレイアウト範囲では、 */
 /* min-width: 1024px を緩めて横スクロールなしで GUI が表示されるように  */
 /* する。レイアウト調整は gui.css と gui.jsx の Smalruby マーカーで    */
-/* 行う (issue #572 Phase 3-C, 閾値を issue #599 で 768→744 に拡張)。 */
+/* 行う。                                                              */
 @media (min-width: 744px) and (max-width: 1023px) {
     html,
     body,


### PR DESCRIPTION
## Summary

ユーザフィードバックを受けて SP/iPad 対応のコードから不要なコメントを取り除く。コードロジックは無変更で、コメントのみのリファクタリング。

旧 PR #607 が PR #606 のマージ時に base ブランチごと削除され自動 close になったため再提出。

## 取り除いたもの

| 種別 | 例 |
|------|-----|
| **進捗トラッキング** | `(Phase 3-B fix)`, `(issue #572 Phase 3-C)`, `(PR #595)`, `(#600)` |
| **段階的経緯** | 「Phase 1 → Phase 2 → Phase 3」型の長大な履歴説明 |
| **WHAT 説明** | 直後のコードを読めば自明な処理内容のコメント |
| **重複** | セクション見出しと中身で同じことを述べているもの |

## 残したコメント

- **WHY** — なぜこの実装か
- **非自明な制約** — バグ回避、ブラウザ依存、API の癖
- **データフロー** — 前後関係を見ないと分からない流れ
- **Smalruby マーカー本体** (`// === Smalruby: Start/End of ... ===`)

## 影響

19 ファイル、**+76 / -157 行 (net -81 行)**

主な圧縮:

| ファイル | docstring 行数 |
|---------|----------------|
| `mobile-gui.jsx` | 30 → 8 |
| `mobile-bottom-tabs.jsx` | 24 → 9 |
| `use-is-narrow-screen.js` | 25 → 9 |
| `responsive-gui.jsx` | 18 → 6 |

## 動作確認

- lint pass、prettier pass
- mobile/responsive 関連 unit test 7 ファイル 46 テスト全 pass
- 1024×768 (desktop GUI) / 844×390 (MobileGui) Playwright で動作確認

## Related

- 旧 PR #607 (closed, base ブランチ削除のため)
- 直前: PR #606 (mobile_gui flag + warning 撤去、マージ済み)
