### PR TITLE
feat(ga): Phase 1 — block_run, mode_switch, furigana_toggle, mesh_v2/smalrubot_s1 connect/disconnect の GA4 イベント追加

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -81,6 +81,9 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/reducers/settings.js` | URL params for Playwright | URL パラメーター import |
 | `src/reducers/settings.js` | ruby_version URL param | Ruby バージョン URL パラメーター |
 | `src/containers/backpack.jsx` | mesh v1 backpack auto-migration | Skyway 停止 (Issue #592) に伴う localStorage バックパックの自動 v1→v2 マイグレーション |
+| `src/containers/controls.jsx` | block_run analytics | 緑旗クリック時に GA4 イベントを発火 (issue #645 Phase 1) |
+| `src/containers/connection-modal.jsx` | mesh_v2/smalrubot_s1 connect analytics | 接続成功時に拡張別カテゴリ (`mesh_v2` / `smalrubot_s1`) で GA4 イベントを発火 (issue #645 Phase 1) |
+| `src/containers/connection-modal.jsx` | mesh_v2/smalrubot_s1 disconnect analytics | 切断時に拡張別カテゴリで GA4 イベントを発火 (issue #645 Phase 1) |
 
 ## 関連ファイル
 

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -202,6 +202,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/components/mobile-sprite-panel.test.jsx`
 - `test/unit/components/mobile-top-bar.test.jsx`
 - `test/unit/components/palette-toggle.test.jsx`
+- `test/unit/components/ruby-toolbar-analytics.test.jsx`
 - `test/unit/components/project-title-input.test.jsx`
 - `test/unit/components/scanning-step-name-search.test.js`
 - `test/unit/components/student-join-form.test.js`
@@ -216,6 +217,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/containers/ruby-tab-project-changed.test.js`
 - `test/unit/containers/rubytee-modal-hoc-sanitize.test.js`
 - `test/unit/empty-block-selection.test.js`
+- `test/unit/lib/analytics.test.js`
 - `test/unit/lib/auto-correct.test.js`
 - `test/unit/lib/backpack-api.test.js`
 - `test/unit/lib/backpack-mesh-v1-migration.test.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -266,6 +266,7 @@ test/unit/components/*
 !test/unit/components/mobile-top-bar.test.jsx
 !test/unit/components/palette-toggle.test.jsx
 !test/unit/components/project-title-input.test.jsx
+!test/unit/components/ruby-toolbar-analytics.test.jsx
 !test/unit/components/scanning-step-name-search.test.js
 !test/unit/components/student-join-form.test.js
 
@@ -293,6 +294,7 @@ test/unit/lib/*
 !test/unit/lib/ruby-roundtrip/
 !test/unit/lib/ruby-to-blocks-converter/
 # Individual Smalruby files
+!test/unit/lib/analytics.test.js
 !test/unit/lib/auto-correct.test.js
 !test/unit/lib/backpack-api.test.js
 !test/unit/lib/backpack-mesh-v1-migration.test.js

--- a/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
+++ b/packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import {useIntl} from 'react-intl';
 import VM from '@smalruby/scratch-vm';
 
+import analytics from '../../lib/analytics';
+
 import styles from './ruby-toolbar.css';
 import messages from './messages.js';
 import TargetSelector from './target-selector.jsx';
@@ -65,32 +67,74 @@ const RubyToolbar = props => {
         if (props.onDownload) props.onDownload();
     }, [props]);
 
+    const trackFuriganaToggle = useCallback(
+        (next) => {
+            try {
+                analytics.event({
+                    category: 'furigana_toggle',
+                    action: 'toggle',
+                    label: next ? 'on' : 'off',
+                });
+            } catch (_e) {
+                // Swallow analytics failures so the editor never breaks.
+            }
+        },
+        [],
+    );
+
+    const trackModeSwitch = useCallback((mode) => {
+        try {
+            analytics.event({
+                category: 'mode_switch',
+                action: 'change',
+                label: mode,
+            });
+        } catch (_e) {
+            // Swallow analytics failures so the editor never breaks.
+        }
+    }, []);
+
     const handleToggleFurigana = useCallback(() => {
         if (props.onDismissBubble) props.onDismissBubble();
-        if (props.onToggleFurigana) props.onToggleFurigana();
-    }, [props]);
+        if (props.onToggleFurigana) {
+            trackFuriganaToggle(!props.furiganaEnabled);
+            props.onToggleFurigana();
+        }
+    }, [props, trackFuriganaToggle]);
 
     // === Smalruby: Start of mode selection handlers ===
     const handleSelectFuriganaMode = useCallback(() => {
         if (props.onDismissBubble) props.onDismissBubble();
+        trackModeSwitch('furigana');
         // Switch to Ruby mode with furigana ON
         if (props.dnclMode && props.onToggleDnclMode) props.onToggleDnclMode();
-        if (!props.furiganaEnabled && props.onToggleFurigana) props.onToggleFurigana();
-    }, [props]);
+        if (!props.furiganaEnabled && props.onToggleFurigana) {
+            trackFuriganaToggle(true);
+            props.onToggleFurigana();
+        }
+    }, [props, trackModeSwitch, trackFuriganaToggle]);
 
     const handleSelectRubyMode = useCallback(() => {
         if (props.onDismissBubble) props.onDismissBubble();
+        trackModeSwitch('ruby');
         // Switch to Ruby mode with furigana OFF
         if (props.dnclMode && props.onToggleDnclMode) props.onToggleDnclMode();
-        if (props.furiganaEnabled && props.onToggleFurigana) props.onToggleFurigana();
-    }, [props]);
+        if (props.furiganaEnabled && props.onToggleFurigana) {
+            trackFuriganaToggle(false);
+            props.onToggleFurigana();
+        }
+    }, [props, trackModeSwitch, trackFuriganaToggle]);
 
     const handleSelectDnclMode = useCallback(() => {
         if (props.onDismissBubble) props.onDismissBubble();
+        trackModeSwitch('dncl');
         // Switch to DNCL mode (disable furigana since DNCL is already in Japanese)
         if (!props.dnclMode && props.onToggleDnclMode) props.onToggleDnclMode();
-        if (props.furiganaEnabled && props.onToggleFurigana) props.onToggleFurigana();
-    }, [props]);
+        if (props.furiganaEnabled && props.onToggleFurigana) {
+            trackFuriganaToggle(false);
+            props.onToggleFurigana();
+        }
+    }, [props, trackModeSwitch, trackFuriganaToggle]);
     // === Smalruby: End of mode selection handlers ===
 
     const handleToggleAutoCorrect = useCallback(() => {

--- a/packages/scratch-gui/src/containers/connection-modal.jsx
+++ b/packages/scratch-gui/src/containers/connection-modal.jsx
@@ -112,6 +112,23 @@ class ConnectionModal extends React.Component {
     }
     handleDisconnect () {
         try {
+            // === Smalruby: Start of mesh_v2/smalrubot_s1 disconnect analytics ===
+            try {
+                if (this.props.extensionId === 'meshV2') {
+                    analytics.event({
+                        category: 'mesh_v2',
+                        action: 'disconnect'
+                    });
+                } else if (this.props.extensionId === 'smalrubotS1') {
+                    analytics.event({
+                        category: 'smalrubot_s1',
+                        action: 'disconnect'
+                    });
+                }
+            } catch (_e) {
+                // Swallow analytics failures so the editor never breaks.
+            }
+            // === Smalruby: End of mesh_v2/smalrubot_s1 disconnect analytics ===
             this.props.vm.disconnectPeripheral(this.props.extensionId);
         } finally {
             this.props.onCancel();
@@ -189,6 +206,28 @@ class ConnectionModal extends React.Component {
             action: 'connected',
             label: this.props.extensionId
         });
+        // === Smalruby: Start of mesh_v2/smalrubot_s1 connect analytics ===
+        try {
+            if (this.props.extensionId === 'meshV2') {
+                const meshExt = this.props.vm.runtime.peripheralExtensions.meshV2;
+                const meshLabel = meshExt && meshExt._service && meshExt._service.useWebSocket === false ?
+                    'polling' :
+                    'websocket';
+                analytics.event({
+                    category: 'mesh_v2',
+                    action: 'connect',
+                    label: meshLabel
+                });
+            } else if (this.props.extensionId === 'smalrubotS1') {
+                analytics.event({
+                    category: 'smalrubot_s1',
+                    action: 'connect'
+                });
+            }
+        } catch (_e) {
+            // Swallow analytics failures so the editor never breaks.
+        }
+        // === Smalruby: End of mesh_v2/smalrubot_s1 connect analytics ===
     }
     handleHelp () {
         window.open(this.state.extension.helpLink, '_blank');

--- a/packages/scratch-gui/src/containers/controls.jsx
+++ b/packages/scratch-gui/src/containers/controls.jsx
@@ -8,6 +8,10 @@ import {connect} from 'react-redux';
 
 import ControlsComponent from '../components/controls/controls.jsx';
 
+// === Smalruby: Start of block_run analytics ===
+import analytics from '../lib/analytics';
+// === Smalruby: End of block_run analytics ===
+
 import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
 
 class Controls extends React.Component {
@@ -35,6 +39,17 @@ class Controls extends React.Component {
                         this.props.vm.start();
                     }
                     this.props.vm.greenFlag();
+                    // === Smalruby: Start of block_run analytics ===
+                    try {
+                        analytics.event({
+                            category: 'block_run',
+                            action: 'green_flag',
+                            label: this.props.turbo ? 'turbo' : 'normal'
+                        });
+                    } catch (_e) {
+                        // Swallow analytics failures so the editor never breaks.
+                    }
+                    // === Smalruby: End of block_run analytics ===
                 }
             });
     }

--- a/packages/scratch-gui/test/unit/components/ruby-toolbar-analytics.test.jsx
+++ b/packages/scratch-gui/test/unit/components/ruby-toolbar-analytics.test.jsx
@@ -1,0 +1,145 @@
+/* eslint-env jest */
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import RubyToolbar from '../../../src/components/ruby-toolbar/ruby-toolbar.jsx';
+import analytics from '../../../src/lib/analytics';
+
+jest.mock('../../../src/lib/analytics', () => ({
+    __esModule: true,
+    default: {
+        event: jest.fn(),
+    },
+}));
+
+const renderToolbar = (overrides = {}) => {
+    const defaultProps = {
+        locale: 'ja',
+        rubyVersion: 2,
+        onChangeRubyVersion: jest.fn(),
+        executing: false,
+        canExecute: true,
+        onToggleExecute: jest.fn(),
+        canUndo: false,
+        canRedo: false,
+        onUndo: jest.fn(),
+        onRedo: jest.fn(),
+        editorRef: null,
+        autoCorrectEnabled: false,
+        onToggleAutoCorrect: jest.fn(),
+        onOpenAutoCorrectSettings: jest.fn(),
+        autoCorrectShowEffects: false,
+        onDownload: jest.fn(),
+        onInsertClass: jest.fn(),
+        onPreviewRubyScript: jest.fn(),
+        onDismissBubble: jest.fn(),
+        onOpenRubyteeModal: jest.fn(),
+        rubyteeBusy: false,
+        // Mode-related props - the fields actually exercised by analytics
+        furiganaEnabled: false,
+        dnclMode: false,
+        onToggleFurigana: jest.fn(),
+        onToggleDnclMode: jest.fn(),
+        // Sprite selector props
+        targets: [],
+        editingTargetId: null,
+        onSelectTarget: jest.fn(),
+        onSelectSprite: jest.fn(),
+        ...overrides,
+    };
+    return render(
+        <IntlProvider locale="ja" messages={{}}>
+            <RubyToolbar {...defaultProps} />
+        </IntlProvider>,
+    );
+};
+
+describe('ruby-toolbar analytics events', () => {
+    beforeEach(() => {
+        analytics.event.mockClear();
+    });
+
+    test('mode_switch fires with label "furigana" when ふりがなモードボタンをクリック', () => {
+        const { container } = renderToolbar({ furiganaEnabled: false, dnclMode: false });
+        const button = container.querySelector('[data-testid="ruby-toolbar-mode-furigana"]');
+        expect(button).toBeTruthy();
+        fireEvent.click(button);
+        expect(analytics.event).toHaveBeenCalledWith({
+            category: 'mode_switch',
+            action: 'change',
+            label: 'furigana',
+        });
+    });
+
+    test('mode_switch fires with label "ruby" when Ruby モードボタンをクリック', () => {
+        const { container } = renderToolbar({ furiganaEnabled: true, dnclMode: false });
+        const button = container.querySelector('[data-testid="ruby-toolbar-mode-ruby"]');
+        expect(button).toBeTruthy();
+        fireEvent.click(button);
+        expect(analytics.event).toHaveBeenCalledWith({
+            category: 'mode_switch',
+            action: 'change',
+            label: 'ruby',
+        });
+    });
+
+    test('mode_switch fires with label "dncl" when DNCL モードボタンをクリック', () => {
+        const { container } = renderToolbar({ furiganaEnabled: false, dnclMode: false });
+        const button = container.querySelector('[data-testid="ruby-toolbar-mode-dncl"]');
+        expect(button).toBeTruthy();
+        fireEvent.click(button);
+        expect(analytics.event).toHaveBeenCalledWith({
+            category: 'mode_switch',
+            action: 'change',
+            label: 'dncl',
+        });
+    });
+
+    test('furigana_toggle fires "on" when ふりがなモード切替で OFF→ON 遷移', () => {
+        const { container } = renderToolbar({ furiganaEnabled: false, dnclMode: false });
+        fireEvent.click(container.querySelector('[data-testid="ruby-toolbar-mode-furigana"]'));
+        expect(analytics.event).toHaveBeenCalledWith({
+            category: 'furigana_toggle',
+            action: 'toggle',
+            label: 'on',
+        });
+    });
+
+    test('furigana_toggle fires "off" when Ruby モード切替で ON→OFF 遷移', () => {
+        const { container } = renderToolbar({ furiganaEnabled: true, dnclMode: false });
+        fireEvent.click(container.querySelector('[data-testid="ruby-toolbar-mode-ruby"]'));
+        expect(analytics.event).toHaveBeenCalledWith({
+            category: 'furigana_toggle',
+            action: 'toggle',
+            label: 'off',
+        });
+    });
+
+    test('furigana_toggle does NOT fire when ふりがなが既に ON で同じモードに切替', () => {
+        const { container } = renderToolbar({ furiganaEnabled: true, dnclMode: false });
+        fireEvent.click(container.querySelector('[data-testid="ruby-toolbar-mode-furigana"]'));
+        const furiganaToggleCalls = analytics.event.mock.calls.filter(
+            (c) => c[0] && c[0].category === 'furigana_toggle',
+        );
+        expect(furiganaToggleCalls).toHaveLength(0);
+    });
+
+    test('analytics failure is swallowed and does not break click handler', () => {
+        analytics.event.mockImplementationOnce(() => {
+            throw new Error('GA failed');
+        });
+        const onToggleFurigana = jest.fn();
+        const { container } = renderToolbar({
+            furiganaEnabled: false,
+            dnclMode: false,
+            onToggleFurigana,
+        });
+        // Should not throw
+        expect(() => {
+            fireEvent.click(container.querySelector('[data-testid="ruby-toolbar-mode-furigana"]'));
+        }).not.toThrow();
+        // The actual mode switch should still happen
+        expect(onToggleFurigana).toHaveBeenCalled();
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/analytics.test.js
+++ b/packages/scratch-gui/test/unit/lib/analytics.test.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+import analytics from '../../../src/lib/analytics';
+
+describe('analytics (GA4 dataLayer wrapper)', () => {
+    let originalDataLayer;
+
+    beforeEach(() => {
+        originalDataLayer = window.dataLayer;
+        delete window.dataLayer;
+    });
+
+    afterEach(() => {
+        if (typeof originalDataLayer === 'undefined') {
+            delete window.dataLayer;
+        } else {
+            window.dataLayer = originalDataLayer;
+        }
+    });
+
+    test('initializes window.dataLayer when missing', () => {
+        expect(window.dataLayer).toBeUndefined();
+        analytics.event({ category: 'cat', action: 'act', label: 'lab' });
+        expect(Array.isArray(window.dataLayer)).toBe(true);
+    });
+
+    test('pushes an entry shaped {event, action, label}', () => {
+        analytics.event({ category: 'mode_switch', action: 'change', label: 'ruby' });
+        expect(window.dataLayer).toEqual([{ event: 'mode_switch', action: 'change', label: 'ruby' }]);
+    });
+
+    test('appends to existing dataLayer rather than overwriting', () => {
+        window.dataLayer = [{ event: 'page_view' }];
+        analytics.event({ category: 'block_run', action: 'green_flag', label: 'normal' });
+        expect(window.dataLayer).toHaveLength(2);
+        expect(window.dataLayer[0]).toEqual({ event: 'page_view' });
+        expect(window.dataLayer[1]).toEqual({
+            event: 'block_run',
+            action: 'green_flag',
+            label: 'normal',
+        });
+    });
+
+    test('records label as undefined when not supplied', () => {
+        analytics.event({ category: 'mesh_v2', action: 'disconnect' });
+        expect(window.dataLayer).toEqual([{ event: 'mesh_v2', action: 'disconnect', label: undefined }]);
+    });
+
+    test('Phase 1 GA event categories are stable identifiers', () => {
+        // This test pins the public contract used by the GA4 dashboard so that
+        // accidental category renames break a unit test rather than silently
+        // splitting historical data into a new category.
+        const categories = ['block_run', 'mesh_v2', 'mode_switch', 'furigana_toggle', 'smalrubot_s1'];
+        for (const category of categories) {
+            analytics.event({ category, action: 'noop' });
+        }
+        expect(window.dataLayer.map((entry) => entry.event)).toEqual(categories);
+    });
+});


### PR DESCRIPTION
## Summary

Issue #645 の Phase 1 として GA4 (dataLayer) に主要機能の利用イベントを追加。既存の `lib/analytics.js` ラッパーをそのまま再利用し、PII は含めず、try-catch で発火失敗時もアプリが落ちないようにした。

## Phase 1 で追加したイベント

| イベント | category / action / label | 発火箇所 |
|---|---|---|
| 緑旗実行 | `block_run` / `green_flag` / `turbo`\|`normal` | `containers/controls.jsx#handleGreenFlagClick` |
| モード切替 | `mode_switch` / `change` / `ruby`\|`furigana`\|`dncl` | `components/ruby-toolbar/ruby-toolbar.jsx` |
| ふりがな切替 | `furigana_toggle` / `toggle` / `on`\|`off` | 同上 (実際に状態が変わった場合のみ) |
| Mesh v2 接続成功 | `mesh_v2` / `connect` / `websocket`\|`polling` | `containers/connection-modal.jsx#handleConnected` |
| Mesh v2 切断 | `mesh_v2` / `disconnect` | `containers/connection-modal.jsx#handleDisconnect` |
| スモウルボットS1 接続成功 | `smalrubot_s1` / `connect` | `containers/connection-modal.jsx#handleConnected` |
| スモウルボットS1 切断 | `smalrubot_s1` / `disconnect` | `containers/connection-modal.jsx#handleDisconnect` |

既存の `extensions / connected / <extensionId>` イベントは互換のため残し、上記の専用 category は **追加発火** として実装。

## 設計方針

- **既存ラッパー再利用**: 新たな実装は追加せず、`lib/analytics.js` の `GA4.event` をそのまま呼ぶ
- **PII を含めない**: 氏名・メール・席番号・生徒番号などは `label` に絶対入れない
- **try-catch で守る**: 発火失敗時も editor 本体の動作は阻害しない (`Swallow analytics failures so the editor never breaks.` コメント付き)
- **マーカー**: upstream ファイル (`controls.jsx`, `connection-modal.jsx`) には Smalruby マーカーを付与し `smalruby-markers.md` に登録
- **新規テスト**: `analytics.js` 単体 + `ruby-toolbar` のクリック → 発火検証 (12 件パス)

## Test Coverage

- 新規ユニットテスト 2 ファイル / 12 件すべて pass
  - `test/unit/lib/analytics.test.js` (5 件) — dataLayer ラッパーの基本動作 + Phase 1 カテゴリの安定 ID 検証
  - `test/unit/components/ruby-toolbar-analytics.test.jsx` (7 件) — モード切替・ふりがな切替の発火検証 + analytics 失敗時の swallow 検証
- lint pass (eslint + prettier 共に zero warnings)

## Test Plan (PR 作成者用、別 issue 作業中のため後追い)

- [ ] Playwright での Phase 1 イベント動作確認 (別途、本 PR とは独立)
- [ ] GA4 デバッグビューでの発火確認 (別途、開発者が担当)

## Related Issues

Refs #645

## Out of scope (Phase 2)

下記は本 PR 範囲外:

- `ruby_tab / open` (Ruby タブ表示)
- `rubytee / use` (Rubytee モーダル送信)
- `classroom / join` `classroom / submit`
- `google_drive / save`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
