### PR TITLE
docs: write Smalruby独自拡張機能 READMEs (#610 Phase 2 batch 3)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,17 +56,17 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 | `extension-translate/` | ⬆️ そのまま | ⏳ |
 | `extension-makeymakey/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
 | `extension-microbit/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
-| `extension-microbit-more/` | 🆕 独自 | ⏳ |
+| [`extension-microbit-more/`](extension-microbit-more/) | 🆕 独自 | ✅ |
 | `extension-gdxfor/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
 | `extension-ev3/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
 | `extension-boost/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
 | `extension-wedo2/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
-| `extension-mesh-v2/` | 🆕 独自 | ⏳ |
-| `extension-smalrubot-s1/` | 🆕 独自 | ⏳ |
-| `extension-koshien/` | 🆕 独自 | ⏳ |
-| `extension-smalruby-ruby/` | 🆕 独自 | ⏳ |
-| `extension-tm2scratch/` | 🆕 独自 | ⏳ |
-| `extension-g2s/` | 🆕 独自 | ⏳ |
+| [`extension-mesh-v2/`](extension-mesh-v2/) | 🆕 独自 | ✅ |
+| [`extension-smalrubot-s1/`](extension-smalrubot-s1/) | 🆕 独自 | ✅ |
+| [`extension-koshien/`](extension-koshien/) | 🆕 独自 | ✅ |
+| [`extension-smalruby-ruby/`](extension-smalruby-ruby/) | 🆕 独自 | ✅ |
+| [`extension-tm2scratch/`](extension-tm2scratch/) | 🆕 独自 | ✅ |
+| [`extension-g2s/`](extension-g2s/) | 🆕 独自 | ✅ |
 | `extension-speech2text/` | ⬆️ そのまま | ⏳ |
 
 ### E. UI 基盤・体験

--- a/docs/extension-g2s/README.md
+++ b/docs/extension-g2s/README.md
@@ -1,0 +1,123 @@
+# 拡張機能: AkaDako (g2s)
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された拡張機能（[microbit-more / akadako](https://akadako.com/) との連携実装）
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem は未対応。Web Serial / WebUSB を使うためブラウザ専用）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+**AkaDako**（Grove 互換のセンサ・アクチュエータを USB 接続できる教育用ボード）を Smalruby から制御する拡張機能。識別子 **g2s** は "Grove to Scratch" の略。
+
+ボード上のサーボ・センサ（超音波、光、温度、気圧、湿度、水温、加速度、ピッチ、ロール、傾き）・NeoPixel LED・デジタル/アナログ I/O などを、Scratch ブロックで操作できる。
+
+I2C デバイスのドライバ（VL53L0X 距離センサ、ADXL345 加速度センサ、BME280 環境センサ、KXTJ3 加速度センサ、LTR303 光センサ）が組み込まれている。
+
+## ユーザーストーリー
+
+- **電子工作好きの中学生・高校生**として、AkaDako を Smalruby に繋いで、自分のセンサデータでゲームや作品を作りたい
+- **教師（理科・技術）**として、温度・湿度・光などの環境センサを使った実験データ収集を Smalruby で扱いたい
+- **メイカー**として、Web ブラウザで完結するセンサプログラミング環境が欲しい
+- **発表会出展者**として、リアルなセンサ入力で動くインタラクティブ作品を作りたい
+
+## UI / 操作フロー
+
+1. ブロックパレットの「拡張機能を追加」から **g2s (AkaDako)** を選ぶ
+2. `connectBoard` ブロックでボードに接続（Web Serial デバイス選択ダイアログ）
+3. 各種センサ・アクチュエータブロックをプログラムに組み込む
+4. `boardStateChanged` Hat ブロックで接続状態の変化を検知
+
+## 主要ファイル
+
+### scratch-gui
+
+- `packages/scratch-gui/src/lib/libraries/extensions/g2s/` — 拡張機能登録（アイコン、descriptions）
+- `packages/scratch-gui/src/lib/ruby-generator/g2s.js` — g2s ブロック → Ruby 変換
+
+### scratch-vm
+
+- `packages/scratch-vm/src/extensions/scratch3_g2s/index.js` — 拡張機能本体
+- `packages/scratch-vm/src/extensions/scratch3_g2s/akadako-connector.js` — AkaDako ボード接続
+- `packages/scratch-vm/src/extensions/scratch3_g2s/vl53l0x.js` — VL53L0X 距離センサドライバ
+- `packages/scratch-vm/src/extensions/scratch3_g2s/adxl345.js` — ADXL345 加速度センサドライバ
+- `packages/scratch-vm/src/extensions/scratch3_g2s/bme280.js` — BME280 環境センサドライバ
+- `packages/scratch-vm/src/extensions/scratch3_g2s/kxtj3.js` — KXTJ3 加速度センサドライバ
+- `packages/scratch-vm/src/extensions/scratch3_g2s/ltr303.js` — LTR303 光センサドライバ
+- `packages/scratch-vm/src/extensions/scratch3_g2s/translations.json` — i18n
+
+### infra
+
+なし（ボードとの通信はクライアント完結）。
+
+## 関連ブロック（主要 opcode 抜粋）
+
+### 接続
+
+| opcode | 説明 |
+|---|---|
+| `connectBoard` | ボード接続 |
+| `disconnectBoard` | ボード切断 |
+| `isConnected` | 接続中か |
+| `boardStateChanged` | 接続状態変化 Hat |
+
+### サーボ・モーター
+
+| opcode | 説明 |
+|---|---|
+| `servoTurn` | サーボ角度設定 |
+
+### 距離・光・環境
+
+| opcode | 説明 |
+|---|---|
+| `measureDistanceWithUltrasonicA/B` | 超音波距離センサ |
+| `measureDistanceWithLight` | 光距離センサ |
+| `getBrightness`, `getAnalogBrightness` | 明るさ |
+| `getTemperature`, `getPressure`, `getHumidity` | 温度・気圧・湿度 (BME280) |
+| `getWaterTemperatureA/B` | 水温 |
+
+### 加速度・傾き
+
+| opcode | 説明 |
+|---|---|
+| `motionSensorValue` | モーションセンサ値 |
+| `getPitch`, `getRoll` | ピッチ・ロール |
+| `getAccelerationX/Y/Z`, `getAccelerationAbsolute` | 加速度 |
+| `whenShaken` | 揺さぶられたとき Hat |
+
+### NeoPixel LED
+
+| opcode | 説明 |
+|---|---|
+| `neoPixelConfigStrip` | LED ストリップ設定 |
+| `neoPixelSetColor`, `neoPixelFillColor` | 色設定 |
+| `neoPixelShiftColor` | 色シフト |
+| `neoPixelColor`, `neoPixelColorMode` | 色取得・モード |
+| `neoPixelShow`, `neoPixelClear` | 表示・クリア |
+
+### デジタル/アナログ I/O
+
+| opcode | 説明 |
+|---|---|
+| `analogLevelA1/A2/B1/B2` | アナログレベル取得 |
+| `digitalLevelA1/A2` ほか | デジタル I/O |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
+
+## 設定・データ永続化
+
+なし（接続情報は揮発的）。
+
+## 動作環境
+
+- **対応 OS**: Windows / macOS / ChromeOS
+- **対応ブラウザ**: Chrome / Edge（Web Serial サポート）
+
+## 関連ドキュメント
+
+- [AkaDako 公式](https://akadako.com/)
+- [`docs/device-connection/`](../device-connection/) — connection-modal 共通基盤 (準備中)
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*g2s|akadako` で grep）。

--- a/docs/extension-koshien/README.md
+++ b/docs/extension-koshien/README.md
@@ -1,0 +1,93 @@
+# 拡張機能: Smalruby Koshien
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された拡張機能
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem は未対応。Koshien サーバとの通信を含むためブラウザ専用）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+**スモウルビー甲子園**（Smalruby Koshien）競技用の拡張機能。プレイヤー（参加者の AI プログラム）がマップ上を移動し、アイテムを集めながらゴールを目指すターン制の競技。本拡張は競技ゲームへの接続、マップ情報取得、移動コマンド送信、ルート計算などのブロックを提供する。
+
+## ユーザーストーリー
+
+- **競技参加者の小学生・中学生**として、自分の AI プログラム (Smalruby スクリプト) を競技サーバに接続して動かしたい
+- **教師**として、生徒たちがチームでアルゴリズムを考えて競い合う題材として使いたい
+- **大会運営**として、競技用のサーバと共通の API でやり取りできる拡張機能を提供したい
+- **プログラミング学習者**として、ターン制ゲームを通じて経路探索などのアルゴリズムを学びたい
+
+## UI / 操作フロー
+
+1. ブロックパレットの「拡張機能を追加」から **Smalruby Koshien** を選ぶ
+2. ブロックパレットに Koshien 専用ブロックが表示される
+3. `connectGame` ブロックで競技サーバに接続
+4. ターンごとに `getMapArea` でマップ情報を取得し、`moveTo` などで移動
+5. `setItem`, `setMessage` で行動・メッセージを送信
+
+### Koshien テストモーダル
+
+開発・デバッグ用の **Koshien テストモーダル** (`koshien-test-modal`) があり、競技サーバなしでローカルテストができる。
+
+## 主要ファイル
+
+### scratch-gui
+
+#### コンポーネント
+
+- `packages/scratch-gui/src/components/koshien-test-modal/koshien-test-modal.jsx` — テスト用モーダル
+
+#### ライブラリ
+
+- `packages/scratch-gui/src/lib/libraries/extensions/koshien/` — 拡張機能登録（アイコン、descriptions）
+- `packages/scratch-gui/src/lib/ruby-generator/koshien.js` — Koshien ブロック → Ruby 変換
+- `packages/scratch-gui/src/lib/ruby-to-blocks-converter/koshien*` — Ruby → Koshien ブロック変換（要追加調査）
+
+#### Redux
+
+- `packages/scratch-gui/src/reducers/koshien-file.js` — Koshien ファイル管理 state
+- AI 保存ステータス（rubytee からの自動保存と連動）
+
+#### スニペット
+
+- `packages/scratch-gui/src/containers/ruby-tab/koshien-snippets.json` — Monaco エディタの Koshien コード補完
+
+### scratch-vm
+
+- `packages/scratch-vm/src/extensions/koshien/index.js` — 拡張機能本体（競技サーバとの WebSocket 通信、コマンド処理）
+
+### infra
+
+なし（Koshien 競技サーバは別リポジトリで管理）。
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `connectGame` | 競技サーバに接続 |
+| `getMapArea`, `map`, `mapFrom`, `mapAll` | マップ情報の取得 |
+| `moveTo` | 指定位置への移動 |
+| `calcGoalRoute`, `calcRoute` | ゴールまでの経路計算 |
+| `setItem`, `locateObjects` | アイテム配置・検出 |
+| `targetCoordinate`, `position`, `positionOf` | 座標操作 |
+| `turnOver` | プレイヤーの向き変更 |
+| `setMessage`, `object` | メッセージ・オブジェクト送信 |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
+
+## 設定・データ永続化
+
+- `koshien-file` reducer で Koshien プロジェクトファイルの状態を管理
+- 競技サーバとの認証情報や接続情報は別途管理
+
+## テスト
+
+- VM 単体テスト: `packages/scratch-vm/test/unit/extension_koshien.js`
+
+## 関連ドキュメント
+
+- [`docs/rubytee/`](../rubytee/) — Koshien プロジェクトの自動保存連携
+- [`docs/extension-smalruby-ruby/`](../extension-smalruby-ruby/) — 競技プログラム作成時に活用される Ruby 拡張
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*koshien` で grep）。

--- a/docs/extension-mesh-v2/README.md
+++ b/docs/extension-mesh-v2/README.md
@@ -1,0 +1,52 @@
+# 拡張機能: Mesh v2
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された拡張機能
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem / Ruby SDL2 デスクトップランタイムは未対応。AppSync を介した通信のためブラウザ専用）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+複数の Smalruby インスタンス間でリアルタイム通信できるネットワーク拡張機能。`broadcast` イベントの送受信と、グローバル変数の自動同期を提供する。
+
+> **本ドキュメントは拡張機能としての観点を簡潔にまとめたもの**。
+> 通信プロトコル、アーキテクチャ、AWS AppSync + DynamoDB バックエンド、コスト試算、運用、デグレ確認手順などの**システム全体像は [`docs/mesh-v2/`](../mesh-v2/) を参照**。
+
+## ユーザーストーリー
+
+詳細は [`docs/mesh-v2/`](../mesh-v2/) 参照。代表例：
+
+- 友達のスモウルビーと自分のスモウルビーで「メッセージを送る」「相手の変数を読む」をして、複数人で動くゲームを作りたい
+- 教室全員がインターネット越しに簡単な合言葉でグループに入れるようにしたい
+
+## 主要ファイル
+
+### scratch-gui
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'meshV2'` エントリ
+- 接続 UI（`mesh-v2-*-step.jsx`）と Redux state は [`docs/mesh-v2/`](../mesh-v2/) 参照
+
+### scratch-vm
+
+- `packages/scratch-vm/src/extensions/scratch3_mesh_v2/` — 拡張機能本体（mixin パターン、約 14 ファイル）
+
+### infra
+
+- `infra/smalruby-mesh-v2/` — AppSync + DynamoDB のサーバ実装
+
+## 関連ブロック
+
+| ブロック ID | 説明 |
+|---|---|
+| `meshV2_broadcast` | 名前付きイベントを送信 |
+| `meshV2_broadcastAndWait` | イベント送信して受信側の処理完了を待つ |
+| `meshV2_whenIReceive` | イベント受信時の Hat ブロック |
+| `meshV2_getSensorValue` | 他ノードのグローバル変数を読み取り |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
+
+## 関連ドキュメント
+
+- **[`docs/mesh-v2/`](../mesh-v2/)** — システム全体（**本拡張の親ドキュメント**）
+- `.claude/rules/scratch-gui/mesh.md` — クライアント側開発ルール
+- `.claude/rules/infra/smalruby-mesh-v2.md` — サーバ側開発ルール

--- a/docs/extension-microbit-more/README.md
+++ b/docs/extension-microbit-more/README.md
@@ -1,0 +1,129 @@
+# 拡張機能: micro:bit More
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された拡張機能（Yengawa Lab の [microbit-more](https://github.com/microbit-more/) との連携実装）
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem は未対応。BLE / Web Serial を使うためブラウザ専用）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+**micro:bit More**（マイクロビット モア）は、標準の Scratch micro:bit 拡張機能に対して大幅に機能を拡張した拡張機能。upstream の `microbit` 拡張がボタン・LED マトリクス・加速度の基本機能のみなのに対し、**More** は以下を追加：
+
+- **詳細なセンサ**: 温度、明るさ、磁気、コンパス方位、ピッチ・ロール、音レベル
+- **ジェスチャ**: 振る、ロゴタッチ、傾きなど多数
+- **ピン I/O**: デジタル / アナログの入出力、プルアップ/ダウン、サーボ、PWM
+- **音楽**: トーン再生
+- **テキスト表示**: 文字列の流し表示
+
+接続方式は **BLE (Bluetooth Low Energy)** と **Web Serial** の両対応。
+
+カスタムファームウェア (microbit-more 公式) を micro:bit に書き込んだ上で利用する。ファームウェア書き込みは別ツールまたは本拡張内のフラッシャから実行できる。
+
+## ユーザーストーリー
+
+- **micro:bit を持っている小学生・中学生**として、加速度や温度センサを使ったプログラムを Smalruby で書きたい
+- **教師**として、micro:bit の全センサとピンを Smalruby から使えるようにしたい
+- **メイカー**として、micro:bit + 各種センサ・モーターで作品を作りたい
+- **理科教育**として、温度・明るさ・磁気を測定する実験を Smalruby から制御したい
+
+## UI / 操作フロー
+
+1. **ファームウェア書き込み**: micro:bit More 用の HEX を micro:bit に書き込む（標準 micro:bit ファームウェアからの差し替え）
+2. ブロックパレットの「拡張機能を追加」から **micro:bit More** を選ぶ
+3. 接続モーダルで BLE または Web Serial を選択
+4. ペアリング後、各種センサ・I/O ブロックを使う
+
+## 主要ファイル
+
+### scratch-gui
+
+- `packages/scratch-gui/src/lib/libraries/extensions/microbitMore/` — 拡張機能登録（アイコン、descriptions、collaborator: 'Yengawa Lab'）
+- `packages/scratch-gui/src/lib/microbit-more-update.js` — micro:bit More ファームウェア更新（DAPjs + microbit-universal-hex）
+- `packages/scratch-gui/src/lib/microbit-update.js` — 標準 micro:bit ファームウェア更新（参考）
+- `packages/scratch-gui/src/lib/ruby-generator/microbit_more.js` — microbit-more ブロック → Ruby 変換
+
+### scratch-vm
+
+- `packages/scratch-vm/src/extensions/microbitMore/index.js` — 拡張機能本体
+- `packages/scratch-vm/src/extensions/microbitMore/ble-llk.js` — BLE 通信
+- `packages/scratch-vm/src/extensions/microbitMore/serial-web.js` — Web Serial 通信
+- `packages/scratch-vm/src/extensions/microbitMore/translations.json` — i18n
+
+### infra
+
+なし。
+
+## 関連ブロック（主要 opcode）
+
+### ボタン・ジェスチャ・タッチ
+
+| opcode | 説明 |
+|---|---|
+| `whenButtonEvent` / `isButtonPressed` | ボタンイベント |
+| `whenGesture` | ジェスチャ Hat |
+| `whenTouchEvent` / `isPinTouched` | タッチ |
+
+### LED 表示
+
+| opcode | 説明 |
+|---|---|
+| `displayMatrix` | LED マトリクス |
+| `display`, `displayClear` | アイコン表示・クリア |
+| `displayText` | 文字列流し表示 |
+
+### 傾き・加速度
+
+| opcode | 説明 |
+|---|---|
+| `whenTilted` / `isTilted` / `getTiltAngle` | 傾き検出 |
+| `getPitch`, `getRoll` | ピッチ・ロール |
+| `getAcceleration` | 加速度 |
+
+### センサ
+
+| opcode | 説明 |
+|---|---|
+| `getLightLevel` | 明るさ |
+| `getTemperature` | 温度 |
+| `getCompassHeading` | コンパス方位 |
+| `getMagneticForce` | 磁気 |
+| `getSoundLevel` | 音レベル |
+
+### ピン I/O
+
+| opcode | 説明 |
+|---|---|
+| `whenPinConnected` | ピン接続 Hat |
+| `whenConnectionChanged` | 接続状態変化 Hat |
+| `setPullMode` | プルアップ/ダウン設定 |
+| `isPinHigh`, `getAnalogValue` | ピン状態取得 |
+| `setDigitalOut`, `setAnalogOut`, `setServo` | デジタル/アナログ/サーボ出力 |
+| `playTone` | トーン再生 |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
+
+## 設定・データ永続化
+
+なし。
+
+## 動作環境
+
+- **対応ブラウザ**:
+  - **BLE**: Chrome / Edge (Web Bluetooth サポート)
+  - **Web Serial**: Chrome / Edge
+- **必須**: micro:bit More カスタムファームウェアを micro:bit に書き込んでおくこと
+
+## ライセンス
+
+- 本拡張は Yengawa Lab の microbit-more プロジェクト由来
+- ブロック定義の collaborator として "Yengawa Lab" を表示
+
+## 関連ドキュメント
+
+- 上流: [microbit-more (Yengawa Lab)](https://github.com/microbit-more/)
+- [`docs/extension-microbit/`](../extension-microbit/) — upstream の標準 micro:bit 拡張 (準備中)
+- [`docs/device-connection/`](../device-connection/) — connection-modal 共通基盤 (準備中)
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*microbit_more|microbitMore` で grep）。

--- a/docs/extension-smalrubot-s1/README.md
+++ b/docs/extension-smalrubot-s1/README.md
@@ -1,0 +1,131 @@
+# 拡張機能: Smalrubot S1
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された拡張機能
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem は未対応。WebSerial API 経由でハードウェアと通信するためブラウザ専用）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+**Smalrubot S1**（Studuino ベースの教育用ロボット）を Smalruby から制御する拡張機能。Web Serial API を使ってブラウザから USB 経由でロボットと通信し、モーター・サーボ・LED・センサを操作する。
+
+ファームウェアの書き込みも内蔵（**WebSerial STK500v1 実装**、`smalrubot-firmware-flasher.js`）しており、初回利用時にブラウザからロボットへファームウェアを転送できる（macOS は PL2303 Serial Driver が別途必要）。
+
+## ユーザーストーリー
+
+- **Smalrubot S1 を購入した小学生**として、Smalruby のブロックでロボットを動かしたい
+- **教師**として、複数台のロボットを生徒それぞれに渡して、教室全体でロボットプログラミングをさせたい
+- **保護者**として、子どもが自分のノート PC から直接ロボットを動かせる（追加アプリのインストール不要）状態にしたい
+- **初めて使う子**として、自分のロボットにファームウェアを書き込む手順を Smalruby の中で完結させたい
+
+## UI / 操作フロー
+
+### 接続
+
+1. ブロックパレットの「拡張機能を追加」から **Smalrubot S1** を選ぶ
+2. 接続モーダルが S1 専用フローで開く（`smalrubot-s1-*-step.jsx` 系）
+3. 「接続」ボタンで Web Serial のデバイス選択ダイアログ
+4. ロボットを選んで承認
+5. 接続完了
+
+### ファームウェアフラッシュ
+
+1. メニューバーの「Smalrubot」メニューから「ファームウェアを書き込む」を選択
+2. ファームウェアフラッシュモーダル (`smalrubot-firmware-modal`) が開く
+3. ロボットを選んで書き込み開始
+4. 進捗表示の後、完了
+
+### ブロックでの制御
+
+接続後はブロックパレットに以下のような S1 専用ブロックが現れる：
+
+| 操作 | 例 |
+|---|---|
+| 動作（前進・後退・回転） | `action(:forward, 100)` |
+| アーム制御 | `bendArm(:up, 90)` |
+| センサ取得 | `getSensorValue(:line)` |
+| LED 点灯 | `turnLedOn(:red)` |
+| モーター速度 | `setMotorSpeed(:left, 50)` |
+| アームキャリブレーション | `setArmCalibration(:zero)` |
+
+## 主要ファイル
+
+### scratch-gui
+
+#### コンポーネント / コンテナ
+
+- `packages/scratch-gui/src/components/smalrubot-firmware-modal/` — ファームウェアフラッシュモーダル
+- `packages/scratch-gui/src/containers/smalrubot-firmware-modal.jsx`
+- `packages/scratch-gui/src/components/connection-modal/smalrubot-s1-*-step.jsx` × 5 — S1 専用接続ステップ（initial / connecting / connected / error / unsupported）
+
+#### ライブラリ
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/lib/smalrubot-firmware-flasher.js` | WebSerial 経由の STK500v1 ファームウェアフラッシュ実装 |
+| `packages/scratch-gui/src/lib/smalrubot-firmware.hex.js` | ファームウェアバイナリ (HEX 形式) |
+| `packages/scratch-gui/src/lib/microbit-update.js` | （参考）類似の更新ロジック |
+
+#### Redux
+
+- `packages/scratch-gui/src/reducers/smalrubot-firmware.js` — フラッシュ進捗 state
+- `packages/scratch-gui/src/reducers/modals.js` — ファームウェアモーダル開時に接続モーダルを自動で閉じる
+
+#### Smalruby マーカー (upstream への埋め込み)
+
+- `src/components/menu-bar/menu-bar.jsx` — Smalrubot ファームウェアメニュー
+- `src/components/connection-modal/connection-modal.jsx` — S1 専用フロー振り分け
+- `src/containers/connection-modal.jsx` — S1 ファームウェアフラッシュ起動
+- `src/components/connection-modal/error-step.jsx` — エラーステップでのファームウェアボタン
+
+詳細マーカー一覧: `.claude/rules/scratch-gui/smalruby-markers.md`
+
+#### Ruby Generator / Converter
+
+- `packages/scratch-gui/src/lib/ruby-generator/` 配下に Smalrubot 系の generator があるはず（要追加調査）
+
+### scratch-vm
+
+- `packages/scratch-vm/src/extensions/scratch3_smalrubot_s1/index.js` — 拡張機能本体（Web Serial 通信、コマンド送受信、センサ値ポーリング）
+
+### infra / ruby
+
+なし。
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `action`, `actionAndStopAfter` | 前進・後退・回転などの動作 |
+| `bendArm` | アームの曲げ |
+| `getSensorValue` | ライン・距離などのセンサ値取得 |
+| `turnLedOn`, `turnLedOff` | LED の点灯・消灯 |
+| `getMotorSpeed`, `setMotorSpeed` | モーター速度の取得・設定 |
+| `setArmCalibration` | アームキャリブレーション |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
+
+## 設定・データ永続化
+
+なし（接続情報は揮発的、リロードで切断される）。
+
+## 動作環境
+
+- **対応 OS**: Windows, ChromeOS, macOS（macOS は PL2303 Serial Driver 必要）
+- **対応ブラウザ**: Chrome / Edge（Web Serial API サポート必要）
+- **iPad / Android**: 非対応（Web Serial 未サポート）
+
+## テスト
+
+- 単体テスト: `packages/scratch-gui/test/unit/lib/smalrubot-firmware-flasher.test.js`
+- 結合テスト: `packages/scratch-gui/test/integration/smalrubot-firmware.test.js`, `smalrubot-s1-connection-flow.test.js`
+- VM 単体テスト: `packages/scratch-vm/test/unit/extension_smalrubot_s1.js`
+
+## 関連ドキュメント
+
+- [`docs/device-connection/`](../device-connection/) — connection-modal 共通基盤 (準備中)
+- `.claude/rules/scratch-gui/smalruby-markers.md` — upstream マーカー一覧
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*smalrubot` で grep）。

--- a/docs/extension-smalruby-ruby/README.md
+++ b/docs/extension-smalruby-ruby/README.md
@@ -1,0 +1,93 @@
+# 拡張機能: Smalruby Ruby
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された拡張機能
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 側はそもそも Ruby 環境のため、本拡張に相当する API は Ruby 言語自体が提供）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+**Ruby 言語の組み込みメソッド**（`String`, `Array`, `Hash` のメソッド）を Scratch ブロックとして提供する拡張機能。「`.upcase`」「`.length`」「`.each` { ... }」のような Ruby 標準メソッドを、ブロックでも書けるようにすることで、**ブロックと Ruby コードの間の表現力ギャップ**を埋める。
+
+Ruby 経験者にとっては馴染みの深いメソッドが、ブロックプログラミングのみのユーザーにとっては「リスト操作」「文字列操作」の道具として提供される。
+
+加えて以下の補助機能も提供：
+
+- **戻り値ブロック**: メソッドからの戻り値を扱う仕組み（`returnValue`, `returnValueTruthy`）
+- **ブロックパラメータ**: ブロック内で受け取る引数 (`_1`, `_2` ...) を取得する仕組み (`blockParam`)
+
+## ユーザーストーリー
+
+- **Ruby を学んでいる中高生**として、Ruby 標準ライブラリのメソッドをブロックでも使いたい
+- **ブロックプログラマー**として、文字列を大文字化する／配列の各要素に処理を適用するなど、より高度な操作をブロックでもしたい
+- **Smalruby ユーザー**として、Ruby コードでよく使う `.map`, `.each`, `.select`, `.upcase` のようなメソッドが Scratch ブロックでも使えると嬉しい
+- **メソッド作成の練習中**として、メソッドが「戻り値」を持つ概念をブロックで実体験したい
+
+## UI / 操作フロー
+
+1. ブロックパレットの「拡張機能を追加」から **Ruby** を選ぶ
+2. ブロックパレットに Ruby 拡張ブロックが表示される
+3. データ（文字列・配列・ハッシュ）に対して **stringMethod / arrayMethod / hashMethod** ブロックを使ってメソッドを呼び出す
+4. メソッドの戻り値は `returnValue` ブロックで取得
+5. ブロック付きメソッド（`.each` 等）は **arrayMethodWithBlock / hashMethodWithBlock** を使い、ブロック内で `blockParam` で引数を参照
+
+## 主要ファイル
+
+### scratch-gui
+
+- `packages/scratch-gui/src/lib/libraries/extensions/smalruby-ruby/` — 拡張機能登録（アイコン）
+- `packages/scratch-gui/src/lib/ruby-generator/` — 各メソッドカテゴリの Ruby 生成（要追加調査）
+
+### scratch-vm
+
+- `packages/scratch-vm/src/extensions/smalruby_ruby/index.js` — 拡張機能本体
+  - `_setReturnValue` / `_getReturnValue` — スレッドローカルな戻り値管理
+  - `stringMethod`, `arrayMethod`, `hashMethod` — メソッド実行ディスパッチ
+  - `arrayMethodWithBlock`, `hashMethodWithBlock` — ブロック付きメソッド
+  - `blockParam` — ブロック内の引数取得 (`_1`, `_2` ...)
+- `packages/scratch-vm/src/extensions/smalruby_ruby/translations.json` — i18n
+- メソッド実装は別ファイルに分割（要追加調査: string-methods.js, array-methods.js, hash-methods.js 等）
+
+### infra
+
+なし。
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `stringMethod` | 文字列メソッド呼び出し（`upcase`, `length`, `split` など）|
+| `arrayMethod` | 配列メソッド呼び出し（`length`, `first`, `last`, `reverse` など）|
+| `arrayMethodWithBlock` | ブロック付き配列メソッド（`each`, `map`, `select` など）|
+| `hashMethod` | ハッシュメソッド呼び出し |
+| `hashMethodWithBlock` | ブロック付きハッシュメソッド |
+| `returnValue` | メソッドの戻り値取得 |
+| `returnValueTruthy` | 戻り値の真偽（Ruby 流: nil/false/'' のみ偽）|
+| `blockParam` | ブロック内引数取得 (`_1`, `_2` ...) |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
+
+## Ruby のセマンティクスとの関係
+
+- 戻り値は **スレッドローカル** (`util.thread._smalrubyReturnValue`) に保存される
+- Ruby の真偽値判定（`nil`, `false`, 空文字を「偽」、それ以外を「真」）を `returnValueTruthy` で再現
+- ブロック内引数 (`_1`, `_2`) は Ruby 2.7+ の Numbered Block Parameters を意識
+
+## 設定・データ永続化
+
+なし。
+
+## テスト
+
+- VM 単体テスト: `packages/scratch-vm/test/unit/extension_smalruby_ruby_each.js` ほか
+
+## 関連ドキュメント
+
+- [`docs/ruby-editor/`](../ruby-editor/) — Ruby ↔ Blocks 変換
+- [`docs/smalruby-language-spec.ja.md`](../smalruby-language-spec.ja.md) — Smalruby Ruby 言語仕様
+- [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) — 拡張機能の Ruby 表現
+- `.claude/rules/scratch-gui/extension-ruby-policy.md` — 拡張機能の Ruby 対応方針
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*ruby_extension|smalruby_ruby` で grep）。

--- a/docs/extension-tm2scratch/README.md
+++ b/docs/extension-tm2scratch/README.md
@@ -1,0 +1,99 @@
+# 拡張機能: TM2Scratch（Teachable Machine）
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された拡張機能（[champierre/tm2scratch](https://github.com/champierre/tm2scratch) を参考に、TensorFlow.js を直接使う形で再実装。AGPL-3.0）
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem は未対応。TensorFlow.js とブラウザ Camera API を使うためブラウザ専用）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+Google の **Teachable Machine** で訓練した機械学習モデル（画像分類・音声分類）を Smalruby から使えるようにする拡張機能。Web カメラやマイクからの入力を AI モデルに通し、検出されたラベルに応じてブロックで反応できる。
+
+機械学習を**実装ではなく利用する側**として体験させることで、子供たちが AI の仕組みを学ぶ入口になる。
+
+## ユーザーストーリー
+
+- **AI に興味を持った小学生**として、Teachable Machine で「自分の顔」「猫の画像」などを学習させたモデルを Scratch ブロックで使いたい
+- **教師**として、機械学習を「ボタンを押したら反応する」レベルから体験させたい
+- **保護者**として、子どもが AI / ML に最初に触れる教材として安全に使えるものが欲しい
+- **発表会出展者**として、画像認識を組み込んだインタラクティブな作品を作りたい
+
+## UI / 操作フロー
+
+### 1. Teachable Machine でモデル作成
+
+1. [Teachable Machine](https://teachablemachine.withgoogle.com/) にアクセス
+2. 画像プロジェクトまたは音声プロジェクトを作成
+3. 各クラスにサンプル画像/音声を追加して訓練
+4. モデルをエクスポート（"Tensorflow.js" 形式）→ 共有 URL を取得
+
+### 2. Smalruby で利用
+
+1. ブロックパレットの「拡張機能を追加」から **TM2Scratch** を選ぶ
+2. `setImageClassificationModelURL` ブロックでモデル URL を設定
+3. `classifyVideoImageBlock` で Web カメラ画像を分類
+4. `whenReceived [ラベル]` Hat ブロックで特定ラベル検出時に処理開始
+5. `getImageLabel`, `imageLabelConfidence` で詳細取得
+
+## 主要ファイル
+
+### scratch-gui
+
+- `packages/scratch-gui/src/lib/libraries/extensions/tm2scratch/` — 拡張機能登録（アイコン）
+- `packages/scratch-gui/src/lib/ruby-generator/tm2scratch.js` — TM2Scratch ブロック → Ruby 変換
+
+### scratch-vm
+
+- `packages/scratch-vm/src/extensions/scratch3_tm2scratch/index.js` — 拡張機能本体（TensorFlow.js モデル読込、推論実行、ラベル検出イベント発火）
+
+### infra
+
+なし（モデル URL は Teachable Machine の Google Cloud Storage 等から直接ロード）。
+
+## 関連ブロック（主要 opcode）
+
+### 画像分類
+
+| opcode | 説明 |
+|---|---|
+| `setImageClassificationModelURL` | 画像分類モデルの URL を設定 |
+| `classifyVideoImageBlock` | Web カメラ画像を分類 |
+| `whenReceived` | 指定ラベル検出時の Hat ブロック |
+| `isImageLabelDetected` | ラベル検出中かどうか |
+| `getImageLabel` | 最後に検出したラベル |
+| `imageLabelConfidence` | ラベルの信頼度 (0.0〜1.0) |
+
+### 音声分類
+
+| opcode | 説明 |
+|---|---|
+| `setSoundClassificationModelURL` | 音声分類モデルの URL を設定 |
+| `whenReceivedSoundLabel` | 音声ラベル検出時 |
+| `isSoundLabelDetected` | 音声ラベル検出中か |
+| `soundLabelConfidence` | 音声ラベルの信頼度 |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
+
+## 設定・データ永続化
+
+なし（モデル URL は実行中のメモリにのみ保持）。
+
+## 動作環境
+
+- **対応ブラウザ**: Chrome / Edge / Firefox / Safari（TensorFlow.js + getUserMedia サポート）
+- **必須権限**: Web カメラ・マイクの利用許可
+
+## ライセンス
+
+- 本実装は **AGPL-3.0**（[champierre/tm2scratch](https://github.com/champierre/tm2scratch) の派生）
+- ブロック定義・翻訳・アイコンは tm2scratch 由来
+- 実装は TensorFlow.js を直接使う形で Smalruby 用に書き直されている
+
+## 関連ドキュメント
+
+- 上流参考: [champierre/tm2scratch](https://github.com/champierre/tm2scratch)
+- [Teachable Machine](https://teachablemachine.withgoogle.com/)
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*tm2scratch` で grep）。


### PR DESCRIPTION
## Summary

Issue #610 Phase 2 batch 3: Smalruby 独自の拡張機能 7 件の README を執筆。これで Smalruby ならではの差別化要素である拡張機能群がすべて文書化された。

## Changes Made

### 新規 Feature README (7 件)

すべて以下の冒頭を持つ：
- 🆕 **Smalruby 独自**
- **Smalruby ランタイム対応**: ❌ (smalruby3 gem は対応せず)
- **デフォルト表示**: ✅ (`defaultHidden: true` なし)

| ドキュメント | 主な内容 |
|---|---|
| `docs/extension-mesh-v2/README.md` | `docs/mesh-v2/` への簡潔なポインタドキュメント |
| `docs/extension-smalrubot-s1/README.md` | Smalrubot S1 (Studuino 教育ロボット) 制御 + WebSerial STK500v1 ファームウェアフラッシュ |
| `docs/extension-koshien/README.md` | スモウルビー甲子園競技用拡張（マップ取得、移動、経路計算） |
| `docs/extension-smalruby-ruby/README.md` | Ruby 標準メソッド (String/Array/Hash) のブロック化 + 戻り値・ブロック引数 |
| `docs/extension-tm2scratch/README.md` | Teachable Machine 連携（画像/音声分類、TensorFlow.js）、AGPL-3.0 |
| `docs/extension-g2s/README.md` | AkaDako (Grove 互換ボード) 制御、各種 I2C センサドライバ内蔵 |
| `docs/extension-microbit-more/README.md` | micro:bit More (Yengawa Lab) 連携、BLE + Web Serial 両対応 |

### Index 更新

- `docs/README.md` の Smalruby 独自拡張 7 件を ✅ に更新

## Smalruby ランタイム対応の判定根拠

`ruby/smalruby3/lib/smalruby3/extension/` に存在するのは **`pen.rb`, `music.rb`** のみ。Smalruby 独自拡張はすべてブラウザ専用 API（Web Serial / Web Bluetooth / TensorFlow.js / AppSync）に依存しているため、Ruby SDL2 デスクトップランタイムでは動作しない。

## 残作業

- **コアエディタ系** (project-management, block-editor, stage, sprite, costume, sound) — 6 件
- **拡張機能 upstream そのまま** (music, pen, video-sensing, face-sensing, text2speech, translate, makeymakey, microbit, gdxfor, ev3, boost, wedo2, speech2text) — 13 件
- **共通基盤** (device-connection, menu-bar, tutorial, alerts, settings, screenshot) — 6 件

## Test Coverage

ドキュメント整備のみ（コード変更なし）。

## Related Issues

Refs #610
