### PR TITLE
fix: Mesh ステータス/接続モーダルが scanning で固まる不具合を修正

### DIFF
--- a/.claude/rules/scratch-vm/development.md
+++ b/.claude/rules/scratch-vm/development.md
@@ -215,6 +215,7 @@ The mesh v2 extension uses AWS AppSync for real-time collaboration:
 | `src/extension-support/extension-manager.js` | extension registration | Smalruby 拡張機能の登録 |
 | `src/blocks/scratch3_operators.js` | regex support | operator_contains で正規表現マッチングをサポート |
 | `src/engine/comment.js` | toXML modernization | Blockly v12 対応: `pinned="${!minimized}"` (cherry-pick from upstream spork@29bdbd1fe) + (0,0) 時の x/y 属性省略 (Smalruby 独自) |
+| `src/engine/runtime.js` | toolboxitemid for extension categories | Blockly v12 対応: 拡張機能のカテゴリ XML に `toolboxitemid` 属性を追加。Blockly v12 の ContinuousToolbox は `toolboxitemid` から id を読むため、未指定だと `blockly-XXX` の auto-id が StatusIndicatorLabel.extensionId に伝搬し、`!` 接続モーダルが拡張機能を見つけられず scanning で固まる |
 
 ### 関連ファイル
 

--- a/packages/scratch-vm/src/engine/runtime.js
+++ b/packages/scratch-vm/src/engine/runtime.js
@@ -1441,8 +1441,19 @@ class Runtime extends EventEmitter {
 
             return {
                 id: categoryInfo.id,
-                xml: `<category name="${name}" id="${categoryInfo.id}" ${statusButtonXML} ${colorXML} ${menuIconXML}>${
+                // === Smalruby: Start of toolboxitemid for extension categories ===
+                // Blockly v12's ContinuousToolbox parses category id from the
+                // `toolboxitemid` attribute (`iI.id_ = e.toolboxitemid || genUid()`).
+                // When only `id` is present, Blockly falls back to an auto-generated
+                // `blockly-XXX` id, which then propagates to the StatusIndicatorLabel
+                // (`extensionId = E.id`). The connection-modal subsequently opens with
+                // a bogus extensionId and never finds the real extension — modal stays
+                // at scanning, status icon stays "!", and `vm.connectPeripheral` is a
+                // no-op. Emit `toolboxitemid` (preferred by v12) alongside the legacy
+                // `id` attribute so the StatusIndicatorLabel receives the real id.
+                xml: `<category name="${name}" toolboxitemid="${categoryInfo.id}" id="${categoryInfo.id}" ${statusButtonXML} ${colorXML} ${menuIconXML}>${
                     paletteBlocks.map(block => block.xml).join('')}</category>`
+                // === Smalruby: End of toolboxitemid for extension categories ===
             };
         });
     }

--- a/packages/scratch-vm/test/unit/runtime_extension_category_xml.js
+++ b/packages/scratch-vm/test/unit/runtime_extension_category_xml.js
@@ -1,0 +1,33 @@
+const test = require('tap').test;
+const Runtime = require('../../src/engine/runtime');
+
+const buildRuntimeWithCategory = () => {
+    const rt = new Runtime();
+    rt._blockInfo = [
+        {
+            id: 'meshV2',
+            name: 'Mesh',
+            color1: '#0FBD8C',
+            color2: '#0DA57A',
+            menuIconURI: '',
+            blockIconURI: '',
+            showStatusButton: true,
+            blocks: [
+                {
+                    info: {hideFromPalette: false, filter: undefined},
+                    xml: '<block type="meshV2_getSensorValue"/>',
+                },
+            ],
+        },
+    ];
+    return rt;
+};
+
+test('extension category XML carries toolboxitemid so Blockly v12 preserves the real extension id', t => {
+    const rt = buildRuntimeWithCategory();
+    const xml = rt.getBlocksXML()[0].xml;
+    t.match(xml, /toolboxitemid="meshV2"/, 'category XML includes toolboxitemid');
+    t.match(xml, /id="meshV2"/, 'category XML preserves legacy id attribute');
+    t.match(xml, /showStatusButton="true"/, 'category XML preserves showStatusButton');
+    t.end();
+});


### PR DESCRIPTION
## Summary

Mesh拡張機能を有効にしてホストになっても、メッシュのステータス（`!` 切断アイコン）が更新されず、接続モーダルがスキャン画面のまま固まる不具合を修正します。

## Root cause

Blockly v12 の `ContinuousToolbox` は **`toolboxitemid` 属性** からカテゴリ id を読みます (`iI.id_ = e.toolboxitemid || genUid()`)。`runtime.js` が拡張機能カテゴリ XML を生成する際、`id="..."` のみを付与していたため、v12 のパーサは `genUid()` にフォールバックし、`blockly-1aw` のような auto id をカテゴリに付けます。

```
StatusIndicatorLabel constructor (scratch-blocks v12):
  this.extensionId = E.id   // ← "blockly-1aw" になっていた
```

ユーザーが `!` 警告アイコンをクリックすると、その auto id (`blockly-1aw`) が `statusButtonCallback` に渡され、連鎖的に:

- 接続モーダルが `extensionId="blockly-1aw"` で開く
- `extensionData.find(ext => ext.extensionId === 'blockly-1aw')` が undefined → `MeshV2InitialStep` に行かず `scanning` フェーズへフォールバック
- `vm.connectPeripheral('blockly-1aw', 'meshV2_host')` は no-op（`runtime.peripheralExtensions['blockly-1aw']` が undefined）
- `PERIPHERAL_CONNECTED` が永遠に発火しないので、モーダルは「デバイスを探索中」の scanning ステップのまま固まる
- 別経路で接続成功してもステータスアイコンの更新キーが拡張 id と一致せず、`!` のまま

ライブの workspace で flyout の `StatusIndicatorLabel.extensionId` を覗くと、修正前は `"blockly-1aw"`、修正後は `"meshV2"` になることを確認しました。

## Fix

`packages/scratch-vm/src/engine/runtime.js` で拡張機能カテゴリ XML に `toolboxitemid="${id}"` を `id="${id}"` と並べて付与します（v12 推奨の `toolboxitemid` を新規・古い `id` を残す）。

これは upstream ファイルへの修正のため Smalruby マーカーを使用し、`.claude/rules/scratch-vm/development.md` の一覧も更新しました。

## Changes

- `packages/scratch-vm/src/engine/runtime.js` — XML に `toolboxitemid` を追加
- `packages/scratch-vm/test/unit/runtime_extension_category_xml.js` (新規) — XML が `toolboxitemid` / `id` / `showStatusButton` をすべて含むことを検証する tap テスト
- `.claude/rules/scratch-vm/development.md` — マーカー一覧を更新

## Test plan

- [x] tap unit test 3 件 pass
- [x] Playwright で実機確認: Mesh 拡張機能を有効化 → flyout の `StatusIndicatorLabel.extensionId === "meshV2"`（修正前は `"blockly-1aw"`）→ `statusButtonCallback` 経由で接続モーダルが `extensionId="meshV2"` で開く
- [ ] CI 全テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
