### PR TITLE
fix(dncl): keep function parameters as local variables in Ruby output

### DIFF
--- a/packages/scratch-gui/src/lib/dncl/dncl-identifier-converter.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-identifier-converter.js
@@ -5,6 +5,7 @@ import {
   addArrayName,
   isArrayName,
   isFunctionName,
+  isFunctionParam,
   mapVarName,
 } from './dncl-state'
 import { skipString } from './paren-utils'
@@ -34,6 +35,12 @@ const convertIdentifier = (name) => {
   if (DNCL_KEYWORDS.has(name)) return name
   if (RUBY_LITERALS.has(name)) return name
   if (isFunctionName(name)) return name
+  // Inside a `関数 ... と定義する` block, a parameter name should stay as
+  // a bare local identifier — Ruby's method parameter — not be prefixed
+  // with `@` (instance variable). Without this check, the def body
+  // would silently reference the sprite's instance vars instead of the
+  // arguments it was called with. (Issue #642)
+  if (isFunctionParam(name)) return name
   if (/^\d/.test(name)) return name
   if (/^[A-Z]/.test(name)) {
     return mapVarName(name, isArrayName(name))

--- a/packages/scratch-gui/src/lib/dncl/dncl-line-converter.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-line-converter.js
@@ -7,6 +7,7 @@ import {
   convertJapaneseStrings,
   processSegments,
 } from './dncl-identifier-converter'
+import { enterFunctionScope, exitFunctionScope } from './dncl-state'
 
 /**
  * Stack tracking for-loop state for increment insertion at `を繰り返す`.
@@ -93,8 +94,11 @@ const convertLine = (line) => {
     return `${indent}end`
   }
 
-  // と定義する → end
+  // と定義する → end (closes a `関数 ... と定義する` block — pop the
+  // function-parameter scope so subsequent identifier conversion at top
+  // level reverts to instance-variable prefixing). See Issue #642.
   if (trimmed === 'と定義する') {
+    exitFunctionScope()
     return `${indent}end`
   }
 
@@ -136,8 +140,16 @@ const convertLine = (line) => {
   }
 
   // 関数 name(params) → def name(params)
+  // Enter a function-parameter scope so references to the params inside
+  // the body are emitted as bare local variables (not `@params`).
+  // See Issue #642.
   const funcMatch = trimmed.match(/^関数\s+(\w+)\(([^)]*)\)$/)
   if (funcMatch) {
+    const params = funcMatch[2]
+      .split(',')
+      .map((p) => p.trim())
+      .filter(Boolean)
+    enterFunctionScope(params)
     return `${indent}def ${funcMatch[1]}(${funcMatch[2]})`
   }
 

--- a/packages/scratch-gui/src/lib/dncl/dncl-state.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-state.js
@@ -18,6 +18,27 @@ let arrayNames = new Set()
 let functionNames = new Set()
 
 /**
+ * Stack of currently-open function parameter scopes. Each entry is a
+ * `Set<string>` of the parameter names of one in-progress function
+ * definition. Pushed by `enterFunctionScope` when the converter visits
+ * `関数 name(p1, p2)`, popped by `exitFunctionScope` when it visits
+ * `と定義する` / `を定義する`.
+ *
+ * `convertIdentifier` consults this stack so that references to function
+ * parameters inside the body stay as bare local-variable names (Ruby
+ * method parameters) instead of being prefixed with `@` (instance
+ * variable). Without this, `関数 maximum(a, b) ... 返す a と定義する`
+ * would compile to `def maximum(a, b); return \@a; end` — the param `a`
+ * never used and the sprite's instance var `\@a` returned instead.
+ *
+ * Reset via `resetFunctionScopes` at the start of each `dnclToRuby`
+ * invocation so a stale half-open scope from a previous (failed)
+ * conversion never leaks.
+ * @type {Array<Set<string>>}
+ */
+let functionParamsStack = []
+
+/**
  * Map an identifier from DNCL to Ruby variable name.
  * - Lowercase identifiers → `@name`
  * - Uppercase identifiers with array value → `@_array_Name_`
@@ -108,11 +129,55 @@ const addArrayName = (name) => {
   arrayNames.add(name)
 }
 
+/**
+ * Push a new function-parameter scope onto the stack. Called when the
+ * converter enters `関数 name(p1, p2, ...)`.
+ * @param {Array<string>} params - Parameter names declared on the def line.
+ */
+const enterFunctionScope = (params) => {
+  functionParamsStack.push(new Set(params))
+}
+
+/**
+ * Pop the top function-parameter scope. Called when the converter
+ * encounters `と定義する` (or DNCLv2 `を定義する`).
+ */
+const exitFunctionScope = () => {
+  functionParamsStack.pop()
+}
+
+/**
+ * Check whether `name` matches a parameter of any currently-open
+ * function definition. Walks the stack from innermost outward so nested
+ * defs (should they ever appear) work correctly.
+ * @param {string} name - The identifier to look up.
+ * @returns {boolean} True if `name` shadows a parameter in scope.
+ */
+const isFunctionParam = (name) => {
+  for (let i = functionParamsStack.length - 1; i >= 0; i--) {
+    if (functionParamsStack[i].has(name)) return true
+  }
+  return false
+}
+
+/**
+ * Reset the function-parameter scope stack. Called at the start of each
+ * `dnclToRuby` so a stale partial scope from a previous run cannot
+ * affect the new conversion.
+ */
+const resetFunctionScopes = () => {
+  functionParamsStack = []
+}
+
 export {
   addArrayName,
   detectArrayNames,
   detectFunctionNames,
+  enterFunctionScope,
+  exitFunctionScope,
   isArrayName,
   isFunctionName,
+  isFunctionParam,
   mapVarName,
+  resetFunctionScopes,
 }

--- a/packages/scratch-gui/src/lib/dncl/dncl-to-ruby.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-to-ruby.js
@@ -1,7 +1,11 @@
 // === Smalruby: This file is Smalruby-specific (DNCL to Ruby transpiler) ===
 
 import { convertLine, resetForLoopStack } from './dncl-line-converter'
-import { detectArrayNames, detectFunctionNames } from './dncl-state'
+import {
+  detectArrayNames,
+  detectFunctionNames,
+  resetFunctionScopes,
+} from './dncl-state'
 import { dnclV2Preprocess } from './dncl-v2-preprocessor'
 import { validateDncl } from './dncl-validator'
 
@@ -32,6 +36,7 @@ const dnclToRuby = (source) => {
   detectArrayNames(normalized)
   detectFunctionNames(normalized)
   resetForLoopStack()
+  resetFunctionScopes()
 
   const lines = normalized.split('\n')
   const rubyLines = lines.map((line) => convertLine(line))

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-function-param-scope.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-function-param-scope.test.js
@@ -1,0 +1,164 @@
+// === Smalruby: Tests for function-parameter scope tracking in DNCL→Ruby ===
+//
+// Issue #642: DNCL function parameters were being converted to instance
+// variables (`@a`) instead of being kept as local Ruby method parameters
+// (`a`). This broke both function semantics and Ruby → blocks conversion.
+//
+// The fix introduces a function-parameter scope stack that
+// `convertIdentifier` consults before adding an `@` prefix to lowercase
+// identifiers. Inside `関数 name(a, b) ... と定義する`, references to
+// `a` and `b` stay as `a` and `b`. Outside, they revert to `@a` and `@b`.
+
+import { dnclToRuby } from '../../../../src/lib/dncl/dncl-to-ruby';
+
+const dToR = (src) => dnclToRuby(src).ruby;
+
+describe('Function parameter scope: body references', () => {
+    test('single-arg function: param stays as local', () => {
+        const dncl = ['関数 f(a)', '  返す a', 'と定義する'].join('\n');
+        expect(dToR(dncl)).toBe(['def f(a)', '  return a', 'end'].join('\n'));
+    });
+
+    test('two-arg function: both params stay as locals', () => {
+        const dncl = [
+            '関数 maximum(a, b)',
+            '  もし a > b ならば',
+            '    返す a',
+            '  そうでなければ',
+            '    返す b',
+            '  を実行する',
+            'と定義する',
+        ].join('\n');
+        const ruby = [
+            'def maximum(a, b)',
+            '  if a > b',
+            '    return a',
+            '  else',
+            '    return b',
+            '  end',
+            'end',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('arithmetic on params stays unprefixed', () => {
+        const dncl = ['関数 add(a, b)', '  返す a + b', 'と定義する'].join('\n');
+        const ruby = ['def add(a, b)', '  return a + b', 'end'].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+});
+
+describe('Function parameter scope: scope boundary', () => {
+    test('outside function: same name reverts to instance variable', () => {
+        const dncl = [
+            '関数 f(a)',
+            '  返す a',
+            'と定義する',
+            'a = 10',
+            '答え = a',
+        ].join('\n');
+        const ruby = [
+            'def f(a)',
+            '  return a',
+            'end',
+            '@a = 10',
+            '@答え = @a',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('global var with same name as future function param: keeps @ at top-level', () => {
+        const dncl = [
+            'a = 5',
+            '関数 f(a)',
+            '  返す a',
+            'と定義する',
+        ].join('\n');
+        const ruby = [
+            '@a = 5',
+            'def f(a)',
+            '  return a',
+            'end',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('two consecutive functions: scopes are independent', () => {
+        const dncl = [
+            '関数 f(a)',
+            '  返す a',
+            'と定義する',
+            '関数 g(b)',
+            '  返す b',
+            'と定義する',
+        ].join('\n');
+        const ruby = [
+            'def f(a)',
+            '  return a',
+            'end',
+            'def g(b)',
+            '  return b',
+            'end',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+});
+
+describe('Function parameter scope: call sites', () => {
+    test('call site arguments use instance vars (call site is outside scope)', () => {
+        const dncl = [
+            '関数 maximum(a, b)',
+            '  もし a > b ならば',
+            '    返す a',
+            '  そうでなければ',
+            '    返す b',
+            '  を実行する',
+            'と定義する',
+            'x = 5',
+            'y = 8',
+            '答え = maximum(x, y)',
+        ].join('\n');
+        const ruby = [
+            'def maximum(a, b)',
+            '  if a > b',
+            '    return a',
+            '  else',
+            '    return b',
+            '  end',
+            'end',
+            '@x = 5',
+            '@y = 8',
+            '@答え = maximum(@x, @y)',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+});
+
+describe('Function parameter scope: idempotency / multiple invocations', () => {
+    test('running dnclToRuby twice in a row gives the same result', () => {
+        const dncl = [
+            '関数 add(a, b)',
+            '  返す a + b',
+            'と定義する',
+            '答え = add(3, 4)',
+        ].join('\n');
+        const r1 = dToR(dncl);
+        const r2 = dToR(dncl);
+        expect(r2).toBe(r1);
+    });
+});
+
+describe('Function parameter scope: edge cases', () => {
+    test('function with no parameters', () => {
+        const dncl = ['関数 hello()', '  返す 1', 'と定義する'].join('\n');
+        const ruby = ['def hello()', '  return 1', 'end'].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('parameter named like a Ruby reserved literal does not break', () => {
+        // `nil` is in RUBY_LITERALS — convertIdentifier returns as-is
+        // anyway, so the scope check is harmless. Just check no crash.
+        const dncl = ['関数 f(x)', '  返す x', 'と定義する'].join('\n');
+        expect(dToR(dncl)).toBe(['def f(x)', '  return x', 'end'].join('\n'));
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-to-ruby.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-to-ruby.test.js
@@ -403,16 +403,20 @@ describe('dnclToRuby', () => {
   })
 
   describe('control flow: function', () => {
-    test('function definition', () => {
+    test('function definition: param stays as local Ruby variable', () => {
+      // Issue #642: previously the body would emit `return @x * 2`,
+      // wrongly referencing the sprite's instance variable instead of
+      // the function parameter `x`. Now the param-scope tracker keeps
+      // it as `return x * 2`.
       expect(
         convert('関数 f(x)\n  返す x * 2\nと定義する'),
-      ).toBe('def f(x)\n  return @x * 2\nend')
+      ).toBe('def f(x)\n  return x * 2\nend')
     })
 
-    test('function with multiple params', () => {
+    test('function with multiple params: each param stays as local', () => {
       expect(
         convert('関数 add(a, b)\n  返す a + b\nと定義する'),
-      ).toBe('def add(a, b)\n  return @a + @b\nend')
+      ).toBe('def add(a, b)\n  return a + b\nend')
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes [Issue #642](https://github.com/smalruby/smalruby3-editor/issues/642) — DNCL の関数定義のローカルパラメータが Ruby 変換時に誤って **インスタンス変数 (`@`)** に変換されていた問題を修正します。

## Problem

DNCL `関数 maximum(a, b) ... もし a > b ... 返す a と定義する` が Ruby

```ruby
def maximum(a, b)
  if @a > @b      # ← 本来 a, b （ローカル引数）を参照すべきが @ 付きインスタンス変数に化けていた
    return @a
  else
    return @b
  end
end
```

になってしまい、結果として:

1. **関数のロジックが破綻**: `if @a > @b` はスプライトのインスタンス変数 (通常 nil) を参照し、関数引数を完全に無視
2. **Ruby → blocks 変換が失敗**: 「`@答え = maximum(@x, @y)」は命令がまちがっています`」のバリデーションエラー (関数 body に `@_return_maximum_ =` 形式がないため `procedure.hasReturnValue = true` が立たず、呼び出し側を「値を返す関数呼び出し」として扱えない)

## Fix

`dncl-state.js` に **関数パラメータのスコープスタック** を追加し、`convertIdentifier()` が `@` プレフィックスを付ける前にスタックをチェックする方式:

- `enterFunctionScope(params)` / `exitFunctionScope()` / `isFunctionParam(name)` / `resetFunctionScopes()` を新規追加
- `dncl-line-converter.js` が `関数 name(p1, p2)` で push、`と定義する` で pop
- `dncl-identifier-converter.js` の `convertIdentifier()` で `isFunctionParam(name)` ならそのまま return（`@` 付与しない）
- `dncl-to-ruby.js` で `resetFunctionScopes()` を毎回呼ぶ（前回失敗時の残留スコープを除去）

Ruby ↔ blocks 側は **既に top-level def + `return X` + 結果代入 (`result = func(args)`) をサポート済み** (`my-blocks.js` の return-via-variable パターン)。DNCL → Ruby が正しい形を吐くようになれば、その先の変換は既存実装でそのまま動作します。

## Test Coverage

- 新規: `test/unit/lib/dncl/dncl-function-param-scope.test.js` (10 cases)
  - 単一引数 / 複数引数の関数 body 内パラメータが `@` 付きにならないこと
  - 関数の外側では同名識別子が `@x` になること（スコープ境界）
  - 連続する関数定義間でスコープが独立していること
  - 呼び出し側 `答え = maximum(x, y)` の引数は `@x, @y` になること
  - dnclToRuby を 2 回連続呼んだ結果が同じ（idempotency）
  - 引数なし関数、Ruby 予約語と同名のパラメータも問題ないこと
- 更新: `dncl-to-ruby.test.js` の `function definition` / `function with multiple params` 既存テスト 2 件
  - 期待値が「バグあり」の `return @x * 2` だったため、修正後の正しい `return x * 2` に更新

318 dncl unit tests pass + 関連 round-trip テスト (method-return / class-attr-accessor / generator-procedure-arguments) も pass.

## Definition of Done

- [ ] CI green
- [ ] **ブラウザ確認 (Playwright MCP)**:
  - [ ] DNCL モードで `関数 maximum(a, b) ... 返す a` を定義し、`答え = maximum(5, 8)` を実行 → `@答え == 8`
  - [ ] DNCL タブ ↔ コードタブ切替で turn-around が安定
  - [ ] Uncaught runtime error なし

## Related Issues

Fixes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)
