### PR TITLE
refactor(classroom): split classroom-modal container into student / teacher

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -64,6 +64,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/containers/block-display-modal.jsx`
 - `src/containers/classroom-error-utils.js`
 - `src/containers/classroom-modal.jsx`
+- `src/containers/classroom-teacher-modal.jsx`
 - `src/containers/use-google-classroom.js`
 - `src/containers/use-student-submit.js`
 - `src/containers/use-teacher-auth.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -89,6 +89,7 @@ src/containers/*
 !src/containers/block-display-modal.jsx
 !src/containers/classroom-error-utils.js
 !src/containers/classroom-modal.jsx
+!src/containers/classroom-teacher-modal.jsx
 !src/containers/use-google-classroom.js
 !src/containers/use-student-submit.js
 !src/containers/use-teacher-auth.js

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -37,6 +37,7 @@ import SmalrubotFirmwareModal from '../../containers/smalrubot-firmware-modal.js
 // === Smalruby: End of smalrubot firmware modal ===
 // === Smalruby: Start of classroom modal ===
 import ClassroomModal from '../../containers/classroom-modal.jsx';
+import ClassroomTeacherModal from '../../containers/classroom-teacher-modal.jsx';
 // === Smalruby: End of classroom modal ===
 // === Smalruby: Start of meshV2 classroom binding ===
 import MeshV2ClassroomBinding from '../../lib/mesh-v2-classroom-binding.jsx';
@@ -443,12 +444,8 @@ const GUIComponent = props => {
                         <SmalrubotFirmwareModal />
                     ) : null}
                     {/* === Smalruby: Start of classroom modal === */}
-                    {classroomModalVisible ? (
-                        <ClassroomModal mode="student" />
-                    ) : null}
-                    {teacherModalVisible ? (
-                        <ClassroomModal mode="teacher" />
-                    ) : null}
+                    {classroomModalVisible ? <ClassroomModal /> : null}
+                    {teacherModalVisible ? <ClassroomTeacherModal /> : null}
                     {/* === Smalruby: End of classroom modal === */}
                     {/* === Smalruby: Start of meshV2 classroom binding === */}
                     <MeshV2ClassroomBinding />

--- a/packages/scratch-gui/src/containers/classroom-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-modal.jsx
@@ -1,9 +1,7 @@
-import PropTypes from 'prop-types';
 import React, { useCallback, useRef, useState, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import ClassroomModalComponent from '../components/classroom-modal/classroom-modal.jsx';
-import ClassroomTeacherModalComponent from '../components/classroom-teacher-modal/classroom-teacher-modal.jsx';
 import analytics from '../lib/analytics';
 import classroomAPI from '../lib/classroom-api.js';
 import { loadHistory, addToHistory } from '../lib/join-code-history.js';
@@ -11,20 +9,16 @@ import { getUrlParams, clearClasscode } from '../lib/url-params.js';
 import { showAlertWithTimeout } from '../reducers/alerts.js';
 import {
     closeClassroomModal,
-    closeTeacherModal,
     openTeacherModal,
     setClassroomSession,
     clearClassroomSession,
     setSubmissionStatus,
-    setTeacherSelection,
-    clearTeacherSelection,
 } from '../reducers/classroom.js';
 import { setProjectTitle } from '../reducers/project-title.js';
 import translateError from './classroom-error-utils.js';
 import useStudentSubmit from './use-student-submit.js';
-import useTeacherClassroom, { getCachedTeacherIdToken, setCachedTeacherIdToken } from './use-teacher-classroom.js';
 
-const ClassroomModal = ({ mode = 'student' }) => {
+const ClassroomModal = () => {
     const dispatch = useDispatch();
     const intl = useIntl();
     const classroomState = useSelector((state) => state.scratchGui.classroom);
@@ -32,20 +26,8 @@ const ClassroomModal = ({ mode = 'student' }) => {
     const projectTitle = useSelector((state) => state.scratchGui.projectTitle);
     const scratchBlocks = useSelector((state) => state.scratchGui.blockDisplay?.scratchBlocks);
 
-    // Auto-login with dev bypass token from URL (e.g. ?devlogin=<secret>)
-    if (mode === 'teacher') {
-        const urlParams = getUrlParams();
-        if (urlParams.devlogin && !getCachedTeacherIdToken()) {
-            setCachedTeacherIdToken(urlParams.devlogin);
-        }
-    }
-
-    // Determine initial phase based on mode and persisted session
+    // Determine initial phase from persisted session
     const getInitialPhase = () => {
-        if (mode === 'teacher') {
-            if (getCachedTeacherIdToken()) return 'teacher-dashboard';
-            return 'teacher-login';
-        }
         if (classroomState.role === 'student' && classroomState.sessionToken) {
             return 'student-status';
         }
@@ -78,21 +60,6 @@ const ClassroomModal = ({ mode = 'student' }) => {
     const showSessionExpiredErrorRef = useRef(null);
     const stableShowSessionExpiredError = useCallback((...args) => showSessionExpiredErrorRef.current?.(...args), []);
 
-    // Teacher hook (called unconditionally — required for teacher modal rendering)
-    const teacher = useTeacherClassroom({
-        mode,
-        dispatch,
-        intl,
-        phase,
-        setPhase,
-        showError,
-        clearError,
-        showSessionExpiredError: stableShowSessionExpiredError,
-        isLoading,
-        setIsLoading,
-        vm,
-    });
-
     // Student submit hook
     const submit = useStudentSubmit({
         classroomState,
@@ -108,38 +75,12 @@ const ClassroomModal = ({ mode = 'student' }) => {
         setPhase,
     });
 
-    // Go back to login/join screen (used as error action for session expiry)
+    // Go back to join screen (used as error action for session expiry)
     const handleGoToLogin = useCallback(() => {
-        if (mode === 'teacher') {
-            setCachedTeacherIdToken(null);
-            teacher.setIdToken(null);
-            teacher.setClassrooms([]);
-            teacher.setSelectedClassroom(null);
-            teacher.setMembers([]);
-            dispatch(clearTeacherSelection());
-            setPhase('teacher-login');
-        } else {
-            dispatch(clearClassroomSession());
-            clearError();
-            setPhase('student-join');
-        }
-    }, [mode, clearError, dispatch, teacher]);
-
-    // Sync teacher's selectedClassroom into Redux so the Mesh v2 binding
-    // (mesh-v2-classroom-binding.jsx) and the connection modal can react to it.
-    useEffect(() => {
-        if (mode !== 'teacher') return;
-        if (teacher.selectedClassroom && teacher.selectedClassroom.joinCode) {
-            dispatch(
-                setTeacherSelection({
-                    classroomId: teacher.selectedClassroom.classroomId,
-                    joinCode: teacher.selectedClassroom.joinCode,
-                    className: teacher.selectedClassroom.className || teacher.selectedClassroom.name || null,
-                    assignmentName: teacher.selectedClassroom.assignmentName || null,
-                }),
-            );
-        }
-    }, [mode, dispatch, teacher.selectedClassroom]);
+        dispatch(clearClassroomSession());
+        clearError();
+        setPhase('student-join');
+    }, [clearError, dispatch]);
 
     // Handle relogin request from Alert "参加しなおす" button
     useEffect(() => {
@@ -150,23 +91,22 @@ const ClassroomModal = ({ mode = 'student' }) => {
     }, [classroomState.reloginRequested, dispatch, handleGoToLogin]);
 
     const showSessionExpiredError = useCallback(() => {
-        const alertId = mode === 'teacher' ? 'classroomTeacherSessionExpired' : 'classroomSessionExpired';
-        showAlertWithTimeout(dispatch, alertId);
-    }, [dispatch, mode]);
+        showAlertWithTimeout(dispatch, 'classroomSessionExpired');
+    }, [dispatch]);
     showSessionExpiredErrorRef.current = showSessionExpiredError;
 
     const handleClose = useCallback(() => {
-        dispatch(mode === 'teacher' ? closeTeacherModal() : closeClassroomModal());
-    }, [dispatch, mode]);
+        dispatch(closeClassroomModal());
+    }, [dispatch]);
 
-    // --- Student: open teacher management modal ---
+    // --- Open teacher management modal ---
 
     const handleSelectTeacher = useCallback(() => {
         dispatch(closeClassroomModal());
         dispatch(openTeacherModal());
     }, [dispatch]);
 
-    // --- Student: join state ---
+    // --- Join state ---
 
     const [joinCodeHistory, setJoinCodeHistory] = useState(() => loadHistory());
     const [pendingJoinCode, setPendingJoinCode] = useState(null);
@@ -176,7 +116,7 @@ const ClassroomModal = ({ mode = 'student' }) => {
     const [pendingClassroomInfo, setPendingClassroomInfo] = useState(null);
     const [joinedInfo, setJoinedInfo] = useState(null);
 
-    // --- Student: Join with code ---
+    // --- Join with code ---
 
     const handleJoinWithCode = useCallback(
         async (joinCode) => {
@@ -212,7 +152,7 @@ const ClassroomModal = ({ mode = 'student' }) => {
         setSelectedSeat(seatNumber);
     }, []);
 
-    // --- Student: Confirm join ---
+    // --- Confirm join ---
 
     const handleConfirmJoin = useCallback(async () => {
         if (!pendingJoinCode || !selectedSeat) return;
@@ -269,7 +209,7 @@ const ClassroomModal = ({ mode = 'student' }) => {
         }
     }, [dispatch, pendingJoinCode, selectedSeat, pendingClassroomInfo, clearError, showError, intl]);
 
-    // --- Student: Verify session + fetch submission status ---
+    // --- Verify session + fetch submission status ---
 
     const [studentTeacherComment, setStudentTeacherComment] = useState(null);
 
@@ -296,7 +236,7 @@ const ClassroomModal = ({ mode = 'student' }) => {
         }
     }, [phase]); // Only on phase change
 
-    // --- Student: Leave classroom ---
+    // --- Leave classroom ---
 
     const handleLeaveClassroom = useCallback(async () => {
         if (classroomState.sessionToken && classroomState.classroomId) {
@@ -334,67 +274,6 @@ const ClassroomModal = ({ mode = 'student' }) => {
         handleJoinWithCode(code);
     }, []); // Run once on mount
 
-    // --- Teacher modal (separate fullscreen modal) ---
-
-    // Wrap the teacher logout so we also clear teacherSelection from Redux —
-    // the underlying handleTeacherLogout only resets local hook state.
-    const handleTeacherLogoutWithReduxClear = useCallback(() => {
-        dispatch(clearTeacherSelection());
-        teacher.handleTeacherLogout();
-    }, [dispatch, teacher]);
-
-    if (mode === 'teacher') {
-        const teacherContainerProps = {
-            phase,
-            classrooms: teacher.classrooms,
-            selectedClassroom: teacher.selectedClassroom,
-            members: teacher.members,
-            error,
-            errorTitle,
-            errorActionLabel,
-            errorActionHandler,
-            isLoading,
-            selectedMember: teacher.selectedMember,
-            codeDisplayClassroom: teacher.codeDisplayClassroom,
-            codeDisplayFullscreen: teacher.codeDisplayFullscreen,
-            downloadProgress: teacher.downloadProgress,
-            googleCourses: teacher.googleCourses,
-            selectedGoogleCourse: teacher.selectedGoogleCourse,
-            onGoogleLogin: teacher.handleGoogleLogin,
-            onMicrosoftLogin: teacher.handleMicrosoftLogin,
-            isMicrosoftAuthAvailable: teacher.isMicrosoftAuthAvailable,
-            authProvider: teacher.authProvider,
-            onTeacherLogout: handleTeacherLogoutWithReduxClear,
-            onShowCreateForm: teacher.handleShowCreateForm,
-            onCreateClassroom: teacher.handleCreateClassroom,
-            onSelectClassroom: teacher.handleSelectClassroom,
-            onBackToDashboard: teacher.handleBackToDashboard,
-            onDeleteClassroom: teacher.handleDeleteClassroom,
-            onDeleteMember: teacher.handleDeleteMember,
-            onRefreshDetail: teacher.handleRefreshDetail,
-            onSelectMember: teacher.handleSelectMember,
-            onOpenSubmission: teacher.handleOpenSubmission,
-            onReturnSubmission: teacher.handleReturnSubmission,
-            onDownloadAll: teacher.handleDownloadAll,
-            onShowCodeDisplay: teacher.handleShowCodeDisplay,
-            onCloseCodeDisplay: teacher.handleCloseCodeDisplay,
-            onCopyInviteLink: teacher.handleCopyInviteLink,
-            onToggleCodeFullscreen: teacher.handleToggleCodeFullscreen,
-            onShowPostAssignment: teacher.handleShowPostAssignment,
-            onBackToDetail: teacher.handleBackToDetail,
-            onPostAssignment: teacher.handlePostAssignment,
-            onShowGoogleCourses: teacher.handleShowGoogleCourses,
-            onLoadGoogleCourses: teacher.handleLoadGoogleCourses,
-            onSelectGoogleCourse: teacher.handleSelectGoogleCourse,
-            onConfirmGoogleImport: teacher.handleConfirmGoogleImport,
-            onUpdateAssignmentName: teacher.handleUpdateAssignmentName,
-            onUpdateStudentCount: teacher.handleUpdateStudentCount,
-        };
-        return <ClassroomTeacherModalComponent containerProps={teacherContainerProps} onClose={handleClose} />;
-    }
-
-    // --- Student modal ---
-
     return (
         <ClassroomModalComponent
             classroomState={classroomState}
@@ -424,10 +303,6 @@ const ClassroomModal = ({ mode = 'student' }) => {
             onStartSubmit={submit.handleStartSubmit}
         />
     );
-};
-
-ClassroomModal.propTypes = {
-    mode: PropTypes.oneOf(['student', 'teacher']),
 };
 
 export default ClassroomModal;

--- a/packages/scratch-gui/src/containers/classroom-teacher-modal.jsx
+++ b/packages/scratch-gui/src/containers/classroom-teacher-modal.jsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useRef, useState, useEffect } from 'react';
+import { useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import ClassroomTeacherModalComponent from '../components/classroom-teacher-modal/classroom-teacher-modal.jsx';
+import { getUrlParams } from '../lib/url-params.js';
+import { showAlertWithTimeout } from '../reducers/alerts.js';
+import {
+    closeTeacherModal,
+    clearClassroomSession,
+    setTeacherSelection,
+    clearTeacherSelection,
+} from '../reducers/classroom.js';
+import useTeacherClassroom, { getCachedTeacherIdToken, setCachedTeacherIdToken } from './use-teacher-classroom.js';
+
+const TEACHER_MODE = 'teacher';
+
+const ClassroomTeacherModal = () => {
+    const dispatch = useDispatch();
+    const intl = useIntl();
+    const classroomState = useSelector((state) => state.scratchGui.classroom);
+    const vm = useSelector((state) => state.scratchGui.vm);
+
+    // Auto-login with dev bypass token from URL (e.g. ?devlogin=<secret>)
+    const urlParams = getUrlParams();
+    if (urlParams.devlogin && !getCachedTeacherIdToken()) {
+        setCachedTeacherIdToken(urlParams.devlogin);
+    }
+
+    // Determine initial phase from cached idToken
+    const getInitialPhase = () => (getCachedTeacherIdToken() ? 'teacher-dashboard' : 'teacher-login');
+
+    // UI state
+    const [phase, setPhase] = useState(getInitialPhase);
+    const [error, setError] = useState(null);
+    const [errorTitle, setErrorTitle] = useState(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [errorActionLabel, setErrorActionLabel] = useState(null);
+    const [errorActionHandler, setErrorActionHandler] = useState(null);
+
+    const showError = useCallback((message, title = null) => {
+        setError(message);
+        setErrorTitle(title);
+        setErrorActionLabel(null);
+        setErrorActionHandler(null);
+    }, []);
+
+    const clearError = useCallback(() => {
+        setError(null);
+        setErrorTitle(null);
+        setErrorActionLabel(null);
+        setErrorActionHandler(null);
+    }, []);
+
+    // Ref-based wrapper for showSessionExpiredError to break circular dependency
+    const showSessionExpiredErrorRef = useRef(null);
+    const stableShowSessionExpiredError = useCallback((...args) => showSessionExpiredErrorRef.current?.(...args), []);
+
+    const teacher = useTeacherClassroom({
+        mode: TEACHER_MODE,
+        dispatch,
+        intl,
+        phase,
+        setPhase,
+        showError,
+        clearError,
+        showSessionExpiredError: stableShowSessionExpiredError,
+        isLoading,
+        setIsLoading,
+        vm,
+    });
+
+    // Go back to login screen (used as error action for session expiry)
+    const handleGoToLogin = useCallback(() => {
+        setCachedTeacherIdToken(null);
+        teacher.setIdToken(null);
+        teacher.setClassrooms([]);
+        teacher.setSelectedClassroom(null);
+        teacher.setMembers([]);
+        dispatch(clearTeacherSelection());
+        setPhase('teacher-login');
+    }, [dispatch, teacher]);
+
+    // Sync teacher's selectedClassroom into Redux so the Mesh v2 binding
+    // (mesh-v2-classroom-binding.jsx) and the connection modal can react to it.
+    useEffect(() => {
+        if (teacher.selectedClassroom && teacher.selectedClassroom.joinCode) {
+            dispatch(
+                setTeacherSelection({
+                    classroomId: teacher.selectedClassroom.classroomId,
+                    joinCode: teacher.selectedClassroom.joinCode,
+                    className: teacher.selectedClassroom.className || teacher.selectedClassroom.name || null,
+                    assignmentName: teacher.selectedClassroom.assignmentName || null,
+                }),
+            );
+        }
+    }, [dispatch, teacher.selectedClassroom]);
+
+    // Handle relogin request from Alert "参加しなおす" button
+    useEffect(() => {
+        if (classroomState.reloginRequested) {
+            dispatch(clearClassroomSession());
+            handleGoToLogin();
+        }
+    }, [classroomState.reloginRequested, dispatch, handleGoToLogin]);
+
+    const showSessionExpiredError = useCallback(() => {
+        showAlertWithTimeout(dispatch, 'classroomTeacherSessionExpired');
+    }, [dispatch]);
+    showSessionExpiredErrorRef.current = showSessionExpiredError;
+
+    const handleClose = useCallback(() => {
+        dispatch(closeTeacherModal());
+    }, [dispatch]);
+
+    // Wrap the teacher logout so we also clear teacherSelection from Redux —
+    // the underlying handleTeacherLogout only resets local hook state.
+    const handleTeacherLogoutWithReduxClear = useCallback(() => {
+        dispatch(clearTeacherSelection());
+        teacher.handleTeacherLogout();
+    }, [dispatch, teacher]);
+
+    const teacherContainerProps = {
+        phase,
+        classrooms: teacher.classrooms,
+        selectedClassroom: teacher.selectedClassroom,
+        members: teacher.members,
+        error,
+        errorTitle,
+        errorActionLabel,
+        errorActionHandler,
+        isLoading,
+        selectedMember: teacher.selectedMember,
+        codeDisplayClassroom: teacher.codeDisplayClassroom,
+        codeDisplayFullscreen: teacher.codeDisplayFullscreen,
+        downloadProgress: teacher.downloadProgress,
+        googleCourses: teacher.googleCourses,
+        selectedGoogleCourse: teacher.selectedGoogleCourse,
+        onGoogleLogin: teacher.handleGoogleLogin,
+        onMicrosoftLogin: teacher.handleMicrosoftLogin,
+        isMicrosoftAuthAvailable: teacher.isMicrosoftAuthAvailable,
+        authProvider: teacher.authProvider,
+        onTeacherLogout: handleTeacherLogoutWithReduxClear,
+        onShowCreateForm: teacher.handleShowCreateForm,
+        onCreateClassroom: teacher.handleCreateClassroom,
+        onSelectClassroom: teacher.handleSelectClassroom,
+        onBackToDashboard: teacher.handleBackToDashboard,
+        onDeleteClassroom: teacher.handleDeleteClassroom,
+        onDeleteMember: teacher.handleDeleteMember,
+        onRefreshDetail: teacher.handleRefreshDetail,
+        onSelectMember: teacher.handleSelectMember,
+        onOpenSubmission: teacher.handleOpenSubmission,
+        onReturnSubmission: teacher.handleReturnSubmission,
+        onDownloadAll: teacher.handleDownloadAll,
+        onShowCodeDisplay: teacher.handleShowCodeDisplay,
+        onCloseCodeDisplay: teacher.handleCloseCodeDisplay,
+        onCopyInviteLink: teacher.handleCopyInviteLink,
+        onToggleCodeFullscreen: teacher.handleToggleCodeFullscreen,
+        onShowPostAssignment: teacher.handleShowPostAssignment,
+        onBackToDetail: teacher.handleBackToDetail,
+        onPostAssignment: teacher.handlePostAssignment,
+        onShowGoogleCourses: teacher.handleShowGoogleCourses,
+        onLoadGoogleCourses: teacher.handleLoadGoogleCourses,
+        onSelectGoogleCourse: teacher.handleSelectGoogleCourse,
+        onConfirmGoogleImport: teacher.handleConfirmGoogleImport,
+        onUpdateAssignmentName: teacher.handleUpdateAssignmentName,
+        onUpdateStudentCount: teacher.handleUpdateStudentCount,
+    };
+    return <ClassroomTeacherModalComponent containerProps={teacherContainerProps} onClose={handleClose} />;
+};
+
+export default ClassroomTeacherModal;


### PR DESCRIPTION
## Summary

`containers/classroom-modal.jsx` を生徒モーダル専用に絞り、教師（クラス管理）モーダル用の新コンテナ `containers/classroom-teacher-modal.jsx` を作成しました。`mode` prop 分岐を全削除します。

## Changes

- `containers/classroom-modal.jsx`: 生徒専用化 (308 行)。`useTeacherClassroom` フック呼び出し・教師ハンドラー・`teacher-*` フェーズ分岐を削除
- `containers/classroom-teacher-modal.jsx`: **新規** (171 行)。教師専用のフック・ハンドラー・状態管理
- `components/gui/gui.jsx`: `<ClassroomModal mode="student"/>` `<ClassroomModal mode="teacher"/>` → `<ClassroomModal/>` `<ClassroomTeacherModal/>` に差し替え
- `.prettierignore` / `smalruby-prettier-files.md`: 新規ファイル登録

## Why

PR #674 のレビューで判明: presentational 層 (`components/classroom-modal/` と `components/classroom-teacher-modal/`) はすでに分かれていたのに、コンテナだけ `mode` 分岐で 1 ファイルに同居していた。結果として:

- 生徒モーダルを開くだけで `useTeacherClassroom` が走る無駄
- `mode === 'teacher'` / `mode !== 'teacher'` の分岐が散らばって読みにくい
- Mesh 連動の追加実装で `mode !== 'teacher'` ガードを書く必要があった

## Behavior

機能挙動・data-testid・state 構造に変更なし。

## Verification

- ✅ Lint (eslint + prettier) zero warnings
- ✅ Unit tests: classroom reducer (15) + mesh-v2 binding (4) = 19 passed
- ✅ E2E (`tools/playwright-verify/mesh-v2-classroom-binding.mjs`): 教師 → クラス作成 → サイドバー選択、生徒 → `?classcode=` 参加、両方の Mesh ドメイン連動 + 解除時の元の値への復元、すべてパス

## Test plan

- [ ] CI: lint, unit, integration が全て green
- [ ] 手動: 生徒として参加コードでクラスに参加できる（提出含む）
- [ ] 手動: 先生としてクラス管理を開きクラス作成→選択→ログアウトできる

closes #675
