### PR TITLE
fix(dncl): support CJK characters in function names

### DIFF
--- a/packages/scratch-gui/src/lib/dncl/dncl-line-converter.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-line-converter.js
@@ -7,7 +7,22 @@ import {
   convertJapaneseStrings,
   processSegments,
 } from './dncl-identifier-converter'
-import { enterFunctionScope, exitFunctionScope } from './dncl-state'
+import {
+  DNCL_IDENT_PATTERN,
+  enterFunctionScope,
+  exitFunctionScope,
+} from './dncl-state'
+
+/**
+ * Pre-compiled regex matching `関数 NAME(args)` in DNCL source. Built
+ * from `DNCL_IDENT_PATTERN` so CJK function names like `関数 最大値`
+ * are recognized — the previous `\\w+` pattern was ASCII-only and let
+ * such names fall through to identifier conversion, producing the
+ * broken `関数 \@最大値(\@a, \@b)`. (Issue #643)
+ */
+const FUNC_DEF_RE = new RegExp(
+  `^関数\\s+(${DNCL_IDENT_PATTERN})\\(([^)]*)\\)$`,
+)
 
 /**
  * Stack tracking for-loop state for increment insertion at `を繰り返す`.
@@ -143,7 +158,7 @@ const convertLine = (line) => {
   // Enter a function-parameter scope so references to the params inside
   // the body are emitted as bare local variables (not `@params`).
   // See Issue #642.
-  const funcMatch = trimmed.match(/^関数\s+(\w+)\(([^)]*)\)$/)
+  const funcMatch = trimmed.match(FUNC_DEF_RE)
   if (funcMatch) {
     const params = funcMatch[2]
       .split(',')

--- a/packages/scratch-gui/src/lib/dncl/dncl-state.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-state.js
@@ -1,6 +1,17 @@
 // === Smalruby: This file is Smalruby-specific (DNCL→Ruby conversion state) ===
 
 const CJK_ID_TAIL = 'a-zA-Z0-9_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF'
+const CJK_ID_HEAD = 'a-zA-Z_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF'
+
+/**
+ * Regex source for a DNCL identifier: starts with an ASCII letter,
+ * underscore, hiragana, katakana, or CJK ideograph; continues with the
+ * same plus digits. Used by every place that needs to match a function
+ * name in source text (definition headers, call-site forward-reference
+ * detection, etc.) so CJK names like `関数 最大値(...)` are recognized
+ * the same way as ASCII ones. (Issue #643)
+ */
+const DNCL_IDENT_PATTERN = `[${CJK_ID_HEAD}][${CJK_ID_TAIL}]*`
 
 /**
  * Track which uppercase identifiers are arrays within a conversion. Reset
@@ -97,9 +108,12 @@ const detectArrayNames = (source) => {
 const detectFunctionNames = (source) => {
   functionNames = new Set()
   const lines = source.split('\n')
+  // CJK-aware function name regex (Issue #643). Built once outside the
+  // loop because RegExp construction is non-trivial.
+  const re = new RegExp(`^関数\\s+(${DNCL_IDENT_PATTERN})\\s*\\(`)
   for (const line of lines) {
     const trimmed = line.trim()
-    const m = trimmed.match(/^関数\s+(\w+)\s*\(/)
+    const m = trimmed.match(re)
     if (m) {
       functionNames.add(m[1])
     }
@@ -171,6 +185,7 @@ const resetFunctionScopes = () => {
 
 export {
   addArrayName,
+  DNCL_IDENT_PATTERN,
   detectArrayNames,
   detectFunctionNames,
   enterFunctionScope,

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-cjk-function-name.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-cjk-function-name.test.js
@@ -1,0 +1,102 @@
+// === Smalruby: Tests for CJK function names in DNCL→Ruby ===
+//
+// Issue #643: `関数 最大値(a, b)` (and similar with hiragana/katakana
+// names) was failing the funcMatch regex `(\w+)` (ASCII-only) and
+// falling through to identifier conversion, producing the broken
+// `関数 @最大値(@a, @b)` instead of `def 最大値(a, b)`.
+//
+// `detectFunctionNames` had the same bug, so call sites for CJK
+// function names were also being prefixed: `@答え = @最大値(@x, @y)`
+// instead of `@答え = 最大値(@x, @y)`.
+
+import { dnclToRuby } from '../../../../src/lib/dncl/dncl-to-ruby';
+
+const dToR = (src) => dnclToRuby(src).ruby;
+
+describe('CJK function names: definition', () => {
+    test('kanji name (関数 最大値)', () => {
+        const dncl = ['関数 最大値(a, b)', '  返す a', 'と定義する'].join('\n');
+        const ruby = ['def 最大値(a, b)', '  return a', 'end'].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('hiragana name (関数 たしざん)', () => {
+        const dncl = ['関数 たしざん(a, b)', '  返す a + b', 'と定義する'].join(
+            '\n',
+        );
+        const ruby = ['def たしざん(a, b)', '  return a + b', 'end'].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('katakana name (関数 ハロー)', () => {
+        const dncl = ['関数 ハロー()', '  返す 1', 'と定義する'].join('\n');
+        const ruby = ['def ハロー()', '  return 1', 'end'].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('mixed CJK + ASCII underscore + digit (関数 add_2つ)', () => {
+        const dncl = ['関数 add_2つ(a)', '  返す a', 'と定義する'].join('\n');
+        const ruby = ['def add_2つ(a)', '  return a', 'end'].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+});
+
+describe('CJK function names: call site', () => {
+    test('call CJK function: name has no @ prefix', () => {
+        const dncl = [
+            '関数 最大値(a, b)',
+            '  返す a',
+            'と定義する',
+            '答え = 最大値(5, 8)',
+        ].join('\n');
+        const ruby = [
+            'def 最大値(a, b)',
+            '  return a',
+            'end',
+            '@答え = 最大値(5, 8)',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('forward reference: call before definition still works', () => {
+        // detectFunctionNames runs before line conversion, so the call
+        // site at line 1 should already know `たしざん` is a function.
+        const dncl = [
+            '答え = たしざん(3, 4)',
+            '関数 たしざん(a, b)',
+            '  返す a + b',
+            'と定義する',
+        ].join('\n');
+        const ruby = [
+            '@答え = たしざん(3, 4)',
+            'def たしざん(a, b)',
+            '  return a + b',
+            'end',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+
+    test('CJK function call inside 表示する argument', () => {
+        const dncl = [
+            '関数 にばい(x)',
+            '  返す x * 2',
+            'と定義する',
+            '表示する(にばい(5))',
+        ].join('\n');
+        const ruby = [
+            'def にばい(x)',
+            '  return x * 2',
+            'end',
+            'puts(にばい(5))',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+});
+
+describe('CJK function names: ASCII still works (no regression)', () => {
+    test('ASCII-only name still converts (regression check)', () => {
+        const dncl = ['関数 add(a, b)', '  返す a + b', 'と定義する'].join('\n');
+        const ruby = ['def add(a, b)', '  return a + b', 'end'].join('\n');
+        expect(dToR(dncl)).toBe(ruby);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes [Issue #643](https://github.com/smalruby/smalruby3-editor/issues/643) — DNCL の **CJK 文字を含む関数名** (`関数 最大値(...)` など) が認識されず `関数 @最大値(@a, @b)` という無効な Ruby に化けていた問題を修正します。

## Problem

DNCL `関数 最大値(a, b) ... と定義する` の関数定義 regex `^関数\s+(\w+)\(...\)$` の `\w+` は ASCII のみで、CJK 文字を含む関数名にマッチしません。結果として:

- 関数定義行が認識されず、識別子変換 fallback で `関数 @最大値(@a, @b)` (関数名にも `@` プレフィックス) に化ける
- `detectFunctionNames()` も同じバグで CJK 関数名を拾えず、呼び出し側 `答え = 最大値(x, y)` の `最大値` も識別子として `@最大値(@x, @y)` に変換される

## Fix

CJK 識別子用パターンを `dncl-state.js` から **export** して、関数定義/検出箇所すべてで使う:

```js
const CJK_ID_HEAD = 'a-zA-Z_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF'
const DNCL_IDENT_PATTERN = `[${CJK_ID_HEAD}][${CJK_ID_TAIL}]*`
```

- `dncl-state.js` `detectFunctionNames()`: regex を CJK 対応に
- `dncl-line-converter.js`: pre-compiled `FUNC_DEF_RE` で関数定義を CJK 対応認識

## Test Coverage

- 新規: `test/unit/lib/dncl/dncl-cjk-function-name.test.js` (8 cases)
  - 漢字 (`関数 最大値`)
  - ひらがな (`関数 たしざん`)
  - カタカナ (`関数 ハロー`)
  - 混在 (`関数 add_2つ`)
  - 呼び出し側で関数名に `@` が付かないこと
  - Forward reference (定義前の呼び出し) も認識
  - `表示する(にばい(5))` のようなネスト引数も OK
  - ASCII 名のリグレッションなし
- 全 dncl unit tests: **326/326 pass**

## Definition of Done

- [ ] CI green
- [ ] **ブラウザ確認 (Playwright MCP)**:
  - [ ] DNCL モードで `関数 最大値(a, b) ... 返す a` を CJK 名で定義し、`答え = 最大値(5, 8)` を実行 → `@答え == 8`
  - [ ] DNCL タブ ↔ コードタブ切替で turn-around が安定
  - [ ] Uncaught runtime error なし

## Related Issues

Fixes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)
