### PR TITLE
fix(dncl): apply convertBuiltinFunctions to for-loop bound expressions

### DIFF
--- a/packages/scratch-gui/src/lib/dncl/dncl-line-converter.js
+++ b/packages/scratch-gui/src/lib/dncl/dncl-line-converter.js
@@ -103,15 +103,19 @@ const convertLine = (line) => {
   }
 
   // i を N1 から N2 まで N3 ずつ増やしながら → @i = N1 + while @i <= N2
+  // The bound expressions are run through `convertBuiltinFunctions` first
+  // so that `要素数(...)`, `整数(...)`, etc. inside the bounds get converted
+  // (Issue #644). `processSegments` alone only handles identifier/operator
+  // conversion, not builtin function calls.
   const forAscMatch = trimmed.match(
     /^(\w+)\s+を\s+(.+?)\s+から\s+(.+?)\s+まで\s+(.+?)\s+ずつ増やしながら$/,
   )
   if (forAscMatch) {
     const [, loopVar, from, to, step] = forAscMatch
     const varName = convertIdentifier(loopVar)
-    const fromRuby = processSegments(from)
-    const toRuby = processSegments(to)
-    const stepRuby = processSegments(step)
+    const fromRuby = processSegments(convertBuiltinFunctions(from))
+    const toRuby = processSegments(convertBuiltinFunctions(to))
+    const stepRuby = processSegments(convertBuiltinFunctions(step))
     forLoopStack.push({ varName, stepRuby, ascending: true, indent })
     return `${indent}${varName} = ${fromRuby}\n${indent}while ${varName} <= ${toRuby}`
   }
@@ -123,9 +127,9 @@ const convertLine = (line) => {
   if (forDescMatch) {
     const [, loopVar, from, to, step] = forDescMatch
     const varName = convertIdentifier(loopVar)
-    const fromRuby = processSegments(from)
-    const toRuby = processSegments(to)
-    const stepRuby = processSegments(step)
+    const fromRuby = processSegments(convertBuiltinFunctions(from))
+    const toRuby = processSegments(convertBuiltinFunctions(to))
+    const stepRuby = processSegments(convertBuiltinFunctions(step))
     forLoopStack.push({ varName, stepRuby, ascending: false, indent })
     return `${indent}${varName} = ${fromRuby}\n${indent}while ${varName} >= ${toRuby}`
   }

--- a/packages/scratch-gui/test/unit/lib/dncl/dncl-builtin-in-loop-bounds.test.js
+++ b/packages/scratch-gui/test/unit/lib/dncl/dncl-builtin-in-loop-bounds.test.js
@@ -1,0 +1,151 @@
+// === Smalruby: Tests for builtin function calls in for/while bounds ===
+//
+// Issue #644: `i を 0 から 要素数(Data) - 1 まで 1 ずつ増やしながら`
+// produced `while @i <= 要素数(@_array_Data_) - 1` because the for-loop
+// handler ran `processSegments` on the bound expression but skipped
+// `convertBuiltinFunctions` — leaving `要素数(...)` unconverted.
+//
+// The same bug affected:
+//   - decreasing for-loop (`ずつ減らしながら`)
+//   - while-loop (`の間` condition) — actually OK (already calls
+//     convertBuiltinFunctions on its condition), but tested for
+//     completeness
+//   - any builtin: `要素数`, `整数`, `文字列`, `乱数`, `四捨五入`,
+//     `切り捨て`, `切り上げ`, `絶対値`, `平方根`, `含む`
+
+import { dnclToRuby } from '../../../../src/lib/dncl/dncl-to-ruby';
+
+const dToR = (src) => dnclToRuby(src).ruby;
+
+describe('Builtin in for-loop bounds: 要素数()', () => {
+    test('要素数(Data) in `to` bound', () => {
+        const dncl = [
+            'Data = [1, 2, 3]',
+            'i を 0 から 要素数(Data) - 1 まで 1 ずつ増やしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        expect(out).toContain('while @i <= @_array_Data_.length - 1');
+        expect(out).not.toContain('要素数(');
+    });
+
+    test('要素数(Data) in `from` bound', () => {
+        const dncl = [
+            'Data = [1, 2, 3]',
+            'i を 要素数(Data) から 1 まで 1 ずつ減らしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        expect(out).toContain('@i = @_array_Data_.length');
+        expect(out).not.toContain('要素数(');
+    });
+});
+
+describe('Builtin in for-loop bounds: 整数() / 乱数()', () => {
+    test('整数(x) in `to` bound', () => {
+        const dncl = [
+            'x = "5"',
+            'i を 1 から 整数(x) まで 1 ずつ増やしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        expect(out).toContain('while @i <= @x.to_i');
+        expect(out).not.toContain('整数(');
+    });
+
+    test('乱数(10) in `to` bound', () => {
+        const dncl = [
+            'i を 1 から 乱数(10) まで 1 ずつ増やしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        expect(out).toContain('while @i <= rand(10)');
+        expect(out).not.toContain('乱数(');
+    });
+
+    test('整数(乱数(10)) — nested builtins', () => {
+        const dncl = [
+            'i を 1 から 整数(乱数(10)) まで 1 ずつ増やしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        expect(out).toContain('while @i <= rand(10).to_i');
+        expect(out).not.toContain('整数(');
+        expect(out).not.toContain('乱数(');
+    });
+});
+
+describe('Builtin in for-loop bounds: descending', () => {
+    test('要素数(Data) in `from` of descending loop', () => {
+        const dncl = [
+            'Data = [1, 2, 3]',
+            'i を 要素数(Data) - 1 から 0 まで 1 ずつ減らしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        expect(out).toContain('@i = @_array_Data_.length - 1');
+        expect(out).toContain('while @i >= 0');
+    });
+});
+
+describe('Builtin in for-loop bounds: step', () => {
+    test('整数(s) as step value', () => {
+        const dncl = [
+            's = "2"',
+            'i を 0 から 10 まで 整数(s) ずつ増やしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        // The step is added at end of loop as `@i += @s.to_i`
+        expect(out).toContain('@i += @s.to_i');
+    });
+});
+
+describe('Builtin in while-loop condition: regression check', () => {
+    // While-loop already calls convertBuiltinFunctions on its condition.
+    // Check that it stays working.
+    test('要素数(Data) > 0 の間 stays converted', () => {
+        const dncl = [
+            'Data = [1, 2, 3]',
+            '要素数(Data) > 0 の間',
+            '  a = 1',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        expect(out).toContain('while @_array_Data_.length > 0');
+        expect(out).not.toContain('要素数(');
+    });
+});
+
+describe('Regression: literal bounds still work', () => {
+    test('plain literal bounds (no builtin)', () => {
+        const dncl = [
+            'i を 1 から 10 まで 1 ずつ増やしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        expect(dToR(dncl)).toBe(
+            ['@i = 1', 'while @i <= 10', '  @a = @i', '  @i += 1', 'end'].join(
+                '\n',
+            ),
+        );
+    });
+
+    test('expression with variable (no builtin)', () => {
+        const dncl = [
+            'n = 10',
+            'i を 0 から n - 1 まで 1 ずつ増やしながら',
+            '  a = i',
+            'を繰り返す',
+        ].join('\n');
+        const out = dToR(dncl);
+        expect(out).toContain('while @i <= @n - 1');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes [Issue #644](https://github.com/smalruby/smalruby3-editor/issues/644) — DNCL の **for ループ境界式** に組み込み関数 (`要素数()`, `整数()`, `乱数()` など) を書いても変換されず、不正な Ruby が生成される問題を修正します。

## Problem

DNCL `i を 0 から 要素数(Data) - 1 まで 1 ずつ増やしながら` を変換すると:

```ruby
@i = 0
while @i <= 要素数(@_array_Data_) - 1   # ← 要素数(...) が変換されない
  ...
  @i += 1
end
```

`要素数` は通常の式中（代入の右辺、`if` 条件、`表示する()` の引数など）では正しく `.length` に変換されますが、**for ループ境界では未変換**でした。

## Root Cause

`packages/scratch-gui/src/lib/dncl/dncl-line-converter.js` の for-loop ハンドラが境界式に **`processSegments` のみ** を呼び、**`convertBuiltinFunctions` を呼んでいない**:

```js
// 既存 (バグあり)
const fromRuby = processSegments(from)
const toRuby = processSegments(to)
const stepRuby = processSegments(step)
```

`processSegments` は識別子・演算子変換のみで、組み込み関数 (`要素数`, `整数`, `文字列`, `乱数`, `四捨五入`, `切り捨て`, `切り上げ`, `絶対値`, `平方根`, `含む`) は別処理。これらが境界・step に出てくるとそのまま残る。

while ループ条件 (`の間`) は内部で `convertBuiltinFunctions` を呼んでいたので影響なし。

## Fix

for-loop (ascending / descending) ハンドラで境界式・step に `convertBuiltinFunctions` を追加:

```js
const fromRuby = processSegments(convertBuiltinFunctions(from))
const toRuby = processSegments(convertBuiltinFunctions(to))
const stepRuby = processSegments(convertBuiltinFunctions(step))
```

if/while/return ハンドラと同じパターン。

## Test Coverage

- 新規: `test/unit/lib/dncl/dncl-builtin-in-loop-bounds.test.js` (10 cases)
  - `要素数(Data)` を `to` / `from` 境界に
  - `整数(x)`, `乱数(10)`, ネスト `整数(乱数(10))` を境界に
  - 降順 for ループの境界
  - step 値 (`整数(s) ずつ`)
  - while ループ条件 (regression check)
  - リテラル境界 / 変数境界 (regression)
- 全 dncl unit tests: **328/328 pass**

## Definition of Done

- [ ] CI green
- [ ] **ブラウザ確認 (Playwright MCP)**:
  - [ ] DNCL モードで `i を 0 から 要素数(Data) - 1 まで 1 ずつ増やしながら ... を繰り返す` を含むコードを実行 → 期待通りループが動作
  - [ ] Uncaught runtime error なし

## Related Issues

Fixes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
