### PR TITLE
docs(rules): require Playwright screenshots and temp files under tmp/

### DIFF
--- a/.claude/rules/scratch-gui/e2e-test.md
+++ b/.claude/rules/scratch-gui/e2e-test.md
@@ -149,6 +149,24 @@ await page.evaluate(() => {
 await page.getByTestId('ruby-toolbar-mode-dncl').click();
 ```
 
+## スクリーンショット / 一時ファイルの保存先は `tmp/` 配下
+
+`mcp__playwright__browser_take_screenshot` の `filename` パラメータ、および Playwright デバッグ中に生成する一時ファイル (console ログ、HAR、抽出した DOM など) は **必ずプロジェクトルートの `tmp/` 配下を指定する**。
+
+- `.gitignore` で `/tmp/` が除外されており、検証用の一時ファイルを置くための公式の場所
+- プロジェクトルート直下に保存するとリポジトリが汚れ、複数セッションを跨ぐと数十枚の `test-*.png` が散乱する
+- `tmp/` ディレクトリは作成済み
+
+```javascript
+// ✅ 正しい
+mcp__playwright__browser_take_screenshot({ filename: 'tmp/issue-634-after-fix.png' })
+
+// ❌ ダメ — プロジェクトルートに保存される
+mcp__playwright__browser_take_screenshot({ filename: 'issue-634-after-fix.png' })
+```
+
+`.playwright-mcp/` ディレクトリは Playwright MCP が自動生成するスナップショット (yml) や、`browser_take_screenshot` の **デフォルト保存先** として使われることがある別物。意図的に Read 用の固有ファイル名を残したいときは `tmp/` を使うこと。
+
 ## URL Parameters for Testing
 
 Playwright MCP でテストする際は以下の URL パラメータを使用:


### PR DESCRIPTION
## Summary

`.claude/rules/scratch-gui/e2e-test.md` に「Playwright のスクリーンショットおよび一時ファイルは `tmp/` 配下に保存する」というルールを追加。

## Background

過去のセッションで Playwright MCP の `browser_take_screenshot` を `filename: 'foo.png'` のように呼び出してプロジェクトルート直下に PNG を量産してしまった実例がある (`test-array-max-*.png` 等が数十枚 untracked で残る状態)。`tmp/` は `.gitignore` で除外済みかつ慣習的に一時ファイルの置き場所として運用されているため、明文化して再発を防ぐ。

## Changes

- `## スクリーンショット / 一時ファイルの保存先は `tmp/` 配下` セクションを `## URL Parameters for Testing` の直前に追加
- `browser_take_screenshot({ filename: 'tmp/...' })` の正しい / ダメな例を併記
- `.playwright-mcp/` ディレクトリとの違いも明記

## Test plan

- 規則の追加のみでコード変更なし
- lint / 既存テストには影響しない
