### PR TITLE
docs: phase 3 - top-level entry points (#625)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,200 @@
+# Contributing to smalruby3-editor
+
+Welcome! This guide is the entry point for new contributors to the Smalruby 3 Editor monorepo.
+
+If you're an AI assistant (Claude Code, etc.), see also `CLAUDE.md` and `.claude/rules/` for additional context.
+
+## Quick links
+
+- [Repository overview](#repository-overview)
+- [Environment setup](#environment-setup)
+- [Common workflows](#common-workflows)
+- [Documentation map](#documentation-map)
+- [Where to ask questions](#where-to-ask-questions)
+
+## Repository overview
+
+Smalruby 3 is a Ruby-based visual programming environment, forked from MIT's [Scratch 3.0](https://github.com/scratchfoundation/scratch-editor). This monorepo contains:
+
+- **Web frontend & VM** (`packages/`) — npm workspaces
+- **AWS infrastructure** (`infra/`) — independent CDK projects
+- **Ruby SDL2 desktop runtime** (`ruby/smalruby3/`) — Ruby gem with submodules
+
+For a complete architectural overview, see [`docs/architecture-overview.md`](docs/architecture-overview.md).
+
+## Environment setup
+
+### Prerequisites
+
+- **Docker** (recommended for all development)
+- Git with submodule support
+- (Optional) Node.js 22.x for host-only commands like husky hooks
+
+### One-time setup
+
+```bash
+# Clone with submodules
+git clone --recurse-submodules git@github.com:smalruby/smalruby3-editor.git
+cd smalruby3-editor
+
+# Install all npm workspace dependencies (in Docker)
+docker compose run --rm app npm install
+
+# Build all packages (development mode)
+docker compose run --rm app npm run build:dev
+```
+
+### `.env` file
+
+Copy `.env.example` to `.env` and fill in required keys:
+
+```bash
+cp .env.example .env
+```
+
+Required keys (for full functionality):
+- `GOOGLE_CLIENT_ID` / `GOOGLE_API_KEY` — Google Drive integration
+- `MESH_GRAPHQL_ENDPOINT` / `MESH_API_KEY` / `MESH_AWS_REGION` — Mesh v2
+- `RUBYTEE_RELAY_ENDPOINT` — Rubytee AI assistant
+- `CLASSROOM_API_ENDPOINT` / `MICROSOFT_CLIENT_ID` / `DEV_BYPASS_TOKEN` — Classroom
+
+For local development, point to **stg** endpoints. See `.claude/rules/env-file.md`.
+
+> **CRITICAL**: Never delete `.env` — secrets are not recoverable from git. See `.claude/rules/env-file.md` for backup/recovery.
+
+### Worktrees (optional, for parallel development)
+
+```bash
+git worktree add ../smalruby3-editor-<feature> -b <type>/<branch-name> develop
+cd ../smalruby3-editor-<feature>
+bin/setup-worktree   # all-in-one: env files + node_modules + dist/
+```
+
+Details: `.claude/rules/git-workflow.md` ("Git Worktree Setup")
+
+## Common workflows
+
+### Start the dev server
+
+```bash
+docker compose up app          # Foreground (with logs)
+docker compose up -d app       # Background
+docker compose logs -f app     # Tail logs
+```
+
+Open http://localhost:8601
+
+### Run tests
+
+```bash
+# Lint (must pass with zero warnings before commit)
+docker compose run --rm app npm run lint
+
+# Specific unit test
+docker compose run --rm app bash -c "cd packages/scratch-gui && npm exec jest test/unit/your-test.test.js"
+
+# Specific integration test
+docker compose run --rm app bash -c "cd packages/scratch-gui && npm exec jest test/integration/your-test.test.js"
+
+# All tests (CI runs this on push)
+docker compose run --rm app npm test
+```
+
+### Branch & PR
+
+- **Default branch**: `develop` (NOT `main`)
+- Branch naming:
+  - `feature/<descriptive-name>`
+  - `fix/<issue-description>`
+  - `docs/<descriptive-name>`
+  - `refactor/<descriptive-name>`
+- **Commit messages**: Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, etc.)
+- **PR target**: `develop`
+- **Merge style**: `--merge` (NOT squash)
+
+```bash
+git checkout -b feature/my-feature develop
+# ... make changes, commit ...
+git push -u origin feature/my-feature
+gh pr create --base develop --title "feat: ..." --body-file /tmp/pr-body.md
+```
+
+### PR checklist
+
+Before creating a PR, verify:
+
+1. ✅ All tests pass (lint + affected unit/integration tests)
+2. ✅ Build succeeds (`npm run build:dev`)
+3. ✅ Code follows existing patterns in the modified files
+4. ✅ **Documentation updated** if behavior / files / settings / blocks / markers changed
+5. ✅ **Screenshots updated** if UI changed visually
+6. ✅ Commit messages follow Conventional Commits
+
+For UI changes, update `docs/<feature>/README.md` and `docs/<feature>/screenshots/`. See `.claude/rules/documentation.md` "開発ワークフローの DoD".
+
+### Upstream sync
+
+The repo is forked from upstream Scratch Foundation. When syncing upstream:
+
+```bash
+# Use the slash command (recommended)
+/upstream:merge
+
+# Or manually fetch only the develop branch (gh-pages is huge)
+git fetch -p upstream develop
+```
+
+Details: `.claude/skills/upstream-merge/SKILL.md`
+
+## Documentation map
+
+The repository has comprehensive documentation. **Start at `docs/README.md`** for the index.
+
+### For end users / feature understanding
+
+- **`docs/<feature>/`** — User-story-based feature documentation (42+ features)
+  - Examples: `docs/classroom/`, `docs/rubytee/`, `docs/mesh-v2/`, `docs/mobile-ui/`, `docs/extension-*/`
+  - Each has README + screenshots + integrated view across packages
+
+### For developers
+
+- **`docs/scratch-vm/`** — VM internal architecture (Runtime / Sequencer / Thread / Target / Blocks / Extensions / Serialization)
+- **`docs/infra/`** — AWS CDK infrastructure cross-cutting overview
+- **`docs/smalruby3-gem/`** — Ruby SDL2 desktop runtime
+- **`docs/architecture-overview.md`** — Whole-monorepo architecture (where to add what)
+
+### For language users
+
+- `docs/smalruby-language-spec.ja.md` — Ruby language specification for Smalruby
+- `docs/smalruby-language-spec-extensions.ja.md` — Extension blocks reference
+- `docs/smalruby-dncl-spec.ja.md` — DNCL (Japanese programming) mode spec
+
+### Project-specific rules (for AI agents)
+
+- `CLAUDE.md` — Top-level Claude Code guidance
+- `.claude/rules/` — Detailed per-package rules
+  - `code-style.md`, `git-workflow.md`, `documentation.md`, `supply-chain-security.md`
+  - `scratch-gui/`, `scratch-vm/`, `infra/`, `ruby/` subdirectories
+
+## Coding conventions
+
+- **JavaScript/TypeScript**: ESLint with `eslint-config-scratch` (zero warnings policy)
+- **Prettier** applied to **Smalruby-specific files only** (whitelist in `.prettierignore`)
+- **Smalruby marker comments** (`// === Smalruby: Start of <feature> ===`) for code added to upstream files
+- **kebab-case** for files (`my-component.jsx`), **PascalCase** for components, **camelCase** for variables
+
+Full guide: `.claude/rules/code-style.md`
+
+## Need help?
+
+- **GitHub Issues**: https://github.com/smalruby/smalruby3-editor/issues
+- **Discussions**: https://github.com/smalruby/smalruby3-editor/discussions (for feedback / questions)
+- **Documentation index**: [`docs/README.md`](docs/README.md)
+- **Architectural questions**: Read [`docs/architecture-overview.md`](docs/architecture-overview.md) first
+- **Smalruby website**: https://smalruby.app
+
+## License
+
+Smalruby 3 is open source. See individual package LICENSE files.
+
+This project is based on Scratch from the Scratch Foundation. Thank you for contributions and support!

--- a/README.md
+++ b/README.md
@@ -1,135 +1,101 @@
-# smalruby3-editor: The Smalruby 3 Editor Monorepo
+# smalruby3-editor
 
-This is the development repository for **Smalruby 3**, a Ruby-based visual programming environment forked from [Scratch 3.0](https://github.com/scratchfoundation/scratch-editor).
+**Smalruby 3** は、MIT の [Scratch 3.0](https://github.com/scratchfoundation/scratch-editor) を fork した Ruby ベースのビジュアルプログラミング環境のモノレポです。
 
-If you'd like to use Scratch, please visit the [Scratch website](https://scratch.mit.edu/). You can build your own
-Scratch project by pressing "Create" on that website or by visiting <https://scratch.mit.edu/projects/editor/>.
+公式サイト: <https://smalruby.app>
 
-This is a source code repository for the packages that make up the Smalruby editor and a few additional support
-packages. Use this if you'd like to learn about how the Smalruby editor works or to contribute to its development.
+## はじめに
 
-## What's in this repository?
+| あなたが知りたいこと | 読むべきドキュメント |
+|---|---|
+| **新しく参加した。何から読めばいい？** | [`CONTRIBUTING.md`](CONTRIBUTING.md) → [`docs/architecture-overview.md`](docs/architecture-overview.md) |
+| **○○機能はどう動いている？** | [`docs/README.md`](docs/README.md) (42+ 機能の索引) |
+| **VM の内部実装が知りたい** | [`docs/scratch-vm/`](docs/scratch-vm/) |
+| **AWS インフラの全体像** | [`docs/infra/`](docs/infra/) |
+| **デスクトップ Ruby 実行 (smalruby3 gem)** | [`docs/smalruby3-gem/`](docs/smalruby3-gem/) |
+| **Smalruby Ruby の言語仕様** | [`docs/smalruby-language-spec.ja.md`](docs/smalruby-language-spec.ja.md) |
+| **AI アシスタントへの指示 (Claude Code 等)** | [`CLAUDE.md`](CLAUDE.md) + [`.claude/rules/`](.claude/rules/) |
 
-The `packages` directory in this repository contains:
+## モノレポ構成
 
-- `scratch-gui`: **Smalruby 3 GUI**. The React-based web interface, customized for Smalruby (e.g., Ruby mode, custom extensions). Forked from `scratch-gui`.
-- `scratch-vm`: **Smalruby 3 VM**. The virtual machine that runs projects, with @ruby/prism integration for Ruby parsing. Forked from `scratch-vm`.
-- `scratch-render` draws backdrops, sprites, and clones on the stage.
-- `scratch-svg-renderer` processes SVG (vector) images for use with projects.
-
-_Please add to this list as more packages are migrated to the monorepo._
-
-The `infra` directory contains AWS CDK infrastructure projects:
-
-- `infra/smalruby-mesh-v2`: **Mesh v2**. AWS CDK project for the serverless mesh networking service (AppSync + DynamoDB), enabling real-time communication between Smalruby instances.
-
-Each package has its own `README.md` file with more information about that package.
-
-## Development
-
-### Installation
-
-To install dependencies for all packages in the monorepo:
-
-```bash
-npm install
+```
+smalruby3-editor/
+├── packages/                    npm workspaces (Web フロントエンド + VM)
+│   ├── scratch-gui/             React UI、Monaco Ruby エディタ
+│   ├── scratch-vm/              ブロック実行 VM
+│   ├── scratch-render/          WebGL ステージレンダラー
+│   ├── scratch-svg-renderer/    SVG 前処理
+│   └── task-herder/             非同期タスクキュー
+│
+├── infra/                       AWS CDK インフラ (各々独立プロジェクト)
+│   ├── smalruby-mesh-v2/        リアルタイム通信 (AppSync + DynamoDB)
+│   ├── smalruby-rubytee-relay/  AI チャット (Lambda + Anthropic Claude)
+│   ├── smalruby-classroom/      クラス管理 (Lambda + DDB + S3)
+│   └── smalruby-api/            共通 API (CORS proxy / Mesh zone / Scratch proxy)
+│
+├── ruby/                        Ruby SDL2 デスクトップランタイム
+│   ├── smalruby3/               smalruby3 gem (本体)
+│   ├── ruby-sdl2/               SDL2 Ruby バインディング (submodule, fork)
+│   └── rsdl/                    macOS SDL2 ラッパー (submodule, fork)
+│
+├── docs/                        Smalruby 独自ドキュメント (機能 / 内部仕様 / インフラ)
+├── .claude/                     Claude Code 用ルール・スキル・設定
+├── scripts/                     モノレポ全体のビルドスクリプト
+└── .github/workflows/           CI/CD 設定
 ```
 
-**Note**: We strictly recommend using the Docker environment for development to ensure consistency. Please refer to the [root README](../../README.md) for Docker instructions.
+詳細図は [`docs/architecture-overview.md`](docs/architecture-overview.md) 参照。
 
-### Build
+## クイックスタート
 
-To build all packages:
+### 必要なもの
 
-```bash
-npm run build
-```
+- **Docker** (推奨。すべての開発作業に使用)
+- Git (submodule サポート)
 
-To build in development mode (faster, with source maps):
-
-```bash
-npm run build:dev
-```
-
-### Running the Development Server
-
-To start the GUI development server (typically on http://localhost:8601):
+### セットアップ
 
 ```bash
-npm start
+git clone --recurse-submodules git@github.com:smalruby/smalruby3-editor.git
+cd smalruby3-editor
+
+# 環境変数 (.env)
+cp .env.example .env
+# .env を編集: GOOGLE_CLIENT_ID, MESH_GRAPHQL_ENDPOINT, RUBYTEE_RELAY_ENDPOINT 等
+
+# 依存インストール + ビルド (Docker 経由)
+docker compose run --rm app npm install
+docker compose run --rm app npm run build:dev
 ```
 
-### Testing
-
-To run all tests (lint, unit, integration):
+### 開発サーバー起動
 
 ```bash
-npm test
+docker compose up app          # http://localhost:8601
 ```
 
-To run unit tests only:
+詳細な開発フロー・テスト・PR 作成手順は [`CONTRIBUTING.md`](CONTRIBUTING.md) を参照。
 
-```bash
-npm run test:unit
-```
+## 主な機能
 
-To run integration tests only:
+- **ブロックプログラミング** — Scratch 3 ベースの GUI
+- **Ruby モード** — Monaco エディタで Ruby を書き、ブロックと相互変換
+- **ふりがなモード / DNCL モード** — 日本語学習者向け表示モード
+- **Rubytee (AI アシスタント)** — Anthropic Claude API でコード生成支援
+- **Mesh v2** — 複数のスモウルビー間でリアルタイム通信
+- **Smalruby Classroom** — 教室での課題提出・管理
+- **Smalrubot S1 / micro:bit / LEGO 等** — 多数の物理デバイス連携
+- **Google Drive 連携** — 自分の Drive に作品保存
+- **デスクトップ実行** — Ruby SDL2 でネイティブ実行 (smalruby3 gem)
 
-```bash
-npm run test:integration
-```
+各機能の詳細は [`docs/README.md`](docs/README.md) を参照。
 
-## Smalruby Specific Features
+## ライセンス
 
-### Language Specification
+各パッケージの LICENSE ファイルを参照。
 
-Smalruby supports a subset of Ruby syntax. See the language specification for details:
+upstream の Scratch は Scratch Foundation のもの。Smalruby は同 Foundation のオープンソース活動に感謝しつつ、独自の進化を続けています。
 
-- **[Language Specification](docs/smalruby-language-spec.md)** ([Japanese](docs/smalruby-language-spec.ja.md)) — Core syntax and built-in methods
-- **[Extension Methods](docs/smalruby-language-spec-extensions.md)** ([Japanese](docs/smalruby-language-spec-extensions.ja.md)) — Pen, Music, Translate, micro:bit, and more
-- **[Version 1 API Differences](docs/smalruby-language-spec-v1-diff.md)** ([Japanese](docs/smalruby-language-spec-v1-diff.ja.md)) — Changes from v1 to v2
+## 寄付
 
-### Ruby Mode
-Smalruby 3 integrates [@ruby/prism](https://github.com/ruby/prism) to parse Ruby code within the browser. The `scratch-gui` package provides the Ruby code editor (using Monaco Editor) with Ruby-to-blocks conversion and blocks-to-Ruby generation.
-
-### Google Drive Integration
-Smalruby 3 supports loading and saving projects directly to Google Drive.
-For setup instructions, please see [Google API Setup Guide](packages/scratch-gui/docs/google-api-setup.md).
-
-### AWS Infrastructure (infra/)
-
-AWS CDK infrastructure projects are managed in the `infra/` directory. Use the `infra` Docker service for CDK operations:
-
-```bash
-# Install dependencies
-docker compose run --rm infra npm install
-
-# Deploy Mesh v2 to staging
-docker compose run --rm infra npx cdk deploy --context stage=stg
-
-# Show deployment diff
-docker compose run --rm infra npx cdk diff --context stage=stg
-```
-
-AWS credentials must be set via environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`) before running these commands.
-
-## Monorepo migration
-
-### What's going on?
-
-We're migrating the Smalruby editor packages into this monorepo, following the upstream Scratch Editor structure. This allows us to manage all packages in one place.
-
-### Why are there only a few packages in this repo?
-
-We're migrating packages in stages.
-
-## Thank you!
-
-Smalruby is based on Scratch from the Scratch Foundation.
-Scratch would not be what it is today without help from the global community of Scratchers and open-source contributors. Thank you for your contributions and support. _[Scratch on!](https://scratch.mit.edu/projects/65347738/fullscreen/)_
-
-## Donate
-
-We provide [Scratch](https://scratch.mit.edu) free of charge, and want to keep it that way! Please consider making a
-[donation](https://secure.donationpay.org/scratchfoundation/) to support our continued engineering, design, community,
-and resource development efforts. Donations of any size are appreciated. Thank you!
+[Scratch](https://scratch.mit.edu) は無料で提供されています。継続的な開発のため、[寄付](https://secure.donationpay.org/scratchfoundation/) を検討してください。

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,9 +90,11 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 
 ### その他
 
+- [`architecture-overview.md`](architecture-overview.md) — モノレポ全体のアーキテクチャ概要 (パッケージ・インフラ・gem の関係 1 枚図)
 - [`adr/`](adr/) — Architecture Decision Records (Smalruby 独自の ADR)
 - `smalruby-language-spec*.md` — Smalruby 言語仕様（機能 docs とは別カテゴリ）
 - `smalruby-dncl-spec.ja.md` — DNCL モードの言語仕様
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — 新規参加者向けの入口
 
 ## ドキュメント執筆テンプレート
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,210 @@
+# Smalruby 3 アーキテクチャ概要
+
+Smalruby 3 モノレポ全体のアーキテクチャを 1 枚にまとめる。**何がどこにあるか、どう繋がっているか、どこに何を追加すべきか**を判断するための地図。
+
+## 1 枚図
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│                              ユーザー (子供 / 教師 / 保護者)                       │
+└──────────────────────┬─────────────────────────┬──────────────────────────────────┘
+                       │                         │
+                       │ ブラウザ                  │ Mac / Windows ネイティブ
+                       ▼                         ▼
+┌─────────────────────────────────────┐  ┌─────────────────────────────────────┐
+│  Web フロントエンド                  │  │  デスクトップランタイム                │
+│  https://smalruby.app                │  │  ruby/smalruby3/ (gem)              │
+│                                      │  │                                      │
+│  ├─ packages/scratch-gui             │  │  ├─ lib/smalruby3/                  │
+│  │   (React UI、Monaco Ruby エディタ)  │  │  │  (Ruby DSL、Fiber 並列、Asset)    │
+│  ├─ packages/scratch-vm              │  │  ├─ ext/smalruby3_imageutil (Rust)  │
+│  │   (Sequencer、Thread、execute)    │  │  ├─ ext/smalruby3_launcher (macOS)  │
+│  ├─ packages/scratch-render          │  │  └─ ruby/ruby-sdl2 (submodule)      │
+│  │   (WebGL、Drawable、Skin)         │  │  └─ ruby/rsdl     (submodule)        │
+│  ├─ packages/scratch-svg-renderer    │  │                                      │
+│  │   (SVG → 描画準備)                 │  └──────────────────────────────────────┘
+│  └─ packages/task-herder             │
+│      (タスクキュー)                    │
+│                                      │
+└──────────────┬───────────────────────┘
+               │
+               │ 各 infra プロジェクトに HTTPS で接続
+               ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                  AWS インフラ (ap-northeast-1, infra/)                       │
+│                                                                              │
+│  ┌─────────────────────┐  ┌──────────────────────┐  ┌────────────────────┐ │
+│  │ smalruby-mesh-v2    │  │ smalruby-rubytee-     │  │ smalruby-classroom │ │
+│  │ AppSync + DynamoDB  │  │ relay                 │  │ Lambda + DDB + S3  │ │
+│  │ graphql.api.        │  │ Lambda + DDB          │  │ classroom.api.     │ │
+│  │  smalruby.app       │  │ rubytee.api.          │  │  smalruby.app      │ │
+│  │                     │  │  smalruby.app         │  │                    │ │
+│  │ → リアルタイム通信     │  │ → Anthropic Claude    │  │ → Google Classroom │ │
+│  │   (broadcast,       │  │   API リレー           │  │   連携、提出物管理   │ │
+│  │   global var sync)  │  │                       │  │                    │ │
+│  └─────────────────────┘  └──────────────────────┘  └────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────┐                                                    │
+│  │ smalruby-api        │                                                    │
+│  │ Lambda × 4          │                                                    │
+│  │ api.smalruby.app    │                                                    │
+│  │                     │                                                    │
+│  │ - cors-proxy        │                                                    │
+│  │ - mesh-domain       │                                                    │
+│  │ - scratch-api-      │                                                    │
+│  │   proxy/projects    │                                                    │
+│  │ - scratch-api-      │                                                    │
+│  │   proxy/translate   │                                                    │
+│  └─────────────────────┘                                                    │
+└─────────────────────────────────────────────────────────────────────────────┘
+              ▲                          ▲                       ▲
+              │                          │                       │
+        ┌─────┴──────┐           ┌──────┴──────┐         ┌──────┴──────┐
+        │ Anthropic  │           │ Google      │         │ Scratch     │
+        │ Claude API │           │ (Classroom, │         │ Foundation  │
+        │            │           │  Drive,     │         │ public APIs │
+        │            │           │  Translate) │         │             │
+        └────────────┘           └─────────────┘         └─────────────┘
+```
+
+## 主要パッケージ
+
+| パッケージ | 役割 | 言語 |
+|---|---|---|
+| `packages/scratch-gui` | React UI、Monaco Ruby エディタ、ブロックパレット、ステージ | JS/JSX |
+| `packages/scratch-vm` | ブロック実行 VM (Runtime / Sequencer / Thread / execute) | JS |
+| `packages/scratch-render` | WebGL ベースのスプライト描画 | JS |
+| `packages/scratch-svg-renderer` | SVG → 描画用前処理 | JS |
+| `packages/task-herder` | 非同期タスクキュー (throttle / concurrency) | JS |
+| `infra/smalruby-mesh-v2` | リアルタイム通信 (AppSync + DynamoDB) | TS (CDK) + Ruby (resolver) |
+| `infra/smalruby-rubytee-relay` | AI チャット (Anthropic Claude relay) | TS (CDK + Lambda) |
+| `infra/smalruby-classroom` | クラス管理・課題提出 | TS (CDK + Lambda) |
+| `infra/smalruby-api` | 共通 API (CORS proxy / Mesh zone / Scratch API proxy) | TS (CDK + Lambda) |
+| `ruby/smalruby3` | デスクトップ Ruby + SDL2 ランタイム (gem) | Ruby + Rust + Swift |
+| `ruby/ruby-sdl2` | Ruby SDL2 バインディング (submodule, fork) | Ruby + C |
+| `ruby/rsdl` | macOS 用 SDL2 ラッパー (submodule, fork) | Ruby |
+
+## データの流れ
+
+### 1. ユーザーが作品を作る
+
+```
+ブラウザ → scratch-gui (React)
+        ├─ ブロックパレットでブロックを組み立て (scratch-blocks 経由)
+        ├─ ↔ Ruby エディタ (Monaco) で双方向変換 (ruby-generator / ruby-to-blocks-converter)
+        └─ コスチューム / サウンド / スプライト追加
+```
+
+### 2. ユーザーがプロジェクトを実行 (緑旗)
+
+```
+緑旗クリック → scratch-vm.runtime.startHats('event_whenflagclicked')
+            → Hat を持つ Thread を生成
+            → Sequencer が 30 FPS で Thread を時分割実行
+            → 各ブロックの primitive 関数が呼ばれる
+            → scratch-render が Drawable をステージに描画
+```
+
+### 3. ユーザーがプロジェクトを保存
+
+```
+保存 → scratch-vm.toJSON() で project.json 生成
+    → scratch-gui がアセットと zip 化 → .sb3 ファイル
+    → ブラウザダウンロード or Google Drive アップロード
+```
+
+### 4. ユーザーがネットワーク通信を使う (Mesh v2)
+
+```
+broadcast / グローバル変数 → scratch-vm の meshV2 拡張
+                          → AWS AppSync に GraphQL mutation
+                          → 他ノードに subscription 配信 (or polling)
+                          → 受信側で broadcast 発火 / 変数更新
+```
+
+### 5. ユーザーが AI に質問 (Rubytee)
+
+```
+ルビティーボタン → scratch-gui の rubytee-modal
+                → POST /generate to rubytee-relay (Lambda)
+                → Anthropic Claude API
+                → 生成された Ruby コードを Monaco に挿入
+```
+
+### 6. ユーザーがデスクトップで実行 (smalruby3 gem)
+
+```
+ruby script.rb (or smalruby exec)
+    → smalruby3_launcher (macOS) or Xvfb (Docker)
+    → Smalruby3.start → Runtime.instance.run
+    → Sprite サブクラスを Fiber として並列実行
+    → SDL2 で描画 (BitmapSkin / PenSkin / TextBubble)
+```
+
+## 主要なディレクトリ判断ガイド
+
+「○○を追加したい」ときどこに置くか：
+
+| 追加するもの | 置く場所 |
+|---|---|
+| 新しい React コンポーネント (UI) | `packages/scratch-gui/src/components/<name>/` |
+| 新しいコンテナ (HOC, Redux 接続) | `packages/scratch-gui/src/containers/<name>.jsx` |
+| Ruby ↔ Blocks 変換ロジック | `packages/scratch-gui/src/lib/ruby-generator/` または `ruby-to-blocks-converter/` |
+| 新しいブロック (拡張機能) | `packages/scratch-vm/src/extensions/<scratch3_xxx>/` |
+| 新しい Smalruby 拡張機能 | `packages/scratch-vm/src/extensions/<name>/` + `packages/scratch-vm/src/extension-support/smalruby-extensions.js` に登録 |
+| 新しい AWS サービス (CDK) | `infra/<smalruby-xxx>/` 新規プロジェクト or 既存に追加 |
+| デスクトップランタイムの新機能 | `ruby/smalruby3/lib/smalruby3/` |
+| Smalruby 独自ドキュメント | `docs/<feature>/` (詳細: `.claude/rules/documentation.md`) |
+| upstream Scratch のドキュメント | `packages/<package>/docs/` (例: `packages/scratch-vm/docs/extensions.md`) |
+
+## upstream との関係
+
+すべての `packages/*` は upstream [scratch-editor](https://github.com/scratchfoundation/scratch-editor) から fork。upstream の develop ブランチを定期的にマージする。
+
+差分管理：
+- **Smalruby 独自ファイル**: 専用ディレクトリ (`smalruby_ruby/`, `koshien/`, `mesh_v2/` 等) または専用ファイル (`smalruby-extensions.js`, `smalruby-migration.js`)
+- **upstream ファイルへの追加**: `// === Smalruby: Start of <feature> ===` マーカーで囲む
+- **マーカー一覧**: `.claude/rules/scratch-gui/smalruby-markers.md`、`.claude/rules/scratch-vm/development.md`
+
+upstream マージ時の競合を最小化するための設計指針：
+1. Smalruby 独自コードは**専用ファイルに集約** (`smalruby-extensions.js` パターン)
+2. upstream ファイルへの追加は**最小限** (require 1 行が理想)
+3. 大きな機能はクロージャ・mixin・HOC でラップ
+
+## ブラウザ専用 vs ネイティブ専用 vs 両対応
+
+| 機能 | ブラウザ (scratch-vm) | ネイティブ (smalruby3 gem) |
+|---|---|---|
+| 標準ブロック (motion / looks / control 等) | ✅ | ✅ |
+| Pen / Music | ✅ | ✅ |
+| Mesh v2 / Rubytee / Classroom | ✅ | ❌ (ブラウザ依存 API) |
+| Smalrubot S1 / G2S | ✅ | ❌ (Web Serial) |
+| micro:bit / EV3 / BOOST / WeDo | ✅ | ❌ (Web Bluetooth) |
+| Video / Face Sensing / TM2Scratch | ✅ | ❌ (getUserMedia / TF.js) |
+| Text2Speech / Translate | ✅ | ❌ (HTTP API + 認証) |
+
+→ デスクトップランタイムは **シンプルな Ruby 学習用途**にフォーカス。ブラウザ専用機能は意図的に対応しない。
+
+## 開発・運用の詳細
+
+それぞれの詳細ドキュメント：
+
+| 領域 | 入口 |
+|---|---|
+| 機能ドキュメント (ユーザー視点) | [`docs/README.md`](README.md) |
+| ブラウザ VM 内部 | [`docs/scratch-vm/README.md`](scratch-vm/README.md) |
+| AWS インフラ | [`docs/infra/README.md`](infra/README.md) |
+| Ruby gem | [`docs/smalruby3-gem/README.md`](smalruby3-gem/README.md) |
+| 言語仕様 (Ruby DSL) | [`docs/smalruby-language-spec.ja.md`](smalruby-language-spec.ja.md) |
+| 開発ワークフロー | [`CLAUDE.md`](../CLAUDE.md) + [`.claude/rules/`](../.claude/rules/) |
+| 新規参加者 | [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
+
+## 関連 Issue / 履歴
+
+主要なドキュメント整備の Issue：
+- #610 — 機能ドキュメント体系
+- #616 — スクリーンショット
+- #620 — scratch-vm 内部仕様
+- #625 — 残り (infra / smalruby3-gem / トップレベル / render)
+
+これらの Issue 履歴を読むと、各ドキュメントの設計判断の経緯が分かる。


### PR DESCRIPTION
## Summary

Issue #625 Phase 3: トップレベルの整備。新規参加者の入口 (`CONTRIBUTING.md`) と全体俯瞰ドキュメント (`docs/architecture-overview.md`) を追加し、`README.md` を現状に合わせて全面更新。

## Changes Made

### 新規 `CONTRIBUTING.md`

新規参加者・コントリビューター向けの入口：

- **「あなたが知りたいことに応じた読むべき docs」表** — 用途別に最初のドキュメントを案内
- 環境セットアップ (Docker / submodule / `.env` / worktree)
- 共通ワークフロー (dev server / test / branch / PR / upstream sync)
- **PR チェックリスト** (DoD = docs / screenshot 更新含む)
- ドキュメント全体マップ
- コーディング規約サマリ + 詳細ルールへの導線

### 新規 `docs/architecture-overview.md`

モノレポ全体のアーキテクチャを 1 枚で把握：

- **1 枚図**: ユーザー → ブラウザ / ネイティブ → AWS インフラ → 外部 API の関係
- **主要パッケージ一覧** (役割・言語)
- **6 種類のデータフロー** (作品作成 / 実行 / 保存 / Mesh v2 / Rubytee / デスクトップ)
- **「○○を追加したいときどこに置くか」判断ガイド表**
- **upstream との関係** (マーカー / 差分管理戦略)
- **ブラウザ専用 vs ネイティブ専用 vs 両対応** の機能対応表
- 各詳細ドキュメントへの入口

### `README.md` 全面更新

旧版は infra / scratch-vm の説明が不完全 + 古い記述あり。以下を更新：

- 冒頭に「**あなたが知りたいことに応じた読むべき docs**」表
- モノレポ構成図 (packages / infra / ruby / docs / .claude)
- クイックスタート (submodule clone → `.env` → install → build)
- 主な機能リスト (Smalruby 独自機能を含む)
- 古いドキュメントへのリンクを最新化

### `docs/README.md`

- `architecture-overview.md` と `CONTRIBUTING.md` への参照を「その他」セクションに追加

## 残作業 (本 Issue 内、別 PR)

- **Phase 4**: scratch-render / scratch-svg-renderer

## Test Coverage

ドキュメント整備のみ（コード変更なし）。

## Related Issues

Refs #625
