### PR TITLE
fix(mobile): improve Android soft-keyboard behavior in Ruby tab

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -70,6 +70,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/lib/blocks.js` | comment icon patch | ScratchCommentIcon.fireCreateEvent をオーバーライドして create 後に block_comment_change を re-fire (Blockly v12 の create payload に text が含まれない問題のフォロー) |
 | `src/lib/blocks.js` | auto style selected patch import | auto_<hex>_selected スタイル登録パッチの import |
 | `src/lib/blocks.js` | auto style selected patch | ConstantProvider.getBlockStyle をラップして `auto_<hex>_selected` を要求された際に on-the-fly で selected variant を登録 (Mesh sensor value のような defaultExtensionColors を使う shadow ドロップダウンを開くと "Invalid colour" で止まる問題の修正) |
+| `src/playground/index.ejs` | interactive-widget viewport for Android keyboard | meta viewport に `interactive-widget=resizes-content` を追加。Android Chrome 108+ でキーボード出現時に layout viewport が縮み、`100dvh` 等の dvh 系単位が追従するようになる |
 | `src/playground/render-gui.jsx` | URL params for Playwright | URL パラメーター import |
 | `src/playground/render-gui.jsx` | no_beforeunload URL param | beforeunload 無効化 |
 | `src/playground/render-gui.jsx` | MobileGui dispatcher | ResponsiveGui import + GUI を ResponsiveGui に差し替え (issue #572 Phase 2-A) |

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -1243,6 +1243,11 @@ const RubyTab = (props) => {
                             fixedOverflowWidgets: true,
                             wordBasedSuggestions: 'off',
                             autoIndent: 'full',
+                            // Android Chrome でキーボード出現により親 div の高さが
+                            // 縮んだとき、Monaco を ResizeObserver で自動再レイアウト
+                            // させる。未設定だと内部キャッシュ寸法のままになり、
+                            // キーボードに隠れた領域に caret が残って入力できない。
+                            automaticLayout: true,
                         }}
                         theme="vs"
                         value={dnclMode ? dnclDisplayCode : code}

--- a/packages/scratch-gui/src/playground/index.ejs
+++ b/packages/scratch-gui/src/playground/index.ejs
@@ -12,7 +12,13 @@
     <!-- End Google Tag Manager -->
     <% } %>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%# === Smalruby: Start of interactive-widget viewport for Android keyboard === %>
+    <%# `interactive-widget=resizes-content` を指定すると Android Chrome 108+ で %>
+    <%# ソフトウェアキーボード出現時に layout viewport が縮むようになり、`100dvh` %>
+    <%# などの dynamic viewport unit が正しく追従する。SP モード Ruby tab で %>
+    <%# キーボードが画面の大部分を占拠して入力できない問題への対策。 %>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content">
+    <%# === Smalruby: End of interactive-widget viewport for Android keyboard === %>
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="google" value="notranslate">

--- a/packages/scratch-gui/src/playground/index.ejs
+++ b/packages/scratch-gui/src/playground/index.ejs
@@ -12,13 +12,13 @@
     <!-- End Google Tag Manager -->
     <% } %>
     <meta charset="UTF-8">
-    <%# === Smalruby: Start of interactive-widget viewport for Android keyboard === %>
-    <%# `interactive-widget=resizes-content` を指定すると Android Chrome 108+ で %>
-    <%# ソフトウェアキーボード出現時に layout viewport が縮むようになり、`100dvh` %>
-    <%# などの dynamic viewport unit が正しく追従する。SP モード Ruby tab で %>
-    <%# キーボードが画面の大部分を占拠して入力できない問題への対策。 %>
+    <!-- === Smalruby: Start of interactive-widget viewport for Android keyboard === -->
+    <!-- `interactive-widget=resizes-content` を指定すると Android Chrome 108+ で
+         ソフトウェアキーボード出現時に layout viewport が縮み、`100dvh` などの
+         dynamic viewport unit が追従する。SP モード Ruby tab でキーボードが
+         画面の大部分を占拠して入力できない問題への対策。 -->
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content">
-    <%# === Smalruby: End of interactive-widget viewport for Android keyboard === %>
+    <!-- === Smalruby: End of interactive-widget viewport for Android keyboard === -->
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="google" value="notranslate">


### PR DESCRIPTION
## Summary

Android Chrome の SP モード Ruby タブで、ソフトウェアキーボード出現時に Monaco エディタが画面の大部分を占めるキーボードに隠れてコード入力ができない問題への、最小・標準ベースの対策。

## Changes

1. **`<meta name="viewport">` に `interactive-widget=resizes-content` を追加** (`src/playground/index.ejs`)
   - Android Chrome 108+ でキーボード出現時に layout viewport が縮む
   - 既存の `100dvh` ベースのモバイルレイアウトがキーボードに追従

2. **Monaco Editor `automaticLayout: true`** (`src/containers/ruby-tab.jsx`)
   - 親 div のサイズ変化を ResizeObserver で検知して Monaco が自動再レイアウト
   - 未設定だと内部キャッシュ寸法のままで caret がキーボード裏に隠れる

## なぜこの 2 段階で十分か

- iOS Safari はもともと visual viewport を縮める + キーボードが小さいので、本変更は no-op に近い (副作用なし)
- Android Chrome では Step 1 で `100dvh` が縮み、Step 2 で Monaco が追従することで「標準機能で入力可能」状態になる
- より高度な UI 圧縮 (visualViewport-aware にメニュー隠す等) や Ruby/DNCL 用シンボルクイックバーは、本 PR の効果を実機で確認した上で必要なら別 PR で追加する

## Test Plan

- [x] lint pass
- [x] ruby-tab 関連 unit tests pass (123/123)
- [ ] CI green
- [ ] Android 実機 (Chrome) で SP モード → Ruby タブ → コードエディタにフォーカス → キーボード出現時に Monaco が見える領域に追従して入力できることを確認
- [ ] iOS Safari で SP モード Ruby タブの挙動が従来通り (リグレッションなし)
- [ ] desktop で従来通り (リグレッションなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
