### PR TITLE
feat(ga): Phase 2 — ruby_tab, rubytee, classroom, google_drive の GA4 イベント追加

### DIFF
--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import ClassroomModalComponent from '../components/classroom-modal/classroom-modal.jsx';
 import ClassroomTeacherModalComponent from '../components/classroom-teacher-modal/classroom-teacher-modal.jsx';
+import analytics from '../lib/analytics';
 import classroomAPI from '../lib/classroom-api.js';
 import { loadHistory, addToHistory } from '../lib/join-code-history.js';
 import { getUrlParams, clearClasscode } from '../lib/url-params.js';
@@ -213,6 +214,15 @@ const ClassroomModal = ({ mode = 'student' }) => {
                     joinedAt: new Date().toISOString(),
                 }),
             );
+            try {
+                analytics.event({
+                    category: 'classroom',
+                    action: 'join',
+                    label: data.assignmentName ? 'with_assignment' : 'no_assignment',
+                });
+            } catch (_e) {
+                // Swallow analytics failures so the editor never breaks.
+            }
             if (data.assignmentName) {
                 dispatch(setProjectTitle(data.assignmentName));
             }

--- a/packages/scratch-gui/src/containers/google-drive-saver-hoc.jsx
+++ b/packages/scratch-gui/src/containers/google-drive-saver-hoc.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
+import analytics from '../lib/analytics';
 import googleDriveAPI from '../lib/google-drive-api';
 import intlShape from '../lib/intlShape.js';
 import log from '../lib/log';
@@ -128,6 +129,16 @@ const GoogleDriveSaverHOC = function (WrappedComponent) {
 
             // Set status to saved
             this.setState({ saveDirectStatus: 'saved' });
+
+            try {
+                analytics.event({
+                    category: 'google_drive',
+                    action: 'save',
+                    label: 'overwrite',
+                });
+            } catch (_e) {
+                // Swallow analytics failures so the editor never breaks.
+            }
 
             // Reset status to idle after 3 seconds
             setTimeout(() => {
@@ -316,6 +327,16 @@ const GoogleDriveSaverHOC = function (WrappedComponent) {
 
                 // Set status to saved
                 this.setState({ saveStatus: 'saved' });
+
+                try {
+                    analytics.event({
+                        category: 'google_drive',
+                        action: 'save',
+                        label: 'new_file',
+                    });
+                } catch (_e) {
+                    // Swallow analytics failures so the editor never breaks.
+                }
 
                 // Reset status to idle after 3 seconds
                 setTimeout(() => {

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -1019,6 +1019,19 @@ const RubyTab = (props) => {
             return;
         }
 
+        // Snapshot the current Ruby tab mode before any wasDncl reset path
+        // mutates dnclModeRef.current later in this effect. This is used
+        // for the `ruby_tab/open` GA event so it observes the user-intended
+        // mode rather than the transient ruby state during DNCL re-application.
+        const rubyTabOpenLabel =
+            isVisible && !prev.isVisible
+                ? dnclModeRef.current
+                    ? 'dncl'
+                    : furiganaEnabledRef.current
+                      ? 'furigana'
+                      : 'ruby'
+                : null;
+
         // Ruby version change
         if (rubyVersion !== prev.rubyVersion) {
             if (rubyVersion === lastProcessedVersionRef.current) {
@@ -1143,11 +1156,10 @@ const RubyTab = (props) => {
             }
             onMarkRubyTabUsed();
             try {
-                const mode = dnclModeRef.current ? 'dncl' : furiganaEnabledRef.current ? 'furigana' : 'ruby';
                 analytics.event({
                     category: 'ruby_tab',
                     action: 'open',
-                    label: mode,
+                    label: rubyTabOpenLabel,
                 });
             } catch (_e) {
                 // Swallow analytics failures so the editor never breaks.

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -9,6 +9,7 @@ import AutoCorrectModal from '../components/auto-correct-modal/auto-correct-moda
 import cameraIcon from '../components/blocks-screenshot-button/icon--camera.svg';
 import RubyScriptPreview from '../components/ruby-script-preview/ruby-script-preview.jsx';
 import RubyToolbar from '../components/ruby-toolbar/ruby-toolbar.jsx';
+import analytics from '../lib/analytics';
 import { autoCorrect, defaultSettings as defaultAutoCorrectSettings } from '../lib/auto-correct';
 import collectMetadata from '../lib/collect-metadata.js';
 import { DnclSourceMap } from '../lib/dncl/dncl-source-map';
@@ -1141,6 +1142,16 @@ const RubyTab = (props) => {
                 editorRef.current.layout();
             }
             onMarkRubyTabUsed();
+            try {
+                const mode = dnclModeRef.current ? 'dncl' : furiganaEnabledRef.current ? 'furigana' : 'ruby';
+                analytics.event({
+                    category: 'ruby_tab',
+                    action: 'open',
+                    label: mode,
+                });
+            } catch (_e) {
+                // Swallow analytics failures so the editor never breaks.
+            }
         }
 
         updateDebugGlobals(vm, {

--- a/packages/scratch-gui/src/containers/rubytee-modal-hoc.jsx
+++ b/packages/scratch-gui/src/containers/rubytee-modal-hoc.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import RubyteeConsent from '../components/rubytee-consent/rubytee-consent.jsx';
 import RubyteeModal from '../components/rubytee-modal/rubytee-modal.jsx';
+import analytics from '../lib/analytics';
 import intlShape from '../lib/intlShape.js';
 import RubyteeAPI, { RateLimitError } from '../lib/rubytee-api';
 
@@ -359,6 +360,15 @@ const RubyteeModalHOC = function (WrappedComponent) {
                     latestCodes: latestCodes,
                     isLoading: false,
                 }));
+                try {
+                    analytics.event({
+                        category: 'rubytee',
+                        action: 'use',
+                        label: latestCodes && latestCodes.length > 0 ? 'with_code' : 'no_code',
+                    });
+                } catch (_e) {
+                    // Swallow analytics failures so the editor never breaks.
+                }
             } catch (error) {
                 this._clearTimers();
 

--- a/packages/scratch-gui/src/containers/use-student-submit.js
+++ b/packages/scratch-gui/src/containers/use-student-submit.js
@@ -5,6 +5,7 @@
  * project upload, and progress tracking.
  */
 import { useCallback, useState } from 'react';
+import analytics from '../lib/analytics';
 import { renderBlocksToCanvas } from '../lib/blocks-screenshot.js';
 import classroomAPI from '../lib/classroom-api.js';
 import { getProjectThumbnail } from '../lib/store-project-thumbnail.js';
@@ -153,6 +154,15 @@ const useStudentSubmit = ({
             setSubmitProgress(null);
             dispatch(setSubmissionStatus('submitted', submissionData.submittedAt));
             setPhase('student-status');
+            try {
+                analytics.event({
+                    category: 'classroom',
+                    action: 'submit',
+                    label: screenshotBlobs && screenshotBlobs.length > 0 ? 'with_screenshots' : 'no_screenshots',
+                });
+            } catch (_e) {
+                // Swallow analytics failures so the editor never breaks.
+            }
         } catch (err) {
             setSubmitProgress(null);
             if (err.status === 401) {

--- a/packages/scratch-gui/test/unit/lib/analytics.test.js
+++ b/packages/scratch-gui/test/unit/lib/analytics.test.js
@@ -55,4 +55,32 @@ describe('analytics (GA4 dataLayer wrapper)', () => {
         }
         expect(window.dataLayer.map((entry) => entry.event)).toEqual(categories);
     });
+
+    test('Phase 2 GA event categories are stable identifiers', () => {
+        const categories = ['ruby_tab', 'rubytee', 'classroom', 'google_drive'];
+        for (const category of categories) {
+            analytics.event({ category, action: 'noop' });
+        }
+        expect(window.dataLayer.map((entry) => entry.event)).toEqual(categories);
+    });
+
+    test('Phase 2 expected (action, label) pairs', () => {
+        const cases = [
+            { category: 'ruby_tab', action: 'open', label: 'ruby' },
+            { category: 'ruby_tab', action: 'open', label: 'furigana' },
+            { category: 'ruby_tab', action: 'open', label: 'dncl' },
+            { category: 'rubytee', action: 'use', label: 'with_code' },
+            { category: 'rubytee', action: 'use', label: 'no_code' },
+            { category: 'classroom', action: 'join', label: 'with_assignment' },
+            { category: 'classroom', action: 'join', label: 'no_assignment' },
+            { category: 'classroom', action: 'submit', label: 'with_screenshots' },
+            { category: 'classroom', action: 'submit', label: 'no_screenshots' },
+            { category: 'google_drive', action: 'save', label: 'overwrite' },
+            { category: 'google_drive', action: 'save', label: 'new_file' },
+        ];
+        for (const c of cases) {
+            analytics.event(c);
+        }
+        expect(window.dataLayer).toEqual(cases.map((c) => ({ event: c.category, action: c.action, label: c.label })));
+    });
 });


### PR DESCRIPTION
## Summary

Issue #645 の Phase 2 として GA4 (dataLayer) に追加 5 種類のイベントを実装。Phase 1 (PR #649) と同じ設計で、既存 `lib/analytics.js` ラッパーを再利用、PII を含めず、try-catch で発火失敗時もアプリ停止しない。

すべて **Smalruby 固有ファイル** への変更のため、upstream マーカーは不要。

## Phase 2 で追加したイベント

| イベント | category / action / label | 発火箇所 |
|---|---|---|
| Ruby タブ表示 | `ruby_tab / open / ruby\|furigana\|dncl` | `containers/ruby-tab.jsx` (`isVisible && !prev.isVisible`) |
| Rubytee 使用 | `rubytee / use / with_code\|no_code` | `containers/rubytee-modal-hoc.jsx` (`sendMessage` 成功) |
| クラス参加 | `classroom / join / with_assignment\|no_assignment` | `containers/classroom-modal.jsx` (`joinClassroom` 成功 + Redux dispatch 後) |
| 作品提出 | `classroom / submit / with_screenshots\|no_screenshots` | `containers/use-student-submit.js` (`setSubmissionStatus('submitted')` 直後) |
| Google Drive 保存 | `google_drive / save / overwrite\|new_file` | `containers/google-drive-saver-hoc.jsx` (`performSaveToGoogleDrive` / `handleSaveToGoogleDrive` の成功時) |

### ラベル設計の意図

- `ruby_tab/open`: 開いた瞬間のモードを記録 → DNCL モードや furigana モードがどれだけ使われているかが GA4 で集計可能
- `rubytee/use`: 「コード生成あり」と「会話のみ」の比率を集計 → AI が実用的に使われているかの指標
- `classroom/join`: 課題ありなしの比率 → 授業課題と自由参加の使い分けを把握
- `classroom/submit`: スクリーンショットの有無 → 提出のリッチさを集計
- `google_drive/save`: 上書き保存と新規保存の比率 → 教材ベース運用と個別ファイル運用の比率

## 設計方針 (Phase 1 と同一)

- **既存ラッパー再利用**: `lib/analytics.js` の `GA4.event` をそのまま呼ぶ
- **PII を含めない**: 氏名・メール・席番号・課題名・ファイル名などは label に絶対入れない
- **try-catch で守る**: 発火失敗時も editor 本体の動作は阻害しない
- **マーカー不要**: 全変更箇所が Smalruby 固有ファイル
- **新規テスト**: `test/unit/lib/analytics.test.js` に Phase 2 用の 2 件を追記 (合計 7 件 pass)

## Test Coverage

- `test/unit/lib/analytics.test.js`: 7 件 pass (Phase 1 5 件 + Phase 2 2 件)
  - Phase 2 categories のスタビリティ pin
  - Phase 2 (action, label) ペアの contract pin
- lint pass (eslint + prettier 共に zero warnings)
- 既存の Phase 1 テスト (`test/unit/components/ruby-toolbar-analytics.test.jsx` 7 件) も green

## Test Plan (PR レビュアー / マージ後)

- [ ] ローカル dev server で `window.dataLayer` を観測して 5 イベント全て発火することを確認 (Phase 1 と同じ手順、PR #649 のコメント参照)
- [ ] develop マージ後、smalruby.app + GA4 DebugView で本番経路の発火確認
- [ ] 24-48 時間後、GA4 レポート → エンゲージメント → イベントで `ruby_tab` `rubytee` `classroom` `google_drive` が出現することを確認

## Out of scope

Issue #645 のリストでは Phase 2 の全イベントを実装しました。

## Related Issues

Refs #645
Closes #645 (Phase 1 + Phase 2 で全イベントが揃う)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
