### PR TITLE
docs(infra): phase 1 - cross-cutting overview + smalruby-api (#625)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,11 +80,12 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 | [`settings/`](settings/) — Ruby バージョン切替・各種設定永続化 | 🔧 改良 | ✅ |
 | [`screenshot/`](screenshot/) — blocks-screenshot・ruby-screenshot | 🆕 独自 | ✅ |
 
-### F. 開発者向け（パッケージ内部仕様）
+### F. 開発者向け（パッケージ内部仕様 / インフラ）
 
 | ドキュメント | 内容 |
 |---|---|
 | [`scratch-vm/`](scratch-vm/) — VM 内部仕様 (Runtime / Sequencer / Thread / Target / Blocks / Extensions / Serialization / Blocks Runtime) | 開発者向け（Issue #620 完了） |
+| [`infra/`](infra/) — AWS CDK インフラ全体 (mesh-v2 / rubytee-relay / classroom / smalruby-api の横断ドキュメント) | 開発者・運用向け（Issue #625） |
 
 ### その他
 

--- a/docs/infra/README.md
+++ b/docs/infra/README.md
@@ -1,0 +1,169 @@
+# Smalruby インフラ全体
+
+Smalruby のバックエンドは **AWS CDK** で管理される 4 つの独立したプロジェクトから構成される。すべて **ap-northeast-1 (東京)** リージョンにデプロイされ、共通の `.env` symlink パターンで stage 切替を行う。
+
+## プロジェクト一覧
+
+| プロジェクト | 用途 | 主要 AWS サービス | カスタムドメイン (prod) | 統合ドキュメント |
+|---|---|---|---|---|
+| **`infra/smalruby-mesh-v2/`** | Mesh v2 リアルタイム通信 | AppSync (GraphQL) + DynamoDB | `graphql.api.smalruby.app` | [`docs/mesh-v2/`](../mesh-v2/) |
+| **`infra/smalruby-rubytee-relay/`** | Rubytee (AI チャット) リレー | API Gateway HTTP API + Lambda + DynamoDB | `rubytee.api.smalruby.app` | [`docs/rubytee/`](../rubytee/) |
+| **`infra/smalruby-classroom/`** | クラスルーム機能 | API Gateway HTTP API + Lambda + DynamoDB + S3 | `classroom.api.smalruby.app` | [`docs/classroom/`](../classroom/) |
+| **`infra/smalruby-api/`** | 共通 API (CORS proxy / Mesh zone / Scratch proxy) | API Gateway HTTP API + Lambda | `api.smalruby.app` | [`smalruby-api.md`](smalruby-api.md) |
+
+## 共通パターン
+
+### AWS 基本
+
+| 項目 | 値 |
+|---|---|
+| リージョン | `ap-northeast-1` (東京) |
+| CDK バージョン | 2.232.x |
+| Lambda ランタイム | Node.js 22.x（mesh-v2 のみ Ruby も使用） |
+| DynamoDB 課金 | `PAY_PER_REQUEST` (オンデマンド) |
+| TTL 属性 | 全テーブル `ttl` フィールドで自動削除 |
+| ログ保持 | prod: 1 ヶ月 / stg: 1 週間 |
+| CORS preflight キャッシュ | 24 時間 |
+
+### Stage 管理 (.env symlink パターン)
+
+すべての CDK プロジェクトは **`.env` symlink** で stage を切り替える：
+
+```bash
+cd infra/smalruby-mesh-v2
+
+# stg に切り替え
+rm .env && ln -s .env.stg .env
+
+# prod に切り替え
+rm .env && ln -s .env.prod .env
+
+# stg2 (検証環境) に切り替え
+rm .env && ln -s .env.stg2 .env
+```
+
+- **コマンドラインで env vars を上書きしない** (`.env` symlink を必ず使う)
+- 詳細は **`.claude/rules/infra/development.md`** を参照
+
+### Stage suffix の命名規則
+
+CloudFormation スタック名・Lambda 関数名・DynamoDB テーブル名等に付く suffix：
+
+```js
+const stageSuffix = stage === 'prod' ? '' : `-${stage}`;
+```
+
+例: `RubyteeRelayHandler` (prod) / `RubyteeRelayHandler-stg` (stg) / `RubyteeRelayHandler-stg2` (stg2)
+
+### カスタムドメイン
+
+すべて **`api.smalruby.app`** を Route53 親ゾーンとして以下のサブドメインを使う：
+
+| Stage | パターン |
+|---|---|
+| prod | `<service>.api.smalruby.app` |
+| stg | `stg.<service>.api.smalruby.app` |
+| stg2 | `stg2.<service>.api.smalruby.app` |
+
+**例外**: `smalruby-api` は **`api.smalruby.app` 直下** (旧 SAM スタックからの移行で既存ドメインをインポート)。
+
+### CORS
+
+| Stage | 許可オリジン (デフォルト) |
+|---|---|
+| stg | `https://smalruby.app`, `https://smalruby.jp`, `http://localhost:8601` |
+| prod | `https://smalruby.app`, `https://smalruby.jp` (localhost 除外) |
+
+→ ローカル開発は **stg エンドポイント** を使う。prod は CORS で localhost を弾く。
+
+### デプロイコマンド
+
+```bash
+# 共通: docker compose で infra service を使う
+docker compose run --rm -w /app/infra/<project> infra npm install
+docker compose run --rm -w /app/infra/<project> infra npx cdk synth
+docker compose run --rm -w /app/infra/<project> infra npx cdk diff
+docker compose run --rm -w /app/infra/<project> infra npx cdk deploy
+
+# 例: rubytee-relay の stg デプロイ
+cd infra/smalruby-rubytee-relay
+rm .env && ln -s .env.stg .env
+docker compose run --rm -w /app/infra/smalruby-rubytee-relay infra npx cdk deploy
+```
+
+### 環境変数の `.env.example`
+
+各プロジェクトに `.env.example` がある。新しい stage を作るときは：
+
+```bash
+cp .env.example .env.<stage>
+# シークレット (ANTHROPIC_API_KEY, MESH_SECRET_KEY 等) を埋める
+ln -sf .env.<stage> .env
+```
+
+## プロジェクト相関図
+
+```
+                          ┌───────────────────────┐
+                          │  smalruby-gui (web)    │
+                          │  smalruby.app          │
+                          └──────────┬─────────────┘
+                                     │
+                ┌──────────┬─────────┼─────────┬──────────┐
+                ▼          ▼         ▼         ▼          ▼
+        smalruby-api  rubytee-   classroom  mesh-v2  (Google Drive,
+        (api)         relay      (classroom (graphql  各種 OAuth)
+        - cors-proxy  (rubytee)  .api)      .api)
+        - mesh-zone               POST /...  AppSync
+        - scratch-                                    subscription
+        api-proxy                                     + polling
+```
+
+各 infra プロジェクトは独立して deploy される。スタック間に CFN export/import の依存はない (環境変数や Route53 経由でのみ繋がる)。
+
+## per-project ドキュメント
+
+### mesh-v2 (最も詳細)
+
+充実したドキュメント群あり：
+
+- **[`docs/mesh-v2/`](../mesh-v2/)** — クライアント + サーバ統合
+- **[`infra/smalruby-mesh-v2/docs/architecture.md`](../../infra/smalruby-mesh-v2/docs/architecture.md)** — システムアーキテクチャ
+- **[`infra/smalruby-mesh-v2/docs/api-reference.md`](../../infra/smalruby-mesh-v2/docs/api-reference.md)** — GraphQL スキーマ
+- **[`infra/smalruby-mesh-v2/docs/deployment.md`](../../infra/smalruby-mesh-v2/docs/deployment.md)** — デプロイ手順
+- **[`infra/smalruby-mesh-v2/docs/development.md`](../../infra/smalruby-mesh-v2/docs/development.md)** — 開発ガイド
+- **[`infra/smalruby-mesh-v2/docs/operations.md`](../../infra/smalruby-mesh-v2/docs/operations.md)** — モニタリング・コスト
+- `.claude/rules/infra/smalruby-mesh-v2.md` — 開発ルール
+
+### rubytee-relay
+
+Rubytee の統合ドキュメントは [`docs/rubytee/`](../rubytee/) を参照。インフラ実装の詳細は `.claude/rules/infra/smalruby-rubytee-relay.md` を参照。
+
+主要構成:
+- Lambda (Node.js 22, `lambda/handler.ts`) が Anthropic Claude API を中継
+- DynamoDB (`RubyteeRelayRateLimit`) で IP ベースのレート制限 (デフォルト 35 分窓 40 リクエスト)
+- Prompt caching (`cache_control: ephemeral`) でコスト削減
+- 子供向けの安全策 (年齢チェック、メッセージ長制限、CORS)
+
+### classroom
+
+クラスルーム機能の統合ドキュメントは [`docs/classroom/architecture.md`](../classroom/architecture.md) を参照。
+
+主要構成:
+- Lambda (Node.js 22, `lambda/handler.ts`) で 13+ エンドポイント
+- 3 テーブル: `Classrooms`, `ClassroomMemberships`, `ClassroomSubmissions`
+- S3 (`smalruby-classroom-submissions`) で `.sb3` 提出物保管 (presigned URL)
+- Google Classroom 連携 (Course / Assignment import)
+- 認証: Google OAuth + Microsoft Entra ID
+- レート制限: 200 req/s (prod) / `/classrooms/join` `/classrooms/lookup` のみ 10 req/s
+
+### smalruby-api
+
+→ **[`smalruby-api.md`](smalruby-api.md)** を参照（本 docs/infra/ の専用ファイル）。
+
+## 関連ドキュメント
+
+- `.claude/rules/infra/` 配下の各プロジェクトルール
+- `CLAUDE.md` の "infra/" セクション
+- [`docs/_template.md`](../_template.md) — 機能 docs テンプレート
+- [`docs/scratch-vm/`](../scratch-vm/) — VM 内部仕様 (クライアント側)

--- a/docs/infra/smalruby-api.md
+++ b/docs/infra/smalruby-api.md
@@ -1,0 +1,166 @@
+# smalruby-api (共通 API インフラ)
+
+> **🆕 Smalruby 独自** — Smalruby のフロントエンドが必要とする共通 API エンドポイント群。旧 SAM 実装 (`smalruby/smalruby-infra` リポジトリ) からの置き換え。
+
+## 概要
+
+`infra/smalruby-api/` は Smalruby のフロントエンド (smalruby.app) が利用する**汎用バックエンド機能**を提供する 4 つの Lambda を束ねた **HTTP API v2** スタック。
+
+| エンドポイント | Lambda | 用途 |
+|---|---|---|
+| `GET /cors-proxy` | `smalruby-api-cors-proxy{stageSuffix}` | 任意 URL の CORS フリーフェッチ + Google Drive URL 変換 + バイナリ Base64 化 |
+| `GET /mesh-domain` | `smalruby-api-mesh-zone{stageSuffix}` | クライアント IP から Mesh ドメイン (CRC32 ハッシュ) を生成 |
+| `GET /scratch-api-proxy/projects/{projectId}` | `smalruby-api-scratch-projects{stageSuffix}` | Scratch 公式 API (project info) のステータス透過プロキシ |
+| `GET /scratch-api-proxy/translate` | `smalruby-api-scratch-translate{stageSuffix}` | Scratch 公式翻訳サービスのプロキシ |
+
+`OPTIONS` (preflight) は HTTP API v2 の **built-in CORS** が自動処理。旧 SAM の `cors-for-smalruby` Lambda は不要。
+
+## カスタムドメイン
+
+| Stage | ドメイン |
+|---|---|
+| stg | `stg.api.smalruby.app` (CDK が ACM + Route53 も管理) |
+| prod | `api.smalruby.app` (**既存ドメインを import**、ACM/Route53 は別管理) |
+
+prod は旧 SAM スタック `smalruby-infra-prod` から既存ドメイン (`api.smalruby.app`) を引き継ぐ形で **2026-04-29 にカットオーバー** 完了済み。詳細は [カットオーバーの記録](#カットオーバー履歴-2026-04-29) を参照。
+
+## Lambda エンドポイントの詳細
+
+### `GET /cors-proxy`
+
+任意 URL を fetch して結果を返す。フロントから直接 fetch すると CORS で弾かれるリソース (例: Google Drive 共有 URL、外部サイトの画像) を経由するために使う。
+
+**入力**: `?url=<encoded_url>`
+
+**処理**:
+1. URL を Google Drive 形式 (`https://drive.google.com/uc?id=...`) に変換 (検出時)
+2. fetch
+3. バイナリレスポンス (画像 / 音声) は Base64 エンコードして返す
+4. テキストはそのまま
+
+実装: `infra/smalruby-api/lambda/cors-proxy.ts`
+
+### `GET /mesh-domain`
+
+リクエストの **source IP** から `MESH_ZONE_SECRET_KEY` (環境変数) と組み合わせて **CRC32 ハッシュ**を計算し、Mesh ドメイン名を生成する。
+
+**入力**: なし (source IP を見る)
+
+**出力**: `{ "domain": "ab12cd34" }` (CRC32 を 16 進数文字列で返す)
+
+> **重要 (互換性)**: prod では旧 SAM 実装でハードコードされていた secret key を引き継ぐ必要がある。新しい値を使うと**既存ユーザーの Mesh group identity が変わってしまう**。`.env.prod` で `MESH_ZONE_SECRET_KEY=<旧 SAM 値>` を設定。stg は新規なので別 random 値で OK。
+
+実装: `infra/smalruby-api/lambda/mesh-zone-get.ts`
+
+### `GET /scratch-api-proxy/projects/{projectId}`
+
+Scratch Foundation 公式 API (`https://api.scratch.mit.edu/projects/{projectId}`) のプロキシ。**ステータスコードを透過する**のがポイント。
+
+旧 SAM 実装は Ruby の `Net::HTTP.get` を使っていたためボディだけ取得で**常に 200** を返していた。これが Issue #573 のバグ (404 を 200 として返してしまう) の原因。CDK 版は `fetch` で status code を透過する。
+
+実装: `infra/smalruby-api/lambda/scratch-api-projects.ts`
+
+### `GET /scratch-api-proxy/translate`
+
+Scratch translate サービス (`https://translate-service.scratch.mit.edu/translate`) のプロキシ。
+
+実装: `infra/smalruby-api/lambda/scratch-api-translate.ts`
+
+## 環境変数
+
+`.env.example` 参照。主要なもの:
+
+| 変数 | デフォルト | 用途 |
+|---|---|---|
+| `STAGE` | - | デプロイ stage (`stg`, `stg2`, `prod`) |
+| `CORS_ALLOWED_ORIGINS` | smalruby.app, smalruby.jp, localhost:8601 | CORS 許可オリジン (カンマ区切り) |
+| `ROUTE53_PARENT_ZONE_NAME` | `api.smalruby.app` | カスタムドメイン親ゾーン |
+| `SMALRUBY_API_CUSTOM_DOMAIN` | (stage により自動) | カスタムドメインのオーバーライド (`false` で無効化) |
+| `MESH_ZONE_SECRET_KEY` | - **(必須)** | Mesh ドメイン生成のシークレット |
+| `IMPORT_EXISTING_CUSTOM_DOMAIN` | `false` | prod カットオーバー時に既存ドメインを import |
+| `IMPORTED_REGIONAL_DOMAIN_NAME` | - | import するドメインの regional domain name |
+| `IMPORTED_REGIONAL_HOSTED_ZONE_ID` | - | import するドメインの hosted zone ID |
+
+## デプロイ
+
+```bash
+cd infra/smalruby-api
+
+# Stage 切り替え
+rm .env && ln -s .env.stg .env    # → stg
+rm .env && ln -s .env.prod .env   # → prod
+
+# ビルド + デプロイ
+docker compose run --rm -w /app/infra/smalruby-api infra npm install
+docker compose run --rm -w /app/infra/smalruby-api infra npx cdk synth
+docker compose run --rm -w /app/infra/smalruby-api infra npx cdk diff
+docker compose run --rm -w /app/infra/smalruby-api infra npx cdk deploy
+```
+
+## テスト
+
+```bash
+# ユニットテスト (mock fetch、高速)
+docker compose run --rm -w /app/infra/smalruby-api infra npm test
+
+# Integration テスト (デプロイ済み stg エンドポイントへ実 HTTP リクエスト)
+docker compose run --rm -w /app/infra/smalruby-api infra npm run test:integration
+```
+
+`lambda/tests/*.integration.test.ts` は **デプロイ済み stg エンドポイント** (`https://stg.api.smalruby.app`) に実リクエストを送ってデグレ検出する。Issue #573 の **404 透過バグ再発防止** が最重要のテストケース。
+
+## ハマりどころ・運用ノート
+
+### カットオーバー履歴 (2026-04-29)
+
+prod 既存ドメイン `api.smalruby.app` を旧 SAM スタックから CDK スタックへ移行：
+
+1. ✅ stg で動作確認 + frontend を `stg.api.smalruby.app` で結合テスト
+2. ✅ `.env.prod` 作成 (`MESH_ZONE_SECRET_KEY` を旧 SAM 値で引き継ぎ、import 設定 3 環境変数を設定)
+3. ✅ SAM スタックのドメインマッピング解除:
+   ```bash
+   aws apigateway delete-base-path-mapping --domain-name api.smalruby.app --base-path '(none)'
+   ```
+4. ✅ CDK deploy で新スタックに mapping 追加
+5. ✅ 動作確認: 全 4 endpoint + CORS + integration tests (18 件) prod で pass
+6. ✅ SAM スタック削除: `aws cloudformation delete-stack --stack-name smalruby-infra-prod`
+
+実測ダウンタイム: **約 5 分** (CDK deploy + HTTP API mapping 反映待ち)
+
+### Lambda 関数名は `smalruby-api-` プレフィックスで衝突回避
+
+旧 SAM スタックの Lambda 関数名 (`smalruby-cors-proxy` 等) と衝突しないよう、CDK 側はすべて `smalruby-api-` で始まる名前に統一した。これで **SAM と CDK が並走できる**。最初から固有プレフィックスを付けるのが正解。
+
+### 既存カスタムドメインは `import` で再利用
+
+`api.smalruby.app` のような既存運用中のカスタムドメインは、CDK で新規作成しようとすると競合エラー。`apigatewayv2.DomainName.fromDomainNameAttributes()` で既存ドメインを参照し、新スタックは `ApiMapping` だけ作るパターンにする。
+
+メリット:
+- 既存 ACM 証明書 (DNS validation 不要) を再利用
+- 既存 Route53 A レコードを再利用
+- ダウンタイム = base path mapping swap の数分のみ
+
+`IMPORT_EXISTING_CUSTOM_DOMAIN=true` フラグで切替。
+
+### `mesh-zone-get` の secret key は引き継ぎ必須
+
+`MESH_ZONE_SECRET_KEY` を変えると **既存ユーザーの Mesh ドメインがすべて変わる**。プライベート Mesh ネットワークで他ユーザーと通信できなくなる致命的な互換性破壊。
+
+prod では必ず旧 SAM 値 (`uXM1VAA6MO39yJ+djz4kbpVGy3Rg1V3Z`) を引き継ぐ。stg は新規なので別 random 値で OK。
+
+### Integration test の Origin は両環境で許可される値を使う
+
+CORS preflight テストで `Origin: http://localhost:8601` を使うと prod の `CORS_ALLOWED_ORIGINS` に localhost が含まれない (意図的) ため fail する。
+
+→ `https://smalruby.app` のように **両環境で許可される値**を使う。
+
+## 関連ドキュメント
+
+- [`README.md`](README.md) — Smalruby インフラ全体 (4 プロジェクト)
+- `.claude/rules/infra/smalruby-api.md` — 開発ルール (より詳細)
+- `.claude/rules/infra/development.md` — Stage 切替の共通パターン
+
+## 関連 Issue
+
+- Issue #573 — `/scratch-api-proxy/projects/{projectId}` の 404 透過バグ
+- 旧 SAM 実装からの移行 (2026-04-29 カットオーバー完了)


### PR DESCRIPTION
## Summary

Issue #625 Phase 1: AWS CDK インフラ 4 プロジェクトの**横断的な統合ドキュメント**を整備。`smalruby-api` は専用の per-project doc を新設、他 3 プロジェクト (mesh-v2 / rubytee-relay / classroom) は既存の統合 docs (`docs/<feature>/`) へリンク。

## Changes Made

### 新規ドキュメント

- **`docs/infra/README.md`** — 4 プロジェクトの横断ドキュメント
  - プロジェクト一覧 + 各統合 docs への導線
  - **共通パターン**: region (ap-northeast-1) / CDK バージョン / Lambda runtime / DynamoDB 課金 / TTL / ログ保持
  - **Stage 管理**: `.env` symlink パターン
  - **Stage suffix 命名規則**: `stage === 'prod' ? '' : '-' + stage`
  - **カスタムドメイン構成**: `api.smalruby.app` 親ゾーン + サブドメイン体系
  - **CORS / デプロイコマンド** の共通形
  - **プロジェクト相関図** (フロント → 各 infra 独立の関係)

- **`docs/infra/smalruby-api.md`** — `smalruby-api` プロジェクト専用
  - 4 endpoint の詳細: `cors-proxy` / `mesh-domain` / `scratch-api-proxy/projects/{projectId}` / `scratch-api-proxy/translate`
  - **Issue #573** (404 透過バグ) の背景と再発防止
  - **カスタムドメイン import モード** (旧 SAM スタックとの並走)
  - 環境変数一覧 + デプロイ手順
  - **カットオーバー履歴** (2026-04-29 prod 移行) の記録
  - ハマりどころ: Lambda 関数名衝突回避、`MESH_ZONE_SECRET_KEY` 引き継ぎ、integration test の Origin 選択

### docs/README.md 更新

- 「F. 開発者向け（パッケージ内部仕様 / インフラ）」セクションに `infra/` への入口を追加

## 残作業 (本 Issue 内、別 PR)

- **Phase 2**: Ruby gem (`docs/smalruby3-gem/`)
- **Phase 3**: トップレベル (`CONTRIBUTING.md`, `docs/architecture-overview.md`)
- **Phase 4**: scratch-render / scratch-svg-renderer

## Test Coverage

ドキュメント整備のみ（コード変更なし）。

## Related Issues

Refs #625
