### PR TITLE
docs(render): phase 4 final - scratch-render + scratch-svg-renderer (#625)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,8 @@ smalruby3-editor の機能ドキュメントは **ユーザーストーリー単
 | [`scratch-vm/`](scratch-vm/) — VM 内部仕様 (Runtime / Sequencer / Thread / Target / Blocks / Extensions / Serialization / Blocks Runtime) | 開発者向け（Issue #620 完了） |
 | [`infra/`](infra/) — AWS CDK インフラ全体 (mesh-v2 / rubytee-relay / classroom / smalruby-api の横断ドキュメント) | 開発者・運用向け（Issue #625） |
 | [`smalruby3-gem/`](smalruby3-gem/) — Ruby SDL2 デスクトップランタイム (`ruby/smalruby3/`) | gem 開発者向け（Issue #625 Phase 2） |
+| [`scratch-render/`](scratch-render/) — WebGL ステージレンダラー内部仕様 | レンダラー開発者向け（Issue #625 Phase 4） |
+| [`scratch-svg-renderer/`](scratch-svg-renderer/) — SVG 前処理パッケージ内部仕様 | レンダラー開発者向け（Issue #625 Phase 4） |
 
 ### その他
 

--- a/docs/scratch-render/README.md
+++ b/docs/scratch-render/README.md
@@ -1,0 +1,177 @@
+# scratch-render 内部仕様
+
+> **⬆️ upstream そのまま** — `packages/scratch-render/` は upstream Scratch Foundation の実装をそのまま利用。Smalruby 独自の改変はパッケージスコープ (`@smalruby/scratch-render`) のリブランドのみ。
+
+`packages/scratch-render/` は **WebGL ベースのステージレンダラー**。スプライト・背景・ペンレイヤー・吹き出しを Canvas 上に描画する。scratch-vm から呼ばれて、毎フレーム再描画する。
+
+## 対象読者
+
+- **描画バグの調査**をする開発者
+- **新しいエフェクト**を追加したい人
+- **新しい Skin 種別**を追加したい人 (例: Smalruby 独自の描画レイヤー)
+- VM とレンダラー間の API を理解したい人
+
+## 概要
+
+| 項目 | 値 |
+|---|---|
+| バージョン | 13.0.0 (upstream 同期) |
+| Entry | `packages/scratch-render/src/index.js` (`RenderWebGL` を export) |
+| 主要依存 | `twgl.js` (WebGL utility), `hull.js` (衝突判定), `@smalruby/scratch-svg-renderer` (SVG 処理) |
+| ステージサイズ | 480 × 360 (xLeft=-240, xRight=240, yBottom=-180, yTop=180) |
+| ステージ境界 fence | 15px (スプライトを画面外に出ないようクランプ) |
+
+## ざっくり構造
+
+```
+RenderWebGL (公開 API)
+  ├─ canvas: HTMLCanvasElement
+  ├─ gl: WebGLRenderingContext (twgl.js でラップ)
+  ├─ _drawables: Map<id, Drawable>
+  ├─ _skins: Map<id, Skin>
+  ├─ _layerGroups: { name → drawableID[] }   (z-order)
+  ├─ _shaderManager: ShaderManager
+  └─ メソッド:
+       - createDrawable(group) → drawableID
+       - updateDrawable(id, props)
+       - updateDrawableEffect(id, effectName, value)
+       - updateDrawableSkinId(id, skinID)
+       - createBitmapSkin(...)/createSVGSkin(...)/createPenSkin(...)/createTextBubbleSkin(...)
+       - draw()                              ← 毎フレーム呼ぶ
+       - setLayerGroupOrdering(["backdrop", "pen", "sprites", "sky"])
+
+Drawable (スプライト・背景・吹き出し等の 1 個)
+  ├─ skin: Skin (テクスチャ供給元)
+  ├─ position, rotation, scale, visible
+  ├─ effects: { color, fisheye, whirl, pixelate, mosaic, brightness, ghost }
+  ├─ enabledEffects: bitmask (有効なエフェクトのみシェーダ分岐)
+  └─ silhouette: 衝突判定用 (Skin 経由)
+
+Skin (抽象基底)
+  ├─ BitmapSkin    — PNG/JPG コスチューム
+  ├─ SVGSkin       — SVG コスチューム (scratch-svg-renderer 経由でラスタ化)
+  ├─ PenSkin       — ペン描画レイヤー (動的に更新される WebGL テクスチャ)
+  └─ TextBubbleSkin — say/think の吹き出し
+
+ShaderManager
+  ├─ EFFECT_INFO: { color, fisheye, whirl, pixelate, mosaic, brightness, ghost }
+  └─ enabledEffects ビットマスクに応じてシェーダプログラムを選択
+```
+
+## VM ↔ Renderer の繋がり
+
+`scratch-vm` の `Runtime` がレンダラーへの参照を持ち、以下のフローで描画する：
+
+```
+1. プロジェクトロード時:
+   for sprite of targets:
+     skinID = renderer.createBitmapSkin(...) または createSVGSkin(...)
+     drawableID = renderer.createDrawable('sprites')
+     renderer.updateDrawableSkinId(drawableID, skinID)
+
+2. ブロック実行時 (move, set x など):
+   renderer.updateDrawablePosition(drawableID, [x, y])
+   renderer.updateDrawableDirection(drawableID, direction)
+   renderer.updateDrawableScale(drawableID, [size, size])
+
+3. エフェクトブロック実行時:
+   renderer.updateDrawableEffect(drawableID, 'color', 25)
+
+4. 毎フレーム:
+   renderer.draw()   ← 全 drawables を z-order で描画
+```
+
+実際のコール元は `packages/scratch-vm/src/sprites/rendered-target.js` の `setXY`, `setDirection`, `setSize` 等。
+
+## エフェクト一覧
+
+`src/ShaderManager.js` で定義されている 7 種類：
+
+| エフェクト | uniform | 入力範囲 | shape 変化 | 説明 |
+|---|---|---|---|---|
+| **color** | `u_color` | 0–200 (200 で 1 周) | × | 色相シフト |
+| **fisheye** | `u_fisheye` | -100 to ∞ | ✅ | 魚眼レンズ歪み |
+| **whirl** | `u_whirl` | ±∞ (degrees) | ✅ | 回転的歪み |
+| **pixelate** | `u_pixelate` | 1–512 | ✅ | ピクセル化 |
+| **mosaic** | `u_mosaic` | 1–512 | ✅ | モザイク |
+| **brightness** | `u_brightness` | -100 to +100 | × | 明度変化 |
+| **ghost** | `u_ghost` | 0–100 (%) | × | 透明度 |
+
+**shape 変化系**は衝突判定の silhouette を invalidate する (再生成が必要)。
+
+### 新しいエフェクトの追加
+
+1. `src/ShaderManager.js` の `EFFECT_INFO` にエントリ追加
+2. `src/shaders/sprite.frag` に `#ifdef ENABLE_EFFECTNAME` で実装追加
+3. `Drawable.js` に uniform を追加
+4. テストを `test/integration/` に追加
+
+## レイヤー (z-order)
+
+`setLayerGroupOrdering(['backdrop', 'pen', 'sprites', 'sky'])` で順序を指定：
+
+| レイヤー | 用途 |
+|---|---|
+| `backdrop` | ステージの背景 |
+| `pen` | ペン拡張の描画レイヤー (PenSkin) |
+| `sprites` | スプライト群 |
+| `sky` | UI overlay (今後拡張用) |
+
+各 drawable は **作成時にどのレイヤーグループに属するか**を指定する。
+
+## Skin 種別
+
+### BitmapSkin
+
+PNG / JPG コスチューム。WebGL テクスチャに直接アップロード。
+
+### SVGSkin
+
+SVG コスチューム。**`scratch-svg-renderer` でサニタイズ・正規化** → Canvas にラスタ化 → WebGL テクスチャ。
+
+複数の MIP レベル (異なる scale でのラスタ化結果) を保持し、表示倍率に応じて適切なものを選ぶ (= テクスチャ品質の維持)。
+
+### PenSkin
+
+ペン拡張機能の描画レイヤー。**動的に更新される WebGL フレームバッファ**として実装され、ブロックから線分・スタンプを書き加えていく。
+
+### TextBubbleSkin
+
+say / think の吹き出し。テキストレイアウト → Canvas 描画 → テクスチャ化。
+
+### 新しい Skin 種別の追加
+
+1. `Skin` 基底クラスを継承したクラスを `src/MySkin.js` に作成
+2. `_uploadTexture()` でテクスチャ生成、`_silhouette` 更新を実装
+3. `RenderWebGL.createMySkin(...)` ファクトリメソッドを追加
+4. テストを追加
+
+## 衝突判定 (Silhouette)
+
+`src/Silhouette.js`:
+
+- **CPU パス**: drawable 単位で convex hull (`hull.js`) を計算、特定座標の色を見て touching を判定
+- **GPU パス**: オフスクリーンテクスチャに描画 → `readPixels()` で touching 判定 (warped shapes に有効、低速)
+
+## デバッグ機能
+
+- `setDebugCanvas(canvas)` — シェーダ出力やピッキング情報を別 Canvas に描画
+- ブラウザコンソールで `window.smalruby.runtime.renderer` から RenderWebGL インスタンスにアクセス可能
+
+## upstream との差分
+
+**ゼロ** (パッケージスコープのリブランドのみ):
+- `package.json` の `"name": "@smalruby/scratch-render"`
+- 内部実装は upstream 同期 (146+ コミットの履歴を fork 後も維持)
+
+upstream マージ時の競合は基本的に発生しない (機能改変なし)。
+
+## 関連ドキュメント
+
+- [`scratch-svg-renderer/README.md`](../scratch-svg-renderer/README.md) — SVG 前処理 (本パッケージから依存)
+- [`scratch-vm/architecture.md`](../scratch-vm/architecture.md) — VM 側からの呼び出しフロー
+- 上流: [scratch-render GitHub](https://github.com/scratchfoundation/scratch-render)
+
+## 関連 Issue
+
+特になし (upstream 同期で進化)。

--- a/docs/scratch-svg-renderer/README.md
+++ b/docs/scratch-svg-renderer/README.md
@@ -1,0 +1,130 @@
+# scratch-svg-renderer 内部仕様
+
+> **⬆️ upstream そのまま** — `packages/scratch-svg-renderer/` は upstream Scratch Foundation の実装をそのまま利用。Smalruby 独自の改変はパッケージスコープ (`@smalruby/scratch-svg-renderer`) のリブランドのみ。
+
+`packages/scratch-svg-renderer/` は **SVG コスチュームの前処理パッケージ**。SVG を WebGL レンダラーに渡せる形 (Canvas / Bitmap) に変換するために、サニタイズ・正規化・フォントインライン化・ラスタ化を行う。
+
+## なぜ独立パッケージなのか
+
+1. **セキュリティ重要**: ユーザーがアップロードする SVG に悪意あるコンテンツ (script, 外部 URL など) が含まれる可能性 → 独立した sanitization 層
+2. **重い依存** (DOMPurify, css-tree): WebGL レンダラーから切り離すことで、SVG 不使用のシナリオでロードしない
+3. **再利用性**: scratch-paint (ペイントエディタ)、コスチュームインポーターなど、レンダラー以外からも使う
+4. **Vector → Raster ブリッジ**: WebGL は SVG をネイティブ描画できないため、Canvas 経由でラスタ化する必要がある
+
+## 対象読者
+
+- **SVG コスチューム関連のバグ**を調査する人
+- **Scratch 2.0 由来の SVG quirks** に対応した何かを追加・修正する人
+- **フォント処理**を理解したい人
+
+## 概要
+
+| 項目 | 値 |
+|---|---|
+| バージョン | 13.0.0 (upstream 同期) |
+| Entry | `packages/scratch-svg-renderer/src/index.js` (関数群を export) |
+| 主要依存 | `css-tree` (CSS パース), `isomorphic-dompurify` (SVG サニタイズ), `transformation-matrix` (2D 行列), `base64-js` |
+
+## 公開 API (`src/index.js`)
+
+```js
+{
+    SVGRenderer,           // (deprecated) quirks-mode renderer クラス
+    loadSvgString,         // SVG 文字列をパース・検証して DOM tree を返す
+    serializeSvgToString,  // DOM tree を文字列化
+    sanitizeSvg,           // 危険なコンテンツを除去
+    convertFonts,          // フォント形式変換 (WOFF ↔ TTF)
+    inlineSvgFonts,        // フォント定義を <defs> に埋め込む
+    BitmapAdapter          // SVG を Canvas にラスタ化
+}
+```
+
+クラスではなく**関数群**として提供される。
+
+## 主要モジュール
+
+### `load-svg-string.js`
+
+SVG 文字列の取り込みのメインフロー：
+
+1. **XML パース** (DOMParser またはサーバ環境では xmldom)
+2. **Scratch 2.0 quirks 修正**:
+   - 誤った viewBox の補正
+   - width/height 欠落の補完
+   - 古い style 属性の正規化
+3. **境界計測** (実際の表示サイズの計算)
+4. **DOM tree + メタデータ** を返す
+
+### `sanitize-svg.js`
+
+セキュリティの要。`isomorphic-dompurify` で以下を除去・無害化：
+
+- **外部 URL 参照** (`xlink:href` で http:// / https:// を指すもの)
+- **`url()` 参照**で外部リソース (フォント、画像) を指すもの
+- **スクリプト** (`<script>`, イベントハンドラ属性)
+- **`data:` URL** (例外: 安全な `data:image/...` のみ許可)
+- 不正な構造の修正
+
+→ ユーザーアップロード SVG の XSS 攻撃を防ぐ。
+
+### `font-inliner.js` + `font-converter.js`
+
+Canvas での描画は **HTML カスタムフォントをリンクできない**ため、SVG 内のフォント定義を **base64 エンコードしたフォントデータとして `<defs>` に埋め込む** 必要がある：
+
+1. SVG 内の `font-family` 属性をスキャン
+2. `scratch-render-fonts` パッケージから対応するフォントデータ (WOFF / TTF) を取得
+3. `<style>@font-face { ... }</style>` を SVG の `<defs>` に注入
+4. これで Canvas 描画時に正しいフォントで描画される
+
+### `bitmap-adapter.js`
+
+SVG → Canvas ラスタ化の本体：
+
+```
+1. SVG bounds を計測
+2. Canvas を bounds に合わせてリサイズ
+3. ctx.drawImage() で SVG をデータ URL 経由で描画
+4. ctx.getImageData() で ImageData (pixel array) を取得
+5. 回転中心情報 + bitmap を返す
+```
+
+これが `scratch-render` の SVGSkin が WebGL テクスチャをアップロードするときの入力。
+
+### `transform-applier.js`
+
+SVG の `transform=""` 属性 (translate / rotate / scale / skew / matrix) をパースして 2D 行列として適用するユーティリティ。
+
+### `svg-renderer.js` (deprecated)
+
+旧 quirks-mode の `SVGRenderer` クラス。新規コードでは使わない。後方互換のため残置。
+
+## scratch-render との連携
+
+```
+SVG コスチューム (string)
+  ↓
+scratch-svg-renderer:
+  loadSvgString → sanitizeSvg → inlineSvgFonts → DOM tree
+  ↓
+scratch-render の SVGSkin:
+  BitmapAdapter で Canvas にラスタ化
+  ↓
+WebGL texture upload
+```
+
+## upstream との差分
+
+**ゼロ** (パッケージスコープのリブランドのみ):
+- `package.json` の `"name": "@smalruby/scratch-svg-renderer"`
+- 内部実装は upstream 同期
+
+upstream マージ時の競合は基本的に発生しない。
+
+## 関連ドキュメント
+
+- [`scratch-render/README.md`](../scratch-render/README.md) — WebGL レンダラー (本パッケージの主要利用者)
+- 上流: [scratch-svg-renderer GitHub](https://github.com/scratchfoundation/scratch-svg-renderer)
+
+## 関連 Issue
+
+特になし (upstream 同期で進化)。


### PR DESCRIPTION
## Summary

Issue #625 Phase 4 (最終): WebGL ステージレンダラーと SVG 前処理パッケージの内部仕様を文書化。**これで Issue #625 の全 Phase が完了**し、ドキュメント整備プロジェクト全体 (Issue #610 / #616 / #620 / #625) が締めくくられる。

両パッケージとも **upstream そのまま** (パッケージスコープのリブランド除く)。

## Changes Made

### 新規 `docs/scratch-render/README.md`

- **WebGL ベースのレンダリング全体構造**: RenderWebGL / Drawable / Skin / ShaderManager
- **VM ↔ Renderer の連携フロー** (`createDrawable` / `updateDrawable*` / `draw`)
- **7 エフェクト一覧** (color / fisheye / whirl / pixelate / mosaic / brightness / ghost) + uniform / 範囲 / shape 変化フラグ
- **レイヤー** (z-order: backdrop / pen / sprites / sky)
- **4 Skin 種別** (BitmapSkin / SVGSkin / PenSkin / TextBubbleSkin)
- **新エフェクト・新 Skin 種別の追加方法**
- **衝突判定** (Silhouette、CPU vs GPU パス)

### 新規 `docs/scratch-svg-renderer/README.md`

- **なぜ独立パッケージなのか** (セキュリティ・依存軽量化・再利用性・vector→raster ブリッジ)
- **公開 API** (関数群、クラスベースではない)
- **主要モジュール** (load-svg-string / sanitize-svg / font-inliner / bitmap-adapter / transform-applier)
- Scratch 2.0 quirks 修正 (viewBox / width-height)
- **フォントインライン化の理由** (HTML Canvas のフォント制約)
- **scratch-render との連携フロー**
- **セキュリティ** (DOMPurify による XSS 防止)

### `docs/README.md` 更新

- 「F. 開発者向け」セクションに 2 ドキュメントの入口を追加

## Issue #625 全 Phase まとめ

| Phase | PR | 内容 |
|---|---|---|
| 1 | #626 ✅ | infra 横断 + smalruby-api |
| 2 | #627 ✅ | smalruby3 gem (Ruby SDL2 ランタイム) |
| 3 | #628 ✅ | CONTRIBUTING.md + architecture-overview.md + README.md 全面更新 |
| 4 | この PR | scratch-render + scratch-svg-renderer |

## ドキュメント整備プロジェクト全体まとめ

| Issue | PR 数 | 内容 |
|---|---|---|
| **#610** | 5 | 機能ドキュメント体系 + 42 機能 README |
| **#616** | 3 | スクリーンショット 50+ 枚 + ガイドライン + DoD ワークフロー |
| **#620** | 4 | scratch-vm 内部仕様 4 doc |
| **#625** | 4 (この PR で完了) | infra / smalruby3-gem / トップレベル / render |

**合計 16 PR、約 80 ドキュメント**でユーザー視点 + 開発者視点 + インフラ + デスクトップランタイム + 全パッケージ内部仕様まで網羅したドキュメント体系が完成。

## Test Coverage

ドキュメント整備のみ（コード変更なし）。

## Closes

Closes #625
