### PR TITLE
fix(mobile): fill modal background white to hide overlay gap

### DIFF
--- a/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
+++ b/packages/scratch-gui/src/components/mobile-gui/mobile-gui.css
@@ -371,6 +371,12 @@
     display: flex !important;
     flex-direction: column !important;
     overflow: hidden !important;
+    /*
+     * モーダルコンテンツの背景色を白に設定する。
+     * prompt 等のモーダルはコンテンツ高さが 100dvh より短い場合があり、
+     * 残領域がオーバーレイ (青) を透かして見えてしまうのを防ぐ。
+     */
+    background-color: #ffffff !important;
 }
 
 /*


### PR DESCRIPTION
## Summary

- モバイル (SP) モードでプロンプト系モーダル（変数を作る・変数名を変更・リストを作る・リスト名を変更・新しいメッセージ）を開いたとき、モーダルコンテンツの下部に青いオーバーレイが透けて見える問題を修正

## Changes Made

- `mobile-gui.css`: `modal_modal-content` に `background-color: #ffffff` を追加

### 原因

`modal.css` の `.modal-content` はデフォルトで背景色が未設定（透明）。
モバイルでは `height: 100dvh; position: fixed` でフルスクリーン表示するが、
プロンプト等のコンテンツ高さが `100dvh` より短い場合、下部の余白から
モーダルオーバーレイ（半透明青）が透けて見えていた。

## Test Plan

- [x] iPhone 横向き (667×375) で「変数を作る」モーダルを開き、画面下部に青いオーバーレイが見えないことを確認
- [x] lint pass
- [x] CI (他モーダルへの影響なし)

## Related Issues

Closes #698 (追加修正)
