### PR TITLE
docs(smalruby3-gem): phase 2 - Ruby SDL2 runtime docs (#625)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,7 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 |---|---|
 | [`scratch-vm/`](scratch-vm/) — VM 内部仕様 (Runtime / Sequencer / Thread / Target / Blocks / Extensions / Serialization / Blocks Runtime) | 開発者向け（Issue #620 完了） |
 | [`infra/`](infra/) — AWS CDK インフラ全体 (mesh-v2 / rubytee-relay / classroom / smalruby-api の横断ドキュメント) | 開発者・運用向け（Issue #625） |
+| [`smalruby3-gem/`](smalruby3-gem/) — Ruby SDL2 デスクトップランタイム (`ruby/smalruby3/`) | gem 開発者向け（Issue #625 Phase 2） |
 
 ### その他
 

--- a/docs/smalruby3-gem/README.md
+++ b/docs/smalruby3-gem/README.md
@@ -1,0 +1,190 @@
+# smalruby3 gem (Ruby SDL2 デスクトップランタイム)
+
+> **🆕 Smalruby 独自** — scratch-vm の Ruby + SDL2 実装。ブラウザの代わりにネイティブ macOS / Docker (Xvfb) で動かす。
+
+`ruby/smalruby3/` は Smalruby のプロジェクトを **Ruby スクリプトとして実行**できるデスクトップランタイム。Web ブラウザ版 (scratch-vm) と並列に存在し、同じ Smalruby Ruby DSL で書かれたプログラムを SDL2 経由でネイティブ描画する。
+
+## 対象読者
+
+- **smalruby3 gem の保守・改良**を行う開発者
+- **scratch-vm 側との挙動差**を埋めたい人 (例: 拡張機能の対応)
+- **デスクトップ実行**を試したいユーザー (smalruby コマンド)
+
+## ドキュメント一覧
+
+| ドキュメント | 内容 |
+|---|---|
+| [`architecture.md`](architecture.md) | Runtime / Renderer / Fiber / Asset / 座標系 |
+| [`extensions.md`](extensions.md) | 拡張機能の仕組み (Pen / Music) と新規追加方法 |
+
+外部参照:
+- [`ruby/smalruby3/README.md`](../../ruby/smalruby3/README.md) — gem の README (インストール手順)
+- [`ruby/smalruby3/docs/ruby-sdl2-api.md`](../../ruby/smalruby3/docs/ruby-sdl2-api.md) — 使用している SDL2 API のリファレンス
+- `.claude/rules/ruby/ruby-sdl2.md` — ruby-sdl2 submodule 運用
+- `.claude/rules/ruby/rsdl.md` — rsdl ラッパー運用
+
+## ざっくり概要
+
+| 項目 | 値 |
+|---|---|
+| Ruby バージョン | ≥ 3.3 |
+| SDL2 依存 | `ruby-sdl2 ~> 0.3` (smalruby fork、submodule) |
+| ステージサイズ | 480 × 360 (Scratch 互換) |
+| FPS | 30 (FRAME_TIME = 33.33ms) |
+| 最大クローン数 | 300 |
+| バージョニング | `YY.MR.DDR` (Year.Month×10+Release.Day×10+Release) |
+| ライセンス | MIT (resvg は MPL-2.0、ruby-sdl2 は LGPL-3.0) |
+
+## クイックスタート
+
+```bash
+# Docker 実行 (Xvfb で headless、スクリーンショット取得用)
+docker compose run --rm smalruby3 bundle exec ruby -Ilib examples/01_move.rb
+
+# macOS ネイティブ実行 (smalruby3_launcher 必須)
+cd ruby/smalruby3
+bundle install
+rake compile           # Rust + Swift 拡張をビルド
+exe/smalruby examples/01_move.rb
+```
+
+> **重要**: macOS では **`smalruby3_launcher` 経由のネイティブバイナリ**を使う必要がある。素の `ruby` から SDL2 を呼ぶと segfault するため。詳細は [architecture.md - 実行環境](architecture.md#実行環境) 参照。
+
+## DSL 例
+
+`examples/01_move.rb` を抜粋：
+
+```ruby
+require "smalruby3"
+
+class Player < Smalruby3::Sprite
+  set_sprite "Shimaraby"   # AssetManager 経由でコスチュームをロード
+  set_x 0
+  set_y 0
+  set_size 100
+
+  when_flag_clicked do     # Hat ブロック相当
+    say("矢印キーで動かしてね！")
+    loop.with_screen_refresh do
+      self.x += 5 if keyboard.pressed?("right arrow")
+      self.x -= 5 if keyboard.pressed?("left arrow")
+      bounce_if_on_edge
+    end
+  end
+end
+
+Smalruby3.start  # イベントループ開始 (省略すると at_exit で自動起動)
+```
+
+→ 「Sprite を継承するクラスを定義」「`when_*` ブロックでイベント登録」「`Smalruby3.start` でイベントループ起動」の 3 ステップ。
+
+## 主要ファイル一覧
+
+### lib/smalruby3.rb (エントリポイント)
+
+- `Smalruby3.start()` — Runtime.instance.run を起動
+- `Smalruby3.register_sprite(klass)` — Sprite サブクラス登録 (継承時自動)
+- `Smalruby3.register_stage(klass)` — Stage シングルトン登録
+- `Smalruby3.home()` — キャッシュディレクトリ (`$SMALRUBY3_HOME` または `~/.smalruby3/`)
+- `at_exit` フック — `start` 未呼出時に自動起動
+
+### lib/smalruby3/
+
+| ファイル | 役割 |
+|---|---|
+| `target.rb` | Sprite / Stage の基底。共通の DSL (`say`, `ask`, `variable`, `set_variable` 等) |
+| `sprite.rb` | スプライト本体 (位置、向き、サイズ、コスチューム、クローン) |
+| `stage.rb` | ステージ (背景、broadcast、`when_backdrop_switches`) |
+| `costume.rb` | コスチューム (path、回転中心、bitmap_resolution、SDL2::Surface 遅延ロード) |
+| `sound.rb` | サウンド (path、name) |
+| `runtime.rb` | イベントループ (Fiber スケジューラ + メインループ) |
+| `asset_manager.rb` | コスチューム/サウンドの解決 (preset / cache / HTTP download) |
+| `asset_manager/svg_converter.rb` | SVG → PNG 変換 (Rust 拡張呼び出し) |
+| `version.rb` | バージョン定数 |
+
+### lib/smalruby3/render/
+
+| ファイル | 役割 |
+|---|---|
+| `renderer.rb` | SDL2 ウィンドウ + アクセラレーテッドレンダラー (Metal on macOS) |
+| `bitmap_skin.rb` | コスチューム描画 |
+| `pen_skin.rb` | ペンレイヤー描画 |
+| `text_bubble.rb` | say/think の吹き出し |
+| `effect_transform.rb` | ghost / whirl 等のエフェクト |
+
+### lib/smalruby3/io/
+
+| ファイル | 役割 |
+|---|---|
+| `clock.rb` | タイマー |
+| `keyboard.rb` | キーボード入力 |
+| `mouse.rb` | マウス入力 |
+
+### lib/smalruby3/extension/
+
+| ファイル | 役割 |
+|---|---|
+| `pen.rb` | ペン拡張 (`@sprite.pen` でアクセス) |
+| `music.rb` | 音楽拡張 (ドラム + 21 楽器) |
+
+詳細は [`extensions.md`](extensions.md) を参照。
+
+### ext/
+
+| ディレクトリ | 内容 | 言語 |
+|---|---|---|
+| `smalruby3_imageutil/` | resvg ベースの SVG → PNG 変換 | Rust |
+| `smalruby3_launcher/` | macOS 用 SDL2 ネイティブバイナリ | Swift / Obj-C |
+
+### test/
+
+29 ファイルの **minitest** テストスイート。SDL2 直接呼び出しは segfault リスクがあるため mock 中心。
+
+### examples/
+
+10 個のサンプルプログラム (`01_move.rb`, `03_clone.rb`, `04_pen.rb`, ...)。新規ユーザー向けの DSL 学習資料。
+
+## ruby-sdl2 / rsdl との関係
+
+### ruby-sdl2 (submodule: `ruby/ruby-sdl2/`)
+
+- [smalruby/ruby-sdl2](https://github.com/smalruby/ruby-sdl2) fork
+- upstream: [ohai/ruby-sdl2](https://github.com/ohai/ruby-sdl2)
+- Smalruby 独自パッチ:
+  - **`Renderer#read_pixels`** 追加 (衝突判定の silhouette 用)
+  - Ruby 3.4+ の TypedData サポート
+- ブランチ: `master` (upstream 同期)、`smalruby/ruby-3.4-support`、`smalruby/add-read-pixels`
+
+### rsdl (submodule: `ruby/rsdl/`)
+
+- [smalruby/rsdl](https://github.com/smalruby/rsdl) fork (CLAUDE.md で言及、本リポジトリの `ruby/` 下にあり)
+- upstream: [knu/rsdl](https://github.com/knu/rsdl)
+- macOS 用の SDL2 Ruby ラッパーコマンド
+
+### 運用ルール
+
+両 submodule の変更時は **smalruby fork に PR → 動作確認後に upstream にも PR**。upstream PR を想定して機能ごとに細かくブランチ/PR を分けること。詳細は `.claude/rules/ruby/ruby-sdl2.md` と `.claude/rules/ruby/rsdl.md` を参照。
+
+## scratch-vm との対応
+
+| 機能 | scratch-vm | smalruby3 gem |
+|---|---|---|
+| 標準ブロック (motion / looks / control / sensing 等) | ✅ | ✅ (DSL として) |
+| **拡張機能 - pen** | ✅ | ✅ (`Extension::Pen`) |
+| **拡張機能 - music** | ✅ | ✅ (`Extension::Music`) |
+| 拡張機能 - その他 (mesh, smalrubot-s1, koshien 等) | ✅ | ❌ (ブラウザ専用 API 依存) |
+| Ruby ↔ Blocks 相互変換 | ❌ | ❌ (gem 単体は Ruby のみ) |
+| ふりがな / DNCL | ❌ | ❌ (Ruby ソース直接実行) |
+
+→ smalruby3 gem は **シンプルな Ruby スクリプト実行**にフォーカス。ブラウザ依存の拡張 (Web Bluetooth, Web Serial, AppSync 等) は対象外。
+
+## 関連 Issue / リポジトリ
+
+- 本 gem は `smalruby/smalruby3` (gem 単体) と `smalruby/smalruby3-editor` (本モノレポの ruby submodule) で並行管理
+- 詳細は [`ruby/smalruby3/README.md`](../../ruby/smalruby3/README.md)
+
+## 関連ドキュメント
+
+- [`docs/ruby-editor/`](../ruby-editor/) — ブラウザ側の Ruby エディタ
+- [`docs/extension-pen/`](../extension-pen/), [`docs/extension-music/`](../extension-music/) — 拡張機能のユーザー視点ドキュメント (両者 Smalruby ランタイム ✅)
+- [`docs/scratch-vm/`](../scratch-vm/) — ブラウザ側 VM の内部仕様 (対比)

--- a/docs/smalruby3-gem/architecture.md
+++ b/docs/smalruby3-gem/architecture.md
@@ -1,0 +1,318 @@
+# smalruby3 gem アーキテクチャ
+
+`ruby/smalruby3/` の中核オブジェクトと、プログラム実行・描画・入力処理のフロー。
+
+## クラス階層と所有関係
+
+```
+Smalruby3 (top-level module)
+  ├─ Runtime (singleton, lib/smalruby3/runtime.rb)
+  │     ├─ targets[]           ← Stage + Sprite サブクラス群
+  │     ├─ fibers[]            ← 各 when_* ブロックの実行 Fiber
+  │     ├─ renderer: Renderer  ← SDL2 描画
+  │     ├─ asset_manager: AssetManager
+  │     ├─ keyboard, mouse, clock (io/)
+  │     └─ event_queue
+  │
+  └─ Target (lib/smalruby3/target.rb, abstract)
+        ├─ Sprite (lib/smalruby3/sprite.rb)
+        │    ├─ x, y, direction, size, rotation_style
+        │    ├─ costumes[], current_costume
+        │    ├─ sounds[]
+        │    ├─ visible, drag_mode
+        │    ├─ @is_clone (300 体上限)
+        │    └─ @pen, @music (Extension モジュール mixin)
+        │
+        └─ Stage (lib/smalruby3/stage.rb, singleton)
+             ├─ backdrops[], current_backdrop
+             ├─ sounds[]
+             └─ tempo, video_state
+```
+
+主な「**所有 (owns)**」:
+
+- `Smalruby3` モジュールは `Runtime.instance` を 1 つ所有 (singleton)
+- `Runtime` は **すべての** targets / fibers / renderer / io デバイスを所有
+- 各 `Sprite` は自身のコスチューム・サウンド・状態を所有、必要に応じて Pen / Music 拡張をインスタンス化
+- `Stage` は singleton (1 プロジェクト = 1 ステージ)
+
+## 実行モデル: 1 メインスレッド + Fiber 並列
+
+scratch-vm のスレッド/シーケンサーモデルとは異なり、smalruby3 は **Ruby Fiber** で並列スクリプトを表現する：
+
+```
+main thread (SDL2 event loop)
+  │
+  ├─ 各 when_* ブロックを Fiber として登録
+  │
+  └─ 30 FPS のメインループ:
+        ├─ SDL2 イベント取得 (key down/up, mouse, quit)
+        ├─ for fiber of fibers:
+        │     fiber.resume   ← 1 ステップ実行
+        │     ↓ Fiber 内で .with_screen_refresh / Fiber.yield されるとここに戻る
+        ├─ レンダラーで全 Drawable を draw
+        ├─ 必要に応じてイベント発火
+        │     - when_key_pressed
+        │     - when_receive (broadcast)
+        │     - when_greater_than
+        │     - when_backdrop_switches
+        └─ FRAME_TIME (33.33ms) になるまで sleep
+```
+
+### フレーム同期の仕組み
+
+```ruby
+loop.with_screen_refresh do   # = loop { ... ; Fiber.yield }
+  self.x += 5
+  bounce_if_on_edge
+end
+```
+
+`with_screen_refresh` は **各イテレーションで `Fiber.yield`** を入れる。これによりメインループに制御が戻り、レンダリング → 次フレームで Fiber.resume となる。
+
+### 非同期メソッド
+
+| メソッド | 動作 |
+|---|---|
+| `wait(seconds)` | Clock 経由で `seconds` 経過まで Fiber.yield |
+| `say(message, seconds:)` | 吹き出し表示 + 待ち |
+| `broadcast_and_wait(name)` | 全 `when_receive` Fiber 完了まで yield |
+| `switch_backdrop_and_wait(name)` | 全 `when_backdrop_switches` Fiber 完了まで yield |
+
+## データフロー: スクリプト → 実行 → 描画
+
+### 1. ロード (Ruby ファイルの require)
+
+```
+ruby script_file.rb
+  → Smalruby3 モジュール load
+  → Sprite サブクラスが定義されると inherited フックで Smalruby3.register_sprite(klass)
+  → DSL (set_sprite, set_x, when_*) はクラス定義時に評価され、metadata 蓄積
+  → at_exit で Smalruby3.start (明示的に呼ばれない場合)
+```
+
+### 2. 起動 (Smalruby3.start)
+
+```
+Runtime.instance.run
+  ├─ asset_manager.prefetch_all   ← 必要なコスチューム/サウンドを download + cache
+  ├─ init_targets                  ← Sprite/Stage インスタンス化
+  ├─ init_renderer                 ← SDL2 ウィンドウ作成 + Renderer
+  ├─ init_mixer                    ← SDL2_mixer 初期化
+  ├─ start_flag_clicked            ← when_flag_clicked Fiber を全件作成して fibers[] に追加
+  ├─ main_loop                     ← 30 FPS のメインループ
+  └─ shutdown                      ← クリーンアップ
+```
+
+### 3. メインループ
+
+```ruby
+# 擬似コード
+loop do
+  next_frame_time = Time.now + FRAME_TIME
+
+  # SDL2 イベント取得
+  while event = SDL2::Event.poll
+    case event
+    when SDL2::Event::Quit then break
+    when SDL2::Event::KeyDown then start_when_key_pressed(event.key)
+    # ...
+    end
+  end
+
+  # Fiber を 1 ステップずつ進める
+  fibers.each do |fiber|
+    next unless fiber.alive?
+    fiber.resume
+  end
+  fibers.delete_if { |f| !f.alive? }
+
+  # 終了したクローンを掃除
+  cleanup_clones
+
+  # レンダリング
+  renderer.draw_frame(targets)
+
+  # スクリーンショット (SMALRUBY3_SCREENSHOT=N で N フレーム目を保存)
+  capture_screenshot if frame_count == ENV['SMALRUBY3_SCREENSHOT']
+
+  # フレームレート同期
+  sleep [next_frame_time - Time.now, 0].max
+end
+```
+
+### 4. 終了
+
+`SDL2::Event::Quit` (ウィンドウクローズ) または `Smalruby3.stop` で main_loop が break、shutdown へ。
+
+## 座標系
+
+Scratch 互換の中央原点座標：
+
+```
+   y=180 ↑
+        │
+ -240 ←─┼─→ x=240
+        │
+   y=-180 ↓
+```
+
+SDL2 の左上原点 (480×360) に変換するときは：
+
+```ruby
+screen_x = 240 + scratch_x
+screen_y = 180 - scratch_y
+```
+
+## アセット解決チェーン
+
+`AssetManager#resolve_costumes(sprite_name)` などの解決ロジック：
+
+```
+1. Preset カタログ (lib/smalruby3/asset_catalog.json) で sprite_name を引く
+   → 該当する asset id (md5ext) のリストを取得
+2. キャッシュ ($SMALRUBY3_HOME/cache/assets/<md5ext>) を確認
+   → あれば使う
+3. なければ HTTPS で download
+   → cache に保存 (md5ext 検証 (path traversal 対策)、MAX_ASSET_SIZE 制限、timeout)
+4. SVG の場合は Rust 拡張 (smalruby3_imageutil) で PNG に変換
+5. Costume オブジェクトを生成 (path / rotation_center / bitmap_resolution)
+   → SDL2::Surface は遅延ロード (使われるまで触らない)
+```
+
+セキュリティ: `md5ext` は `/\A[a-f0-9]+\.(png|svg|wav|mp3|jpg)\z/` の正規表現でバリデーション。任意のパス traversal を防ぐ。
+
+## レンダリング
+
+`Renderer` は SDL2 のアクセラレーテッドレンダラー (macOS は Metal バックエンド)：
+
+```ruby
+# 擬似コード
+def draw_frame(targets)
+  renderer.clear
+
+  # Stage の背景描画
+  draw_drawable(stage.current_backdrop_skin)
+
+  # 各 Sprite を z-order でソート
+  visible_sprites = targets.select(&:visible?).sort_by(&:layer)
+
+  # Pen レイヤー (背景の上、スプライトの下)
+  draw_drawable(pen_skin)
+
+  # 各 Sprite を描画
+  visible_sprites.each do |sprite|
+    apply_effects(sprite.effects)
+    draw_drawable(sprite.current_costume.skin)
+    draw_drawable(sprite.text_bubble) if sprite.bubble?
+  end
+
+  renderer.present
+end
+```
+
+### Drawable 種別
+
+| Skin | 用途 |
+|---|---|
+| `BitmapSkin` | コスチューム (PNG/SVG→PNG) |
+| `PenSkin` | ペン描画レイヤー |
+| `TextBubble` | say/think の吹き出し |
+
+### エフェクト
+
+`color`, `fisheye`, `whirl`, `pixelate`, `mosaic`, `brightness`, `ghost` の 7 種類を `effect_transform.rb` で実装。SDL2 の texture transform で実現。
+
+## 衝突判定
+
+`Costume#silhouette` で SDL2::Surface の **アルファチャネルから silhouette を生成**してキャッシュ。スプライト同士の衝突は silhouette の bounding box → pixel-level の 2 段階チェック。
+
+`Renderer#read_pixels` (smalruby fork で追加) を使って描画後の pixel を読み出すこともできる。
+
+## 実行環境
+
+### macOS (ネイティブ)
+
+- **`smalruby3_launcher`** (Swift/Obj-C) を経由する必要がある
+- 素の `ruby` から SDL2 を呼ぶと segfault する (macOS 固有の問題)
+- `exe/smalruby` ラッパーがこれを exec する
+
+### Docker (Xvfb)
+
+- `Dockerfile` で Xvfb (X virtual framebuffer) + 必要な SDL2 dev ライブラリをインストール
+- 環境変数 `SMALRUBY3_SCREENSHOT=N` で N フレーム目の PNG を `/tmp/smalruby3_screenshot.png` に保存
+- CI / 自動テスト用途
+
+```bash
+docker compose run --rm smalruby3 \
+  bash -c "SMALRUBY3_SCREENSHOT=3 timeout 15 ruby -Ilib examples/01_move.rb"
+```
+
+## 設定・データ永続化
+
+### 環境変数
+
+| 変数 | デフォルト | 用途 |
+|---|---|---|
+| `SMALRUBY3_HOME` | `~/.smalruby3/` | キャッシュディレクトリ |
+| `SMALRUBY3_SCREENSHOT` | (なし) | 指定フレーム数で PNG 保存 |
+| `SMALRUBY3_SCREENSHOT_PATH` | `/tmp/smalruby3_screenshot.png` | スクリーンショット出力先 |
+
+### キャッシュ
+
+- `$SMALRUBY3_HOME/cache/assets/<md5ext>` — ダウンロード済みアセット
+- 起動時に prefetch_all で必要なものを download
+
+## 主要 API リファレンス
+
+### モジュールレベル
+
+| メソッド | 用途 |
+|---|---|
+| `Smalruby3.start()` | イベントループ起動 (省略時は at_exit で自動) |
+| `Smalruby3.started?()` | 起動済みか |
+| `Smalruby3.home()` | キャッシュディレクトリ |
+| `Smalruby3.register_sprite(klass)` | Sprite サブクラス登録 (継承時自動) |
+| `Smalruby3.register_stage(klass)` | Stage クラス登録 |
+
+### Sprite DSL
+
+| メソッド | 用途 |
+|---|---|
+| `set_sprite(name)` | プリセット名でコスチュームをロード |
+| `set_costume_names([...])` | 明示的にコスチュームリストを指定 |
+| `set_x(n)`, `set_y(n)` | 初期位置 |
+| `set_size(n)` | 初期サイズ % |
+| `set_direction(deg)` | 初期向き |
+| `when_flag_clicked { }` | 緑旗 Hat |
+| `when_key_pressed("a") { }` | キー Hat |
+| `when_receive("name") { }` | broadcast 受信 Hat |
+| `when_start_as_a_clone { }` | クローン開始 Hat |
+| `when_backdrop_switches("backdrop1") { }` | 背景切替 Hat |
+
+### インスタンスメソッド (実行時)
+
+| メソッド | 用途 |
+|---|---|
+| `x`, `x=`, `y`, `y=` | 座標 |
+| `direction`, `direction=` | 向き |
+| `size`, `size=` | サイズ |
+| `say("hello", seconds: 2)` | 吹き出し |
+| `think("...")` | 考え事吹き出し |
+| `move(steps)` | 向きに従って移動 |
+| `bounce_if_on_edge` | 端で跳ね返る |
+| `switch_costume("name")` | コスチューム切替 |
+| `next_costume` | 次のコスチューム |
+| `clone` | 自身のクローン作成 |
+| `delete_this_clone` | このクローン削除 |
+| `broadcast("name")` | 非同期 broadcast |
+| `broadcast_and_wait("name")` | 同期 broadcast |
+
+完全な API は `lib/smalruby3/sprite.rb` と `lib/smalruby3/target.rb` を参照。
+
+## 関連ドキュメント
+
+- [`README.md`](README.md) — gem 全体ナビゲーション
+- [`extensions.md`](extensions.md) — 拡張機能 (Pen / Music) の仕組み
+- [`ruby/smalruby3/docs/ruby-sdl2-api.md`](../../ruby/smalruby3/docs/ruby-sdl2-api.md) — 使用 SDL2 API
+- [`docs/scratch-vm/architecture.md`](../scratch-vm/architecture.md) — ブラウザ側 VM との対比

--- a/docs/smalruby3-gem/extensions.md
+++ b/docs/smalruby3-gem/extensions.md
@@ -1,0 +1,240 @@
+# smalruby3 gem の拡張機能
+
+scratch-vm の拡張機能のうち、smalruby3 gem (Ruby SDL2 ランタイム) で実装されているのは **Pen** と **Music** の 2 つのみ。本ドキュメントでは両者の実装と、新しい拡張機能を追加する方法を解説する。
+
+## Smalruby ランタイム対応の判断基準
+
+scratch-vm 全 22 拡張機能のうち、gem で対応しているのは **2 件のみ**。残り 20 件はブラウザ専用 API (Web Bluetooth, Web Serial, getUserMedia, AppSync 等) に依存しているため対応不可：
+
+| 拡張機能 | gem 対応 | 対応不可の理由 |
+|---|---|---|
+| Pen | ✅ | SDL2 で描画レイヤー実装可 |
+| Music | ✅ | SDL2_mixer で実装可 |
+| Video Sensing | ❌ | getUserMedia (ブラウザ専用) |
+| Face Sensing | ❌ | TensorFlow.js + getUserMedia |
+| Text to Speech | ❌ | AWS Polly (HTTP API、認証込み) |
+| Translate | ❌ | Google Translate API |
+| Makey Makey | ❌ | USB HID キーボード (ブラウザ独自) |
+| micro:bit / micro:bit More | ❌ | Web Bluetooth |
+| GdxFor / EV3 / BOOST / WeDo 2.0 | ❌ | Web Bluetooth |
+| Mesh v2 | ❌ | AWS AppSync subscription |
+| Smalrubot S1 / G2S | ❌ | Web Serial |
+| TM2Scratch | ❌ | TensorFlow.js |
+| Koshien | ❌ | WebSocket (Smalruby 競技サーバ) |
+| Smalruby Ruby | ❌ | （Ruby ランタイム上では Ruby 標準ライブラリで代替可だが gem 拡張としては未実装） |
+
+→ `lib/smalruby3/extension/` 配下に存在するのは `pen.rb` と `music.rb` のみ。
+
+## 拡張機能の登録パターン
+
+```ruby
+# lib/smalruby3/extension/pen.rb (抜粋)
+module Smalruby3
+  module Extension
+    class Pen
+      def initialize(sprite)
+        @sprite = sprite
+        @is_down = false
+        @color_h = 66.66
+        @color_s = 100
+        @color_b = 100
+        @transparency = 0
+        @size = 1
+        @last_x = nil
+        @last_y = nil
+      end
+
+      def down; @is_down = true; end
+      def up;   @is_down = false; end
+      def down?; @is_down; end
+
+      def on_move(x, y)
+        return unless @is_down
+        # @sprite.runtime.pen_skin に線を描画
+      end
+
+      def clear
+        # ペンレイヤー全消去
+      end
+
+      # ...
+    end
+  end
+end
+```
+
+Sprite クラス側で **遅延インスタンス化**：
+
+```ruby
+# lib/smalruby3/sprite.rb (抜粋)
+class Sprite < Target
+  def pen
+    @pen ||= Extension::Pen.new(self)
+  end
+end
+```
+
+→ ペンを使わないスプライトは Pen インスタンスを持たない。
+
+## Pen 拡張
+
+`lib/smalruby3/extension/pen.rb`:
+
+### 状態
+
+| 属性 | デフォルト | 説明 |
+|---|---|---|
+| `@is_down` | `false` | ペンが下りているか |
+| `@color_h` | `66.66` | 色相 (HSB) — Scratch デフォルトの青 |
+| `@color_s` | `100` | 彩度 |
+| `@color_b` | `100` | 明度 |
+| `@transparency` | `0` | 透明度 (0=不透明) |
+| `@size` | `1` | 線の太さ (px) |
+| `@last_x`, `@last_y` | `nil` | 直前位置 (連続線用) |
+
+### 主要メソッド
+
+| メソッド | 用途 |
+|---|---|
+| `down` / `up` / `down?` | ペンの上げ下げ |
+| `clear` | ペンレイヤー全消去 |
+| `stamp` | スプライトの現在見た目をペンレイヤーにスタンプ |
+| `set_color(rgb)` / `change_color(amount)` | 色変更 |
+| `set_transparency(n)` / `change_transparency(n)` | 透明度変更 |
+| `set_size(n)` / `change_size(n)` | 太さ変更 |
+
+### 描画タイミング
+
+`Sprite#x=`, `y=`, `direction=` 等で位置・向きが変わるたびに `@pen&.on_move()` が呼ばれる。down 中なら `@last_x, @last_y` から新位置への線分を **Renderer の pen_skin** (SDL2 の独立した surface レイヤー) に描画。
+
+### ステージとの統合
+
+ペンレイヤーは **背景の上、スプライトの下** に描画される (`Runtime#draw_frame` 参照)。
+
+### 衝突判定
+
+スタンプ済みのペンレイヤーもスプライト衝突判定の対象 (silhouette ベース)。
+
+## Music 拡張
+
+`lib/smalruby3/extension/music.rb`:
+
+### ドラム
+
+`PLAY_DRUM` ブロック (`music.play_drum(drum: 1, beats: 0.25)` 相当) で 18 種類のドラムを再生：
+
+| 番号 | 名称 | release time (ms) |
+|---|---|---|
+| 1 | スネアドラム | 250 |
+| 2 | バスドラム | 250 |
+| 3 | サイドスティック | 100 |
+| ... | (合計 18 種) | ... |
+
+### 楽器
+
+`SET_INSTRUMENT` で 21 種類の楽器を選択：
+
+| 番号 | 楽器 |
+|---|---|
+| 1 | ピアノ |
+| 2 | エレクトリックピアノ |
+| 3 | オルガン |
+| 4 | ギター |
+| 5 | エレキギター |
+| ... | (合計 21 種) |
+
+各楽器は **複数の MIDI ノートのサンプル**を持ち、近いノートを引き伸ばして使う。
+
+### 音符の再生
+
+`music.play_note(note: 60, beats: 0.5)` (60 = C4):
+
+```ruby
+# 擬似コード
+def play_note(note:, beats:)
+  freq = 440 * 2 ** ((note - 69) / 12.0)   # MIDI note → Hz
+  closest_sample = find_closest_instrument_sample(note)
+  pitch_ratio = freq / closest_sample.freq
+  chunk = SDL2::Mixer.load_with_pitch(closest_sample.path, pitch_ratio)
+  channel = SDL2::Mixer.play_channel(-1, chunk)
+  schedule_release(channel, beats, instrument.release_time)
+  wait(beats * (60.0 / @tempo))   # ビート → 秒
+end
+```
+
+### テンポ
+
+`set_tempo(120)` でテンポ (BPM) を設定。`play_note` の待ち時間に影響。
+
+## 新しい拡張機能を追加する方法
+
+### 1. クラスを `lib/smalruby3/extension/` に作る
+
+```ruby
+# lib/smalruby3/extension/my_extension.rb
+module Smalruby3
+  module Extension
+    class MyExtension
+      def initialize(sprite_or_stage)
+        @target = sprite_or_stage
+        # ... 状態の初期化
+      end
+
+      def my_block(args)
+        # 実装
+      end
+    end
+  end
+end
+```
+
+### 2. Target / Sprite / Stage に accessor を追加
+
+```ruby
+# lib/smalruby3/sprite.rb
+class Sprite < Target
+  def my_extension
+    @my_extension ||= Extension::MyExtension.new(self)
+  end
+end
+```
+
+### 3. Runtime に必要なら統合フック
+
+例: フレーム前処理 (描画前) や後処理 (描画後) が必要なら `Runtime#main_loop` にフックを追加。
+
+例: スプライトがコピーされたとき (clone) に状態を引き継ぐなら `Sprite#clone` で `@my_extension.dup` を呼ぶ。
+
+### 4. テスト追加
+
+`test/my_extension_test.rb` で minitest で書く。SDL2 直接呼び出しは避ける (mock 中心)。
+
+### 5. examples 追加
+
+`examples/XX_my_extension_demo.rb` で動作確認用のサンプルを追加。
+
+### 6. ドキュメント更新
+
+- 本ドキュメント (`docs/smalruby3-gem/extensions.md`) のセクション追加
+- 該当 `docs/extension-<name>/README.md` の **Smalruby ランタイム対応** バッジを ✅ に更新
+
+## scratch-vm の拡張機能との対応関係
+
+両者で実装する場合は **同じ DSL / opcode** で書けるようにする。例: pen の場合：
+
+| scratch-vm | smalruby3 gem |
+|---|---|
+| ブロックパレット: 「ペンを下ろす」 | DSL: `pen.down` |
+| opcode: `pen_penDown` | メソッド: `Pen#down` |
+| ブロックパレット: 「ペンの色を ... にする」 | DSL: `pen.set_color(rgb)` |
+| opcode: `pen_setPenColorToColor` | メソッド: `Pen#set_color(rgb)` |
+
+→ Ruby ↔ Blocks 変換 (scratch-gui の ruby-generator / ruby-to-blocks-converter) でこの対応を維持する必要がある。詳細は [`docs/extension-pen/`](../extension-pen/) や [`docs/extension-music/`](../extension-music/) を参照。
+
+## 関連ドキュメント
+
+- [`README.md`](README.md) — gem 全体ナビゲーション
+- [`architecture.md`](architecture.md) — Runtime / Renderer / Fiber / Asset
+- [`docs/extension-pen/`](../extension-pen/) — ペン拡張のユーザー視点ドキュメント (Smalruby ランタイム ✅)
+- [`docs/extension-music/`](../extension-music/) — 音楽拡張のユーザー視点ドキュメント (Smalruby ランタイム ✅)
+- [`docs/scratch-vm/extensions.md`](../scratch-vm/extensions.md) — ブラウザ側 VM の拡張機能の仕組み (対比)


### PR DESCRIPTION
## Summary

Issue #625 Phase 2: `ruby/smalruby3/` (Ruby SDL2 デスクトップランタイム) の包括的なドキュメント整備。3 ファイル新規追加。

## Changes Made

### 新規ドキュメント

- **`docs/smalruby3-gem/README.md`** — エントリポイント
  - 対象読者 / scratch-vm との並列存在の説明
  - Ruby ≥ 3.3 / 480×360 ステージ / 30 FPS / 300 クローン上限
  - DSL 例 (Sprite サブクラス + when_*)
  - 主要ファイル一覧
  - **ruby-sdl2 / rsdl submodule との関係** (smalruby fork、独自パッチ `Renderer#read_pixels`、Ruby 3.4+ TypedData サポート)
  - **scratch-vm との対応表** (Smalruby ランタイム ✅ なのは pen / music のみ)

- **`docs/smalruby3-gem/architecture.md`** — 内部仕様
  - クラス階層と所有関係 (Smalruby3 → Runtime → targets / fibers / renderer / asset_manager / io)
  - **実行モデル**: 1 メインスレッド + Fiber 並列 (vs scratch-vm の thread + sequencer)
  - `with_screen_refresh` による Fiber.yield 同期
  - 起動フロー (prefetch_all → init_targets → init_renderer → init_mixer → start_flag_clicked → main_loop)
  - 30 FPS メインループの擬似コード
  - 座標系 (Scratch 中央原点 → SDL2 左上)
  - アセット解決チェーン (preset → cache → HTTP、md5ext 検証)
  - レンダリング (BitmapSkin / PenSkin / TextBubble / Effect)
  - 衝突判定 (silhouette ベース)
  - **実行環境**: macOS launcher 必須 / Docker Xvfb
  - 環境変数 / API リファレンス

- **`docs/smalruby3-gem/extensions.md`** — 拡張機能
  - **ランタイム対応の判断**: なぜ pen / music の 2 件のみか — 残り 20 件はブラウザ専用 API 依存
  - **Pen 拡張**: 状態 (HSB color)、sprite 移動時の `on_move` フック
  - **Music 拡張**: 18 ドラム + 21 楽器、MIDI ノート → Hz 変換、テンポ
  - **新しい拡張機能の追加方法** (lib/extension/ にクラス → Sprite/Stage に accessor → Runtime フック → テスト → docs 更新)
  - scratch-vm 拡張機能との対応 (両者で同じ DSL を保つ重要性)

### docs/README.md 更新

- 「F. 開発者向け」セクションに `smalruby3-gem/` への入口を追加

## 残作業 (本 Issue 内、別 PR)

- **Phase 3**: `CONTRIBUTING.md`, `docs/architecture-overview.md` (トップレベル)
- **Phase 4**: scratch-render / scratch-svg-renderer

## Test Coverage

ドキュメント整備のみ（コード変更なし）。

## Related Issues

Refs #625
