### PR TITLE
chore(devpod): install aws CLI v2 + headful-capable Playwright verify smoke

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,18 @@ RUN \
     tmux \
     vim
 
+# AWS CLI v2 — needed to deploy the CDK infra projects (infra/*) from inside
+# the container. CDK itself comes from each project's npm devDependencies, but
+# the aws CLI is not an npm package so it is installed here for reproducibility.
+RUN \
+  set -eux \
+  && apt install -y --no-install-recommends unzip \
+  && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip \
+  && unzip -q /tmp/awscliv2.zip -d /tmp \
+  && /tmp/aws/install \
+  && rm -rf /tmp/aws /tmp/awscliv2.zip \
+  && aws --version
+
 # Install Playwright and its dependencies
 RUN npx playwright install chromium --with-deps
 

--- a/tools/playwright-verify/README.md
+++ b/tools/playwright-verify/README.md
@@ -28,6 +28,36 @@ node <script>.mjs
 rm -rf .profiles
 ```
 
+## 目視確認（ホストの Chrome で見ながら動かす）
+
+devpod コンテナは画面を持たない（`DISPLAY` 未設定）ので、コンテナ内で `headless:false`
+にしてもウィンドウは出ない。**ブラウザはホスト（Mac）側で開き、dev サーバはコンテナで動かす**
+構成にする。`/app` はホストのバインドマウントなので、ここのスクリプトはそのままホストにもある。
+
+前提:
+- dev サーバはコンテナ内で起動（`set -a; . ./.env; set +a; SMALRUBY3_HOST=0.0.0.0 PORT=8601 npm start`）
+- `devcontainer.json` の `forwardPorts: [8601]` により **ホストから `localhost:8601` に到達可能**
+  （普段ホストのブラウザでエディタを見ているのと同じ経路）
+
+ホスト（Mac）側で実行:
+
+```bash
+cd <repo>/tools/playwright-verify
+# 初回のみ: ホスト用のブラウザを用意（どちらか）
+#   a) 既存の Google Chrome を使う → 追加インストール不要（CHANNEL=chrome）
+#   b) Playwright 同梱 Chromium を使う → npx playwright install chromium
+
+# 目視モードで実行（実 Chrome ウィンドウが開く・ゆっくり動く・最後まで開いたまま）
+HEADLESS=false CHANNEL=chrome SLOWMO=300 KEEP_OPEN=1 node smoke-teacher-dashboard.mjs
+```
+
+同じスクリプトをコンテナ内では `node smoke-teacher-dashboard.mjs`（headless 既定）で回せる。
+env トグル: `HEADLESS=false` 表示 / `CHANNEL=chrome` 実 Chrome / `SLOWMO=<ms>` 低速 /
+`KEEP_OPEN=1` 終了後も開いたまま / `BASE_URL=...` 接続先上書き。
+
+> メモ: ホスト node が Linux 用に入った `node_modules` を読んで不具合が出たら、ホストで
+> `npm install` し直す（playwright 本体は JS なので通常はそのまま動く。ブラウザバイナリは OS 別キャッシュ）。
+
 ## スクリプト一覧
 
 | ファイル | 検証対象 |

--- a/tools/playwright-verify/smoke-teacher-dashboard.mjs
+++ b/tools/playwright-verify/smoke-teacher-dashboard.mjs
@@ -1,0 +1,108 @@
+// Smoke test: navigate with devlogin, open classroom management, reach the
+// teacher dashboard, screenshot, and exit (does NOT hang).
+//
+// Runs both headless (in the container) and headful (on the host, so you can
+// WATCH it in your own Chrome). Controlled by env vars:
+//
+//   # In the container (my quick checks) — headless, default:
+//   node smoke-teacher-dashboard.mjs
+//
+//   # On the HOST (macOS) — visible Google Chrome window you can watch:
+//   #   port 8601 is already forwarded to the host (devcontainer forwardPorts),
+//   #   so the dev server in the container is reachable at localhost:8601.
+//   HEADLESS=false CHANNEL=chrome SLOWMO=300 node smoke-teacher-dashboard.mjs
+//
+// Env:
+//   HEADLESS=false  -> show the browser window (default true)
+//   CHANNEL=chrome  -> use the installed Google Chrome instead of bundled Chromium
+//   SLOWMO=<ms>     -> slow each action down so it's easy to follow by eye
+//   KEEP_OPEN=1     -> leave the browser open at the end for inspection
+//   BASE_URL=...    -> override http://localhost:8601
+import { chromium } from 'playwright';
+import { readFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const log = (...a) => console.log('[smoke]', ...a);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const ENV_PATH = resolve(REPO_ROOT, '.env');
+const SHOTS = resolve(__dirname, '.screenshots');
+mkdirSync(SHOTS, { recursive: true });
+
+const envText = readFileSync(ENV_PATH, 'utf8');
+const tokenMatch = envText.match(/^DEV_BYPASS_TOKEN=(.+)$/m);
+const DEV_TOKEN = tokenMatch ? tokenMatch[1].trim().replace(/^"|"$/g, '') : null;
+if (!DEV_TOKEN) throw new Error('DEV_BYPASS_TOKEN missing in .env');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8601';
+const TEACHER_URL = `${BASE_URL}/?no_beforeunload=1&devlogin=${encodeURIComponent(DEV_TOKEN)}`;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HEADLESS = process.env.HEADLESS !== 'false';
+const launchOpts = { headless: HEADLESS };
+if (process.env.CHANNEL) launchOpts.channel = process.env.CHANNEL; // e.g. 'chrome'
+if (process.env.SLOWMO) launchOpts.slowMo = Number(process.env.SLOWMO);
+log(`launching browser (headless=${HEADLESS}, channel=${process.env.CHANNEL || 'bundled-chromium'})`);
+
+const browser = await chromium.launch(launchOpts);
+const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+page.on('pageerror', (e) => log('[pageerror]', e.message));
+
+let ok = false;
+try {
+    log('navigating with devlogin...');
+    await page.goto(TEACHER_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[class*="gui_editor-wrapper"]', { timeout: 90000 });
+    await sleep(1500);
+
+    log('opening Settings -> Classroom management...');
+    await page.click('[data-testid="settings-menu"]');
+    await sleep(300);
+    await page.click('[data-testid="settings-classroom-management"]');
+
+    log('waiting for classroom modal (login or dashboard)...');
+    await page.waitForSelector(
+        '[data-testid="classroom-phase-teacher-login"], [data-testid="classroom-create"]',
+        { timeout: 20000 },
+    );
+
+    log('polling for teacher dashboard (devlogin auto-login, up to 60s)...');
+    const deadline = Date.now() + 60000;
+    while (Date.now() < deadline) {
+        if (await page.$('[data-testid="classroom-create"]')) {
+            ok = true;
+            break;
+        }
+        await sleep(1500);
+    }
+
+    const shot = resolve(SHOTS, 'smoke-teacher-dashboard.png');
+    await page.screenshot({ path: shot });
+    log('screenshot saved:', shot);
+
+    if (ok) {
+        const classCount = await page.$$eval(
+            '[data-testid^="classroom-sidebar-item-"]',
+            (els) => els.length,
+        ).catch(() => 0);
+        log(`PASS: teacher dashboard reached. sidebar classes visible: ${classCount}`);
+    } else {
+        const phase = await page
+            .evaluate(() => {
+                const el = document.querySelector('[data-testid^="classroom-phase-"]');
+                return el ? el.getAttribute('data-testid') : '(none)';
+            })
+            .catch(() => '(unknown)');
+        log(`FAIL: dashboard not reached. current phase: ${phase}`);
+    }
+} catch (e) {
+    log('ERROR:', e.message);
+} finally {
+    if (process.env.KEEP_OPEN === '1') {
+        log('KEEP_OPEN=1 set — leaving browser open. Ctrl+C to exit.');
+        await new Promise(() => {});
+    }
+    await browser.close();
+    process.exit(ok ? 0 : 1);
+}


### PR DESCRIPTION
## 概要

devpod 開発ワークフローの再現性向上。

## 変更

- **Dockerfile**: aws CLI v2 を arch-aware で導入。`infra/*` の CDK デプロイをコンテナ内から実行でき、**コンテナ再作成後も手動セットアップ不要**で再現される。CDK は各 infra プロジェクトの npm devDependency 由来なので変更不要、aws CLI のみ npm パッケージでないため Dockerfile で導入。
- **tools/playwright-verify/smoke-teacher-dashboard.mjs**: devlogin で先生ダッシュボードへ到達するスモーク。**コンテナ内 headless / ホストで headful** の両対応（`HEADLESS`/`CHANNEL`/`SLOWMO`/`KEEP_OPEN` env トグル）。ホストの Chrome で目視確認できる。
- **README**: ホスト Chrome での目視手順を追記。

## 動作確認

- aws CLI: コンテナ内で手動導入版が `aws-cli/2.34.58` で動作（本 PR はそれを Dockerfile に恒久化）
- smoke: コンテナ内 headless で先生ダッシュボード到達を PASS 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)