### PR TITLE
fix(menu): close menu on click instead of pointerup for iPadOS

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -92,7 +92,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/containers/controls.jsx` | block_run analytics | 緑旗クリック時に GA4 イベントを発火 (issue #645 Phase 1) |
 | `src/containers/connection-modal.jsx` | mesh_v2/smalrubot_s1 connect analytics | 接続成功時に拡張別カテゴリ (`mesh_v2` / `smalrubot_s1`) で GA4 イベントを発火 (issue #645 Phase 1) |
 | `src/containers/connection-modal.jsx` | mesh_v2/smalrubot_s1 disconnect analytics | 切断時に拡張別カテゴリで GA4 イベントを発火 (issue #645 Phase 1) |
-| `src/containers/menu.jsx` | iPad menu item click fix | メニュー項目を `click` (bubble)、メニュー外を `pointerup` で受ける 2 系統リスナ。`pointerup`+`setTimeout(0)` で close すると iPadOS Safari で `<li>` が click 発火前に unmount され React onClick が skip される問題への対応 |
+| `src/containers/menu.jsx` | iPad menu item click fix | メニュー項目クリック時の `setTimeout` 遅延を 0 → 100ms に拡大。iPadOS Safari は `pointerup` から `click` 発火まで ~16–32ms 程度のラグがあり、setTimeout(0) で close すると `<li>` が click 発火前に unmount され React onClick が skip される問題への対応 |
 
 ## 関連ファイル
 

--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -92,6 +92,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/containers/controls.jsx` | block_run analytics | 緑旗クリック時に GA4 イベントを発火 (issue #645 Phase 1) |
 | `src/containers/connection-modal.jsx` | mesh_v2/smalrubot_s1 connect analytics | 接続成功時に拡張別カテゴリ (`mesh_v2` / `smalrubot_s1`) で GA4 イベントを発火 (issue #645 Phase 1) |
 | `src/containers/connection-modal.jsx` | mesh_v2/smalrubot_s1 disconnect analytics | 切断時に拡張別カテゴリで GA4 イベントを発火 (issue #645 Phase 1) |
+| `src/containers/menu.jsx` | iPad menu item click fix | メニュー項目を `click` (bubble)、メニュー外を `pointerup` で受ける 2 系統リスナ。`pointerup`+`setTimeout(0)` で close すると iPadOS Safari で `<li>` が click 発火前に unmount され React onClick が skip される問題への対応 |
 
 ## 関連ファイル
 

--- a/packages/scratch-gui/src/containers/menu.jsx
+++ b/packages/scratch-gui/src/containers/menu.jsx
@@ -11,7 +11,6 @@ class Menu extends React.Component {
             'addListeners',
             'removeListeners',
             'handleClick',
-            'handlePointerUp',
             'ref'
         ]);
     }
@@ -26,55 +25,56 @@ class Menu extends React.Component {
         this.removeListeners();
     }
     addListeners () {
-        // === Smalruby: Start of iPad menu item click fix ===
-        // Menu item clicks: listen on `click` (bubble) so React's onClick on the
-        // <li> fires first. iPadOS Safari has a delay between `pointerup` and
-        // `click`; closing the menu in `pointerup` (even via setTimeout(0))
-        // unmounts the <li> before iOS dispatches `click`, so React onClick is
-        // skipped and the file picker never opens (issue: iPad Load from
-        // Computer doing nothing).
-        document.addEventListener('click', this.handleClick);
-        // Outside clicks: keep `pointerup` because the Blockly workspace
-        // suppresses compat events like `click` on workspace interactions.
-        document.addEventListener('pointerup', this.handlePointerUp);
-        // === Smalruby: End of iPad menu item click fix ===
+        // The Blockly workspace suppresses compat events like `mouseup`.
+        // Listen for `pointerup` instead.
+        document.addEventListener('pointerup', this.handleClick);
     }
     removeListeners () {
-        // === Smalruby: Start of iPad menu item click fix ===
-        document.removeEventListener('click', this.handleClick);
-        document.removeEventListener('pointerup', this.handlePointerUp);
-        // === Smalruby: End of iPad menu item click fix ===
+        document.removeEventListener('pointerup', this.handleClick);
     }
     handleClick (e) {
-        if (!this.props.open || !this.menu) return;
+        if (!this.props.open) return;
 
-        // Check if clicked element is a menu item (li element within menu).
-        // Runs in document bubble phase, after React's synthetic onClick on
-        // the <li> has already fired — so closing the menu here is safe.
+        // Check if clicked element is a menu item (li element within menu)
         let target = e.target;
         while (target && target !== this.menu) {
             if (target.tagName === 'LI' && this.menu.contains(target)) {
+                // Check if this menu item should close the menu
                 const closeOnClick = target.getAttribute('data-close-on-click');
+                // Default to true if attribute is not set (null)
+                // closeOnClick can be "true" or "false" as a string
                 if (closeOnClick === 'false') {
+                    // Don't close the menu for this item
                     return;
                 }
-                this.props.onRequestClose();
+                // === Smalruby: Start of iPad menu item click fix ===
+                // Defer the close long enough for the native click event +
+                // React's synthetic onClick to fire. On iPadOS Safari there
+                // is a non-trivial gap between `pointerup` and `click`
+                // (typically ~16–32ms with optimal viewport, can be longer);
+                // closing on pointerup with setTimeout(0) unmounts the <li>
+                // before iOS dispatches `click`, causing React's onClick to
+                // be skipped (e.g. ファイル → コンピュータから読み込む does
+                // nothing). 100ms is comfortably above the click latency on
+                // all observed devices while still feeling instantaneous.
+                setTimeout(() => {
+                    this.props.onRequestClose();
+                }, 100);
+                // === Smalruby: End of iPad menu item click fix ===
                 return;
             }
             target = target.parentElement;
         }
-    }
-    handlePointerUp (e) {
-        if (!this.props.open || !this.menu) return;
-        // Inside-menu pointerup is handled by `click` (handleClick) so the
-        // menu item's React onClick gets a chance to run first.
-        if (this.menu.contains(e.target)) return;
-        // Outside-menu close: defer so the menu button's own onClick toggle
-        // can run first. If the button already closed the menu, this becomes
-        // a no-op via the open check.
-        setTimeout(() => {
-            if (this.props.open) this.props.onRequestClose();
-        }, 0);
+
+        // Clicked outside the menu, close it after React event handlers execute
+        // In React 18, document mouseup fires before React synthetic click events,
+        // so delaying here allows the menu button's onClick (toggle) to run first.
+        // If the button's toggle already closed the menu, onRequestClose becomes a no-op.
+        if (!this.menu.contains(e.target)) {
+            setTimeout(() => {
+                this.props.onRequestClose();
+            }, 0);
+        }
     }
     ref (c) {
         this.menu = c;

--- a/packages/scratch-gui/src/containers/menu.jsx
+++ b/packages/scratch-gui/src/containers/menu.jsx
@@ -11,6 +11,7 @@ class Menu extends React.Component {
             'addListeners',
             'removeListeners',
             'handleClick',
+            'handlePointerUp',
             'ref'
         ]);
     }
@@ -25,48 +26,55 @@ class Menu extends React.Component {
         this.removeListeners();
     }
     addListeners () {
-        // The Blockly workspace suppresses compat events like `mouseup`.
-        // Listen for `pointerup` instead.
-        document.addEventListener('pointerup', this.handleClick);
+        // === Smalruby: Start of iPad menu item click fix ===
+        // Menu item clicks: listen on `click` (bubble) so React's onClick on the
+        // <li> fires first. iPadOS Safari has a delay between `pointerup` and
+        // `click`; closing the menu in `pointerup` (even via setTimeout(0))
+        // unmounts the <li> before iOS dispatches `click`, so React onClick is
+        // skipped and the file picker never opens (issue: iPad Load from
+        // Computer doing nothing).
+        document.addEventListener('click', this.handleClick);
+        // Outside clicks: keep `pointerup` because the Blockly workspace
+        // suppresses compat events like `click` on workspace interactions.
+        document.addEventListener('pointerup', this.handlePointerUp);
+        // === Smalruby: End of iPad menu item click fix ===
     }
     removeListeners () {
-        document.removeEventListener('pointerup', this.handleClick);
+        // === Smalruby: Start of iPad menu item click fix ===
+        document.removeEventListener('click', this.handleClick);
+        document.removeEventListener('pointerup', this.handlePointerUp);
+        // === Smalruby: End of iPad menu item click fix ===
     }
     handleClick (e) {
-        if (!this.props.open) return;
+        if (!this.props.open || !this.menu) return;
 
-        // Check if clicked element is a menu item (li element within menu)
+        // Check if clicked element is a menu item (li element within menu).
+        // Runs in document bubble phase, after React's synthetic onClick on
+        // the <li> has already fired — so closing the menu here is safe.
         let target = e.target;
         while (target && target !== this.menu) {
             if (target.tagName === 'LI' && this.menu.contains(target)) {
-                // Check if this menu item should close the menu
                 const closeOnClick = target.getAttribute('data-close-on-click');
-                // Default to true if attribute is not set (null)
-                // closeOnClick can be "true" or "false" as a string
                 if (closeOnClick === 'false') {
-                    // Don't close the menu for this item
                     return;
                 }
-                // Clicked on a menu item, close the menu after React event handlers execute
-                // In React 18, document listeners may fire before React synthetic events,
-                // so we need to delay closing the menu to allow MenuItem onClick to execute
-                setTimeout(() => {
-                    this.props.onRequestClose();
-                }, 0);
+                this.props.onRequestClose();
                 return;
             }
             target = target.parentElement;
         }
-
-        // Clicked outside the menu, close it after React event handlers execute
-        // In React 18, document mouseup fires before React synthetic click events,
-        // so delaying here allows the menu button's onClick (toggle) to run first.
-        // If the button's toggle already closed the menu, onRequestClose becomes a no-op.
-        if (!this.menu.contains(e.target)) {
-            setTimeout(() => {
-                this.props.onRequestClose();
-            }, 0);
-        }
+    }
+    handlePointerUp (e) {
+        if (!this.props.open || !this.menu) return;
+        // Inside-menu pointerup is handled by `click` (handleClick) so the
+        // menu item's React onClick gets a chance to run first.
+        if (this.menu.contains(e.target)) return;
+        // Outside-menu close: defer so the menu button's own onClick toggle
+        // can run first. If the button already closed the menu, this becomes
+        // a no-op via the open check.
+        setTimeout(() => {
+            if (this.props.open) this.props.onRequestClose();
+        }, 0);
     }
     ref (c) {
         this.menu = c;


### PR DESCRIPTION
## Summary

- iPadOS Safari で File メニュー項目 (および同じ `<Menu>` container を使う設定メニュー / クラス管理メニュー等) をタップしても何も起きない不具合を修正
- `Menu` container の `pointerup` + `setTimeout(0) close` で `<li>` が click 発火前に unmount されることが原因。メニュー項目クリックは `click` (bubble phase)、メニュー外クリックは `pointerup` で受ける 2 系統リスナに変更
- File メニュー全項目 (新規 / コンピュータから読み込む / コンピュータに保存 / Scratch から読み込む / Google ドライブから読み込む / Google ドライブに保存) を一律に解消する想定

Closes #667

## 原因と修正方針

iPad 実機 (Safari Web Inspector) に probe を仕込んで確認した結果:

- メニュー項目 `<li>` をタップすると `pointerup` は発火するが **`click` が発火しない**
- user gesture 経由で `<input type=file>.click()` を直接叩くと picker は問題なく開く (display:none 含む)
- 真因: `Menu.handleClick` が `pointerup` リスナで `setTimeout(0)` 経由で `onRequestClose` を呼ぶため、iPadOS Safari の `pointerup` → `click` 発火遅延中に `<li>` が unmount され、click イベント自体が発火しなくなる

修正: メニュー項目クリックは document の `click` (bubble phase) で受ける。React の onClick は document より先に走るため、`onClick` 発火を保証してから `onRequestClose` を呼べる。メニュー外クリックは Blockly workspace の `click` suppression に対応するため `pointerup` のままにする。

## 影響範囲

`Menu` container (`src/containers/menu.jsx`) を使うすべてのドロップダウンメニュー:

- File メニュー (新規 / 保存 / リミックス / コンピュータ読み込み・保存 / Scratch から / Google ドライブ系)
- 編集メニュー (元に戻す / ターボモード / Ruby 生成 等)
- 設定 (⚙) メニュー (クラス管理 等)
- 言語メニュー / About メニュー

スプライト/コスチューム/サウンド追加の **アップロードボタン** は `action-menu` の `<button>` 内 `<input type=file>` 経由で `Menu` container を通らないため影響なし (実機でも正常動作を確認済み)。

## Test plan

- [x] lint pass (`npm run lint`)
- [ ] CI green
- [ ] iPad 実機 (PR プレビュー URL) で:
  - [ ] ファイル → コンピュータから読み込む → ファイル picker が出る (本命)
  - [ ] ファイル → コンピュータに保存 → ダウンロード開始
  - [ ] ファイル → Google ドライブから読み込む → Google Picker が開く
  - [ ] ファイル → 新規 / コピーを保存 / Scratch から読み込む / Google ドライブに保存 が反応する
  - [ ] 編集メニューの各項目 (ターボモード等) が反応する
  - [ ] 設定 (⚙) メニュー → クラス管理 が反応する
  - [ ] メニュー外 (Blockly workspace 上) をタップしてメニューが閉じる (リグレッション無し)
- [ ] PC (Chrome) で従来通り動作 (リグレッション無し)

## Risks

- **コンピュータに保存** は `SB3Downloader.downloadProject` の `async/await` chain 経由で `<a download>.click()` を呼ぶ。本修正で onClick は発火するが gesture が切れる可能性あり (iPad Safari は `<a download>` に寛容なので動くはず、要実機確認)
- **Google ドライブから読み込む** は `googleDriveAPI.showPicker(...)` 内部で `window.open` がどう呼ばれるかに依存。要実機確認
