### PR TITLE
docs: complete Phase 2 with remaining 25 feature READMEs (#610)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,12 +18,12 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 
 | 機能 | upstream 区分 | 状態 |
 |---|---|---|
-| `project-management/` — プロジェクト新規作成・読込・保存・タイトル編集・URL ローダー・SB3 ダウンロード | 🔧 改良 | ⏳ |
-| `block-editor/` — ブロックパレット・ツールボックス・ワークスペース・変数モニター・カスタムブロック | 🔧 改良 | ⏳ |
-| `stage/` — ステージ表示・緑旗/停止・ステージサイズ・背景・watermark・表示モード | ⬆️ そのまま | ⏳ |
-| `sprite/` — スプライト一覧・選択・追加・座標/向き/サイズ編集 | ⬆️ そのまま | ⏳ |
-| `costume/` — コスチュームタブ・ペイントエディタ・コスチュームライブラリ・コスチューム操作ブロック | ⬆️ そのまま | ⏳ |
-| `sound/` — 音タブ・サウンドエディタ・サウンドライブラリ・録音・音操作ブロック | ⬆️ そのまま | ⏳ |
+| [`project-management/`](project-management/) — プロジェクト新規作成・読込・保存・タイトル編集・URL ローダー・SB3 ダウンロード | 🔧 改良 | ✅ |
+| [`block-editor/`](block-editor/) — ブロックパレット・ツールボックス・ワークスペース・変数モニター・カスタムブロック | 🔧 改良 | ✅ |
+| [`stage/`](stage/) — ステージ表示・緑旗/停止・ステージサイズ・背景・watermark・表示モード | 🔧 改良 | ✅ |
+| [`sprite/`](sprite/) — スプライト一覧・選択・追加・座標/向き/サイズ編集 | ⬆️ そのまま | ✅ |
+| [`costume/`](costume/) — コスチュームタブ・ペイントエディタ・コスチュームライブラリ・コスチューム操作ブロック | ⬆️ そのまま | ✅ |
+| [`sound/`](sound/) — 音タブ・サウンドエディタ・サウンドライブラリ・録音・音操作ブロック | ⬆️ そのまま | ✅ |
 
 ### B. Smalruby 独自エディタ機能
 
@@ -42,43 +42,43 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 | [`google-drive/`](google-drive/) — Google Drive 保存・読込 | 🆕 独自 | ✅ |
 | [`classroom/`](classroom/) — クラスルーム機能 | 🆕 独自 | ✅ |
 | [`mesh-v2/`](mesh-v2/) — Mesh v2 ネットワーク | 🆕 独自 | ✅ |
-| `device-connection/` — connection-modal 共通基盤 | 🔧 改良 | ⏳ |
+| [`device-connection/`](device-connection/) — connection-modal 共通基盤 | 🔧 改良 | ✅ |
 
 ### D. 拡張機能
 
 | 機能 | upstream 区分 | 状態 |
 |---|---|---|
-| `extension-music/` | ⬆️ そのまま | ⏳ |
-| `extension-pen/` | ⬆️ そのまま | ⏳ |
-| `extension-video-sensing/` | ⬆️ そのまま | ⏳ |
-| `extension-face-sensing/` | ⬆️ そのまま | ⏳ |
-| `extension-text2speech/` | ⬆️ そのまま | ⏳ |
-| `extension-translate/` | ⬆️ そのまま | ⏳ |
-| `extension-makeymakey/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
-| `extension-microbit/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
+| [`extension-music/`](extension-music/) | ⬆️ そのまま (Smalruby ランタイム ✅) | ✅ |
+| [`extension-pen/`](extension-pen/) | ⬆️ そのまま (Smalruby ランタイム ✅) | ✅ |
+| [`extension-video-sensing/`](extension-video-sensing/) | ⬆️ そのまま | ✅ |
+| [`extension-face-sensing/`](extension-face-sensing/) | ⬆️ そのまま | ✅ |
+| [`extension-text2speech/`](extension-text2speech/) | ⬆️ そのまま | ✅ |
+| [`extension-translate/`](extension-translate/) | ⬆️ そのまま | ✅ |
+| [`extension-makeymakey/`](extension-makeymakey/) (`defaultHidden: true`) | ⬆️ そのまま | ✅ |
+| [`extension-microbit/`](extension-microbit/) (`defaultHidden: true`) | ⬆️ そのまま | ✅ |
 | [`extension-microbit-more/`](extension-microbit-more/) | 🆕 独自 | ✅ |
-| `extension-gdxfor/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
-| `extension-ev3/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
-| `extension-boost/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
-| `extension-wedo2/` (`defaultHidden: true`) | ⬆️ そのまま | ⏳ |
+| [`extension-gdxfor/`](extension-gdxfor/) (`defaultHidden: true`) | ⬆️ そのまま | ✅ |
+| [`extension-ev3/`](extension-ev3/) (`defaultHidden: true`) | ⬆️ そのまま | ✅ |
+| [`extension-boost/`](extension-boost/) (`defaultHidden: true`) | ⬆️ そのまま | ✅ |
+| [`extension-wedo2/`](extension-wedo2/) (`defaultHidden: true`) | ⬆️ そのまま | ✅ |
 | [`extension-mesh-v2/`](extension-mesh-v2/) | 🆕 独自 | ✅ |
 | [`extension-smalrubot-s1/`](extension-smalrubot-s1/) | 🆕 独自 | ✅ |
 | [`extension-koshien/`](extension-koshien/) | 🆕 独自 | ✅ |
 | [`extension-smalruby-ruby/`](extension-smalruby-ruby/) | 🆕 独自 | ✅ |
 | [`extension-tm2scratch/`](extension-tm2scratch/) | 🆕 独自 | ✅ |
 | [`extension-g2s/`](extension-g2s/) | 🆕 独自 | ✅ |
-| `extension-speech2text/` | ⬆️ そのまま | ⏳ |
+| [`extension-speech2text/`](extension-speech2text/) | ⬆️ そのまま (GUI 未登録) | ✅ |
 
 ### E. UI 基盤・体験
 
 | 機能 | upstream 区分 | 状態 |
 |---|---|---|
 | [`mobile-ui/`](mobile-ui/) — モバイル/タブレット UI 全般（旧 `docs/sp/`） | 🆕 独自 | ✅ |
-| `menu-bar/` — メニューバー・言語切替・アカウントメニュー・tutorial-tooltip | 🔧 改良 | ⏳ |
-| `tutorial/` — cards・tips-library・tutorial-onboarding・classroom-tutorial | 🔧 改良 | ⏳ |
-| `alerts/` — alerts・crash-message・error-boundary・coming-soon・browser/webgl-modal | ⬆️ そのまま | ⏳ |
-| `settings/` — テーマ・フォント・各種設定 | ⬆️ そのまま | ⏳ |
-| `screenshot/` — blocks-screenshot・ruby-screenshot | 🆕 独自 | ⏳ |
+| [`menu-bar/`](menu-bar/) — メニューバー・言語切替・アカウントメニュー・tutorial-tooltip | 🔧 改良 | ✅ |
+| [`tutorial/`](tutorial/) — cards・tips-library・tutorial-onboarding・classroom-tutorial | 🔧 改良 | ✅ |
+| [`alerts/`](alerts/) — alerts・crash-message・error-boundary・coming-soon・browser/webgl-modal | ⬆️ そのまま | ✅ |
+| [`settings/`](settings/) — Ruby バージョン切替・各種設定永続化 | 🔧 改良 | ✅ |
+| [`screenshot/`](screenshot/) — blocks-screenshot・ruby-screenshot | 🆕 独自 | ✅ |
 
 ### その他
 

--- a/docs/alerts/README.md
+++ b/docs/alerts/README.md
@@ -1,0 +1,81 @@
+# アラート / エラー通知
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+## 概要
+
+ユーザーへの**通知・アラート・エラー表示**を扱う UI 機能群。upstream Scratch の `alerts` システムを継承し、各種モーダル（クラッシュ、未対応ブラウザ、WebGL 未対応、近日公開）を含む。Smalruby 固有の独自追加はないが、Smalruby 独自機能（Mesh v2、Rubytee 等）からも本仕組みを通じてアラートを発信する。
+
+## ユーザーステップ
+
+- **作品制作中の小学生**として、エラーが起きたら何が問題か分かるようにメッセージで通知してほしい
+- **未対応ブラウザを使っている子**として、Smalruby が動かない理由がわかるようにしてほしい
+- **作品が壊れてしまった子**として、クラッシュ時にもなるべく作業内容を保存できるよう案内してほしい
+
+## UI / 操作フロー
+
+### Alert
+
+ステージ上部に滑り込むようにバナー表示される（自動消滅、もしくはクリックで閉じる）。
+
+### Modal
+
+| モーダル | 役割 |
+|---|---|
+| `crash-message` | クラッシュ時の致命的エラー画面 |
+| `error-boundary` | React Error Boundary によるエラーキャッチ |
+| `coming-soon` | 「近日公開」表示（一部 placeholder 機能用）|
+| `browser-modal` | 未対応ブラウザ警告 |
+| `webgl-modal` | WebGL 未対応警告 |
+
+## 主要ファイル
+
+### scratch-gui
+
+#### コンテナ
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/alerts.jsx` | アラート一覧コンテナ |
+| `packages/scratch-gui/src/containers/alert.jsx` | 単一アラート |
+| `packages/scratch-gui/src/containers/inline-messages.jsx` | インラインメッセージ |
+| `packages/scratch-gui/src/containers/error-boundary.jsx` | Error Boundary HOC |
+
+#### コンポーネント
+
+- `packages/scratch-gui/src/components/alerts/`
+- `packages/scratch-gui/src/components/crash-message/`
+- `packages/scratch-gui/src/components/coming-soon/`
+- `packages/scratch-gui/src/components/browser-modal/`
+- `packages/scratch-gui/src/components/webgl-modal/`
+
+#### State 管理
+
+- `packages/scratch-gui/src/reducers/alerts.js` — アラートキュー
+- `packages/scratch-gui/src/reducers/modals.js` — モーダル開閉
+- `packages/scratch-gui/src/lib/alerts/` — アラート定義
+- `packages/scratch-gui/src/lib/error-boundary-hoc.jsx` — Error Boundary HOC
+
+### scratch-vm
+
+VM のランタイムエラーや拡張機能エラーは `runtime.emit('PROJECT_ERROR', ...)` などで通知される。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+なし。
+
+## 設定・データ永続化
+
+### Redux state
+
+- `alerts` — 表示中アラートのキュー
+- `modals` — 各モーダルの開閉状態
+
+## 関連ドキュメント
+
+- [`docs/project-management/`](../project-management/) — クラッシュ時の自動保存
+- 上流: [scratch-gui のドキュメント](https://github.com/scratchfoundation/scratch-gui)

--- a/docs/block-editor/README.md
+++ b/docs/block-editor/README.md
@@ -1,0 +1,119 @@
+# ブロックエディタ
+
+> **🔧 upstream 改良** — upstream にあるが Smalruby で機能を改良・拡張している
+> **改良点**: ① Ruby 対応ブロックを定義 (`define-ruby-blocks.js`)。② スタックブロックのジェスチャー復旧 (`blocks-gesture-recovery.js`)。③ ブロックスクリーンショット (`blocks-screenshot.js`)。④ ブロックパレット表示の Smalruby 独自トグル (palette-toggle)。⑤ ブロック表示モーダル (block-display-modal) で表示モードを切替可能。
+
+## 概要
+
+Smalruby のメインのブロックプログラミング画面。upstream の Scratch Blocks (Blockly fork) を基盤に、Ruby ↔ Blocks 変換のための拡張、Smalruby 独自ブロック、UI 改善（パレット表示切替、ジェスチャー復旧、スクリーンショット）を加えている。
+
+## ユーザーストーリー
+
+- **小学生**として、ブロックを組み合わせてプログラムを作りたい
+- **教師**として、生徒のブロックプログラムを画像で記録・共有したい
+- **モバイル/iPad ユーザー**として、ブロックパレットの表示を切替えてステージを広く使いたい
+- **何度も操作する子**として、ドラッグ中のブロックが固まったり消えたりしないでほしい
+- **作品を発表する子**として、変数モニターをステージ上に表示してデータを見せたい
+
+## UI / 操作フロー
+
+### ワークスペース
+
+- 左カラムに **ブロックパレット** (カテゴリ別に整理されたブロック)
+- 中央に **ワークスペース** (ブロックを組み立てる領域)
+- ステージ上に **変数モニター** が表示される
+
+### カスタムブロック (Custom Procedures)
+
+- 「自分で作る」カテゴリから「ブロックを作る」を選択
+- カスタムブロック定義モーダル (`custom-procedures`) で名前・引数・形を定義
+
+### ブロックスクリーンショット
+
+- 右クリック → 「スクリプトの画像を保存」で `.png` ダウンロード
+
+### ブロック表示モーダル
+
+- ブロックの表示形態（コンパクト・通常・拡大）を切替
+
+## 主要ファイル
+
+### scratch-gui
+
+#### コアコンポーネント
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/blocks.jsx` | ブロックワークスペース (Blockly) のコンテナ |
+| `packages/scratch-gui/src/lib/blocks.js` | scratch-blocks 設定 + Smalruby マーカー（gesture recovery）|
+| `packages/scratch-gui/src/lib/make-toolbox-xml.js` | ツールボックス XML 生成 (Smalruby 改良含む) |
+| `packages/scratch-gui/src/containers/custom-procedures.jsx` | カスタムブロック定義 |
+
+#### Smalruby 独自追加
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/lib/define-ruby-blocks.js` | Ruby 対応ブロックの定義 |
+| `packages/scratch-gui/src/lib/blocks-gesture-recovery.js` | ドラッグ中のブロックが固まった場合の復旧ロジック |
+| `packages/scratch-gui/src/lib/blocks-screenshot.js` | ブロックの画像化 |
+| `packages/scratch-gui/src/components/blocks-screenshot-button/` | スクリーンショットボタン UI |
+| `packages/scratch-gui/src/components/block-display-modal/` | ブロック表示モード切替モーダル |
+| `packages/scratch-gui/src/containers/block-display-modal.jsx` | ブロック表示モーダル コンテナ |
+| `packages/scratch-gui/src/components/palette-toggle/` | パレット表示切替ボタン |
+| `packages/scratch-gui/src/reducers/palette-visibility.js` | パレット表示 state |
+| `packages/scratch-gui/src/reducers/block-display.js` | ブロック表示モード state |
+
+#### モニター (変数表示)
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/monitor.jsx` | 単一モニター |
+| `packages/scratch-gui/src/containers/monitor-list.jsx` | モニター一覧 |
+| `packages/scratch-gui/src/containers/list-monitor.jsx` | リストモニター |
+| `packages/scratch-gui/src/containers/slider-monitor.jsx` | スライダーモニター |
+| `packages/scratch-gui/src/lib/monitor-adapter.js` | モニター値変換 |
+
+### scratch-vm
+
+ブロック実行エンジン本体。Smalruby マーカーは少なく、主に `serialization/smalruby-migration.js`（Mesh v1 → v2 マイグレーション）程度。
+
+### infra
+
+なし。
+
+## upstream との差分（マーカー）
+
+主な Smalruby マーカーは `.claude/rules/scratch-gui/smalruby-markers.md` 参照：
+
+- `src/lib/blocks.js` — gesture recovery import + install
+
+## 関連ブロック
+
+ブロックエディタ自体はすべての標準ブロックと拡張機能ブロックを扱う。**カテゴリ**:
+
+- 動き / 見た目 / 音 / イベント / 制御 / 調べる / 演算 / 変数 / リスト / ブロック定義（カスタム）
+- 拡張機能 (Mesh v2, Smalrubot S1, micro:bit More など) を追加するとカテゴリが追加される
+
+> 各ブロックの詳細は [`docs/smalruby-language-spec.ja.md`](../smalruby-language-spec.ja.md) を参照。
+
+## 設定・データ永続化
+
+### Redux state
+
+- `block-display` — ブロック表示モード
+- `palette-visibility` — パレット表示
+- `monitor-layout` / `monitors` — モニターのレイアウトと値
+- `toolbox` — ツールボックスの状態
+- `workspace-metrics` — ワークスペースのスクロール・ズーム
+- `extension-filter` — ブロックパレットでの拡張機能フィルタ
+
+## 関連ドキュメント
+
+- [`docs/ruby-editor/`](../ruby-editor/) — Ruby ↔ Blocks 変換
+- [`docs/smalruby-language-spec.ja.md`](../smalruby-language-spec.ja.md) — 言語仕様（ブロック詳細）
+- [`docs/mobile-ui/`](../mobile-ui/) — モバイル時のパレット表示
+- `.claude/rules/scratch-gui/smalruby-markers.md` — upstream マーカー一覧
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*block` で grep）。

--- a/docs/costume/README.md
+++ b/docs/costume/README.md
@@ -1,0 +1,88 @@
+# コスチューム
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+## 概要
+
+スプライトの見た目（**コスチューム**）の編集機能。コスチュームライブラリからの選択、自分で描く（**ペイントエディタ**）、ファイルから取り込む、コスチューム間の切替を行う。upstream Scratch から継承しており、Smalruby 固有の改良はない。
+
+ステージの**背景 (backdrop)** も技術的にはコスチュームの一種で、同じ仕組みで管理される（[`docs/stage/`](../stage/) 参照）。
+
+## ユーザーストーリー
+
+- **小学生**として、スプライトに複数のコスチュームを持たせて、アニメーションのように切替えたい
+- **作品を作る子**として、自分で描いた絵（PNG / SVG）をコスチュームとして使いたい
+- **発表会の出展者**として、ライブラリの素材を組み合わせて見栄えのするキャラクターを作りたい
+
+## UI / 操作フロー
+
+エディタ上部のタブで **コスチューム** タブを選択：
+
+1. 左カラムにコスチューム一覧
+2. 右カラムにペイントエディタ
+3. 「+」ボタン → コスチュームライブラリ / カメラ / ファイル / 自分で描く
+
+ペイントエディタは upstream の [`scratch-paint`](https://github.com/scratchfoundation/scratch-paint) を統合。
+
+## 主要ファイル
+
+### scratch-gui
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/costume-tab.jsx` | コスチュームタブのメインコンテナ |
+| `packages/scratch-gui/src/containers/costume-library.jsx` | コスチュームライブラリモーダル |
+| `packages/scratch-gui/src/containers/paint-editor-wrapper.jsx` | ペイントエディタのラッパー |
+| `packages/scratch-gui/src/components/asset-panel/` | アセット (コスチューム/サウンド) パネル UI |
+| `packages/scratch-gui/src/lib/get-costume-url.js` | コスチューム URL の生成 |
+| `packages/scratch-gui/src/lib/empty-assets.js` | 空コスチュームの定義 |
+
+#### 関連ライブラリ
+
+- `packages/scratch-gui/src/lib/bmp-converter.js` — BMP → PNG 変換
+- `packages/scratch-gui/src/lib/data-uri-to-blob.js` — Data URI → Blob 変換
+- `packages/scratch-gui/src/lib/gif-decoder.js` — アニメーション GIF 分解
+- `packages/scratch-gui/src/lib/import-csv.js` — CSV インポート（リスト用、コスチュームと共通）
+
+### scratch-svg-renderer
+
+`packages/scratch-svg-renderer/` — SVG 処理（描画前処理、サイズ計測など）
+
+### scratch-render
+
+`packages/scratch-render/` — WebGL レンダリング
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+コスチューム自体を**操作する**ブロックのみ列挙（見た目全般のブロックは含めない）：
+
+| ブロック | 説明 |
+|---|---|
+| `looks_switchcostumeto` | 指定コスチュームに切替 |
+| `looks_nextcostume` | 次のコスチュームに切替 |
+| `looks_costume` | コスチューム選択メニュー（引数用）|
+| `looks_costumenumbername` | 現在のコスチュームの番号 / 名前を取得 |
+
+> 「見た目」全般（`looks_say`, `looks_show`, `looks_changesizeby` など）はコスチュームに直接関係しないため含めない。各ブロックの Ruby 表現は [`docs/smalruby-language-spec.ja.md`](../smalruby-language-spec.ja.md) を参照。
+
+## 設定・データ永続化
+
+なし（コスチュームデータはプロジェクトの一部として `.sb3` に保存される）。
+
+## ペイントエディタ
+
+ペイントエディタは別パッケージ ([scratch-paint](https://github.com/scratchfoundation/scratch-paint)) を統合している。本リポジトリでは管理外。
+
+## 関連ドキュメント
+
+- [`docs/sprite/`](../sprite/) — コスチュームを持つスプライト
+- [`docs/stage/`](../stage/) — 背景もコスチュームの一種
+- [`docs/sound/`](../sound/) — サウンドも同じアセットパネル
+
+## 関連 Issue / PR
+
+upstream そのままの機能のため、Smalruby 固有の Issue はほとんどなし。

--- a/docs/device-connection/README.md
+++ b/docs/device-connection/README.md
@@ -1,0 +1,103 @@
+# デバイス接続 (Connection Modal)
+
+> **🔧 upstream 改良** — upstream にあるが Smalruby で機能を改良・拡張している
+> **改良点**: ① Mesh v2 専用ステップ（`mesh-v2-*-step.jsx`）。② Smalrubot S1 専用フロー（`smalrubot-s1-*-step.jsx` × 5）。③ ファームウェアフラッシュ起動の差し込み。④ ネットワークフィルター検出。⑤ 接続済みメッセージのカスタマイズ。
+
+## 概要
+
+外部デバイス（micro:bit, Smalrubot S1, EV3, BOOST, WeDo, Mesh v2 など）への接続を管理する**共通基盤**。upstream の `connection-modal` を継承しつつ、Smalruby は Mesh v2 / Smalrubot S1 / micro:bit More 等の独自・改良デバイス用にステップを追加している。
+
+各デバイスごとの機能詳細は対応する拡張機能ドキュメントを参照（[`docs/extension-mesh-v2/`](../extension-mesh-v2/), [`docs/extension-smalrubot-s1/`](../extension-smalrubot-s1/) など）。
+
+## ユーザーストーリー
+
+- **デバイスを持っている小学生**として、Smalruby を開いてデバイスに接続するまでの手順を一貫した UI で行いたい
+- **教室の生徒**として、教師の指示通りにペアリング・接続できるようガイド付きの画面で進めたい
+- **接続失敗時の子**として、エラー時に何をすべきか（ファームウェア書き込み、ネットワーク確認等）が画面で示されてほしい
+
+## UI / 操作フロー
+
+接続モーダルは **共通のフェーズ管理** で動作し、選んだ拡張機能に応じて表示するステップが切り替わる：
+
+| フェーズ | 説明 | UI コンポーネント |
+|---|---|---|
+| initial | 初期画面 | `*-initial-step.jsx` |
+| scanning | デバイススキャン中 | `*-scanning-step.jsx` |
+| connecting | 接続試行中 | `*-connecting-step.jsx` |
+| connected | 接続成功 | `*-connected-step.jsx` / `connected-step.jsx` |
+| error | エラー | `*-error-step.jsx` / `error-step.jsx` |
+| unsupported | 環境非対応 | `*-unsupported-step.jsx` / `unsupported-browser-step.jsx` |
+
+## 主要ファイル
+
+### scratch-gui
+
+#### コンテナ / 共通 UI
+
+- `packages/scratch-gui/src/containers/connection-modal.jsx` — 接続モーダルコンテナ（フェーズ振り分け、Smalruby マーカーで Smalrubot/Mesh v2 フロー追加）
+- `packages/scratch-gui/src/components/connection-modal/` — 共通ステップ UI
+
+#### Smalruby 独自ステップ
+
+- `packages/scratch-gui/src/components/connection-modal/mesh-v2-initial-step.jsx`
+- `packages/scratch-gui/src/components/connection-modal/mesh-v2-network-filtered-step.jsx` — ネットワークフィルター検出
+- `packages/scratch-gui/src/components/connection-modal/mesh-v2-scanning-step.jsx`
+- `packages/scratch-gui/src/components/connection-modal/smalrubot-s1-initial-step.jsx`
+- `packages/scratch-gui/src/components/connection-modal/smalrubot-s1-connecting-step.jsx`
+- `packages/scratch-gui/src/components/connection-modal/smalrubot-s1-connected-step.jsx`
+- `packages/scratch-gui/src/components/connection-modal/smalrubot-s1-error-step.jsx`
+- `packages/scratch-gui/src/components/connection-modal/smalrubot-s1-unsupported-step.jsx`
+
+#### Smalruby マーカー (upstream への埋め込み)
+
+`src/components/connection-modal/connection-modal.jsx` 内：
+- meshV2 initial step
+- network filter detection
+- smalrubotS1 dedicated flow (PHASES, ステップ振り分け, propTypes)
+
+`src/containers/connection-modal.jsx` 内：
+- smalrubot firmware flash 起動
+- smalrubotS1 dedicated flow handlers
+- meshV2 initial step / connected message / back button
+
+`src/components/connection-modal/error-step.jsx` 内：
+- smalrubot firmware flash button
+
+`src/components/connection-modal/connected-step.jsx` 内：
+- meshV2 connected message
+
+詳細マーカー一覧: `.claude/rules/scratch-gui/smalruby-markers.md`
+
+#### State 管理
+
+- `packages/scratch-gui/src/reducers/connection-modal.js` — 接続モーダル state
+
+### scratch-vm
+
+各拡張機能の VM 側実装が **PeripheralEvents** (`extension-support/peripheral-events.js`) を発行し、それをコネクションモーダルが購読する形。
+
+### infra
+
+なし（接続はクライアント側で完結）。
+
+## 関連ブロック
+
+なし（接続管理 UI のため）。
+
+## 設定・データ永続化
+
+なし（接続情報は揮発的）。
+
+## 関連ドキュメント
+
+- [`docs/extension-mesh-v2/`](../extension-mesh-v2/), [`docs/mesh-v2/`](../mesh-v2/) — Mesh v2 接続詳細
+- [`docs/extension-smalrubot-s1/`](../extension-smalrubot-s1/) — Smalrubot S1 接続 + ファームウェアフラッシュ
+- [`docs/extension-microbit-more/`](../extension-microbit-more/) — micro:bit More 接続
+- [`docs/extension-microbit/`](../extension-microbit/) — 標準 micro:bit 接続
+- [`docs/extension-ev3/`](../extension-ev3/), [`docs/extension-boost/`](../extension-boost/), [`docs/extension-wedo2/`](../extension-wedo2/) — LEGO 系接続
+- [`docs/extension-gdxfor/`](../extension-gdxfor/) — Vernier センサ接続
+- `.claude/rules/scratch-gui/smalruby-markers.md` — upstream マーカー一覧
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*connection|feat:.*smalrubot.*flow` で grep）。

--- a/docs/extension-boost/README.md
+++ b/docs/extension-boost/README.md
@@ -1,0 +1,43 @@
+# 拡張機能: LEGO BOOST
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Web Bluetooth 経由）
+- **デフォルト表示**: ❌（`defaultHidden: true`）— 拡張機能ライブラリで「見る」ボタンを押すと表示
+- **collaborator**: LEGO
+
+## 概要
+
+[LEGO BOOST](https://www.lego.com/en-us/themes/boost) を Smalruby から制御する拡張機能。BOOST のモーター・LED・距離センサ・カラーセンサを Web Bluetooth 経由で操作。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **LEGO BOOST を持っている小学生**として、LEGO ロボットを Smalruby から動かしたい
+- **保護者**として、市販の LEGO 教材で子供のプログラミング学習をさせたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'boost'` (`defaultHidden: true`)
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_boost/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `boost_motorOnFor` / `boost_motorOnForRotation` | モーター動作（時間/回転） |
+| `boost_motorOn` / `boost_motorOff` | モーター ON/OFF |
+| `boost_setMotorPower` | モーターパワー設定 |
+| `boost_setMotorDirection` | 方向設定 |
+| `boost_whenColor` | カラーセンサが N の時 |
+| `boost_getColor` | カラーセンサ値 |
+| `boost_seeingColor` | カラー検出中か |
+| `boost_whenTilted` | 傾いたとき |
+| `boost_setLightHue` | LED の色 |
+
+## 動作環境
+
+- **対応ブラウザ**: Chrome / Edge (Web Bluetooth サポート)
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)

--- a/docs/extension-ev3/README.md
+++ b/docs/extension-ev3/README.md
@@ -1,0 +1,42 @@
+# 拡張機能: LEGO MINDSTORMS EV3
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Web Bluetooth 経由）
+- **デフォルト表示**: ❌（`defaultHidden: true`）— 拡張機能ライブラリで「見る」ボタンを押すと表示
+- **collaborator**: LEGO
+
+## 概要
+
+[LEGO MINDSTORMS EV3](https://education.lego.com/en-us/products/lego-mindstorms-education-ev3-core-set/5003400/) を Smalruby から制御する拡張機能。EV3 のモーター・センサを Web Bluetooth 経由で操作する。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **EV3 を持っている小学生・中学生**として、LEGO ロボットを Smalruby から動かしたい
+- **教師**として、Scratch ベースのプログラミング教材として EV3 を使いたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'ev3'` (`defaultHidden: true`)
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_ev3/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `ev3_motorTurnClockwise` / `ev3_motorTurnCounterClockwise` | モーター回転 |
+| `ev3_motorSetPower` | モーターパワー設定 |
+| `ev3_getMotorPosition` | モーター位置取得 |
+| `ev3_whenButtonPressed` | ボタン押下 Hat |
+| `ev3_whenDistanceLessThan` | 距離センサが N より小さい時 |
+| `ev3_getDistance` | 距離 |
+| `ev3_whenBrightnessLessThan` | 明るさが N より小さい時 |
+| `ev3_beep` | ビープ音 |
+
+## 動作環境
+
+- **対応ブラウザ**: Chrome / Edge (Web Bluetooth サポート)
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)

--- a/docs/extension-face-sensing/README.md
+++ b/docs/extension-face-sensing/README.md
@@ -1,0 +1,38 @@
+# 拡張機能: 顔センサー (Face Sensing)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Web カメラと TensorFlow.js を使うため）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+Web カメラからの映像で**顔のランドマーク（目・口・鼻など）**を検出する拡張機能。顔の位置・特徴点を取得してインタラクティブな作品が作れる。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **小学生**として、自分の顔の動きでスプライトを操作したい
+- **教師**として、AR 風のアプリ（顔にメガネを重ねる等）を作らせたい
+- **発表会の出展者**として、顔認識を使った双方向作品を作りたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'faceSensing'`
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_face_sensing/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `faceSensing_goToFacePart` | 顔のパーツへ移動（目、口、鼻など）|
+| `faceSensing_pointInDirectionOfFace` | 顔の向きへ向く |
+| `faceSensing_whenFaceDetected` | 顔検出時 Hat |
+
+## 動作環境
+
+- **必須**: Web カメラ + ブラウザの getUserMedia 許可
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [`docs/extension-video-sensing/`](../extension-video-sensing/) — シンプルな動き検出

--- a/docs/extension-gdxfor/README.md
+++ b/docs/extension-gdxfor/README.md
@@ -1,0 +1,41 @@
+# 拡張機能: Vernier Go Direct Force & Acceleration (gdxfor)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Web Bluetooth 経由）
+- **デフォルト表示**: ❌（`defaultHidden: true`）— 拡張機能ライブラリで「見る」ボタンを押すと表示
+- **collaborator**: Vernier
+
+## 概要
+
+[Vernier の Go Direct Force & Acceleration センサ](https://www.vernier.com/product/go-direct-force-acceleration-sensor/) を Smalruby から制御する拡張機能。理科教育向けの精密な力・加速度測定。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **理科の授業で実験する中学生・高校生**として、力や加速度のリアルなデータを Smalruby に取り込みたい
+- **教師（理科）**として、振り子・斜面実験などをデジタル化したい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'gdxfor'` (`defaultHidden: true`)
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_gdx_for/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `gdxfor_whenForcePushedOrPulled` | 力をかけたとき |
+| `gdxfor_getForce` | 力（N）|
+| `gdxfor_whenAccelerationCompare` | 加速度の比較 |
+| `gdxfor_getAcceleration` | 加速度 |
+| `gdxfor_isFreeFalling` | 自由落下中か |
+| `gdxfor_whenSpinDirection` | 回転方向検知 |
+
+## 動作環境
+
+- **対応ブラウザ**: Chrome / Edge (Web Bluetooth サポート)
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [Vernier 公式](https://www.vernier.com/)

--- a/docs/extension-makeymakey/README.md
+++ b/docs/extension-makeymakey/README.md
@@ -1,0 +1,37 @@
+# 拡張機能: Makey Makey
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。USB HID キーボードイベント検出）
+- **デフォルト表示**: ❌（`defaultHidden: true`）— 拡張機能ライブラリで「見る」ボタンを押すと表示
+- **collaborator**: JoyLabz
+
+## 概要
+
+[Makey Makey](https://makeymakey.com/) (バナナや果物を電気的にキーとして使えるデバイス) のキー入力を検知する拡張機能。デバイス自体は USB キーボードとしてふるまうため、特別なドライバ不要。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **Makey Makey 所有の小学生**として、フルーツや段ボールで自作したコントローラーで Smalruby を動かしたい
+- **教師**として、フィジカル入力を伴う体感型授業をしたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'makeymakey'` (`defaultHidden: true`)
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_makeymakey/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `makeymakey_whenMakeyKeyPressed` | キーが押されたとき |
+| `makeymakey_whenCodePressed` | キーシーケンス（コナミコマンド等）|
+
+## 動作環境
+
+- USB に接続した Makey Makey ボード（ドライバ不要、汎用 HID キーボードとして動作）
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [Makey Makey 公式](https://makeymakey.com/)

--- a/docs/extension-microbit/README.md
+++ b/docs/extension-microbit/README.md
@@ -1,0 +1,45 @@
+# 拡張機能: micro:bit
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Web Bluetooth または WebUSB を使うため）
+- **デフォルト表示**: ❌（`defaultHidden: true`）— 拡張機能ライブラリで「見る」ボタンを押すと表示
+- **collaborator**: micro:bit
+
+## 概要
+
+micro:bit（マイクロビット）デバイスを Smalruby から制御する**標準**拡張機能。基本機能（ボタン、LED マトリクス、加速度、傾き）のみ。upstream Scratch 標準。
+
+> より多くのセンサ・I/O を扱いたい場合は **Smalruby 独自の [`extension-microbit-more/`](../extension-microbit-more/)** を使う。
+
+## ユーザーストーリー
+
+- **micro:bit を持っている小学生**として、ボタンや LED の基本機能を Smalruby から使いたい
+- **教師**として、追加ファームウェア書き込み不要の標準 micro:bit 環境をすぐに使わせたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'microbit'` (`defaultHidden: true`)
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_microbit/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `microbit_whenButtonPressed` | ボタンが押されたとき |
+| `microbit_isButtonPressed` | ボタンが押されているか |
+| `microbit_displaySymbol` | LED マトリクスにシンボル表示 |
+| `microbit_displayText` | テキスト流し表示 |
+| `microbit_displayClear` | 表示クリア |
+| `microbit_whenTilted` | 傾いたとき |
+| `microbit_whenGesture` | ジェスチャ（振る、論理ロゴアップ等）|
+
+## 動作環境
+
+- **対応ブラウザ**: Chrome / Edge (Web Bluetooth サポート)
+- micro:bit 標準ファームウェア
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [`docs/extension-microbit-more/`](../extension-microbit-more/) — Smalruby 独自の機能拡張版

--- a/docs/extension-music/README.md
+++ b/docs/extension-music/README.md
@@ -1,0 +1,38 @@
+# 拡張機能: 音楽 (Music)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ✅（`ruby/smalruby3/lib/smalruby3/extension/music.rb` あり）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+ドラム・楽器の演奏ブロックを提供する**音楽**拡張機能。upstream Scratch 標準。Smalruby の Ruby SDL2 デスクトップランタイム (smalruby3 gem) でも動作する数少ない拡張機能の 1 つ。
+
+## ユーザーストーリー
+
+- **小学生**として、ドラムの音を作って自分だけのリズムを作りたい
+- **ピアノ経験がある子**として、メロディを Scratch ブロックで再現したい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'music'`
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_music/`
+- Ruby Generator: `packages/scratch-gui/src/lib/ruby-generator/music.js`
+- Ruby ランタイム: `ruby/smalruby3/lib/smalruby3/extension/music.rb`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `music_playDrumForBeats` | ドラムを N 拍鳴らす |
+| `music_restForBeats` | N 拍休む |
+| `music_playNoteForBeats` | 音符を N 拍鳴らす |
+| `music_setInstrument` | 楽器を選ぶ |
+| `music_setTempo` / `music_changeTempo` | テンポ設定・変更 |
+| `music_getTempo` | テンポ取得 |
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [`docs/sound/`](../sound/) — サウンド (録音再生) との違い

--- a/docs/extension-pen/README.md
+++ b/docs/extension-pen/README.md
@@ -1,0 +1,38 @@
+# 拡張機能: ペン (Pen)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ✅（`ruby/smalruby3/lib/smalruby3/extension/pen.rb` あり）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+スプライトの軌跡を線として残す**ペン**拡張機能。スタンプ機能（スプライトの形状をそのまま描画）も含む。upstream Scratch 標準。Smalruby の Ruby SDL2 デスクトップランタイムでも動作する。
+
+## ユーザーストーリー
+
+- **小学生**として、スプライトの動きで絵を描きたい（タートルグラフィックス）
+- **算数好きな子**として、図形を描くプログラムを作りたい
+- **アート好きな子**として、ランダムな模様や万華鏡のような作品を作りたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'pen'`
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_pen/`
+- Ruby Generator: `packages/scratch-gui/src/lib/ruby-generator/pen.js`
+- Ruby ランタイム: `ruby/smalruby3/lib/smalruby3/extension/pen.rb`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `pen_clear` | すべてのペンを消す |
+| `pen_stamp` | スタンプ（現在の見た目を描画）|
+| `pen_penDown` / `pen_penUp` | ペンを下ろす / 上げる |
+| `pen_setPenColorToColor` | ペンの色設定 (HSL) |
+| `pen_changePenColorParamBy` / `pen_setPenColorParamTo` | ペン色パラメータ変更 |
+| `pen_changePenSizeBy` / `pen_setPenSizeTo` | ペンサイズ変更 |
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)

--- a/docs/extension-speech2text/README.md
+++ b/docs/extension-speech2text/README.md
@@ -1,0 +1,46 @@
+# 拡張機能: 音声認識 (Speech to Text)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用（ただし**現状 GUI ライブラリ未登録**、VM 実装のみ存在）
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Web Speech API + マイク使用）
+- **GUI 登録状態**: ❌ **`packages/scratch-gui/src/lib/libraries/extensions/index.jsx` に登録なし**
+
+## 概要
+
+マイクから入力された音声をテキストに変換する**音声認識**拡張機能。upstream の VM には実装が存在するが、Smalruby の **GUI 拡張機能ライブラリには登録されていない** ため、現在ユーザーは追加できない（実装ファイルは将来の有効化に備えて残されている）。
+
+## ユーザーストーリー（将来有効化時）
+
+- **小学生**として、自分の声でゲームを操作したい
+- **教師**として、発話を伴うインタラクティブな教材を作らせたい
+
+## 主要ファイル
+
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_speech2text/` （**現在 GUI からは到達不能**）
+- GUI 登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` には**未登録**
+
+## 有効化する場合
+
+GUI 拡張機能ライブラリに登録するには、`packages/scratch-gui/src/lib/libraries/extensions/index.jsx` に以下のような entry を追加する：
+
+```jsx
+{
+    name: '音声認識',
+    extensionId: 'speech2text',
+    iconURL: speech2textIconURL,
+    insetIconURL: speech2textInsetIconURL,
+    description: '...',
+    featured: true,
+    // defaultHidden を付けるか付けないかは要件次第
+}
+```
+
+## 動作環境
+
+- **対応ブラウザ**: Chrome / Edge (Web Speech API)
+- **必須**: マイク許可
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [`docs/extension-tm2scratch/`](../extension-tm2scratch/) — 機械学習ベースの音声分類（こちらは Smalruby 独自で利用可能）

--- a/docs/extension-text2speech/README.md
+++ b/docs/extension-text2speech/README.md
@@ -1,0 +1,35 @@
+# 拡張機能: 音声合成 (Text to Speech)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。AWS Polly API + ブラウザ音声再生）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+- **collaborator**: Amazon Web Services
+
+## 概要
+
+入力したテキストを**音声で読み上げる**拡張機能。AWS Polly を使った音声合成（複数の声・言語対応）。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **小学生**として、自分の作ったキャラクターに「しゃべらせたい」
+- **物語作品を作る子**として、ナレーションを音声で入れたい
+- **多言語学習中の子**として、英語など他言語の発音を聞きたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'text2speech'`
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_text2speech/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `text2speech_speakAndWait` | テキストを話して終わるまで待つ |
+| `text2speech_setVoice` | 声を選ぶ（Alto, Tenor, Squeak, Giant, Kitten など）|
+| `text2speech_setLanguage` | 言語を選ぶ |
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [AWS Polly](https://aws.amazon.com/polly/)

--- a/docs/extension-translate/README.md
+++ b/docs/extension-translate/README.md
@@ -1,0 +1,34 @@
+# 拡張機能: 翻訳 (Translate)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Google Translate API 経由）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+- **collaborator**: Google
+
+## 概要
+
+テキストを Google Translate 経由で**他言語に翻訳**する拡張機能。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **多言語に興味がある小学生**として、自分の作品を多言語対応させたい
+- **語学学習中の子**として、英語の文を入れて翻訳結果を確認したい
+- **国際交流したい子**として、海外の友達向けに翻訳機能を組み込んだ作品を作りたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'translate'`
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_translate/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `translate_getTranslate` | テキストを指定言語に翻訳 |
+| `translate_getViewerLanguage` | 閲覧者の言語を取得 |
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [Google Translate](https://translate.google.com/)

--- a/docs/extension-video-sensing/README.md
+++ b/docs/extension-video-sensing/README.md
@@ -1,0 +1,39 @@
+# 拡張機能: ビデオモーションセンサー (Video Sensing)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Web カメラとブラウザ画像処理を使うため）
+- **デフォルト表示**: ✅（拡張機能ライブラリにデフォルトで表示される）
+
+## 概要
+
+Web カメラからの映像で**動きを検知**し、スプライト上の動き量や向きを取得する拡張機能。動きをトリガーにブロックを実行できる。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **小学生**として、自分の手の動きでゲームを操作したい
+- **教師**として、フィジカル入力を伴う体感型作品を作らせたい
+- **発表会の出展者**として、観客が手を振ると反応する作品を作りたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'videoSensing'`
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_video_sensing/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `videoSensing_whenMotionGreaterThan` | 動きが N より大きいとき |
+| `videoSensing_videoOn` | 動きの量・向きを取得 |
+| `videoSensing_videoToggle` | カメラ表示の ON/OFF |
+| `videoSensing_setVideoTransparency` | カメラ表示の透明度 |
+
+## 動作環境
+
+- **必須**: Web カメラ + ブラウザの getUserMedia 許可
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)
+- [`docs/extension-face-sensing/`](../extension-face-sensing/) — 顔検出（より高度なビデオ処理）

--- a/docs/extension-wedo2/README.md
+++ b/docs/extension-wedo2/README.md
@@ -1,0 +1,42 @@
+# 拡張機能: LEGO Education WeDo 2.0
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+- **Smalruby ランタイム対応**: ❌（smalruby3 gem 未対応。Web Bluetooth 経由）
+- **デフォルト表示**: ❌（`defaultHidden: true`）— 拡張機能ライブラリで「見る」ボタンを押すと表示
+- **collaborator**: LEGO
+
+## 概要
+
+[LEGO Education WeDo 2.0](https://education.lego.com/en-us/products/lego-education-wedo-2-0-core-set/2000094/) を Smalruby から制御する拡張機能。低学年向けの LEGO ロボット教材。upstream Scratch 標準。
+
+## ユーザーストーリー
+
+- **WeDo を持っている小学校低学年**として、LEGO ロボットを Smalruby から動かしたい
+- **小学校教師**として、低学年向けの簡単な LEGO ロボットプログラミングをさせたい
+
+## 主要ファイル
+
+- 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'wedo2'` (`defaultHidden: true`)
+- VM 実装: `packages/scratch-vm/src/extensions/scratch3_wedo2/`
+
+## 関連ブロック（主要 opcode）
+
+| opcode | 説明 |
+|---|---|
+| `wedo2_motorOnFor` | モーター N 秒回す |
+| `wedo2_motorOn` / `wedo2_motorOff` | モーター ON/OFF |
+| `wedo2_startMotorPower` | モーターパワー設定 |
+| `wedo2_setMotorDirection` | 方向設定 |
+| `wedo2_setLightHue` | LED の色 |
+| `wedo2_whenDistance` | 距離センサ |
+| `wedo2_whenTilted` | 傾き検知 |
+| `wedo2_getDistance` | 距離取得 |
+
+## 動作環境
+
+- **対応ブラウザ**: Chrome / Edge (Web Bluetooth サポート)
+
+## 関連ドキュメント
+
+- 上流: [scratch-vm のドキュメント](https://github.com/scratchfoundation/scratch-vm)

--- a/docs/menu-bar/README.md
+++ b/docs/menu-bar/README.md
@@ -1,0 +1,91 @@
+# メニューバー
+
+> **🔧 upstream 改良** — upstream にあるが Smalruby で機能を改良・拡張している
+> **改良点**: ① **Smalruby ロゴ**に置換（upstream の Scratch ロゴから）。② **クラスルーム** ボタン追加。③ **Smalrubot ファームウェア** メニュー追加。④ **バージョン更新通知** バナー追加。⑤ **設定** メニューにクラスルーム管理を追加。
+
+## 概要
+
+エディタ最上部の**メニューバー**。新規/開く/保存/ファイル名変更などのファイル操作、編集メニュー、設定メニュー、言語選択、アカウントメニュー、Smalruby 独自のクラスルームボタン・Smalrubot ファームウェアメニュー・バージョン更新通知などを集約する。
+
+## ユーザーストーリー
+
+- **小学生**として、Smalruby のロゴで自分が今何のアプリを使っているか確認したい
+- **教師**として、メニューバーから直接「クラス」や「設定」にアクセスしたい
+- **Smalrubot 利用者**として、ロボットのファームウェア書き込みをメニューから起動したい
+- **長期間使っているユーザー**として、Smalruby に新しいバージョンが出たら通知してほしい
+- **多言語ユーザー**として、画面右下の地球アイコンから言語を切り替えたい
+
+## UI / 操作フロー
+
+### メニューバー構成
+
+| 要素 | 機能 |
+|---|---|
+| Smalruby ロゴ | アプリ識別（Smalruby 改良） |
+| ファイルメニュー | 新規 / 開く / 保存 / Drive 連携 / URL ローダー |
+| 編集メニュー | 元に戻す / やり直し / ターボモード切替 |
+| 設定メニュー (⚙) | クラスルーム管理（Smalruby 改良） / 言語 / その他 |
+| クラスボタン | クラスルームモーダルを開く（Smalruby 独自）|
+| Smalrubot メニュー | ファームウェア書き込み（Smalruby 独自）|
+| プロジェクトタイトル入力欄 | タイトル編集 |
+| 共有 / 見る ボタン | upstream の Scratch アカウント機能（Smalruby では削減）|
+| バージョン更新通知 | 新バージョン検出時にバナー表示（Smalruby 独自）|
+
+### tutorial-tooltip
+
+特定のメニュー項目に対して**チュートリアルツールチップ**を表示できる（`tutorial-tooltip`）。
+
+## 主要ファイル
+
+### scratch-gui
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/components/menu-bar/menu-bar.jsx` | メニューバー本体（Smalruby マーカー多数）|
+| `packages/scratch-gui/src/components/menu-bar/menu-bar.css` | スタイル（mobile-ui 用 `max-height: 800px` 圧縮も含む）|
+| `packages/scratch-gui/src/components/menu-bar/settings-menu.jsx` | 設定メニュー（Smalruby のクラスルーム管理を含む）|
+| `packages/scratch-gui/src/components/menu-bar/tutorial-tooltip.jsx` | チュートリアルツールチップ |
+| `packages/scratch-gui/src/lib/menu-bar-hoc.jsx` | メニューバー HOC |
+| `packages/scratch-gui/src/components/language-selector/` | 言語選択 |
+| `packages/scratch-gui/src/lib/version-checker.js` | バージョン更新確認（Smalruby 独自）|
+
+#### Smalruby マーカー (upstream への埋め込み)
+
+主な箇所（詳細は `.claude/rules/scratch-gui/smalruby-markers.md`）：
+
+- smalrubot firmware menu — Smalrubot ファームウェアメニュー
+- classroom button — クラスルームボタン
+- replace Scratch logos with Smalruby logo — ロゴ置換
+- version update notification — バージョン更新通知
+
+### scratch-vm
+
+なし。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+なし。
+
+## 設定・データ永続化
+
+### Redux state
+
+- `menus.js` — メニュー開閉状態
+- `tutorial-onboarding.js` — チュートリアルツールチップの表示状態
+- `locales.js` — 言語設定
+
+## 関連ドキュメント
+
+- [`docs/classroom/`](../classroom/) — クラスルームボタン → クラスルームモーダル
+- [`docs/extension-smalrubot-s1/`](../extension-smalrubot-s1/) — Smalrubot ファームウェアメニュー
+- [`docs/tutorial/`](../tutorial/) — チュートリアルツールチップ
+- [`docs/mobile-ui/`](../mobile-ui/) — mobile での menu-bar 圧縮
+- `.claude/rules/scratch-gui/smalruby-markers.md` — upstream マーカー一覧
+
+## 関連 Issue / PR
+
+- Issue #600 — narrow-height (max-height: 800px) で menu-bar 48→40px 圧縮

--- a/docs/project-management/README.md
+++ b/docs/project-management/README.md
@@ -1,0 +1,128 @@
+# プロジェクト管理
+
+> **🔧 upstream 改良** — upstream にあるが Smalruby で機能を改良・拡張している
+> **改良点**: ① **URL ローダー**で外部 URL からプロジェクトを直接読み込み可能。② Google Drive との連携（保存・読込時に Drive state クリア）。③ URL パラメータでの初期タブ・Playwright 制御。④ プロジェクトタイトル変更時の挙動微調整。
+
+## 概要
+
+Scratch プロジェクト（`.sb3` ファイル）の **新規作成・読み込み・保存・URL からのロード・タイトル編集** を扱う機能群。Smalruby は upstream の Project Saver/Fetcher HOC を継承しつつ、Smalruby 固有の保存先（ローカルファイル、Google Drive、Smalruby Classroom）に対応する。
+
+## ユーザーストーリー
+
+- **小学生**として、自分のプロジェクトを `.sb3` でダウンロードして保存したい
+- **教師**として、配布する作例の URL を子供たちに開かせて、すぐに編集を始められるようにしたい
+- **複数デバイスを使う子**として、Google Drive 経由で作品を行き来させたい
+- **作品を発表する子**として、プロジェクトのタイトルをわかりやすい名前に変更したい
+
+## UI / 操作フロー
+
+### 新規 / 読込 / 保存
+
+メニューバーの「ファイル」メニュー：
+- 新しく作る
+- ファイルから読み込む（`.sb3`）
+- ファイルとして保存する（`.sb3` ダウンロード）
+- Google Drive から読み込み / Drive に保存（[`docs/google-drive/`](../google-drive/) 参照）
+
+### URL からのロード
+
+URL パラメータ `?project_url=https://...` または、URL ローダーモーダル (`url-loader-modal`) から URL を入力してロード。
+
+### タイトル
+
+メニューバー上部の「プロジェクトタイトル入力欄」をクリックして変更。
+
+## 主要ファイル
+
+### scratch-gui
+
+#### Project HOC (upstream + Smalruby マーカー)
+
+| ファイル | 役割 / Smalruby 改良 |
+|---|---|
+| `packages/scratch-gui/src/lib/project-fetcher-hoc.jsx` | プロジェクト取得 HOC。URL パラメータ (Playwright)、初期タブパラメータの追加 |
+| `packages/scratch-gui/src/lib/project-saver-hoc.jsx` | プロジェクト保存 HOC。URL パラメータ・no_beforeunload の追加 |
+| `packages/scratch-gui/src/lib/sb-file-uploader-hoc.jsx` | `.sb3` アップロード HOC。Google Drive state のクリア |
+| `packages/scratch-gui/src/containers/sb3-downloader.jsx` | `.sb3` ダウンロード |
+
+#### URL Loader (Smalruby 独自追加)
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/components/url-loader-modal/` | URL 入力モーダル UI |
+| `packages/scratch-gui/src/lib/url-loader.js` | URL からのプロジェクト取得ロジック |
+| `packages/scratch-gui/src/lib/url-loader-hoc.jsx` | HOC ラッパー |
+| `packages/scratch-gui/src/lib/url-parser.js` | URL パース |
+
+#### URL パラメータ (Smalruby 独自追加)
+
+- `packages/scratch-gui/src/lib/url-params.js` — `tab`, `rubyMode`, `ruby_version`, `no_beforeunload`, `project_url`, `classcode`, `force_polling`, `mesh_debug` などの統一パーサ
+
+#### Project Loader Utils
+
+- `packages/scratch-gui/src/lib/project-loader-utils.js` — プロジェクトロード共通処理
+- `packages/scratch-gui/src/lib/sb-file-uploader-utils.js` — `.sb3` アップロード共通処理
+
+#### State 管理
+
+- `packages/scratch-gui/src/reducers/project-state.js` — プロジェクトのライフサイクル state（loading, ready, saving, ...）
+- `packages/scratch-gui/src/reducers/project-changed.js` — 未保存変更の検出
+- `packages/scratch-gui/src/reducers/project-title.js` — タイトル
+- `packages/scratch-gui/src/reducers/google-drive-file.js` — Google Drive ファイル state（[`docs/google-drive/`](../google-drive/) 参照）
+
+#### プロジェクト状態図
+
+`docs/project-management/project_state_diagram.svg` (SVG 図) — プロジェクトのライフサイクル状態遷移
+`docs/project-management/project_state_example.png` — 状態遷移の具体例
+
+### scratch-vm
+
+VM 側の `loadProject`, `saveProjectSb3` を呼ぶ。Smalruby 独自の Marker は `serialization/smalruby-migration.js`（Mesh v1 → v2 ブロックマイグレーション）。
+
+### infra
+
+- Google Drive 経由は `infra/smalruby-classroom/` の課題提出機能と連動
+
+## 関連ブロック
+
+なし（プロジェクト管理は UI 機能でブロックを持たない）。
+
+ただし、新規プロジェクトには **デフォルトプロジェクト** (`packages/scratch-gui/src/lib/default-project/`) のブロック構成が組み込まれる。
+
+## 設定・データ永続化
+
+### URL パラメータ（Smalruby 独自）
+
+| パラメータ | 用途 |
+|---|---|
+| `project_url` | 指定 URL からプロジェクトを取得 |
+| `tab` | 初期表示タブ |
+| `ruby_version` | Ruby バージョン |
+| `no_beforeunload` | beforeunload 無効化（Playwright 用）|
+
+### LocalStorage
+
+- `legacy-storage.ts` — 旧バージョンとの互換性データ管理
+
+## upstream との差分（マーカー）
+
+主な Smalruby マーカーは `.claude/rules/scratch-gui/smalruby-markers.md` を参照：
+
+- `src/lib/project-fetcher-hoc.jsx` — URL params, initial tab
+- `src/lib/project-saver-hoc.jsx` — URL params, no_beforeunload
+- `src/lib/sb-file-uploader-hoc.jsx` — Google Drive state クリア
+
+## 関連ドキュメント
+
+- [`docs/google-drive/`](../google-drive/) — Google Drive 保存・読込
+- [`docs/classroom/`](../classroom/) — Smalruby Classroom 提出機能
+- [`docs/backpack/`](../backpack/) — バックパック (mesh v1 マイグレーション含む)
+
+## プロジェクトライフサイクル詳細
+
+[`project_state_diagram.svg`](project_state_diagram.svg) — Project State Machine の状態遷移図
+[`project_state_example.png`](project_state_example.png) — 具体的なフロー例
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*url_loader|feat:.*project_url` で grep）。

--- a/docs/screenshot/README.md
+++ b/docs/screenshot/README.md
@@ -1,0 +1,73 @@
+# スクリーンショット
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために新規追加された機能
+
+## 概要
+
+ブロックスクリプトや Ruby コードを **画像 (PNG)** として保存する機能。upstream の Scratch にはコードを画像として保存する機能はない。Smalruby は学習・共有・発表会の場で「自分が書いたプログラムを見せる」用途のために独自実装した。
+
+## ユーザーストーリー
+
+- **作品を発表する小学生**として、自分のプログラムをスクリーンショットして印刷物や Web に貼りたい
+- **教師**として、生徒のプログラムを画像として記録・共有したい
+- **保護者**として、子どもが書いたプログラムを家族や友達に見せたい
+- **Ruby を書いている子**として、ブロックではなく Ruby コードのスクリーンショットも撮りたい
+
+## UI / 操作フロー
+
+### ブロックスクリプトのスクリーンショット
+
+1. ブロックを右クリック → 「スクリプトの画像を保存」
+2. 選択したスクリプト全体が PNG としてダウンロードされる
+
+### Ruby コードのスクリーンショット
+
+1. Ruby タブの **ruby-toolbar** メニューから「Ruby スクリプトの画像を保存」
+2. 現在の Ruby コードが PNG としてダウンロードされる
+
+## 主要ファイル
+
+### scratch-gui
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/lib/blocks-screenshot.js` | ブロックスクリーンショット生成 |
+| `packages/scratch-gui/src/components/blocks-screenshot-button/` | スクリーンショットボタン UI |
+| `packages/scratch-gui/src/lib/ruby-screenshot.js` | Ruby コードスクリーンショット生成 |
+| `packages/scratch-gui/src/lib/backpack/block-to-image.js` | バックパック用のブロック画像化（共通ロジック）|
+
+ブロック画像生成は SVG → PNG 変換で行い、Ruby コードは Monaco の表示状態を canvas に描画する。
+
+### scratch-vm
+
+なし。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+なし。
+
+## 設定・データ永続化
+
+なし（生成された画像はファイルとしてダウンロードされる）。
+
+## 出力形式
+
+- 形式: PNG
+- 解像度: 元の表示サイズに準拠
+
+## テスト
+
+- 単体テスト: `packages/scratch-gui/test/unit/lib/blocks-screenshot.test.js`, `ruby-screenshot.test.js`
+
+## 関連ドキュメント
+
+- [`docs/block-editor/`](../block-editor/) — ブロックエディタ全般
+- [`docs/ruby-editor/`](../ruby-editor/) — Ruby エディタ全般
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*screenshot` で grep）。

--- a/docs/settings/README.md
+++ b/docs/settings/README.md
@@ -1,0 +1,95 @@
+# 設定
+
+> **🔧 upstream 改良** — upstream にあるが Smalruby で機能を改良・拡張している
+> **改良点**: ① **Ruby バージョン (v1/v2)** の切替設定。② URL パラメータでの設定上書き (`ruby_version`)。③ V1 検出プロンプトのスキップフラグ。
+
+## 概要
+
+Smalruby のエディタ全体に影響する**設定**を管理する仕組み。upstream の `settings` reducer を継承しつつ、Smalruby 固有の Ruby バージョン切替などの項目を追加している。
+
+設定 UI は主にメニューバーの設定メニュー (⚙) からアクセスする。
+
+## ユーザーストーリー
+
+- **既存ユーザー**として、Ruby v1 で書いた作品を v2 で開きたい / v1 で動かし続けたい
+- **教師**として、生徒に共通の設定（バージョン）を URL パラメータで配布したい
+- **作品ロード時**に、v1 構文を含むプロジェクトが検出されたら警告を出してほしい
+
+## UI / 操作フロー
+
+メニューバーの ⚙ ボタンから設定メニューを開き、各設定項目を変更する。
+
+主な設定項目：
+
+| 項目 | 値 | 永続化 |
+|---|---|---|
+| Ruby バージョン | v1 / v2 | localStorage `smalruby:rubyVersion` |
+| ふりがな | ON / OFF | localStorage `smalruby:furiganaEnabled` ([`docs/furigana/`](../furigana/)) |
+| DNCL モード | ON / OFF | localStorage `smalruby:dnclMode` ([`docs/dncl/`](../dncl/)) |
+| Auto-correct | ON / OFF | localStorage `smalruby:autoCorrectEnabled` ([`docs/ruby-editor/`](../ruby-editor/)) |
+| ルビティー同意 | 同意済み | localStorage `smalruby:rubyteeConsent` ([`docs/rubytee/`](../rubytee/)) |
+| クラスルーム管理 | (Smalruby 改良) | メニューから直接アクセス |
+
+## 主要ファイル
+
+### scratch-gui
+
+#### Settings reducer (Smalruby マーカー追加)
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/reducers/settings.js` | 設定 state（Ruby version, V1 prompt dismiss）|
+| `packages/scratch-gui/src/lib/settings/` | 設定永続化ライブラリ |
+
+#### URL パラメータ連携
+
+- `packages/scratch-gui/src/lib/url-params.js` — `ruby_version` 等の URL パラメータパーサ
+
+#### Smalruby マーカー (upstream への埋め込み)
+
+`src/reducers/settings.js`:
+- "URL params for Playwright" — URL パラメータ import
+- "ruby_version URL param" — `ruby_version` パラメータ反映
+
+### scratch-vm
+
+なし。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+なし。
+
+## 設定・データ永続化
+
+### Redux state (settings reducer)
+
+- `rubyVersion` (1 / 2)
+- `dismissV1Prompt` (boolean) — v1 検出プロンプトをスキップするか
+
+### LocalStorage キー
+
+各設定機能ごとに独立した key を持つ（上記表参照）。
+
+### URL パラメータ
+
+| パラメータ | 効果 |
+|---|---|
+| `ruby_version` | Ruby バージョンを 1 または 2 に強制 |
+| `rubyMode` | Ruby タブの初期モード |
+| `tab` | 初期表示タブ |
+| `no_beforeunload` | beforeunload 無効化（Playwright 用）|
+
+## 関連ドキュメント
+
+- [`docs/ruby-editor/`](../ruby-editor/) — Ruby v1/v2 の差異
+- [`docs/smalruby-language-spec-v1-diff.ja.md`](../smalruby-language-spec-v1-diff.ja.md) — v1/v2 言語仕様差分
+- [`docs/menu-bar/`](../menu-bar/) — 設定メニュー UI
+- `.claude/rules/scratch-gui/smalruby-markers.md` — upstream マーカー一覧
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*ruby_version|feat:.*settings` で grep）。

--- a/docs/sound/README.md
+++ b/docs/sound/README.md
@@ -1,0 +1,101 @@
+# 音 (サウンド)
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+## 概要
+
+スプライトが鳴らす**音 (サウンド)** の編集機能。サウンドライブラリからの選択、自分で録音 (`record-modal`)、ファイルから取り込む、波形編集 (audio-trimmer) などを行う。upstream Scratch から継承しており、Smalruby 固有の改良はない。
+
+## ユーザーストーリー
+
+- **小学生**として、効果音やBGMをスプライトに付けたい
+- **作品を作る子**として、自分の声を録音して使いたい
+- **発表会の出展者**として、ライブラリから音を選んで作品の世界観を作りたい
+- **音の編集をしたい子**として、不要な部分をトリミングしたい
+
+## UI / 操作フロー
+
+エディタ上部のタブで **音** タブを選択：
+
+1. 左カラムにサウンド一覧
+2. 右カラムにサウンドエディタ (波形表示 + トリム + エフェクト)
+3. 「+」ボタン → サウンドライブラリ / マイク録音 / ファイル / サプライズ
+
+### 録音
+
+`record-modal` を開いて：
+1. マイク許可
+2. 録音開始 (`recording-step`)
+3. 再生確認 (`playback-step`)
+4. 必要に応じてトリミング (`audio-trimmer`)
+5. 保存
+
+## 主要ファイル
+
+### scratch-gui
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/sound-tab.jsx` | サウンドタブのメインコンテナ |
+| `packages/scratch-gui/src/containers/sound-editor.jsx` | サウンドエディタ |
+| `packages/scratch-gui/src/containers/sound-library.jsx` | サウンドライブラリモーダル |
+| `packages/scratch-gui/src/containers/audio-trimmer.jsx` | 波形トリミング |
+| `packages/scratch-gui/src/containers/audio-selector.jsx` | 範囲選択 |
+| `packages/scratch-gui/src/containers/record-modal.jsx` | 録音モーダル |
+| `packages/scratch-gui/src/containers/recording-step.jsx` | 録音ステップ |
+| `packages/scratch-gui/src/containers/playback-step.jsx` | 再生確認ステップ |
+
+#### コンポーネント
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/components/audio-trimmer/` | トリマー UI |
+| `packages/scratch-gui/src/components/sound-editor/` | エディタ UI |
+| `packages/scratch-gui/src/components/record-modal/` | モーダル UI |
+| `packages/scratch-gui/src/components/mic-indicator/` | マイク入力レベル表示 |
+| `packages/scratch-gui/src/components/waveform/` | 波形表示 |
+| `packages/scratch-gui/src/components/meter/` | メーター UI |
+| `packages/scratch-gui/src/components/play-button/` | 再生ボタン |
+
+#### ライブラリ
+
+- `packages/scratch-gui/src/lib/audio/` — Audio 関連ユーティリティ
+
+#### State 管理
+
+- `packages/scratch-gui/src/reducers/mic-indicator.js` — マイク入力 state
+
+### scratch-vm
+
+VM の `audio-engine` (依存パッケージ) でサウンド再生・エフェクト処理。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+サウンド自体を**操作する**ブロックのみ列挙（音楽生成系の `music_*` などは含めない）：
+
+| ブロック | 説明 |
+|---|---|
+| `sound_play` | 音を鳴らす（最後まで待たない）|
+| `sound_playuntildone` | 音を鳴らして終わるまで待つ |
+| `sound_stopallsounds` | すべての音を止める |
+| `sound_sounds_menu` | サウンド選択メニュー（引数用）|
+
+> 「音楽」関連 (`music_playDrumForBeats`, `music_playNoteForBeats` など) は別拡張機能 [`docs/extension-music/`](../extension-music/) を参照。
+
+## 設定・データ永続化
+
+なし（サウンドデータはプロジェクトの一部として `.sb3` に保存される）。
+
+## 関連ドキュメント
+
+- [`docs/sprite/`](../sprite/) — サウンドを持つスプライト
+- [`docs/costume/`](../costume/) — コスチュームと同じアセットパネル
+- [`docs/extension-music/`](../extension-music/) — 音楽生成拡張
+
+## 関連 Issue / PR
+
+upstream そのままの機能のため、Smalruby 固有の Issue はほとんどなし。

--- a/docs/sprite/README.md
+++ b/docs/sprite/README.md
@@ -1,0 +1,100 @@
+# スプライト
+
+> **⬆️ upstream そのまま** — upstream の実装をほぼそのまま利用
+
+## 概要
+
+Scratch プロジェクトに登場する**キャラクター（スプライト）**の追加・選択・配置・属性編集を扱う機能群。スプライトライブラリからの選択、自分で描く、ファイルから取り込む、ステージ上のドラッグでの配置、座標・向き・サイズの編集など、upstream Scratch から継承する機能をそのまま提供している。
+
+## ユーザーストーリー
+
+- **小学生**として、ライブラリから猫やボールなどのキャラクターを選んで作品に追加したい
+- **オリジナル作品を作る子**として、自分で描いたスプライトを使いたい
+- **発表会の出展者**として、複数のキャラクターを配置して画面構成を作りたい
+- **作品制作中の子**として、スプライトの座標・向き・サイズを GUI で直接調整したい
+
+## UI / 操作フロー
+
+エディタ右下の **スプライトペイン** で操作：
+
+| 操作 | UI |
+|---|---|
+| スプライト追加 | 「+」ボタン → スプライトライブラリ / カメラ撮影 / ファイル / 自分で描く |
+| スプライト選択 | スプライト一覧をクリック |
+| スプライト削除 | スプライトカードの「×」 |
+| 座標設定 | スプライト情報の x, y 入力欄 |
+| 向き設定 | direction-picker (時計型 UI) |
+| サイズ設定 | size 入力欄 |
+| 表示/非表示 | show/hide トグル |
+| ロック | スプライトをドラッグ移動できないようにロック |
+
+## 主要ファイル
+
+### scratch-gui
+
+#### コンポーネント / コンテナ
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/sprite-info.jsx` | スプライト情報パネル (座標・向き・サイズ・表示) |
+| `packages/scratch-gui/src/components/sprite-info/` | UI コンポーネント |
+| `packages/scratch-gui/src/containers/sprite-selector-item.jsx` | スプライト一覧の各カード |
+| `packages/scratch-gui/src/components/sprite-selector/` | スプライト一覧 UI |
+| `packages/scratch-gui/src/components/sprite-selector-item/` | カード UI |
+| `packages/scratch-gui/src/containers/sprite-library.jsx` | スプライトライブラリモーダル |
+| `packages/scratch-gui/src/containers/target-pane.jsx` | スプライトペイン全体 |
+| `packages/scratch-gui/src/containers/target-highlight.jsx` | 選択中スプライトのハイライト |
+
+#### 向き・方向
+
+- `packages/scratch-gui/src/containers/direction-picker.jsx` — 向き選択 UI
+
+#### State 管理
+
+- `packages/scratch-gui/src/reducers/targets.js` — スプライト一覧 / 選択中ターゲット
+- `packages/scratch-gui/src/reducers/hovered-target.js` — ホバー中ターゲット
+
+### scratch-vm
+
+`packages/scratch-vm/src/sprites/` — Sprite, RenderedTarget の実装。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+スプライト自体の操作に関連するブロック：
+
+| ブロック | 説明 |
+|---|---|
+| `motion_gotoxy` | 指定座標へ移動 |
+| `motion_setx` / `motion_sety` | x / y 座標設定 |
+| `motion_changexby` / `motion_changeyby` | 座標変化 |
+| `motion_pointindirection` | 向き設定 |
+| `motion_movesteps` | 歩数移動 |
+| `looks_changesizeby` / `looks_setsizeto` | サイズ変更 |
+| `control_create_clone_of` | クローン作成 |
+| `control_delete_this_clone` | クローン削除 |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec.ja.md`](../smalruby-language-spec.ja.md) を参照。
+> 「見た目」関連のブロック (`looks_say`, `looks_show` など) は将来 `docs/looks/` を作る場合に分離可能。
+
+## 設定・データ永続化
+
+### Redux state
+
+- `targets` — スプライト一覧 / 編集中ターゲット
+- `hovered-target` — ホバー中
+- `asset-drag` — アセットドラッグ状態
+- `dynamic-assets` — 動的アセット
+
+## 関連ドキュメント
+
+- [`docs/costume/`](../costume/) — スプライトのコスチューム編集
+- [`docs/sound/`](../sound/) — スプライトのサウンド編集
+- [`docs/stage/`](../stage/) — ステージ全体
+
+## 関連 Issue / PR
+
+upstream そのままの機能のため、Smalruby 固有の Issue はほとんどなし。

--- a/docs/stage/README.md
+++ b/docs/stage/README.md
@@ -1,0 +1,132 @@
+# ステージ
+
+> **🔧 upstream 改良** — upstream にあるが Smalruby で機能を改良・拡張している
+> **改良点**: ① iPad portrait での **stage size を small に強制** (`narrow-desktop` 対応、issue #572 / #599)。② モバイル UI 向けの調整（`mobile-ui/` 参照）。
+
+## 概要
+
+Scratch プロジェクトの実行結果を表示する**ステージ**領域。緑旗 (実行)、赤い停止ボタン、ステージサイズ切替、背景 (backdrop) ライブラリ、表示モード (90s, oldtimey, prehistoric) など、upstream Scratch から継承する機能群。
+
+Smalruby は基本的に upstream のステージをそのまま使用しているが、**iPad portrait** などの狭い viewport で stage を `small` サイズに強制する独自対応がある（[`docs/mobile-ui/`](../mobile-ui/) と連動）。
+
+## ユーザーストーリー
+
+- **作品制作中の小学生**として、緑旗をクリックしてプログラムを実行したい
+- **発表会の出展者**として、フルスクリーンモードで作品を見せたい
+- **iPad portrait のユーザー**として、画面が狭くてもブロックエディタが圧迫されないように stage が自動でコンパクトになってほしい
+- **ターボモードを使う子**として、計算重視のプログラムを高速で動かしたい
+
+## UI / 操作フロー
+
+### コントロール
+
+| 要素 | 機能 |
+|---|---|
+| 緑旗 | 全スプライトの `when_flag_clicked` を発火 |
+| 停止ボタン | 全スクリプト停止 |
+| ステージサイズ切替 | small / large / fullscreen |
+| watermark | プロジェクトロード中の透かし表示 |
+
+### 表示モード
+
+特殊な表示モード（メニューから起動）：
+- 90s モード (`nineties-mode`)
+- oldtimey モード
+- prehistoric モード
+- ターボモード (`turbo-mode`)
+
+### 背景 (Backdrop)
+
+ステージ自身の「コスチューム」相当。`backdrop-library` から選択。
+
+## 主要ファイル
+
+### scratch-gui
+
+#### ステージ本体
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/stage.jsx` | ステージのメインコンテナ |
+| `packages/scratch-gui/src/containers/stage-wrapper.jsx` | ステージラッパー |
+| `packages/scratch-gui/src/containers/stage-header.jsx` | ステージヘッダー (size 切替、フルスクリーン) |
+| `packages/scratch-gui/src/containers/stage-selector.jsx` | ステージ自体の選択 (sprite-pane の "Stage") |
+
+#### コントロール
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/controls.jsx` | 緑旗 + 停止ボタン |
+| `packages/scratch-gui/src/components/green-flag/` | 緑旗 UI |
+| `packages/scratch-gui/src/components/stop-all/` | 停止ボタン UI |
+
+#### 表示モード
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/components/turbo-mode/` | ターボモード表示 |
+| `packages/scratch-gui/src/components/nineties-mode/` | 90s モード |
+| `packages/scratch-gui/src/components/oldtimey-mode/` | oldtimey モード |
+| `packages/scratch-gui/src/components/prehistoric-mode/` | prehistoric モード |
+| `packages/scratch-gui/src/containers/turbo-mode.jsx` | ターボモード コンテナ |
+
+#### 背景
+
+- `packages/scratch-gui/src/containers/backdrop-library.jsx` — 背景ライブラリ
+
+#### Smalruby マーカー (upstream への埋め込み)
+
+`packages/scratch-gui/src/components/gui/gui.jsx` 内：
+- "iPad portrait narrow desktop stage size" — 744〜1023px viewport で `stageSize` を `'small'` に強制（issue #572 Phase 3-C, #599）
+
+#### State 管理
+
+- `packages/scratch-gui/src/reducers/stage-size.js`
+- `packages/scratch-gui/src/reducers/mode.js` — 表示モード
+- `packages/scratch-gui/src/reducers/vm-status.js` — VM 実行状態
+
+### scratch-vm / scratch-render
+
+ステージ描画は `scratch-render` (WebGL) を使用。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+ステージは特定のブロックに紐づかないが、以下が関連：
+
+| ブロック | 説明 |
+|---|---|
+| `event_whenflagclicked` | 緑旗クリックで発火 |
+| `event_whenstageclicked` | ステージクリックで発火 |
+| `event_whenbackdropswitchesto` | 背景切替時 |
+| `looks_switchbackdropto` | 背景切替 |
+| `looks_nextbackdrop` | 次の背景 |
+
+> 各ブロックの Ruby 表現は [`docs/smalruby-language-spec.ja.md`](../smalruby-language-spec.ja.md) を参照。
+
+## 設定・データ永続化
+
+### Redux state
+
+- `stage-size` — small / large / fullscreen
+- `mode` — 表示モード
+- `vm-status` — running / stopped
+
+### Smalruby 独自 narrow-desktop ロジック
+
+`@media (max-width: 1023px) and (min-width: 744px)` で stage を `'small'` に強制。詳細は [`docs/mobile-ui/`](../mobile-ui/) 参照。
+
+## 関連ドキュメント
+
+- [`docs/sprite/`](../sprite/) — スプライト管理
+- [`docs/costume/`](../costume/) — 背景はコスチュームの一種
+- [`docs/mobile-ui/`](../mobile-ui/) — iPad portrait での stage size 調整
+
+## 関連 Issue / PR
+
+- Issue #572 Phase 3-C — iPad portrait narrow desktop stage size
+- Issue #599 — 768→744px へのしきい値拡張
+- Issue #602 — Ruby tab の column overflow

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -1,0 +1,92 @@
+# チュートリアル
+
+> **🔧 upstream 改良** — upstream にあるが Smalruby で機能を改良・拡張している
+> **改良点**: ① **チュートリアル glow animation** をハイライト用に追加。② **Ruby タブの onboarding** を追加（初回 Ruby タブ訪問時のガイド）。③ **classroom-tutorial**（クラスルーム機能のチュートリアル）を追加。
+
+## 概要
+
+新しいユーザーや特定の機能を初めて使うユーザー向けの**チュートリアル**機能。upstream Scratch には基本的な「カード」形式のチュートリアル (`cards`) と「ヒント」(`tips-library`) があり、Smalruby はそれを継承しつつ Smalruby 独自のオンボーディング（Ruby タブ・クラスルーム）を追加している。
+
+## ユーザーストーリー
+
+- **初めて Smalruby を開いた小学生**として、簡単な作品例の作り方を順を追って教えてほしい
+- **Ruby タブを初めて開いた子**として、ブロックとの違いやどう使うかを画面上で学びたい
+- **Smalruby Classroom を初めて使う先生・生徒**として、操作方法をその場でガイドしてほしい
+- **教師**として、生徒に既存のチュートリアル（カード）を順番に見せていきたい
+
+## UI / 操作フロー
+
+### カードチュートリアル (upstream 由来)
+
+メニューバーの「ヒント」ボタンから `tips-library` を開き、チュートリアルを選ぶ：
+1. 全画面のチュートリアルカードが表示される
+2. 「次へ」「前へ」で進む
+3. 完了で閉じる
+
+### Ruby タブオンボーディング (Smalruby 独自)
+
+初めて Ruby タブを訪問したときに、tutorial-tooltip がメニューバー周辺に表示され、Ruby タブの使い方をガイド。`tutorial-onboarding` reducer の `MARK_RUBY_TAB_USED` で表示状態を管理。
+
+### classroom-tutorial (Smalruby 独自)
+
+Smalruby Classroom の各フェーズ（教師ログイン、クラス作成、生徒参加など）でツールチップ風の解説を表示。
+
+## 主要ファイル
+
+### scratch-gui
+
+#### upstream 由来（Smalruby マーカー追加あり）
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/containers/cards.jsx` | チュートリアルカードのコンテナ（Smalruby: glow animation 追加）|
+| `packages/scratch-gui/src/components/cards/` | カード UI |
+| `packages/scratch-gui/src/containers/tips-library.jsx` | ヒント / チュートリアル一覧 |
+
+#### Smalruby 独自
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-gui/src/components/menu-bar/tutorial-tooltip.jsx` | ツールチップ UI |
+| `packages/scratch-gui/src/reducers/tutorial-onboarding.js` | onboarding state（`MARK_TUTORIAL_SEEN`, `MARK_RUBY_TAB_USED`, `DISMISS_TOOLTIP`）|
+| `packages/scratch-gui/src/components/classroom-tutorial/` | クラスルーム機能のチュートリアル UI |
+| `packages/scratch-gui/src/reducers/classroom-tutorial.js` | クラスルームチュートリアル state |
+
+#### Smalruby マーカー (upstream への埋め込み)
+
+`src/containers/cards.jsx`, `src/components/cards/cards.jsx`:
+- "tutorial glow animation" — チュートリアルのハイライト用アニメーション
+
+### scratch-vm
+
+なし。
+
+### infra
+
+なし。
+
+## 関連ブロック
+
+なし。
+
+## 設定・データ永続化
+
+### Redux state
+
+- `tutorial-onboarding` — `tutorialSeen`, `rubyTabUsed`, `dismissedTooltips`
+- `classroom-tutorial` — クラスルームチュートリアル状態
+- `cards` — チュートリアルカードの開閉・現在ステップ
+
+### LocalStorage
+
+特定の onboarding 完了フラグは Redux state にあるが、永続化はプロジェクト state や `legacy-storage` 経由で扱われる場合がある。
+
+## 関連ドキュメント
+
+- [`docs/menu-bar/`](../menu-bar/) — `tutorial-tooltip` の表示位置
+- [`docs/classroom/`](../classroom/) — `classroom-tutorial` の対象機能
+- [`docs/ruby-editor/`](../ruby-editor/) — Ruby タブ onboarding の対象
+
+## 関連 Issue / PR
+
+主要 PR は履歴を参照（`feat:.*tutorial|feat:.*onboarding` で grep）。


### PR DESCRIPTION
## Summary

Issue #610 Phase 2 batch 4（最終）: 残り 25 機能のドキュメントを一気に整備し、**Issue #610 で計画したすべての機能ドキュメントが揃った**（合計 42 機能）。

## Changes Made

### コアエディタ系 6 件

| ドキュメント | 区分 | 主な内容 |
|---|---|---|
| `project-management/` | 🔧 改良 | Project HOC + URL ローダー + Google Drive クリア |
| `block-editor/` | 🔧 改良 | Blockly + Ruby ブロック注入 + ジェスチャー復旧 |
| `stage/` | 🔧 改良 | narrow-desktop で stage size 強制 small |
| `sprite/` | ⬆️ そのまま | スプライト管理一般 |
| `costume/` | ⬆️ そのまま | `looks_switchcostumeto` 等の操作ブロック含む |
| `sound/` | ⬆️ そのまま | `sound_play` 等の操作ブロック含む |

### upstream そのまま拡張機能 13 件

| ドキュメント | 備考 |
|---|---|
| `extension-music/` | Smalruby ランタイム ✅ |
| `extension-pen/` | Smalruby ランタイム ✅ |
| `extension-video-sensing/`, `extension-face-sensing/` | カメラ系 |
| `extension-text2speech/` (AWS Polly), `extension-translate/` (Google) | クラウド API |
| `extension-makeymakey/`, `extension-microbit/`, `extension-gdxfor/`, `extension-ev3/`, `extension-boost/`, `extension-wedo2/` | `defaultHidden: true` |
| `extension-speech2text/` | VM のみ、GUI 未登録（注記） |

### 共通基盤 6 件

| ドキュメント | 区分 |
|---|---|
| `device-connection/` | 🔧 改良 (Mesh v2 / Smalrubot S1 ステップ追加) |
| `menu-bar/` | 🔧 改良 (Smalruby ロゴ・classroom button・version notif 等) |
| `tutorial/` | 🔧 改良 (onboarding + classroom-tutorial) |
| `alerts/` | ⬆️ そのまま |
| `settings/` | 🔧 改良 (Ruby v1/v2 切替) |
| `screenshot/` | 🆕 Smalruby 独自 (blocks/ruby スクリーンショット) |

### Index 更新

- `docs/README.md` の全項目を ✅ に更新

## 全 42 機能ドキュメントの内訳

- 🆕 Smalruby 独自: **15 件** (ruby-editor, furigana, dncl, rubytee, classroom, mesh-v2, google-drive, screenshot, extension-mesh-v2, extension-smalrubot-s1, extension-koshien, extension-smalruby-ruby, extension-tm2scratch, extension-g2s, extension-microbit-more)
- 🔧 upstream 改良: **9 件** (project-management, block-editor, stage, backpack, mobile-ui, device-connection, menu-bar, tutorial, settings)
- ⬆️ upstream そのまま: **18 件** (sprite, costume, sound, alerts, extension-music, extension-pen, extension-video-sensing, extension-face-sensing, extension-text2speech, extension-translate, extension-makeymakey, extension-microbit, extension-gdxfor, extension-ev3, extension-boost, extension-wedo2, extension-speech2text)

## Test Coverage

ドキュメント整備のみ（コード変更なし）。

## Related Issues

Closes #610
