### PR TITLE
docs: write Smalruby独自エディタ機能 READMEs (#610 Phase 2 batch 2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,11 +29,11 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 
 | 機能 | upstream 区分 | 状態 |
 |---|---|---|
-| `ruby-editor/` — Ruby タブ・Monaco・ruby-toolbar・ruby-generator・ruby-to-blocks-converter | 🆕 独自 | ⏳ |
+| [`ruby-editor/`](ruby-editor/) — Ruby タブ・Monaco・ruby-toolbar・ruby-generator・ruby-to-blocks-converter | 🆕 独自 | ✅ |
 | [`furigana/`](furigana/) — ふりがな表示モード | 🆕 独自 | ✅ |
-| `dncl/` — 日本語プログラミング (DNCL) モード | 🆕 独自 | ⏳ |
-| `rubytee/` — AI アシスタント (scratch-gui + infra 統合) | 🆕 独自 | ⏳ |
-| `backpack/` — バックパック (mesh v1 → v2 移行ロジック含む) | 🔧 改良 | ⏳ |
+| [`dncl/`](dncl/) — 日本語プログラミング (DNCL) モード | 🆕 独自 | ✅ |
+| [`rubytee/`](rubytee/) — AI アシスタント (scratch-gui + infra 統合) | 🆕 独自 | ✅ |
+| [`backpack/`](backpack/) — バックパック (mesh v1 → v2 移行ロジック含む) | 🔧 改良 | ✅ |
 
 ### C. 統合・連携機能
 

--- a/docs/backpack/README.md
+++ b/docs/backpack/README.md
@@ -1,0 +1,128 @@
+# バックパック (Backpack)
+
+> **🔧 upstream 改良** — upstream にあるが Smalruby で機能を改良・拡張している
+> **改良点**: ① バックパックの保存先を **localStorage** に変更（upstream はサーバ）。② Mesh v1 (Skyway) → v2 への**自動マイグレーション**を起動時に実行。
+
+## 概要
+
+バックパックは、スプライト・コスチューム・サウンド・コード片（スクリプト）を**プロジェクト間で持ち運ぶ**ための機能。upstream はサーバ上に保存するが、Smalruby はサーバを持たないため **localStorage** に保存する形に改良している。
+
+加えて、旧 Mesh (v1) を含むスクリプトがバックパックに残っていると、v1 サービス停止後（Issue #592, Skyway 終了）に復元したときにブロックが壊れる。これを防ぐため、**起動時に自動で Mesh v1 → v2 マイグレーション**を実行する。
+
+## ユーザーストーリー
+
+- **小学生**として、よくできたスプライトを別の作品でも使いたい
+- **アニメーション制作中の子**として、書いたスクリプトを使い回したい
+- **作品を作り続けてきたユーザー**として、過去にバックパックに保存したものが Skyway 停止後も使えるようにしてほしい（Mesh v2 に自動更新）
+- **教師**として、ローカル保存なのでサーバ運用コストなしでバックパック機能を提供したい
+
+## UI / 操作フロー
+
+エディタ右下の **バックパック** ペインをクリックすると展開。
+
+### 保存
+
+- ブロック / コスチューム / サウンド / スプライトを **ドラッグ&ドロップ** でバックパックに入れる
+- スクリプトは右クリックメニューからも追加可能
+
+### 復元
+
+- バックパック内のアイテムを **ドラッグ&ドロップ** でワークスペースに戻す
+- ステージ・スプライトに対象が応じて自動配置
+
+### 自動マイグレーション（起動時）
+
+- 起動時、`localStorage.smalruby:meshV1BackpackMigratedAt` が無ければ実行
+- バックパック内のスクリプト・スプライト zip を全件スキャン
+- Mesh v1 のブロック opcode (`mesh_*`) を Mesh v2 (`meshV2_*`) に書き換え
+- マイグレーション後にフラグを保存して以降は no-op
+
+## 主要ファイル
+
+### scratch-gui
+
+#### コンポーネント / コンテナ
+
+- `packages/scratch-gui/src/components/backpack/` — UI コンポーネント
+- `packages/scratch-gui/src/containers/backpack.jsx` — コンテナ。**起動時の Mesh v1 マイグレーション呼び出し** を含む
+
+#### ライブラリ
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/lib/backpack-api.js` | localStorage ベースの保存・取得 API |
+| `packages/scratch-gui/src/lib/backpack/code-payload.js` | コードスニペットのペイロード処理 |
+| `packages/scratch-gui/src/lib/backpack/costume-payload.js` | コスチュームのペイロード処理 |
+| `packages/scratch-gui/src/lib/backpack/sound-payload.js` | サウンドのペイロード処理 |
+| `packages/scratch-gui/src/lib/backpack/sprite-payload.js` | スプライトのペイロード処理 |
+| `packages/scratch-gui/src/lib/backpack/block-to-image.js` | ブロックの画像化 |
+| `packages/scratch-gui/src/lib/backpack/jpeg-thumbnail.js` | JPEG サムネイル生成 |
+| `packages/scratch-gui/src/lib/backpack-mesh-v1-migration.js` | **Mesh v1 → v2 自動マイグレーション**（Smalruby 独自）|
+
+#### Smalruby マーカー (upstream への埋め込み)
+
+`src/containers/backpack.jsx` 内の `// === Smalruby: Start of mesh v1 backpack auto-migration ===` で囲まれた箇所：
+
+- import `migrateMeshV1InLocalStorageBackpack`
+- componentDidMount でマイグレーション呼び出し
+- ローディング state の追加
+
+詳細は `.claude/rules/scratch-gui/smalruby-markers.md` 参照。
+
+### scratch-vm
+
+`vm.migrateMeshV1InBackpackBlocks(json)` — Mesh v1 → v2 のブロック書き換え本体は VM 側に実装。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+バックパックは特定のブロックには紐づかない（**全ブロックが対象**）。
+
+ただし Mesh v1 マイグレーションでは以下の opcode を v2 に書き換える：
+- `mesh_*` → `meshV2_*`
+
+## 設定・データ永続化
+
+### localStorage
+
+| キー | 用途 |
+|---|---|
+| `smalrubyBackpack` | バックパックの全アイテム（JSON 配列、Base64 エンコード）|
+| `smalruby:meshV1BackpackMigratedAt` | マイグレーション完了タイムスタンプ（フラグ）|
+
+### 環境変数
+
+なし（完全クライアント完結）。
+
+## 既知の制限
+
+- **localStorage の容量制限** (5〜10MB) があるため、大きなスプライトを多数バックパックに入れると失敗することがある
+- **ブラウザ間でバックパックは共有されない**（同じデバイス・同じブラウザ・同じドメインのみ）
+- プライベートブラウジング/シークレットモードではタブを閉じると消える
+
+## upstream との差分
+
+`.claude/rules/scratch-gui/smalruby-markers.md` で全マーカーを把握できる。バックパック関連の主な差分：
+
+| 場所 | 差分 |
+|---|---|
+| `src/containers/backpack.jsx` | Mesh v1 → v2 自動マイグレーション機構 |
+| `src/lib/backpack-api.js` | サーバ送信ではなく localStorage 経由 (`STORAGE_KEY = 'smalrubyBackpack'`) |
+| `src/lib/backpack-mesh-v1-migration.js` | 新規ファイル（Smalruby 独自）|
+
+## テスト
+
+- 単体テスト: `packages/scratch-gui/test/unit/lib/backpack-api.test.js`, `backpack-mesh-v1-migration.test.js`
+- 結合テスト: `packages/scratch-gui/test/unit/containers/backpack.test.jsx`
+
+## 関連ドキュメント
+
+- [`docs/mesh-v2/`](../mesh-v2/) — Mesh v2 ネットワーク（マイグレーション先）
+- `.claude/rules/scratch-gui/smalruby-markers.md` — upstream マーカー一覧
+
+## 関連 Issue / PR
+
+- Issue #592 — Skyway 終了に伴う Mesh v1 → v2 自動マイグレーション

--- a/docs/dncl/README.md
+++ b/docs/dncl/README.md
@@ -1,0 +1,136 @@
+# DNCL モード（日本語プログラミング）
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された機能
+
+## 概要
+
+Ruby タブで **日本語のプログラミング言語（DNCL モード）** を使えるようにする機能。`a = 1`, `if`, `while` ではなく `a ← 1`, `もし...ならば`, `を繰り返す` のように、英語キーワードを一切使わずにプログラムを書ける。
+
+DNCL は大学入学共通テスト手順記述標準言語（DNCLv2）を参考にした日本語ベースの記法で、Smalruby ではこれを内部的に Ruby コードにトランスパイルしてから Scratch ブロックに変換して実行する。
+
+```
+DNCL コード → Ruby コード → Scratch ブロック → 実行
+```
+
+ブロック → Ruby → DNCL の逆方向変換にも対応しているため、ビジュアルブロックで作った作品を日本語コードで読むことも可能。
+
+## ユーザーストーリー
+
+- **小学校高学年**として、英語を覚えなくても本格的なプログラミングをしたい
+- **共通テスト対策中の高校生**として、DNCL を実際に動くプログラムとして書いて練習したい
+- **教師**として、英語キーワードに躓く生徒に「日本語でプログラミングできる」段階的な学習体験を提供したい
+- **プログラミング初心者**として、`if (x > 0) { ... }` のような記号より「もし x > 0 ならば」のように母国語で読みたい
+
+## UI / 操作フロー
+
+Ruby タブの **ruby-toolbar** の「日本語(DNCL)」ボタン (`ruby-toolbar-mode-dncl`) で切替。
+
+| モード | 表示内容 |
+|---|---|
+| Ruby | `if x > 0` |
+| 日本語 (DNCL) | `もし x > 0 ならば` |
+
+DNCL モードに切り替えると：
+- Monaco Editor の言語定義が DNCL 用に切り替わる（シンタックスハイライト、補完）
+- 既存の Ruby コードは自動的に DNCL 表記に変換されて表示される
+- 編集後 Ruby に戻すと、DNCL 表記が Ruby に戻って表示される
+
+DNCL モードと**ふりがな**は排他（DNCL 自体が日本語のためふりがな不要）。
+
+## 主要ファイル
+
+### scratch-gui
+
+#### DNCL ↔ Ruby トランスパイラ
+
+`packages/scratch-gui/src/lib/dncl/`:
+
+| ファイル | 役割 |
+|---|---|
+| `dncl-to-ruby.js` | DNCL → Ruby 変換のエントリポイント |
+| `dncl-line-converter.js` | 行単位の DNCL → Ruby 変換 |
+| `dncl-identifier-converter.js` | 識別子（変数名）の変換 |
+| `dncl-builtins.js` | DNCL 組み込み関数の定義（`表示する`, `入力する` など）|
+| `dncl-keywords.js` | DNCL キーワード定義（`もし`, `ならば`, `を繰り返す` など）|
+| `dncl-validator.js` | DNCL コードの構文検証 |
+| `dncl-state.js` | パーサー状態管理 |
+| `dncl-source-map.js` | DNCL 行 ↔ Ruby 行のマッピング（エラー位置表示用）|
+| `dncl-block-filter.js` | DNCL モードで使えるブロックのフィルタ |
+| `paren-utils.js` | 括弧解析ユーティリティ |
+| `ruby-to-dncl.js` | Ruby → DNCL 逆変換のエントリポイント |
+| `ruby-to-dncl-line-converter.js` | 行単位の Ruby → DNCL 変換 |
+| `ruby-to-dncl-identifier.js` | 識別子の逆変換 |
+| `ruby-to-dncl-builtins.js` | 組み込み関数の逆変換 |
+
+#### Monaco Editor 言語定義
+
+- `packages/scratch-gui/src/containers/ruby-tab/dncl-mode.js` — Monaco の DNCL 言語定義（トークナイザ、シンタックスハイライト）
+- `packages/scratch-gui/src/containers/ruby-tab/dncl-snippets.js` — DNCL コード補完スニペット
+
+#### UI / 状態管理
+
+- `packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx` — DNCL モード切替ボタン
+- `packages/scratch-gui/src/containers/ruby-tab.jsx` — DNCL モード state、エディタ切替制御
+- `packages/scratch-gui/src/reducers/dncl-mode.js` — DNCL モードの Redux state
+- `packages/scratch-gui/src/lib/locale-utils.js` — `isJapaneseLocale` (DNCL は日本語ロケール限定)
+
+### scratch-vm
+
+なし（GUI 側のトランスパイルで完結）。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+DNCL モードは特定のブロックに紐づくものではなく、**Ruby に変換できるすべてのブロックを DNCL でも書ける**。ただし dncl-block-filter.js により、DNCL モードでは表示しないブロック（class 定義など Ruby 高度機能）がある。
+
+## 設定・データ永続化
+
+### localStorage
+
+- `smalruby:dnclMode` — DNCL モードのオン/オフ
+  - 値が `'true'` のときのみ ON（デフォルト OFF）
+  - 日本語以外のロケールでは無視される
+
+### URL パラメータ
+
+- `?rubyMode=dncl` または `?rubyMode=ja` または `?rubyMode=japanese` — DNCL モード強制 ON
+- `?rubyMode=furigana` または `?rubyMode=ruby` — DNCL モード強制 OFF
+
+## DNCLv2 との主な違い
+
+Smalruby の DNCL モードは標準 DNCL（DNCLv2）と以下が異なる：
+
+- **ブロック終端が日本語キーワード**（`を実行する`, `を繰り返す`, `と定義する`）。コロン `:` は使わない
+- **条件分岐の末尾にコロンがない**（`もし 条件 ならば`）
+- Scratch ブロックに変換されるため、**使える機能が Scratch の範囲に限定される**
+- 変数に `@`, `$` プレフィックスは使えない（Ruby の変数記法は自動処理）
+
+## 言語仕様
+
+完全な構文・機能リストは **[`docs/smalruby-dncl-spec.ja.md`](../smalruby-dncl-spec.ja.md)** を参照。以下の要素を網羅：
+
+- プログラム構造（文、コメント）
+- 変数と代入
+- リテラル（数値、文字列、真偽値、配列、ハッシュ）
+- 演算子
+- 制御構造（条件分岐、繰り返し）
+- 関数定義
+- DNCLv2 との違い
+
+## テスト
+
+- 単体テスト: `packages/scratch-gui/test/unit/lib/dncl/`
+- 結合テスト: `packages/scratch-gui/test/integration/dncl-mode-validation.test.js`
+
+## 関連ドキュメント
+
+- [`docs/smalruby-dncl-spec.ja.md`](../smalruby-dncl-spec.ja.md) — DNCL 言語仕様完全版
+- [`docs/ruby-editor/`](../ruby-editor/) — Ruby エディタ全般（DNCL の親機能）
+- [`docs/furigana/`](../furigana/) — ふりがなモード（DNCL とは排他）
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*dncl` で grep）。

--- a/docs/ruby-editor/README.md
+++ b/docs/ruby-editor/README.md
@@ -1,0 +1,214 @@
+# Ruby エディタ
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された機能
+> upstream の Scratch はビジュアルブロックのみ。Smalruby は Monaco Editor を使った Ruby コード編集タブを独自に追加し、ブロックと Ruby コードを相互変換する機能を実装している。
+
+## 概要
+
+Ruby エディタは、Scratch ブロックと **Ruby コードを相互変換** しながら編集できるタブ機能。Monaco Editor で Ruby コードを書き、その結果がリアルタイムにブロックに変換され、逆にブロックを編集した結果も Ruby コードに反映される。
+
+これによりユーザーは「ビジュアルプログラミング → テキストプログラミング」の段階的な学習を、同じ作品の中でシームレスに進められる。
+
+## ユーザーストーリー
+
+- **ブロックに慣れた小学生**として、テキストでプログラムを書く第一歩として、自分が作ったブロックがどんな Ruby コードになるか見たい
+- **中学生・高校生**として、ビジュアルブロックでアイデアを試しつつ、本格的な Ruby コードを書く練習をしたい
+- **教師**として、ブロックとテキストを行き来できる教材として使いたい
+- **保護者**として、子どもがブロックから卒業して「本物のプログラミング言語」に進めるようにしたい
+
+## UI / 操作フロー
+
+### タブ切替
+
+エディタ上部のタブで「ブロック」「コスチューム」「サウンド」「**Ruby**」を切替。Ruby タブが Smalruby 独自。
+
+### Ruby タブの 3 モード
+
+ruby-toolbar 上部のセグメントで切替：
+
+| モード | testid | 表示 |
+|---|---|---|
+| **ふりがな** | `ruby-toolbar-mode-furigana` | Ruby + ふりがな（日本語ロケール時のみ）|
+| **Ruby** | `ruby-toolbar-mode-ruby` | プレーン Ruby |
+| **日本語 (DNCL)** | `ruby-toolbar-mode-dncl` | DNCL モード（日本語プログラミング）|
+
+ふりがな・DNCL は独立した機能として個別ドキュメントあり（[`docs/furigana/`](../furigana/), [`docs/dncl/`](../dncl/)）。
+
+### ruby-toolbar の操作
+
+| ボタン | 機能 |
+|---|---|
+| 実行/停止 (`ruby-toolbar-execute`) | 緑旗を発火・停止 |
+| 元に戻す/やり直す | Monaco の undo/redo |
+| 検索 | Monaco の find |
+| 自動置換 (`ruby-toolbar-auto-correct`) | 自動置換のオン/オフ |
+| ルビティー (`ruby-toolbar-rubytee`) | AI アシスタントを開く（[`docs/rubytee/`](../rubytee/) 参照）|
+| その他メニュー (`ruby-toolbar-more-menu`) | Ruby スクリプト保存、クラス挿入、プレビュー、自動置換設定 |
+| スプライト切替 | エディタ対象スプライトの prev/next |
+
+## 主要ファイル
+
+### scratch-gui
+
+#### Ruby ↔ Blocks 相互変換
+
+| ディレクトリ | 役割 |
+|---|---|
+| `packages/scratch-gui/src/lib/ruby-to-blocks-converter/` | Ruby AST → Scratch ブロックデータへの変換（`@ruby/prism` AST を walk）|
+| `packages/scratch-gui/src/lib/ruby-generator/` | Scratch ブロック → Ruby コード生成（拡張機能ごとに `motion.js`, `looks.js` などのジェネレータ）|
+
+#### Ruby パーサー
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/lib/prism-parser.js` | `@ruby/prism` (WebAssembly) ローダ、prism インスタンスのキャッシュ |
+| `packages/scratch-gui/src/lib/ruby-parser.js` | prism-parser を高レベル API でラップ |
+
+#### Monaco Editor 統合
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/ruby-tab.jsx` | Ruby タブのメインコンテナ。Monaco 初期化、モード切替、debounce、永続化 |
+| `packages/scratch-gui/src/containers/ruby-tab/editor-setup.js` | Monaco Editor の初期設定 |
+| `packages/scratch-gui/src/containers/ruby-tab/smalruby-mode.js` | Monaco の Smalruby 言語定義 |
+| `packages/scratch-gui/src/containers/ruby-tab/dncl-mode.js` | Monaco の DNCL 言語定義 |
+| `packages/scratch-gui/src/containers/ruby-tab/snippets-completer.js` | コード補完エンジン |
+| `packages/scratch-gui/src/containers/ruby-tab/*-snippets.json` | 拡張機能ごとのスニペット定義（motion, looks, sound, koshien, microbit-more など）|
+| `packages/scratch-gui/src/containers/ruby-tab/quick-fix-provider.js` | エラー時の Quick Fix |
+| `packages/scratch-gui/src/containers/ruby-tab/execution-highlighter.js` | 実行中の行ハイライト |
+| `packages/scratch-gui/src/containers/ruby-tab/visual-report-bubble.js` | ブロックの実行結果をエディタにバブル表示 |
+
+#### ruby-toolbar
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx` | ツールバー本体 |
+| `packages/scratch-gui/src/components/ruby-toolbar/target-selector.jsx` | スプライト切替セレクタ |
+| `packages/scratch-gui/src/components/ruby-toolbar/messages.js` | i18n |
+
+#### 補助機能
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/lib/auto-correct.js` | 自動置換（typo の自動修正）|
+| `packages/scratch-gui/src/lib/insert-class.js` | 「クラス挿入」機能 |
+| `packages/scratch-gui/src/lib/ruby-script-preview.js` | Ruby スクリプトのプレビュー生成 |
+| `packages/scratch-gui/src/lib/ruby-screenshot.js` | Ruby コードの画像化 |
+| `packages/scratch-gui/src/containers/ruby-downloader.jsx` | Ruby スクリプトの .rb ダウンロード |
+
+#### 状態管理
+
+- `packages/scratch-gui/src/reducers/ruby-code.js` — Ruby コード state
+- `packages/scratch-gui/src/reducers/editor-tab.js` — `RUBY_TAB_INDEX` の管理
+- `packages/scratch-gui/src/reducers/settings.js` — `rubyVersion` (1 / 2)
+
+### scratch-vm
+
+Ruby ↔ Blocks 変換は scratch-gui 側で完結する（VM 側の変更なし）。ただし Ruby 実行時は scratch-vm のブロック実行エンジンが使われる。
+
+### infra
+
+なし。Ruby 実行はブラウザ内で完結（`@ruby/prism` WebAssembly）。
+
+### ruby/
+
+Ruby ランタイム実装は `ruby/smalruby3/` (smalruby3 gem, SDL2 ベースのデスクトップランタイム)。エディタからは独立だが、生成された Ruby コードはこの gem でも実行できる。
+
+## 関連ブロック
+
+Ruby エディタはすべてのブロックと連携する（変換可能）。**カテゴリごとの Ruby コード対応** は以下の generator/converter を参照：
+
+| カテゴリ | Ruby Generator | Ruby → Blocks Converter |
+|---|---|---|
+| motion | `motion.js` | `motion.js` |
+| looks | `looks.js` | `looks.js` |
+| sound | `sound.js` | `sound.js` |
+| event | `event.js` | `event.js` |
+| control | `control.js` | `control.js` |
+| sensing | `sensing.js` | `sensing.js` |
+| operators | `operators.js` | `operators.js` |
+| data (variables/lists) | `data.js`, `data-list.js` | `data.js`, `data-list.js` |
+| procedure | `procedure.js` | `procedure.js` |
+
+> 各ブロックの Ruby 表現詳細は [`docs/smalruby-language-spec.ja.md`](../smalruby-language-spec.ja.md) を参照。
+
+## Ruby バージョン (v1 vs v2)
+
+Smalruby Ruby は 2 つのバージョンが共存：
+
+- **v1**: 旧バージョン（後方互換性のために保持）
+- **v2**: 現行バージョン（推奨）
+
+切替方法：
+- URL パラメータ `?ruby_version=2`
+- メニューバー「ファイル」→ 設定
+- localStorage `smalruby:rubyVersion`
+
+v1 コード自動検出 (`v1-detection.js`) があり、v1 構文を含むプロジェクトを開くとプロンプトが表示される。
+
+## 設定・データ永続化
+
+### localStorage
+
+| キー | 用途 |
+|---|---|
+| `smalruby:furiganaEnabled` | ふりがなオン/オフ |
+| `smalruby:dnclMode` | DNCL モードオン/オフ |
+| `smalruby:autoCorrectEnabled` | 自動置換オン/オフ |
+| `smalruby:autoCorrectSettings` | 自動置換のルール詳細 |
+| `smalruby:rubyFontSize` | フォントサイズ |
+| `smalruby:rubyVersion` | Ruby バージョン |
+
+### URL パラメータ
+
+| パラメータ | 値 | 効果 |
+|---|---|---|
+| `tab=ruby` | - | Ruby タブを初期表示 |
+| `rubyMode` | `furigana` / `rubi` / `ruby` / `dncl` / `ja` / `japanese` | 初期モード |
+| `ruby_version` | `1` / `2` | Ruby バージョン |
+| `no_beforeunload` | `1` | beforeunload 無効化（Playwright 用）|
+
+## デバッグ用グローバル
+
+Ruby タブを一度開くと `window.smalruby` が利用可能：
+
+```js
+window.smalruby.vm        // Scratch VM インスタンス
+window.smalruby.sprite    // 現在編集中の RenderedTarget
+window.smalruby.blocks    // 現在のブロック
+window.smalruby.runtime   // VM runtime
+
+monaco.editor.getEditors()[0]  // Monaco エディタインスタンス
+```
+
+詳細は `packages/scratch-gui/src/containers/ruby-tab/debug-globals.js` 参照。
+
+## アダプティブ debounce
+
+タイピング中の連続レンダリングを抑えるため、ふりがなレンダラ等で **前回処理時間の 2 倍** を debounce 時間として動的調整する：
+
+```js
+debounceMs = Math.max(50, lastRenderMs * 2);
+```
+
+## テスト
+
+- 単体テスト: `packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/`, `test/unit/lib/ruby-generator/`, `test/unit/lib/ruby-roundtrip-*.test.js`
+- 結合テスト: `packages/scratch-gui/test/integration/ruby-tab*.test.js`
+
+詳細は `.claude/rules/scratch-gui/testing.md` の "Testing Philosophy for Ruby ↔ Blocks Conversion" を参照。
+
+## 関連ドキュメント
+
+- [`docs/furigana/`](../furigana/) — ふりがな機能（Ruby エディタ上の表示モード）
+- [`docs/dncl/`](../dncl/) — 日本語プログラミングモード
+- [`docs/rubytee/`](../rubytee/) — AI アシスタント
+- [`docs/smalruby-language-spec.ja.md`](../smalruby-language-spec.ja.md) — Smalruby Ruby 言語仕様
+- [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) — 拡張機能の Ruby 表現
+- [`docs/smalruby-language-spec-v1-diff.ja.md`](../smalruby-language-spec-v1-diff.ja.md) — Ruby v1 と v2 の差分
+- `.claude/rules/scratch-gui/ruby-mode.md` — Ruby モード開発ルール
+- `.claude/rules/scratch-gui/extension-ruby-policy.md` — 拡張機能の Ruby 対応方針
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*ruby` で grep）。

--- a/docs/rubytee/README.md
+++ b/docs/rubytee/README.md
@@ -1,0 +1,159 @@
+# Rubytee（ルビティー）
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された機能
+> Anthropic Claude API を使った AI コード生成支援機能。upstream の Scratch には AI 機能なし。
+
+## 概要
+
+Rubytee（ルビティー）は **Anthropic Claude API（claude-haiku-4-5）** を使って Ruby コードの生成・修正をチャット形式で支援する機能。Ruby タブの "ルビティー" ボタンから起動し、自然言語で要望を伝えると、現在のスプライト・ステージ・コードのコンテキストを踏まえたコードを生成する。
+
+API キーをクライアントに直接持たせず、AWS Lambda の専用リレー（`infra/smalruby-rubytee-relay`）を経由することで、API キー管理・レート制限・入力検証・年齢適合チェックを集約している。
+
+> **命名**: ルビティー = Ruby + ティー(Teacher)、また "Ruby Tea" 🍵 のニュアンス。前身の **スモウルビー先生** は Gemini API を使っていたが、Anthropic に移行する際にリブランディングした (Issue #346)。
+
+## ユーザーストーリー
+
+- **Ruby を書き始めた小学生**として、「キャラクターを左右に動かしたい」と日本語で頼んで、動くサンプルコードを得たい
+- **教師**として、生徒が詰まったときに「どこをどう直せばよいか」を AI に聞ける環境を提供したい
+- **保護者**として、子どもが AI に依存しすぎないよう、初回利用時に**同意ダイアログ**で AI の特性を説明してほしい
+- **共通テスト対策中の高校生**として、自分が書いた DNCL/Ruby コードのレビューを AI に頼みたい
+
+## 安全・コンプライアンス（重要）
+
+このプロダクトは **未成年者向け** であり、Anthropic の利用規約に明示的に準拠する形で設計されている：
+
+- **同意ダイアログ**: 初回利用時に `rubytee-consent` モーダルで AI の特性・利用規約を表示し、ユーザーの同意を取得（localStorage に保存）
+- **年齢チェック**: 同意ダイアログにチェックボックス
+- **AI 生成物であることの明示**: 出力に AI 生成のラベル
+- **COPPA 対応**: 法的文書（プライバシーポリシー）でも明示
+- **API キー秘匿**: クライアントは API キーを持たず、Lambda リレー経由
+- **レート制限**: IP ベースで `35 分あたり 40 リクエスト`（DynamoDB の TTL で実装）
+- **入力長制限**: ユーザーメッセージ 10〜250 文字、現在コード 1000 文字、履歴 20 ターン
+
+> **背景**: Gemini/Vertex AI ToS は 18 歳未満ユーザー向けアプリでの利用を禁止していたため、Anthropic へ移行した。Anthropic は安全措置を取れば未成年向け製品での利用を明示的に許可している。
+
+## UI / 操作フロー
+
+1. Ruby タブの **ruby-toolbar** で「ルビティー」ボタン (`ruby-toolbar-rubytee`) をクリック
+2. **初回のみ**: 同意ダイアログ (`rubytee-consent`) が表示される。チェックを入れて「OK」で `localStorage.smalruby:rubyteeConsent = 'true'` が保存される
+3. チャットモーダル (`rubytee-modal`) が開く
+4. 自然言語で要望を入力 → AI が現在のコンテキスト（編集中スプライト、ステージ、コード）を踏まえて Ruby コードを生成
+5. 生成されたコードは「適用」ボタンでエディタに挿入できる
+6. 「同意をリセット」で同意状態を削除可能
+
+## 主要ファイル
+
+### scratch-gui
+
+#### UI コンポーネント
+
+- `packages/scratch-gui/src/components/rubytee-modal/rubytee-modal.jsx` — チャット UI 本体
+- `packages/scratch-gui/src/components/rubytee-modal/rubytee-modal.css` — スタイル
+- `packages/scratch-gui/src/components/rubytee-consent/rubytee-consent.jsx` — 同意ダイアログ
+- `packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx` — ルビティーボタン
+
+#### コンテナ・ライブラリ
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/rubytee-modal-hoc.jsx` | モーダル HOC、同意フロー、チャット履歴、API 呼び出し |
+| `packages/scratch-gui/src/lib/rubytee-api.js` | Relay API クライアント (`RubyteeAPI` クラス、`RateLimitError`)|
+| `packages/scratch-gui/src/lib/rubytee-context.js` | スプライト/ステージの状態コンテキスト構築 |
+
+#### Props 配線
+
+`RubyteeModalHOC` → `RubyTab` → `RubyToolbar` の props 伝播：
+
+- `onOpenRubyteeModal` — ルビティーボタンのクリックハンドラ
+- `onRegisterRubyteeApply` — AI 生成コードをエディタに挿入するコールバック登録
+
+### infra/smalruby-rubytee-relay
+
+AWS Lambda リレーサービス（API Gateway HTTP API + Lambda + DynamoDB）：
+
+| ファイル | 役割 |
+|---|---|
+| `infra/smalruby-rubytee-relay/lambda/handler.ts` | Lambda 本体。リクエスト検証、レート制限、Claude API 呼び出し |
+| `infra/smalruby-rubytee-relay/lib/rubytee-relay-stack.ts` | CDK スタック定義 |
+| `infra/smalruby-rubytee-relay/lambda/tests/` | 単体テスト |
+
+#### Lambda の主要ロジック
+
+- 入力検証（メッセージ長、フィールド長、履歴ターン数の上限）
+- IP ベースレート制限（DynamoDB の TTL 機能で window 管理）
+- `system` プロンプト + `messages` 配列に変換して Anthropic API へ POST
+- **Prompt caching** (`cache_control: ephemeral`) を有効化してコスト削減
+- CORS 検証（`CORS_ALLOWED_ORIGINS` 環境変数）
+- エラー時は `429 RATE_LIMIT_EXCEEDED` などの構造化エラー
+
+### scratch-vm
+
+なし（GUI 側で完結）。
+
+## 設定・データ永続化
+
+### クライアント側（webpack で `process.env` に注入、`.env` から読込）
+
+| 環境変数 | 用途 |
+|---|---|
+| `RUBYTEE_RELAY_ENDPOINT` | Lambda リレーのエンドポイント URL |
+
+ローカル開発では stg エンドポイントを使う（prod は CORS で localhost を許可しない）。
+
+### Lambda 側（CDK で渡す）
+
+| 環境変数 | デフォルト | 用途 |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | - | Anthropic API キー |
+| `CLAUDE_MODEL` | `claude-haiku-4-5-20251001` | 使用モデル |
+| `RATE_LIMIT_WINDOW_MINUTES` | `35` | レート制限ウィンドウ |
+| `RATE_LIMIT_MAX_REQUESTS` | `40` | ウィンドウ内最大リクエスト |
+| `MAX_USER_MESSAGE_LENGTH` | `250` | ユーザーメッセージ最大文字数 |
+| `MIN_USER_MESSAGE_LENGTH` | `10` | ユーザーメッセージ最小文字数 |
+| `CORS_ALLOWED_ORIGINS` | `https://smalruby.app` | CORS 許可オリジン |
+| `RATE_LIMIT_TABLE_NAME` | - | DynamoDB テーブル名（CDK で設定）|
+
+固定の上限値:
+- `MAX_FIELD_NAME_LENGTH = 100`（スプライト/コスチューム/サウンド名）
+- `MAX_CURRENT_CODE_LENGTH = 1000`（現在編集中コード）
+- `MAX_HISTORY_TURNS = 20`（会話履歴）
+- `MAX_HISTORY_TURN_TEXT_LENGTH = 1000`（履歴 1 ターンあたり）
+
+### localStorage
+
+- `smalruby:rubyteeConsent` — 同意状態（`'true'` のみ ON）
+
+## モニタリング
+
+CloudWatch ログで利用状況を監視。Rubytee 利用パターンとコスト異常検出は `rubytee-monitor` skill を使用（`.claude/skills/rubytee-monitor/`）。
+
+## デプロイ
+
+詳細手順は `.claude/rules/infra/smalruby-rubytee-relay.md` を参照。
+
+```bash
+# stg
+docker compose run --rm -w /app/infra/smalruby-rubytee-relay infra npx cdk deploy
+
+# prod
+cd infra/smalruby-rubytee-relay && rm .env && ln -s .env.prod .env
+docker compose run --rm -w /app/infra/smalruby-rubytee-relay infra npx cdk deploy
+```
+
+## テスト
+
+- 単体テスト（クライアント）: `packages/scratch-gui/test/unit/lib/rubytee-api.test.js`, `rubytee-context.test.js`, `containers/rubytee-modal-hoc-sanitize.test.js`
+- 結合テスト（クライアント）: `packages/scratch-gui/test/integration/rubytee-consent.test.js`
+- 単体テスト（Lambda）: `infra/smalruby-rubytee-relay/lambda/tests/`
+
+## 関連ドキュメント
+
+- [`docs/ruby-editor/`](../ruby-editor/) — Rubytee の起点となる Ruby エディタ
+- `.claude/rules/infra/smalruby-rubytee-relay.md` — リレー実装・デプロイ・運用ルール
+- `.claude/rules/scratch-gui/development.md` — Rubytee セクション (props 配線等)
+- `.claude/skills/rubytee-monitor/SKILL.md` — CloudWatch ログ監視運用
+
+## 関連 Issue / PR
+
+- Issue #346 — Gemini → Claude 移行、ルビティーへのリブランディング
+- 主要 PR は履歴を参照（`feat:.*rubytee` で grep）


### PR DESCRIPTION
## Summary

Issue #610 Phase 2 batch 2: Smalruby 独自のエディタ機能 4 件の README を執筆。これで Smalruby らしさを示すエディタ機能群（Ruby エディタ + ふりがな + DNCL + Rubytee + バックパック）のドキュメントが揃う。

## Changes Made

### 新規 Feature README

| ドキュメント | 区分 | 内容 |
|---|---|---|
| `docs/ruby-editor/README.md` | 🆕 Smalruby 独自 | Ruby タブの全体像。Ruby ↔ Blocks 相互変換、Monaco 統合、ruby-toolbar、3 モード切替（ふりがな/Ruby/DNCL）、Ruby v1/v2、デバッグ globals まで網羅 |
| `docs/dncl/README.md` | 🆕 Smalruby 独自 | 日本語プログラミング (DNCL) モード。DNCL ↔ Ruby トランスパイラ、DNCLv2 との違い、言語仕様への参照 |
| `docs/rubytee/README.md` | 🆕 Smalruby 独自 | AI アシスタント。**scratch-gui 側** (rubytee-modal/api/context/consent) と **infra/smalruby-rubytee-relay** (Lambda + DynamoDB) を統合参照。安全・コンプライアンス（年齢チェック、レート制限、API キー秘匿）を明記 |
| `docs/backpack/README.md` | 🔧 upstream 改良 | バックパック。upstream のサーバ保存 → localStorage 化、Mesh v1 → v2 自動マイグレーション |

### Index 更新

- `docs/README.md` の各機能を ✅ に更新

## 残作業（Phase 2 batch 3 以降）

- **コアエディタ系**: project-management, block-editor, stage, sprite, costume, sound
- **拡張機能 22 件**: extension-music ... extension-g2s
- **共通基盤**: device-connection, menu-bar, tutorial, alerts, settings, screenshot

## Test Coverage

- ドキュメント整備のみ（コード変更なし）

## Related Issues

Refs #610
