### PR TITLE
fix: Mesh センサー値ブロックのドロップダウンが "Invalid colour" でクラッシュする不具合を修正

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -66,6 +66,8 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/lib/blocks.js` | gesture recovery | ジェスチャー復旧ハンドラーのインストール |
 | `src/lib/blocks.js` | comment icon patch import | ScratchCommentIcon パッチモジュールの import |
 | `src/lib/blocks.js` | comment icon patch | ScratchCommentIcon.fireCreateEvent をオーバーライドして create 後に block_comment_change を re-fire (Blockly v12 の create payload に text が含まれない問題のフォロー) |
+| `src/lib/blocks.js` | auto style selected patch import | auto_<hex>_selected スタイル登録パッチの import |
+| `src/lib/blocks.js` | auto style selected patch | ConstantProvider.getBlockStyle をラップして `auto_<hex>_selected` を要求された際に on-the-fly で selected variant を登録 (Mesh sensor value のような defaultExtensionColors を使う shadow ドロップダウンを開くと "Invalid colour" で止まる問題の修正) |
 | `src/playground/render-gui.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui.jsx` | no_beforeunload URL param | beforeunload 無効化 |
 | `src/playground/render-gui.jsx` | MobileGui dispatcher | ResponsiveGui import + GUI を ResponsiveGui に差し替え (issue #572 Phase 2-A) |

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -127,6 +127,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/lib/storage-worker-timeout-hoc.jsx`
 - `src/lib/ruby-script-preview.js`
 - `src/lib/ruby-to-blocks-converter-hoc.jsx`
+- `src/lib/scratch-blocks-auto-style-patch.js`
 - `src/lib/scratch-blocks-comment-icon-patch.js`
 - `src/lib/rubytee-api.js`
 - `src/lib/rubytee-context.js`
@@ -230,6 +231,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/lib/furigana-annotator.test.js`
 - `test/unit/lib/google-drive-api.test.js`
 - `test/unit/lib/responsive-gui.test.jsx`
+- `test/unit/lib/scratch-blocks-auto-style-patch.test.js`
 - `test/unit/lib/url-loader.test.js`
 - `test/unit/lib/use-is-narrow-screen.test.js`
 - `test/unit/lib/insert-class.test.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -121,6 +121,7 @@ src/lib/*
 !src/lib/google-classroom-auth.js
 !src/lib/block-utils.js
 !src/lib/blocks-gesture-recovery.js
+!src/lib/scratch-blocks-auto-style-patch.js
 !src/lib/scratch-blocks-comment-icon-patch.js
 !src/lib/blocks-screenshot.js
 !src/lib/furigana-annotator.js
@@ -313,6 +314,7 @@ test/unit/lib/*
 !test/unit/lib/legacy-storage.test.js
 !test/unit/lib/make-toolbox-xml.test.js
 !test/unit/lib/responsive-gui.test.jsx
+!test/unit/lib/scratch-blocks-auto-style-patch.test.js
 !test/unit/lib/use-is-narrow-screen.test.js
 !test/unit/lib/module-sync.test.js
 !test/unit/lib/prism-parser.test.js

--- a/packages/scratch-gui/src/lib/blocks.js
+++ b/packages/scratch-gui/src/lib/blocks.js
@@ -4,6 +4,9 @@ import {installGestureRecovery} from './blocks-gesture-recovery.js';
 // === Smalruby: Start of comment icon patch import ===
 import {installCommentIconPatch} from './scratch-blocks-comment-icon-patch.js';
 // === Smalruby: End of comment icon patch import ===
+// === Smalruby: Start of auto style selected patch import ===
+import {installAutoStyleSelectedPatch} from './scratch-blocks-auto-style-patch.js';
+// === Smalruby: End of auto style selected patch import ===
 
 /**
  * Connect scratch blocks with the vm
@@ -352,6 +355,10 @@ export default function (vm) {
     // === Smalruby: Start of comment icon patch ===
     installCommentIconPatch(ScratchBlocks);
     // === Smalruby: End of comment icon patch ===
+
+    // === Smalruby: Start of auto style selected patch ===
+    installAutoStyleSelectedPatch(ScratchBlocks);
+    // === Smalruby: End of auto style selected patch ===
 
     return ScratchBlocks;
 }

--- a/packages/scratch-gui/src/lib/scratch-blocks-auto-style-patch.js
+++ b/packages/scratch-gui/src/lib/scratch-blocks-auto-style-patch.js
@@ -1,0 +1,62 @@
+/**
+ * Why this patch exists:
+ *
+ * Blockly v12's dropdown / matrix / colour fields call
+ * `block.setStyle(`${originalStyle}_selected`)` when the user opens the
+ * editor on a shadow block, to highlight the shadow while editing. The
+ * `*_selected` style variant is registered for every named theme style by
+ * `Theme.setBlockStyle`, but **not** for "auto" styles created on the fly
+ * by `ConstantProvider.getBlockStyleForColour` (style name = `auto_<hex>`).
+ *
+ * When such a shadow lives on an extension block whose colour did not
+ * resolve to a named theme style — e.g. the Smalruby Mesh extension's
+ * `[NAME] sensor value` reporter, which uses the default extension
+ * colour `#0FBD8C` — `originalStyle` is `auto_#0fbd8c`, and the field
+ * asks the renderer for `auto_#0fbd8c_selected`. The renderer's
+ * `getBlockStyle` falls through its `auto_` branch and forwards the
+ * full remainder to `getBlockStyleForColour`, which calls
+ * `validatedBlockStyle_({colourPrimary: "#0fbd8c_selected"})` and throws
+ * `Invalid colour: "#0fbd8c_selected"`. The thrown error breaks the
+ * field click and freezes the workspace.
+ *
+ * Fix: register an `auto_<hex>_selected` style on first access by
+ * wrapping `getBlockStyle`. The selected variant we register matches
+ * how Blockly v12's `Theme.setBlockStyle` builds them — same primary
+ * colour, secondary becomes the original tertiary, hat cleared — so the
+ * highlight looks identical to a themed shadow's selected state.
+ * @param {object} ScratchBlocks - the scratch-blocks module
+ */
+export const installAutoStyleSelectedPatch = function (ScratchBlocks) {
+    const ConstantProvider = ScratchBlocks?.blockRendering?.ConstantProvider;
+    if (!ConstantProvider || !ConstantProvider.prototype) return;
+    if (ConstantProvider.prototype.__smalrubyAutoStyleSelectedPatched) return;
+
+    const origGetBlockStyle = ConstantProvider.prototype.getBlockStyle;
+    if (typeof origGetBlockStyle !== 'function') return;
+
+    ConstantProvider.prototype.getBlockStyle = function (name) {
+        if (
+            name &&
+            this.blockStyles &&
+            !this.blockStyles[name] &&
+            name.startsWith('auto_') &&
+            name.endsWith('_selected')
+        ) {
+            const baseName = name.slice(0, -'_selected'.length);
+            const baseStyle = origGetBlockStyle.call(this, baseName);
+            if (baseStyle) {
+                this.blockStyles[name] = {
+                    colourPrimary: baseStyle.colourPrimary,
+                    colourSecondary: baseStyle.colourTertiary,
+                    colourTertiary: baseStyle.colourTertiary,
+                    colourQuaternary: baseStyle.colourQuaternary,
+                    hat: '',
+                };
+                return this.blockStyles[name];
+            }
+        }
+        return origGetBlockStyle.call(this, name);
+    };
+
+    ConstantProvider.prototype.__smalrubyAutoStyleSelectedPatched = true;
+};

--- a/packages/scratch-gui/test/unit/lib/scratch-blocks-auto-style-patch.test.js
+++ b/packages/scratch-gui/test/unit/lib/scratch-blocks-auto-style-patch.test.js
@@ -1,0 +1,90 @@
+import { installAutoStyleSelectedPatch } from '../../../src/lib/scratch-blocks-auto-style-patch.js';
+
+const buildMockScratchBlocks = () => {
+    class ConstantProvider {
+        constructor() {
+            this.blockStyles = {};
+        }
+
+        validatedBlockStyle_(input) {
+            const colour = input.colourPrimary;
+            if (typeof colour !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(colour)) {
+                throw new Error(`Invalid colour: "${colour}"`);
+            }
+            return {
+                colourPrimary: colour,
+                colourSecondary: colour,
+                colourTertiary: '#0b8e69',
+                hat: '',
+            };
+        }
+
+        createBlockStyle_(colour) {
+            return this.validatedBlockStyle_({ colourPrimary: colour });
+        }
+
+        getBlockStyleForColour(colour) {
+            const name = `auto_${colour}`;
+            if (!this.blockStyles[name]) {
+                this.blockStyles[name] = this.createBlockStyle_(colour);
+            }
+            return { style: this.blockStyles[name], name };
+        }
+
+        getBlockStyle(name) {
+            if (this.blockStyles[name || '']) return this.blockStyles[name];
+            if (name && name.startsWith('auto_')) {
+                return this.getBlockStyleForColour(name.substring(5)).style;
+            }
+            return this.createBlockStyle_('#000000');
+        }
+    }
+    return { blockRendering: { ConstantProvider } };
+};
+
+describe('installAutoStyleSelectedPatch', () => {
+    test('without patch: opening dropdown on auto-styled shadow throws "Invalid colour"', () => {
+        const ScratchBlocks = buildMockScratchBlocks();
+        const constants = new ScratchBlocks.blockRendering.ConstantProvider();
+        constants.getBlockStyleForColour('#0fbd8c');
+        expect(() => constants.getBlockStyle('auto_#0fbd8c_selected')).toThrow(/Invalid colour/);
+    });
+
+    test('with patch: returns a selected variant matching the base style', () => {
+        const ScratchBlocks = buildMockScratchBlocks();
+        installAutoStyleSelectedPatch(ScratchBlocks);
+        const constants = new ScratchBlocks.blockRendering.ConstantProvider();
+        const base = constants.getBlockStyleForColour('#0fbd8c').style;
+
+        const selected = constants.getBlockStyle('auto_#0fbd8c_selected');
+
+        expect(selected).toBeDefined();
+        expect(selected.colourPrimary).toBe(base.colourPrimary);
+        expect(selected.colourSecondary).toBe(base.colourTertiary);
+        expect(selected.hat).toBe('');
+        // cached so subsequent calls return the same object
+        expect(constants.getBlockStyle('auto_#0fbd8c_selected')).toBe(selected);
+    });
+
+    test('with patch: existing named styles still resolve unchanged', () => {
+        const ScratchBlocks = buildMockScratchBlocks();
+        installAutoStyleSelectedPatch(ScratchBlocks);
+        const constants = new ScratchBlocks.blockRendering.ConstantProvider();
+        const named = { colourPrimary: '#abcdef', colourSecondary: '#abcdef', colourTertiary: '#000000', hat: '' };
+        constants.blockStyles.foo = named;
+        expect(constants.getBlockStyle('foo')).toBe(named);
+    });
+
+    test('idempotent: applying the patch twice does not double-wrap', () => {
+        const ScratchBlocks = buildMockScratchBlocks();
+        installAutoStyleSelectedPatch(ScratchBlocks);
+        const wrapped = ScratchBlocks.blockRendering.ConstantProvider.prototype.getBlockStyle;
+        installAutoStyleSelectedPatch(ScratchBlocks);
+        expect(ScratchBlocks.blockRendering.ConstantProvider.prototype.getBlockStyle).toBe(wrapped);
+    });
+
+    test('no-op when ConstantProvider is missing', () => {
+        expect(() => installAutoStyleSelectedPatch({})).not.toThrow();
+        expect(() => installAutoStyleSelectedPatch(null)).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Summary

Mesh拡張機能の「センサーの値」ブロックの入力フィールドのドロップダウンをクリックすると `Uncaught Error: Invalid colour: "#0fbd8c_selected"` でエディタが操作不能になる不具合を修正します。

## Root cause

Blockly v12 のドロップダウン / マトリクス / カラーピッカー系フィールドは、shadow ブロック上でエディタを開く際に ``block.setStyle(`${originalStyle}_selected`)`` を呼んでハイライト表示します。`_selected` バリアントは `Theme.setBlockStyle` で**名前付きテーマスタイル**については登録されますが、`ConstantProvider.getBlockStyleForColour` がオンザフライで作る "auto" スタイル（スタイル名 `auto_<hex>`）には登録されません。

`defaultExtensionColors` (`#0FBD8C`) にフォールバックしている拡張機能のレポーター — Mesh の `[NAME] sensor value` など — では `originalStyle = auto_#0fbd8c` となり、`auto_#0fbd8c_selected` がレンダラに要求されます。レンダラはこれを `auto_` スタイルとして処理しようとして `getBlockStyleForColour("#0fbd8c_selected")` → `validatedBlockStyle_({colourPrimary: "#0fbd8c_selected"})` と進み、最終的に `Invalid colour` を throw してエディタが操作不能になります。

## Fix

`packages/scratch-gui/src/lib/scratch-blocks-auto-style-patch.js` で `ConstantProvider.getBlockStyle` をラップし、`auto_<hex>_selected` を要求された際に `Theme.setBlockStyle` の selected バリアント生成と同等のスタイル（primary 同じ、secondary が元の tertiary、hat 空）を遅延登録します。

既存の `scratch-blocks-comment-icon-patch.js` と同様に、`packages/scratch-gui/src/lib/blocks.js` でマーカー付きで適用します。

## Changes

- `packages/scratch-gui/src/lib/scratch-blocks-auto-style-patch.js` (新規)
- `packages/scratch-gui/src/lib/blocks.js` — パッチ適用箇所
- `packages/scratch-gui/test/unit/lib/scratch-blocks-auto-style-patch.test.js` (新規) — 5 件（修正前の "Invalid colour" 再現を含む）
- `.prettierignore` / `smalruby-prettier-files.md` / `smalruby-markers.md` を更新

## Test plan

- [x] Unit tests pass (5/5)
- [ ] CI 全テスト pass
- [ ] Mesh 拡張機能を有効化し、`[NAME] センサーの値` ブロックの NAME フィールドのドロップダウンをクリックしてもクラッシュせず、メニューが開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
