### PR TITLE
fix(google-drive): pre-initialize API on mount to fix iPad OAuth popup

### DIFF
--- a/packages/scratch-gui/src/containers/google-drive-loader-hoc.jsx
+++ b/packages/scratch-gui/src/containers/google-drive-loader-hoc.jsx
@@ -62,6 +62,21 @@ const GoogleDriveLoaderHOC = function (WrappedComponent) {
             ]);
         }
 
+        componentDidMount() {
+            // Eagerly initialize Google Drive API on mount so that the user
+            // click that opens the picker doesn't have to await script loads
+            // and gapi/GIS init. On iOS Safari those awaits consume the user
+            // gesture, causing the OAuth popup that GIS opens during
+            // tokenClient.requestAccessToken() to be blocked. Pre-initializing
+            // means showPicker can call tokenClient.requestAccessToken()
+            // synchronously inside the click handler's call stack.
+            if (googleDriveAPI.constructor.isConfigured()) {
+                googleDriveAPI.initialize().catch((error) => {
+                    log.warn('Google Drive API pre-initialization failed; will retry on user click:', error);
+                });
+            }
+        }
+
         componentDidUpdate(prevProps) {
             if (this.props.isLoadingUpload && !prevProps.isLoadingUpload) {
                 this.handleFinishedLoadingUpload();


### PR DESCRIPTION
## Summary

- iPad Safari で「ファイル → Google ドライブから読み込む」を選択すると OAuth popup がブラウザにブロックされる不具合を修正
- `GoogleDriveLoaderHOC` の `componentDidMount` で `googleDriveAPI.initialize()` を eager に呼び出し、アプリマウント時に gapi / GIS スクリプトと token client の初期化を済ませておく
- これにより `showPicker()` 初回呼び出し時の await チェーンが消え、`tokenClient.requestAccessToken()` が user gesture stack 内で同期的に popup を開ける

Closes #669

## 原因

`showPicker()` 初回呼び出しの内部フロー:

```js
async showPicker(...) {
    if (!this.isInitialized) {
        await this.initialize();   // gapi/GIS load + 数段の await — user gesture 消費
    }
    const token = await this.requestAccessToken();
    // ↑ Promise executor 内で tokenClient.requestAccessToken() が popup を開こうとするが
    //   既に user gesture が消費されているため iOS Safari の popup blocker で拒否
}
```

iPad 実機ログ:
```
[GSI_LOGGER]: Failed to open popup window on url: https://accounts.google.com/o/oauth2/v2/auth?...
&display=popup&response_mode=form_post. Maybe blocked by the browser?
```

## 修正

`GoogleDriveLoaderHOC.componentDidMount` で `googleDriveAPI.initialize()` を呼び出す。idempotent なので 2 回目以降は短絡される。

ユーザーがメニュー項目をタップした時点では `isInitialized === true` なので、`showPicker` は同期で `await this.requestAccessToken()` に到達する。`requestAccessToken()` が返す Promise の executor は同期実行されるため、`tokenClient.requestAccessToken()` の呼び出しは React onClick の同期スタック内で行われ、user gesture は保持される。

## Test plan

- [x] lint pass
- [ ] CI green
- [ ] iPad 実機 (PR プレビュー URL) で:
  - [ ] ファイル → Google ドライブから読み込む → OAuth popup / 認可ダイアログが表示される
  - [ ] 認証後、Google Picker が表示されてファイルが選べる
  - [ ] ファイル → Google ドライブに保存 (新規保存) も同様に動く (saver 側も同じ singleton 経由)
- [ ] PC (Chrome) でも従来通り動作 (リグレッション無し)

## Risks

- マウント時に gapi / GIS のスクリプト (https://apis.google.com/js/api.js, https://accounts.google.com/gsi/client) を読み込むため、初回ロードのネットワーク帯域がわずかに増える。ただしどちらも軽量 (各 50KB 程度)、かつ HTTP cache が効くので 2 回目以降は影響なし
- `googleDriveAPI.initialize()` が configured 環境でないと早期 return するが、念のため `isConfigured()` チェックを入れて非 configured 環境では動かない
- 並行呼び出しの race condition (componentDidMount の pre-init が完了する前にユーザーがクリック) は理論上残るが、実用上はネットワーク遅延 + ユーザー操作タイミングを考えると無視できる
