### PR TITLE
feat(menu-bar): add "about smalruby" item linking to /about.html

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -72,6 +72,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/playground/render-gui.jsx` | no_beforeunload URL param | beforeunload 無効化 |
 | `src/playground/render-gui.jsx` | MobileGui dispatcher | ResponsiveGui import + GUI を ResponsiveGui に差し替え (issue #572 Phase 2-A) |
 | `src/playground/render-gui.jsx` | storage worker timeout HOC | scratch-storage の FetchWorkerTool に 5s タイムアウトを当てる HOC import と compose 配置 (subdir deploy + iOS Safari の Worker hang 対策) |
+| `src/playground/render-gui.jsx` | about menu | About メニュー項目（`/about.html` を新規タブで開く）の定義と GUI への注入 |
 | `src/components/target-pane/target-pane.jsx` | mobile-sprite-panel suppress-library | MobileSpritePanel が同一ツリーで TargetPane を再描画する際の SpriteLibrary 二重表示を `hideSpriteLibrary` prop で抑止 (issue #572 Phase 2-F) |
 | `src/playground/render-gui-standalone.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui-standalone.jsx` | no_beforeunload URL param | beforeunload 無効化 |

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -46,6 +46,7 @@ export default {
     'gui.classroom.title': 'Classroom',
     'gui.menuBar.classroom': 'Classroom',
     'gui.menuBar.classroomManagement': 'Class Management...',
+    'gui.menuBar.aboutSmalruby': 'About Smalruby',
     'gui.classroom.management.title': 'Class Management',
     'gui.classroom.roleSelect.prompt': 'How do you use the classroom?',
     'gui.classroom.roleSelect.teacher': 'Teacher',

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -38,6 +38,7 @@ export default {
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',
     'gui.menuBar.classroomManagement': 'クラスかんり...',
+    'gui.menuBar.aboutSmalruby': 'スモウルビーについて',
     'gui.classroom.management.title': 'クラスかんり',
     'gui.classroom.roleSelect.prompt': 'どちらでつかいますか？',
     'gui.classroom.roleSelect.teacher': 'せんせい',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -37,6 +37,7 @@ export default {
     'gui.classroom.title': 'クラス',
     'gui.menuBar.classroom': 'クラス',
     'gui.menuBar.classroomManagement': 'クラス管理...',
+    'gui.menuBar.aboutSmalruby': 'スモウルビーについて',
     'gui.classroom.management.title': 'クラス管理',
     'gui.classroom.roleSelect.prompt': 'どちらで使いますか？',
     'gui.classroom.roleSelect.teacher': '先生',

--- a/packages/scratch-gui/src/playground/render-gui.jsx
+++ b/packages/scratch-gui/src/playground/render-gui.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDomClient from 'react-dom/client';
+import {FormattedMessage} from 'react-intl';
 import {compose} from 'redux';
 
 import AppStateHOC from '../lib/app-state-hoc.jsx';
@@ -20,6 +21,23 @@ import StorageWorkerTimeoutHOC from '../lib/storage-worker-timeout-hoc.jsx';
 const onClickLogo = () => {
     window.location = 'https://smalruby.jp';
 };
+
+// === Smalruby: Start of about menu ===
+const aboutMenuItems = [
+    {
+        title: (
+            <FormattedMessage
+                defaultMessage="About Smalruby"
+                description="Menu item that opens the Smalruby introduction page (/about.html)"
+                id="gui.menuBar.aboutSmalruby"
+            />
+        ),
+        onClick: () => {
+            window.open('about.html', '_blank', 'noopener,noreferrer');
+        }
+    }
+];
+// === Smalruby: End of about menu ===
 
 const handleTelemetryModalCancel = () => {
     log('User canceled telemetry modal');
@@ -106,6 +124,9 @@ export default appTarget => {
                 backpackHost={backpackHost}
                 canSave={false}
                 onClickLogo={onClickLogo}
+                // === Smalruby: Start of about menu ===
+                onClickAbout={aboutMenuItems}
+                // === Smalruby: End of about menu ===
             />
     );
 };


### PR DESCRIPTION
## Summary

About メニューに「スモウルビーについて」項目を追加し、既存の `/about.html`（Smalruby 紹介ランディングページ）を新規タブで開けるようにした。

これまで `pages/about.html` は webpack の CopyPlugin でビルド成果物に含まれ、`https://smalruby.app/about.html` で配信されていたものの、**エディタ内からのリンクがゼロ**で SEO 検索流入のみが訪問経路だった。Discussion #88 の「どういうサイトかわからない」というフィードバックへの動線整備の第一歩。

## Changes

- `src/playground/render-gui.jsx` — `onClickAbout` array prop を追加し、「スモウルビーについて」項目を `window.open('about.html', '_blank', 'noopener,noreferrer')` で開くように
- `src/locales/{ja,ja-Hira,en}.js` — `gui.menuBar.aboutSmalruby` メッセージを 3 言語追加
- `.claude/rules/scratch-gui/smalruby-markers.md` — マーカー一覧を更新

## Test plan

- [x] `npm run lint` pass（warnings 0）
- [x] Playwright で About アイコンをクリック → メニューに「スモウルビーについて」が表示されることを確認（`tmp/pr3-about-menu-open.png`）
- [x] `/about.html` が HTTP 200 で配信されていることを確認

## Related

- Issue #658（PR 3/4）
- Discussion #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
