### PR TITLE
fix(mobile): flip popup side when viewport overflows (#671)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -92,6 +92,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/containers/controls.jsx` | block_run analytics | 緑旗クリック時に GA4 イベントを発火 (issue #645 Phase 1) |
 | `src/containers/connection-modal.jsx` | mesh_v2/smalrubot_s1 connect analytics | 接続成功時に拡張別カテゴリ (`mesh_v2` / `smalrubot_s1`) で GA4 イベントを発火 (issue #645 Phase 1) |
 | `src/containers/connection-modal.jsx` | mesh_v2/smalrubot_s1 disconnect analytics | 切断時に拡張別カテゴリで GA4 イベントを発火 (issue #645 Phase 1) |
+| `src/lib/calculatePopupPosition.js` | viewport-aware popup flip | LEFT/RIGHT 配置で配置側にポップアップが収まらない場合、反対側にフリップする (issue #671: SP モードのスプライト削除確認ポップアップが画面外で押せない問題への対策) |
 | `src/containers/menu.jsx` | iPad menu item click fix | メニュー項目クリック時の `setTimeout` 遅延を 0 → 100ms に拡大。iPadOS Safari は `pointerup` から `click` 発火まで ~16–32ms 程度のラグがあり、setTimeout(0) で close すると `<li>` が click 発火前に unmount され React onClick が skip される問題への対応 |
 
 ## 関連ファイル

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -229,6 +229,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/lib/blockly-private-api.test.js`
 - `test/unit/lib/blocks-gesture-recovery.test.js`
 - `test/unit/lib/blocks-screenshot.test.js`
+- `test/unit/lib/calculate-popup-position.test.js`
 - `test/unit/lib/furigana-annotator-perf.test.js`
 - `test/unit/lib/furigana-annotator.test.js`
 - `test/unit/lib/google-drive-api.test.js`

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -230,6 +230,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/lib/blocks-gesture-recovery.test.js`
 - `test/unit/lib/blocks-screenshot.test.js`
 - `test/unit/lib/calculate-popup-position.test.js`
+- `test/unit/lib/calculate-popup-position-regression.test.js`
 - `test/unit/lib/furigana-annotator-perf.test.js`
 - `test/unit/lib/furigana-annotator.test.js`
 - `test/unit/lib/google-drive-api.test.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -306,6 +306,7 @@ test/unit/lib/*
 !test/unit/lib/blockly-private-api.test.js
 !test/unit/lib/blocks-gesture-recovery.test.js
 !test/unit/lib/blocks-screenshot.test.js
+!test/unit/lib/calculate-popup-position.test.js
 !test/unit/lib/furigana-annotator-perf.test.js
 !test/unit/lib/furigana-annotator.test.js
 !test/unit/lib/google-drive-api.test.js

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -307,6 +307,7 @@ test/unit/lib/*
 !test/unit/lib/blocks-gesture-recovery.test.js
 !test/unit/lib/blocks-screenshot.test.js
 !test/unit/lib/calculate-popup-position.test.js
+!test/unit/lib/calculate-popup-position-regression.test.js
 !test/unit/lib/furigana-annotator-perf.test.js
 !test/unit/lib/furigana-annotator.test.js
 !test/unit/lib/google-drive-api.test.js

--- a/packages/scratch-gui/src/lib/calculatePopupPosition.js
+++ b/packages/scratch-gui/src/lib/calculatePopupPosition.js
@@ -13,10 +13,43 @@ export const PopupAlign = {
     CENTER: 'center'
 };
 
+// === Smalruby: Start of viewport-aware popup flip ===
+// LEFT/RIGHT 配置で配置側にポップアップ幅 + spaceForArrow が収まらない場合は反対側にフリップする。
+// MobileSpritePanel など狭幅レイアウトで、左端列のスプライト削除確認ポップアップが
+// 画面外にはみ出して押せない問題への対策 (issue #671)。
+const getViewportWidth = () => {
+    if (typeof window === 'undefined') return Infinity;
+    if (window.visualViewport && typeof window.visualViewport.width === 'number') {
+        return window.visualViewport.width;
+    }
+    return window.innerWidth;
+};
+
+const flipSideIfOverflow = (side, targetRect, popupWidth, spaceForArrow) => {
+    const required = popupWidth + spaceForArrow;
+    if (side === PopupSide.LEFT) {
+        if (targetRect.left < required) {
+            const viewportWidth = getViewportWidth();
+            if (viewportWidth - targetRect.right >= required) {
+                return PopupSide.RIGHT;
+            }
+        }
+    } else if (side === PopupSide.RIGHT) {
+        const viewportWidth = getViewportWidth();
+        if (viewportWidth - targetRect.right < required) {
+            if (targetRect.left >= required) {
+                return PopupSide.LEFT;
+            }
+        }
+    }
+    return side;
+};
+// === Smalruby: End of viewport-aware popup flip ===
+
 const calculatePopupPosition = ({
     relativeElementRef,
     popupRef,
-    side,
+    side: requestedSide,
     align = PopupAlign.CENTER,
     popupWidth,
     spaceForArrow,
@@ -32,6 +65,10 @@ const calculatePopupPosition = ({
 
     const modalHeight = popupRef.current.getBoundingClientRect().height;
     const targetRect = el.getBoundingClientRect();
+
+    // === Smalruby: Start of viewport-aware popup flip ===
+    const side = flipSideIfOverflow(requestedSide, targetRect, popupWidth, spaceForArrow);
+    // === Smalruby: End of viewport-aware popup flip ===
 
     let top = 0;
     let left = 0;

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -1,6 +1,8 @@
 export default {
     'gui.modal.reload': 'さいよみこみ',
     'gui.modal.stop': 'ちゅうし',
+    'gui.confirmationPrompt.confirm': 'はい',
+    'gui.confirmationPrompt.cancel': 'いいえ',
     'gui.menuBar.loadFromUrl': 'Scratchからよみこむ',
     'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.rubyVersion': 'ルビー',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -1,6 +1,8 @@
 export default {
     'gui.modal.reload': '再読み込み',
     'gui.modal.stop': '中止',
+    'gui.confirmationPrompt.confirm': 'はい',
+    'gui.confirmationPrompt.cancel': 'いいえ',
     'gui.menuBar.loadFromUrl': 'Scratchから読み込む',
     'gui.menuBar.colorMode': 'カラーモード',
     'gui.menuBar.rubyVersion': 'ルビー',

--- a/packages/scratch-gui/test/unit/lib/calculate-popup-position-regression.test.js
+++ b/packages/scratch-gui/test/unit/lib/calculate-popup-position-regression.test.js
@@ -1,0 +1,143 @@
+/**
+ * Regression test for issue #671:
+ * SP モード (MobileSpritePanel) でスプライト 2 個の状態で 1 個目を削除しようとした際、
+ * 削除確認ポップアップの「はい」ボタンが画面左端で見切れて押せない問題への
+ * リグレッション検出。
+ *
+ * delete-confirmation-prompt.jsx の layoutConfig (modalWidth: 290, spaceForArrow: 30)
+ * と sprite-list.jsx の deleteConfirmationModalPosition='left' を使い、
+ * - SP viewport (844px) + 左端のスプライト → ポップアップが画面内に収まること
+ * - desktop viewport (1280px) + 右ペインのスプライト → 従来通り左側 (リグレッションなし)
+ * を検証する。
+ */
+import calculatePopupPosition, { PopupSide, PopupAlign } from '../../../src/lib/calculatePopupPosition.js';
+
+// delete-confirmation-prompt.jsx と同じ値
+const deleteConfirmationLayout = {
+    popupWidth: 290,
+    spaceForArrow: 30,
+    counterOffset: 0,
+    arrowOffsetFromBottom: 2,
+    arrowHeight: 14,
+    arrowWidth: 25,
+};
+
+const makeRefs = ({ targetRect, popupHeight = 220 }) => ({
+    relativeElementRef: {
+        current: {
+            getBoundingClientRect: () => ({
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                width: 0,
+                height: 0,
+                ...targetRect,
+            }),
+        },
+    },
+    popupRef: {
+        current: {
+            getBoundingClientRect: () => ({
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                width: 0,
+                height: popupHeight,
+            }),
+        },
+    },
+});
+
+describe('Regression: issue #671 sprite delete popup off-screen', () => {
+    afterEach(() => {
+        delete window.visualViewport;
+        window.innerWidth = 1024;
+        window.innerHeight = 768;
+    });
+
+    test('SP viewport (844x390): popup for leftmost sprite stays within viewport', () => {
+        // MobileSpritePanel は左サイドレール (56px) の右隣からビューポート右端まで。
+        // sprite-list の左端列に並ぶ最初のスプライト (約 80px 幅) は left ~= 70px 付近に置かれる。
+        window.innerWidth = 844;
+        window.innerHeight = 390;
+
+        const refs = makeRefs({
+            targetRect: { top: 100, left: 70, right: 150, bottom: 180, width: 80, height: 80 },
+        });
+
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...deleteConfirmationLayout,
+        });
+
+        // ポップアップの左端 (left) と右端 (left + popupWidth) が画面内に収まること
+        expect(left).toBeGreaterThanOrEqual(0);
+        expect(left + deleteConfirmationLayout.popupWidth).toBeLessThanOrEqual(844);
+    });
+
+    test('SP viewport (844x390): popup for last remaining sprite stays within viewport', () => {
+        // 最後の 1 個 (スプライト 1 個のみ) でも左端列に置かれる
+        window.innerWidth = 844;
+        window.innerHeight = 390;
+
+        const refs = makeRefs({
+            targetRect: { top: 60, left: 70, right: 150, bottom: 140, width: 80, height: 80 },
+        });
+
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...deleteConfirmationLayout,
+        });
+
+        expect(left).toBeGreaterThanOrEqual(0);
+        expect(left + deleteConfirmationLayout.popupWidth).toBeLessThanOrEqual(844);
+    });
+
+    test('Desktop viewport (1280x800): popup for sprite in right pane stays on the left side (no regression)', () => {
+        // upstream desktop GUI の右ペイン (sprite-selector) は画面右側にある。
+        // 削除確認ポップアップは従来通り左側に表示されることを確認。
+        window.innerWidth = 1280;
+        window.innerHeight = 800;
+
+        const refs = makeRefs({
+            targetRect: { top: 600, left: 1050, right: 1130, bottom: 680, width: 80, height: 80 },
+        });
+
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...deleteConfirmationLayout,
+        });
+
+        // LEFT 配置: 1050 - 290 - 30 = 730 (画面内、左側)
+        expect(left).toBe(730);
+    });
+
+    test('iPad portrait (768x1024): popup for sprite in right pane stays on the left side (no regression)', () => {
+        // iPad portrait は narrow desktop CSS で右ペインが圧縮されるが、
+        // sprite-selector は引き続き右側にあるため LEFT 配置が画面内に収まる。
+        window.innerWidth = 768;
+        window.innerHeight = 1024;
+
+        const refs = makeRefs({
+            targetRect: { top: 800, left: 600, right: 680, bottom: 880, width: 80, height: 80 },
+        });
+
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...deleteConfirmationLayout,
+        });
+
+        // LEFT 配置: 600 - 290 - 30 = 280 (画面内、左側)
+        expect(left).toBe(280);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/calculate-popup-position.test.js
+++ b/packages/scratch-gui/test/unit/lib/calculate-popup-position.test.js
@@ -1,0 +1,218 @@
+import calculatePopupPosition, { PopupSide, PopupAlign } from '../../../src/lib/calculatePopupPosition.js';
+
+const makeRefs = ({ targetRect, popupHeight = 200 }) => ({
+    relativeElementRef: {
+        current: {
+            getBoundingClientRect: () => ({
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                width: 0,
+                height: 0,
+                ...targetRect,
+            }),
+        },
+    },
+    popupRef: {
+        current: {
+            getBoundingClientRect: () => ({
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                width: 0,
+                height: popupHeight,
+            }),
+        },
+    },
+});
+
+const defaultLayout = {
+    popupWidth: 290,
+    spaceForArrow: 30,
+    arrowHeight: 14,
+    arrowWidth: 25,
+    arrowOffsetFromBottom: 2,
+    counterOffset: 0,
+};
+
+const setViewport = (width, height = 800) => {
+    window.innerWidth = width;
+    window.innerHeight = height;
+    delete window.visualViewport;
+};
+
+describe('calculatePopupPosition viewport-aware flip', () => {
+    afterEach(() => {
+        setViewport(1024, 768);
+    });
+
+    test('LEFT keeps LEFT placement when there is enough space on the left', () => {
+        setViewport(1024);
+        const refs = makeRefs({
+            targetRect: {
+                top: 100,
+                left: 600,
+                right: 660,
+                bottom: 160,
+                width: 60,
+                height: 60,
+            },
+        });
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...defaultLayout,
+        });
+        // LEFT placement: targetRect.left - popupWidth - spaceForArrow = 600 - 290 - 30 = 280
+        expect(left).toBe(280);
+    });
+
+    test('LEFT flips to RIGHT when there is not enough space on the left (mobile sprite panel case)', () => {
+        // Simulate MobileSpritePanel: viewport width 844, sprite at left ~70px
+        setViewport(844);
+        const refs = makeRefs({
+            targetRect: {
+                top: 100,
+                left: 70,
+                right: 130,
+                bottom: 160,
+                width: 60,
+                height: 60,
+            },
+        });
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...defaultLayout,
+        });
+        // Flipped to RIGHT: targetRect.right + spaceForArrow = 130 + 30 = 160
+        expect(left).toBe(160);
+    });
+
+    test('RIGHT flips to LEFT when there is not enough space on the right', () => {
+        setViewport(844);
+        const refs = makeRefs({
+            targetRect: {
+                top: 100,
+                left: 700,
+                right: 760,
+                bottom: 160,
+                width: 60,
+                height: 60,
+            },
+        });
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.RIGHT,
+            align: PopupAlign.CENTER,
+            ...defaultLayout,
+        });
+        // Flipped to LEFT: 700 - 290 - 30 = 380
+        expect(left).toBe(380);
+    });
+
+    test('LEFT stays LEFT when neither side has enough space (prefer original)', () => {
+        setViewport(400);
+        const refs = makeRefs({
+            targetRect: {
+                top: 100,
+                left: 50,
+                right: 110,
+                bottom: 160,
+                width: 60,
+                height: 60,
+            },
+        });
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...defaultLayout,
+        });
+        // Stays LEFT: 50 - 290 - 30 = -270
+        expect(left).toBe(-270);
+    });
+
+    test('arrow position is recalculated for the flipped side', () => {
+        setViewport(844);
+        const refs = makeRefs({
+            targetRect: {
+                top: 100,
+                left: 70,
+                right: 130,
+                bottom: 160,
+                width: 60,
+                height: 60,
+            },
+        });
+        const { arrowLeft } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...defaultLayout,
+        });
+        // Flipped to RIGHT: arrowLeft = targetRect.right + spaceForArrow - arrowWidth + arrowOffsetFromBottom
+        // = 130 + 30 - 25 + 2 = 137
+        expect(arrowLeft).toBe(137);
+    });
+
+    test('UP/DOWN placements are unaffected by horizontal viewport', () => {
+        setViewport(844);
+        const refs = makeRefs({
+            targetRect: {
+                top: 100,
+                left: 70,
+                right: 130,
+                bottom: 160,
+                width: 60,
+                height: 60,
+            },
+            popupHeight: 200,
+        });
+        const { top } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.DOWN,
+            align: PopupAlign.CENTER,
+            ...defaultLayout,
+        });
+        // DOWN: targetRect.bottom + spaceForArrow = 160 + 30 = 190
+        expect(top).toBe(190);
+    });
+
+    test('uses visualViewport.width when available', () => {
+        window.innerWidth = 9999;
+        window.visualViewport = { width: 844, height: 800 };
+        const refs = makeRefs({
+            targetRect: {
+                top: 100,
+                left: 70,
+                right: 130,
+                bottom: 160,
+                width: 60,
+                height: 60,
+            },
+        });
+        const { left } = calculatePopupPosition({
+            ...refs,
+            side: PopupSide.LEFT,
+            align: PopupAlign.CENTER,
+            ...defaultLayout,
+        });
+        // Flips to RIGHT because visualViewport indicates narrow width
+        expect(left).toBe(160);
+    });
+
+    test('returns empty object when refs are missing', () => {
+        const result = calculatePopupPosition({
+            relativeElementRef: { current: null },
+            popupRef: { current: null },
+            side: PopupSide.LEFT,
+            ...defaultLayout,
+        });
+        expect(result).toEqual({});
+    });
+});


### PR DESCRIPTION
## Summary

Fix #671 — SP モードでスプライトを 2 個まで減らすと、削除確認ポップアップの「はい」ボタンが画面左端で見切れて押せず、3 個以上に戻さないとスプライトを消せない問題を修正。

`calculatePopupPosition.js` に viewport-aware な自動フリップを追加。LEFT (または RIGHT) 配置でポップアップ幅 + spaceForArrow が確保できない場合、反対側に余裕があればそちらにフリップする。両方収まらない場合は元の側を維持する。

汎用修正のため delete-confirmation-prompt 以外の popup でも自動的に画面外見切れが防止される。

加えて、手動確認中に検出した upstream 由来 `gui.confirmationPrompt.confirm/cancel` の日本語訳欠落 (scratch-l10n 未翻訳) を `ja.js` / `ja-Hira.js` に追加。

## Implementation Steps

- [x] Phase 1: フリップロジック追加 + ユニットテスト
  - [x] [RED] calculate-popup-position.test.js (8 tests) を作成し失敗確認
  - [x] [GREEN] calculatePopupPosition.js に flipSideIfOverflow を追加 (Smalruby マーカーで囲む)
  - [x] [PASS] lint pass + 8/8 unit tests pass
  - [x] [COMMIT & PUSH]
- [x] Phase 2: Integration テスト (リグレッション検出) + 日本語訳追加
  - [x] regression test 追加 (4 tests, SP / iPad portrait / desktop)
  - [x] gui.confirmationPrompt.{confirm,cancel} の日本語訳を追加
  - [x] [COMMIT & PUSH]
- [ ] Phase DoD: CI 完了待ち + Playwright MCP 確認

## Definition of Done

- [x] ユニットテスト pass (calculate-popup-position{,-regression}.test.js: 12/12)
- [x] Integration テスト pass (regression test 含む)
- [x] lint pass
- [ ] CI green
- [x] ブラウザ確認 (ローカル):
  - [x] SP viewport でスプライト 2 個 → 左端のスプライト × ボタン → ポップアップが画面内に表示・「はい」が押せる
  - [x] 動作問題なしをユーザー確認済み
- [ ] CI が green になり次第マージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
