### PR TITLE
docs(scratch-vm): phase 1 - architecture overview (#620)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,12 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 | [`settings/`](settings/) — Ruby バージョン切替・各種設定永続化 | 🔧 改良 | ✅ |
 | [`screenshot/`](screenshot/) — blocks-screenshot・ruby-screenshot | 🆕 独自 | ✅ |
 
+### F. 開発者向け（パッケージ内部仕様）
+
+| ドキュメント | 内容 |
+|---|---|
+| [`scratch-vm/`](scratch-vm/) — VM 内部仕様 (Runtime / Sequencer / Thread / Target / Blocks / Extensions / Serialization) | 開発者向け（Issue #620、Phase 1 完了） |
+
 ### その他
 
 - [`adr/`](adr/) — Architecture Decision Records (Smalruby 独自の ADR)

--- a/docs/scratch-vm/README.md
+++ b/docs/scratch-vm/README.md
@@ -1,0 +1,98 @@
+# scratch-vm 内部仕様
+
+> **対象読者**: 新しく `packages/scratch-vm/` を触る開発者、AI アシスタント (Claude Code 等)、upstream マージ時に差分を判断する人
+
+scratch-vm は **Scratch プロジェクトを実行する仮想マシン**。プロジェクトをロードして、ブロックを並列のスレッドとして実行し、レンダリングを通じてステージに反映する。Scratch Foundation の [`scratch-vm`](https://github.com/scratchfoundation/scratch-vm) を fork し、Smalruby 独自の拡張機能 (Mesh v2, Smalrubot S1, Koshien 等) と Mesh v1 マイグレーションを追加している。
+
+このディレクトリは **Smalruby が VM の理解を深めるために書いた独自ドキュメント**。upstream の既存ドキュメント (`packages/scratch-vm/docs/extensions.md`) は別途参照する。
+
+## ドキュメント一覧
+
+| ドキュメント | 内容 | 状態 |
+|---|---|---|
+| [`architecture.md`](architecture.md) | Runtime / Sequencer / Thread / Target / Blocks の関係、データフロー | ✅ |
+| [`extensions.md`](extensions.md) | 拡張機能の仕組み + Smalruby 独自追加 (`smalruby-extensions.js`) | ⏳ |
+| [`serialization.md`](serialization.md) | `.sb3` フォーマット + Smalruby マイグレーション (`smalruby-migration.js`) | ⏳ |
+| [`blocks-runtime.md`](blocks-runtime.md) | ブロック実行モデル (execute / sequencer / thread の協調) | ⏳ |
+
+⏳ は未着手。Issue #620 で順次追加予定。
+
+## 主要ファイルマップ
+
+### Public API
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-vm/src/index.js` | `VirtualMachine` クラスのみ export |
+| `packages/scratch-vm/src/virtual-machine.js` | 公開 API。`loadProject`, `greenFlag`, `setEditingTarget`, イベント発火 |
+
+### Engine（実行エンジン）
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-vm/src/engine/runtime.js` | 中核。Targets / Threads / Sequencer / IO devices / 拡張プリミティブを保有 |
+| `packages/scratch-vm/src/engine/sequencer.js` | スレッドの時分割実行スケジューラ |
+| `packages/scratch-vm/src/engine/thread.js` | 1 スクリプトの実行スレッド (status, stack, blockId) |
+| `packages/scratch-vm/src/engine/blocks.js` | Target ごとのブロックコンテナ |
+| `packages/scratch-vm/src/engine/execute.js` | ブロック関数を呼ぶ実行器 (Command / Reporter / Hat / Boolean) |
+| `packages/scratch-vm/src/engine/target.js` | Sprite / Stage の基底クラス |
+| `packages/scratch-vm/src/engine/block-utility.js` | ブロック関数に渡される utility (thread, sequencer, runtime, stackFrame) |
+| `packages/scratch-vm/src/engine/adapter.js` | Blockly XML/JSON ↔ runtime block 形式 |
+
+### Sprites
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-vm/src/sprites/sprite.js` | プロトタイプ (コスチューム/サウンド共有資産) |
+| `packages/scratch-vm/src/sprites/rendered-target.js` | Target の具象。renderer state を持つ |
+
+### Extension Support
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-vm/src/extension-support/extension-manager.js` | 拡張機能のロード機構 (built-in + worker) |
+| `packages/scratch-vm/src/extension-support/smalruby-extensions.js` | **Smalruby 独自**。microbitMore, koshien, tm2scratch, g2s, smalrubyRuby を built-in として登録 |
+| `packages/scratch-vm/src/extension-support/block-type.js` | BlockType enum (COMMAND, REPORTER, BOOLEAN, HAT, EVENT, LOOP) |
+| `packages/scratch-vm/src/extension-support/argument-type.js` | ArgumentType enum (NUMBER, STRING, BOOLEAN, COLOR 等) |
+| `packages/scratch-vm/src/extension-support/target-type.js` | TargetType enum (SPRITE, STAGE) |
+
+### Serialization
+
+| ファイル | 役割 |
+|---|---|
+| `packages/scratch-vm/src/serialization/sb3.js` | `.sb3` (zip) のシリアライズ・デシリアライズ |
+| `packages/scratch-vm/src/serialization/smalruby-migration.js` | **Smalruby 独自**。Mesh v1 → v2 のオパコード書き換え、koshien 検出 |
+
+### IO Devices
+
+`packages/scratch-vm/src/io/`:
+- `clock`, `keyboard`, `mouse`, `mouseWheel`, `video`, `userData`, `cloud`
+
+### Util
+
+`packages/scratch-vm/src/util/`:
+- `cast.js` (型強制), `color.js`, `math-util.js`, `string-util.js`, `timer.js`
+
+### Built-in Extensions
+
+`packages/scratch-vm/src/extensions/`:
+- upstream: `scratch3_pen`, `scratch3_music`, `scratch3_video_sensing`, `scratch3_face_sensing`, `scratch3_text2speech`, `scratch3_translate`, `scratch3_makeymakey`, `scratch3_microbit`, `scratch3_gdx_for`, `scratch3_ev3`, `scratch3_boost`, `scratch3_wedo2`, `scratch3_mesh` (旧 v1), `scratch3_speech2text`
+- Smalruby 独自: `scratch3_mesh_v2`, `scratch3_smalrubot_s1`, `microbitMore`, `koshien`, `scratch3_tm2scratch`, `scratch3_g2s`, `smalruby_ruby`
+
+各拡張機能の詳細は `docs/extension-<name>/` を参照。
+
+## upstream マーカー
+
+upstream ファイルに埋め込んだ Smalruby 固有コードは `=== Smalruby:` マーカーで囲まれている。VM 側のマーカー一覧は **`.claude/rules/scratch-vm/development.md`** を参照。
+
+## 関連ドキュメント
+
+- [`packages/scratch-vm/docs/extensions.md`](../../packages/scratch-vm/docs/extensions.md) — upstream の拡張機能仕様（Scratch 3.0 Extension Specification）
+- [`docs/extension-*/`](../) — 各拡張機能のユーザー視点ドキュメント
+- `.claude/rules/scratch-vm/development.md` — VM 開発ワークフロー
+- `.claude/rules/scratch-vm/smalruby-prettier-files.md` — Smalruby 独自ファイル一覧
+
+## 関連 Issue
+
+- Issue #620 — 本ドキュメント体系の整備 (Open)
+- Issue #610 — 機能ドキュメント体系 (Closed)

--- a/docs/scratch-vm/architecture.md
+++ b/docs/scratch-vm/architecture.md
@@ -1,0 +1,172 @@
+# scratch-vm アーキテクチャ
+
+scratch-vm の中核オブジェクトと、プロジェクトロード〜実行〜描画までのデータフロー。
+
+## クラス階層と所有関係
+
+```
+VirtualMachine (EventEmitter, public API)
+  └─ runtime: Runtime
+        ├─ targets: Target[]                ← Stage + Sprite (RenderedTarget)
+        │     └─ blocks: Blocks            ← opcode/inputs/fields の dict
+        │           └─ comments, variables
+        ├─ threads: Thread[]                ← 実行中のスクリプト
+        │     ├─ stack: blockId[]
+        │     ├─ stackFrames: StackFrame[] ← ループ状態, 報告値
+        │     └─ status: RUNNING / PROMISE_WAIT / DONE / ...
+        ├─ sequencer: Sequencer            ← フレームごとに threads を進める
+        ├─ ioDevices                        ← clock / keyboard / mouse / video / cloud
+        ├─ _primitives: Map<opcode, fn>    ← ブロック関数の解決辞書
+        └─ _hats: Map<opcode, HatMeta>      ← Hat ブロック metadata
+```
+
+主要な「**所有 (owns)**」関係：
+
+- `VirtualMachine` は `Runtime` を 1 つ所有
+- `Runtime` は **すべての** Targets / Threads / Sequencer / IO デバイスを所有
+- 各 `Target` は **自身の** `Blocks` と `Variables` を所有
+- 各 `Thread` は実行コンテキスト (`Target` への参照、`Block` の stack、状態) を持つ
+- `Sequencer` は `Runtime` を参照し、`Runtime.threads` を時分割で進める
+
+## データフロー: プロジェクトロード → 実行 → 描画
+
+### 1. ロード
+
+```
+vm.loadProject(json)
+  → VirtualMachine.loadProject (virtual-machine.js)
+  → sb3.deserialize(json) (serialization/sb3.js)
+       → Targets を生成、各 Target に Blocks を生成
+       → Variables を初期化
+  → Smalruby マイグレーション (smalruby-migration.js)
+       → mesh_* opcode を meshV2_* に書き換え
+       → koshien 拡張使用を検出 (必要なら追加ロード)
+  → ExtensionManager がプロジェクト依存の拡張機能をロード
+  → PROJECT_LOADED イベント発火
+```
+
+### 2. 編集 (オプション)
+
+エディタが `vm.setEditingTarget(targetId)` で編集対象を切替。Blocks の追加・削除・接続変更は `editingTarget.blocks` を直接編集する。**Runtime の実行とは独立**して編集できる（実行中も含む）。
+
+### 3. 実行開始
+
+```
+vm.greenFlag()
+  → Runtime.start() / startHats('event_whenflagclicked')
+  → 該当 Hat ブロックを持つすべての Thread を生成
+  → Runtime.threads に push
+  → PROJECT_START イベント発火
+```
+
+### 4. ステップ (フレームごと)
+
+```
+Runtime._step() が requestAnimationFrame で呼ばれる
+  → Sequencer.stepThreads()
+       → 時間予算 (currentStepTime × 0.75) 内で
+       → for thread of runtime.threads:
+            execute(sequencer, thread)
+              → 現在の blockId を thread.peekStack() で取得
+              → primitive = runtime._primitives[block.opcode]
+              → result = primitive(args, blockUtility)
+              → Promise なら thread.status = PROMISE_WAIT、resolve で続行
+              → Reporter なら値を stack frame に push
+              → Hat なら edge-trigger 判定
+              → 次の blockId に移動 or 親 stack に戻る or DONE
+       → DONE thread を runtime.threads から削除
+  → Runtime._renderInterpolatedPositions() で補間
+  → Renderer がステージを再描画
+  → 必要なら新しい Hat を起動
+```
+
+### 5. 停止
+
+```
+vm.stopAll()
+  → Runtime.stopAll()
+       → すべての thread.status = DONE
+       → ioDevices をリセット (timer 等)
+       → PROJECT_RUN_STOP イベント発火
+```
+
+## 役割分担: 編集 vs 実行
+
+scratch-vm の **重要な設計判断**は、データ (Blocks / Targets / Variables) と実行 (Sequencer / Thread / execute) を**分離**していること：
+
+| 層 | 役割 | エディタの関与 |
+|---|---|---|
+| **データ** | Blocks / Targets / Variables | エディタが直接書き換え (CRUD) |
+| **実行** | Sequencer / Thread / execute | エディタは `vm.greenFlag()` 等のハイレベル API しか触らない |
+
+→ **編集と実行が共存できる** (ライブコーディング、実行中のブロック追加)。
+
+## ブロック実行モデル (詳細は別 doc)
+
+ブロック関数 (primitive) は以下のシグネチャ：
+
+```js
+function blockPrimitive(args, util) {
+  // args: { ARGUMENT_NAME: value, ... }
+  // util: BlockUtility
+  //   util.thread, util.sequencer, util.runtime
+  //   util.target (= util.thread.target)
+  //   util.stackFrame (= 現在の StackFrame, ループ状態を保持)
+  return value;        // Reporter / Boolean
+  return Promise;      // 非同期 (status は自動で PROMISE_WAIT に)
+  // void                  Command (次のブロックへ)
+}
+```
+
+詳細は [`blocks-runtime.md`](blocks-runtime.md) (準備中) を参照。
+
+## Smalruby 固有の改良点
+
+upstream `extension-manager.js` の中央付近に以下のマーカー：
+
+```js
+// === Smalruby: Start of register Smalruby extensions ===
+require('./smalruby-extensions')(builtinExtensions);
+// === Smalruby: End of register Smalruby extensions ===
+```
+
+→ `smalruby-extensions.js` (Smalruby 独自ファイル) で microbitMore / koshien / tm2scratch / g2s / smalrubyRuby を built-in 拡張として登録。**upstream マージ時の差分は最小** (1 require 行のみ)。詳細は [`extensions.md`](extensions.md) (準備中) を参照。
+
+`virtual-machine.js` の `loadProject` 内では `smalruby-migration.js` が呼ばれて Mesh v1 → v2 のオパコード書き換えが行われる。詳細は [`serialization.md`](serialization.md) (準備中) を参照。
+
+## 主要 API リファレンス（公開メソッド）
+
+`VirtualMachine` クラスから外部に公開されるメソッド：
+
+| メソッド | 用途 |
+|---|---|
+| `loadProject(json)` | `.sb3` プロジェクトをロード |
+| `saveProjectSb3()` | 現プロジェクトを `.sb3` Blob として export |
+| `greenFlag()` | 緑旗を発火 (event_whenflagclicked Hat を起動) |
+| `stopAll()` | 全スクリプト停止 |
+| `setEditingTarget(targetId)` | 編集対象スプライトを切替 |
+| `addSprite(spriteJson)`, `deleteSprite(targetId)` | スプライト追加・削除 |
+| `addBackdrop(...)`, `addCostume(...)`, `addSound(...)` | アセット追加 |
+| `runtime` (getter) | 内部 Runtime への参照 (高度な用途) |
+
+完全な API は `packages/scratch-vm/src/virtual-machine.js` を参照。
+
+## イベント
+
+`VirtualMachine` は EventEmitter として以下を発火：
+
+- `PROJECT_LOADED` — プロジェクトロード完了
+- `PROJECT_START` — 緑旗実行開始
+- `PROJECT_RUN_STOP` — 全スクリプト停止
+- `SCRIPT_GLOW_ON` / `SCRIPT_GLOW_OFF` — 実行中スクリプトのハイライト
+- `BLOCK_GLOW_ON` / `BLOCK_GLOW_OFF` — 実行中ブロックのハイライト
+- `PROJECT_CHANGED` — プロジェクトに変更があった
+- `targetsUpdate` — Targets 一覧が変わった
+
+## 関連ドキュメント
+
+- [`README.md`](README.md) — 主要ファイルマップ
+- [`extensions.md`](extensions.md) — 拡張機能の仕組み (準備中)
+- [`serialization.md`](serialization.md) — `.sb3` フォーマット (準備中)
+- [`blocks-runtime.md`](blocks-runtime.md) — ブロック実行モデル詳細 (準備中)
+- 上流: [scratch-vm GitHub](https://github.com/scratchfoundation/scratch-vm)


### PR DESCRIPTION
## Summary

Issue #620 Phase 1: scratch-vm 内部仕様ドキュメントの土台を整備。全体ナビゲーション (`README.md`) と architecture overview (`architecture.md`) を執筆。

## Changes Made

### 新規ドキュメント

- **`docs/scratch-vm/README.md`** — エントリポイント
  - 対象読者 (新規開発者 / AI アシスタント / upstream マージ担当)
  - ドキュメント一覧 + 状態 (Phase 1 完了 / Phase 2-4 準備中)
  - **主要ファイルマップ**: engine / sprites / extension-support / serialization / io / util / extensions の各レイヤー
  - upstream マーカー (`=== Smalruby:`) への参照
  - 関連ドキュメント

- **`docs/scratch-vm/architecture.md`** — VM の中核アーキテクチャ
  - **クラス階層と所有関係**: VirtualMachine → Runtime → Targets/Threads/Sequencer/IO/_primitives
  - **データフロー**: load → edit → start → step → stop
  - **編集と実行の分離設計**: なぜデータ層と実行層が分かれているか
  - ブロック関数 (primitive) のシグネチャと BlockUtility
  - Smalruby 固有の改良点: `smalruby-extensions.js` (built-in 登録) と `smalruby-migration.js` (Mesh v1 → v2)
  - 公開 API リファレンス + イベント一覧

### docs/README.md 更新

「**F. 開発者向け（パッケージ内部仕様）**」セクションを新設し、`scratch-vm/` への入口を追加。

## 残作業 (別 PR)

- **Phase 2**: `extensions.md` — 拡張機能の仕組み + Smalruby `smalruby-extensions.js`
- **Phase 3**: `serialization.md` — `.sb3` フォーマット + `smalruby-migration.js`
- **Phase 4**: `blocks-runtime.md` — execute / sequencer / thread の協調

## Test Coverage

ドキュメント整備のみ（コード変更なし）。

## Related Issues

Refs #620
