### PR TITLE
feat(mesh-v2): self-inclusive sensor value (gated by project flag)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -46,6 +46,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/components/gui/gui.jsx` | smalrubot firmware modal | SmalrubotS1 ファームウェアモーダルの import と配置 |
 | `src/components/gui/gui.jsx` | classroom modal | クラスルームモーダルの import と配置 |
 | `src/components/gui/gui.jsx` | meshV2 classroom binding | クラス状態に応じて Mesh v2 ドメインを参加コードに固定する常時マウントの binding |
+| `src/components/gui/gui.jsx` | meshV2 self-inclusive upgrade modal | mesh 拡張有効化時に旧動作のままなら新動作への切替を促す常時マウントのモーダル (Issue #707) の import と配置 |
 | `src/components/gui/gui.jsx` | welcome modal | 初回訪問者向けウェルカムモーダル HOC の import と配置、`onShowWelcomeModal` prop |
 | `src/containers/gui.jsx` | welcome modal | `onShowWelcomeModal` を Redux `openWelcomeModal()` にマップ |
 | `src/components/gui/gui.jsx` | DNCL mode notice | DnclModeNotice コンポーネントの import・配置・`onRequestExitDnclMode` prop |

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -22,6 +22,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/components/blocks-screenshot-button/`
 - `src/components/google-drive-save-dialog/`
 - `src/components/koshien-test-modal/`
+- `src/components/mesh-v2-upgrade-modal/`
 - `src/components/mobile-bottom-tabs/`
 - `src/components/mobile-drawer/`
 - `src/components/mobile-gui/`
@@ -76,6 +77,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/containers/use-teacher-submissions.js`
 - `src/containers/extension-library.css`
 - `src/containers/google-drive-loader-hoc.jsx`
+- `src/containers/mesh-v2-upgrade-modal.jsx`
 - `src/containers/google-drive-saver-hoc.jsx`
 - `src/containers/ruby-downloader.jsx`
 - `src/containers/ruby-tab.jsx`
@@ -208,6 +210,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/components/dncl-mode-notice.test.jsx`
 - `test/unit/components/extension-button-dncl.test.jsx`
 - `test/unit/components/connected-step.test.jsx`
+- `test/unit/components/mesh-v2-upgrade-modal.test.jsx`
 - `test/unit/components/mobile-bottom-tabs.test.jsx`
 - `test/unit/components/mobile-drawer.test.jsx`
 - `test/unit/components/mobile-orientation-gate.test.jsx`

--- a/.claude/rules/scratch-vm/development.md
+++ b/.claude/rules/scratch-vm/development.md
@@ -216,6 +216,7 @@ The mesh v2 extension uses AWS AppSync for real-time collaboration:
 | `src/blocks/scratch3_operators.js` | regex support | operator_contains で正規表現マッチングをサポート |
 | `src/engine/comment.js` | toXML modernization | Blockly v12 対応: `pinned="${!minimized}"` (cherry-pick from upstream spork@29bdbd1fe) + (0,0) 時の x/y 属性省略 (Smalruby 独自) |
 | `src/engine/runtime.js` | toolboxitemid for extension categories | Blockly v12 対応: 拡張機能のカテゴリ XML に `toolboxitemid` 属性を追加。Blockly v12 の ContinuousToolbox は `toolboxitemid` から id を読むため、未指定だと `blockly-XXX` の auto-id が StatusIndicatorLabel.extensionId に伝搬し、`!` 接続モーダルが拡張機能を見つけられず scanning で固まる |
+| `src/serialization/sb3.js` | mesh self-inclusive flag | Mesh v2 センサーの値の自己参照モードを `meta.smalruby.meshSelfInclusive` として serialize/deserialize する (Issue #707)。`runtime.meshSelfInclusive` を読み書き |
 
 ### 関連ファイル
 

--- a/.claude/rules/scratch-vm/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-vm/smalruby-prettier-files.md
@@ -57,6 +57,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/mesh_service_v2_subscription.js`
 - `test/unit/mesh_service_v2_timestamp.js`
 - `test/unit/mesh_service_v2.js`
+- `test/unit/mesh_v2_self_inclusive_serialization.js`
 - `test/unit/rate_limiter.js`
 - `test/unit/scratch3_mesh_v2_rate_limiter_repro.js`
 - `test/unit/smalruby_migration.js`

--- a/docs/extension-mesh-v2/README.md
+++ b/docs/extension-mesh-v2/README.md
@@ -25,6 +25,7 @@
 
 - 拡張機能登録: `packages/scratch-gui/src/lib/libraries/extensions/index.jsx` の `extensionId: 'meshV2'` エントリ
 - 接続 UI（`mesh-v2-*-step.jsx`）と Redux state は [`docs/mesh-v2/`](../mesh-v2/) 参照
+- 自己参照アップグレードモーダル: `src/containers/mesh-v2-upgrade-modal.jsx`、`src/components/mesh-v2-upgrade-modal/`、`src/reducers/mesh-v2.js`（`upgradeModalVisible`）、解説ページ `pages/mesh-self-sensor.html`
 
 ### scratch-vm
 
@@ -45,8 +46,81 @@
 
 > 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
 
+## 変数同期とセンサーの値の仕組み
+
+旧 Mesh (`mesh`) と同様、Mesh v2 も **標準ブロックのランタイム関数を差し替え (HOC)** してグローバル変数と broadcast を伝播する。
+
+### 送信側（自分が変数を変更したとき）
+
+接続時 (`connect`) に `setOpcodeFunctionHOC` / `setVariableFunctionHOC` が以下を差し替える（`index.js:472-615`）。
+
+- `data_setvariableto` / `data_changevariableby` → ローカル実行 ＋ `syncVariable(args)` → `meshService.sendData([{key, value}])`
+- `createNewGlobalVariable` / `createVariable` / `setVariableValue` / `renameVariable` / `lookupOrCreateVariable` → ローカル実行 ＋ `sendData(...)`
+- `event_broadcast` / `event_broadcastandwait` → ローカル実行 ＋ `meshService.fireEvent(name)`
+
+`sendData` は `reportDataByNode` mutation で AppSync に送る（`data-sender.js:22-55`）。**送信するだけで、自ノードの受信ストアには書き込まない。**
+
+### 受信側（他ノードのデータを受け取ったとき）
+
+受信データは **`remoteData`**（`{ nodeId: { key: { value, timestamp } } }`）に格納される（`mesh-service.js:75`）。書き込みは **`handleDataUpdate(nodeStatus)` の 1 箇所のみ**で、WebSocket subscription / polling (`pollEvents`) / 定期同期 (`fetchAllNodesData`) の 3 経路すべてがここを通る。既定では自ノードのエコーを破棄するが、**`runtime.meshSelfInclusive` が true のときは自ノード分も取り込む**（後述「センサーの値の自己参照」）。
+
+### センサーの値の読み取り
+
+`getSensorValue(args)` → `meshService.getRemoteVariable(args.NAME)`（`index.js:188-192`）。`getRemoteVariable` は **`remoteData` を全ノード横断で走査し、同名キーのうち最新 `timestamp` の値**を返す（`data-sender.js:160-175`）。メニュー候補も `remoteData` のキーから生成される（`index.js:195-200`）。
+
+```
+[自分のステージ変数] --(set)--> sendData --(AppSync reportDataByNode)--> 配信
+                                                                          └─> handleDataUpdate
+                                                                                └─> remoteData (受信ストア)
+                                                                                      └─> getRemoteVariable / getSensorValue
+```
+
+## センサーの値の自己参照（自分のグローバル変数を読む）
+
+`meshV2_getSensorValue` は、**プロジェクト単位のフラグで切り替わる 2 つの動作**を持つ。
+
+| 動作 | 既定 | 振る舞い |
+|------|------|----------|
+| **旧動作（自ノード除外）** | ✅ 既定 | `handleDataUpdate` で自ノードのエコーを破棄。`remoteData` には他ノードのデータしか入らず、自分の変数は読めない（同名を他ノードが送ってきた場合のみ返る）。 |
+| **新動作（自己参照）** | フラグ true 時 | 自ノードのエコーも `remoteData` に取り込む。自分の変数も他ノードと同列に読める。 |
+
+### 仕組み（新動作）
+
+AppSync は **送信者にも自分の更新を配信する**。新動作では `handleDataUpdate` の自ノード除外を **`runtime.meshSelfInclusive` が true のときだけ撤廃**し（`subscription-manager.js`）、自ノードのエコーを `remoteData` に格納する。
+
+- 自分も他者も **すべてサーバータイムスタンプで `remoteData` に入る** ため、クライアント/サーバー間のクロック不整合が起きない（ローカルシードはしない）。
+- `getRemoteVariable` / `getSensorValue` / メニュー生成は変更不要。新動作では自ノードの変数名もメニュー候補に出る（エコー到着後）。
+- 自分の変数が読めるのは **送信 → サーバーエコー受信の往復後**（接続時は `sendAllGlobalVariables` で全変数が送られる）。
+
+### フラグの永続化（`meta.smalruby.meshSelfInclusive`）
+
+新動作のオプトインはプロジェクト `meta.smalruby.meshSelfInclusive`（boolean）として保存される（`sb3.js` serialize/deserialize、`runtime.meshSelfInclusive` に保持）。**フィールドが無い／false なら旧動作**（mirrors `origin` の扱い。読み込みのたびにリセット）。
+
+### 旧動作からの切り替え導線（アップグレードモーダル）
+
+mesh 拡張を有効化したとき、フラグが新動作でなければ **毎回** モーダルを表示し、新動作への切り替えを促す（`containers/mesh-v2-upgrade-modal.jsx`、`EXTENSION_ADDED` を監視）。
+
+- **新しい動きに切り替える** → `runtime.meshSelfInclusive = true` を設定しプロジェクトを dirty 化（保存で永続化）。
+- **このまま続ける** → 何も保存しない。次回有効化時にまた表示され、常に切り替え導線が残る。
+- 「くわしくはこちら」→ `pages/mesh-self-sensor.html`（about.html と同じ流儀の静的解説ページ）。
+
+### 後方互換性
+
+**メッシュは「同一グローバル変数名を複数ノードで共有しない」ことを前提**にしている（同名共有は挙動理解が困難なため）。この前提下では:
+
+| 読み取り対象 | 旧動作 | 新動作 | 影響 |
+|---|---|---|---|
+| 他ノードの変数（共有しない名前） | 他ノードの最新値 | 同左（自ノードに同名 entry が無い） | **完全互換** |
+| 自分の変数（誰も共有しない名前） | 常に `''` | 自分の最新値 | `''` 依存は想定不可 → 実質無害 |
+| 同名を複数ノードが共有 | 相手の最新値 | 自分含む最新値 | 唯一の挙動変化（前提により対象外） |
+
+既定は旧動作で挙動が変わらず、新動作は明示オプトインのみ。**broadcast の自ノード除外（`subscription-manager.js`、`polling-client.js`）は本変更の対象外で現状維持**のため、「変数は自分も読めるがメッセージは自分には届かない」非対称が残る。
+
+> 関連: Issue #707。実装回帰の確認は scratch-vm のテスト（`test/unit/mesh_service_v2_timestamp.js`、`test/unit/mesh_v2_self_inclusive_serialization.js`、`test/integration/extensions/mesh-v2-variable-sync.test.js`）と [`docs/mesh-v2/`](../mesh-v2/) のデグレ確認手順を参照。
+
 ## 関連ドキュメント
 
 - **[`docs/mesh-v2/`](../mesh-v2/)** — システム全体（**本拡張の親ドキュメント**）
+- **[`docs/extension-mesh/`](../extension-mesh/)** — 旧 Mesh（`mesh`, SkyWay 版）拡張機能
 - `.claude/rules/scratch-gui/mesh.md` — クライアント側開発ルール
 - `.claude/rules/infra/smalruby-mesh-v2.md` — サーバ側開発ルール

--- a/docs/extension-mesh/README.md
+++ b/docs/extension-mesh/README.md
@@ -1,0 +1,99 @@
+# 拡張機能: Mesh（旧 Mesh / mesh）
+
+> **🆕 Smalruby 独自** — upstream に存在しない、Smalruby のために追加された拡張機能
+
+> **⚠️ レガシー** — 外部サービス **SkyWay (skyway-js)** に依存する旧実装。SkyWay の旧 API 終了に伴い実質的に動作しないため、後継の [Mesh v2](../extension-mesh-v2/) に置き換えられている。本ドキュメントは**仕様調査・後継機能設計の参照用**に残す。
+
+- **拡張機能 ID**: `mesh`（カテゴリ表示名は "Old Mesh"）
+- **Smalruby ランタイム対応**: ❌（ブラウザ専用。WebRTC / SkyWay を利用）
+- **デフォルト表示**: 状況により非表示（後継の `meshV2` が既定）
+
+## 概要
+
+複数の Smalruby インスタンス間で、**broadcast イベント**と**グローバル変数**をリアルタイム共有するネットワーク拡張機能。SkyWay の P2P ルーム（`Room`）を使い、ホスト 1 台に各メンバーが接続する star 型トポロジで通信する。
+
+ピアのいずれかがグローバル変数を変更すると、その値が他ピアに伝播し、受信側は **`センサーの値`ブロック (`mesh_getSensorValue`)** で参照できる。
+
+> 後継の Mesh v2（AppSync + DynamoDB バックエンド）の全体像は [`docs/mesh-v2/`](../mesh-v2/) および [`docs/extension-mesh-v2/`](../extension-mesh-v2/) を参照。
+
+## ユーザーストーリー
+
+- **小学生**として、友達のスモウルビーと自分のスモウルビーで「メッセージを送る」「相手の変数を読む」をして、複数人で動くゲームを作りたい
+- **教師**として、教室の全員を簡単な合言葉（メッシュ ID）で 1 つのグループに入れたい
+
+## 主要ファイル
+
+### scratch-vm
+
+`packages/scratch-vm/src/extensions/scratch3_mesh/`
+
+| ファイル | 役割 |
+|---|---|
+| `index.js` | 拡張機能本体。ブロック定義、ランタイム関数の差し替え（HOC）、`getSensorValue` |
+| `mesh-service.js` | 通信の中核。SkyWay の `Peer` / `Room` 管理、変数・イベントの送受信、受信値ストア |
+| `mesh-host.js` | ホスト役のサービス（`MeshService` を継承） |
+| `mesh-peer.js` | メンバー役のサービス（`MeshService` を継承） |
+
+## 関連ブロック
+
+| ブロック ID | 説明 |
+|---|---|
+| `mesh_getSensorValue` | **他ノード**のグローバル変数を読み取る（`センサーの値`） |
+
+> broadcast とグローバル変数の同期は専用ブロックではなく、標準の `event_broadcast` / `data_setvariableto` 等の**ランタイム関数を差し替えて**実現している（後述）。
+
+## 変数同期とセンサーの値の仕組み
+
+### 標準ブロックの差し替え（HOC）
+
+接続時 (`connect`) に `setOpcodeFunctionHOC` / `setVariableFunctionHOC` が呼ばれ、Scratch 標準の以下の関数を拡張機能側のラッパーに差し替える（`index.js:202-304`）。
+
+- `event_broadcast` / `event_broadcastandwait` → ローカル実行 **＋** `meshService.sendBroadcastMessage(name)`
+- `data_setvariableto` / `data_changevariableby` → ローカル実行 **＋** `sendVariableByOpcodeFunction(args)`
+- `runtime.createNewGlobalVariable`、`stage.createVariable` / `setVariableValue` / `renameVariable` / `lookupOrCreateVariable` → ローカル実行 **＋** `meshService.sendVariableMessage(name, value)`
+
+つまり「自分が変数を変更する」操作はすべて、**`sendVariableMessage` で他ピアに送信するだけ**で、ローカルには Scratch のステージ変数として残る。
+
+### 受信値の格納
+
+受信側は `onRoomData` → `variableAction` / `variablesAction` → **`setVariable(name, value, owner)`** で、サービス内の専用ストア `this.variables`（`{name: {name, value, owner}}`）に格納する（`mesh-service.js:369-395, 446-463`）。
+
+### センサーの値の読み取り
+
+`getSensorValue(args)` は `meshService.getVariable(args.NAME)` を呼び、この**受信専用ストア `this.variables` だけ**を読む（`index.js:122-124`、`mesh-service.js:389-395`）。メニュー候補 `getVariableNamesMenuItems` も `meshService.variableNames`（= 受信した名前のみ）を返す。
+
+```
+[自分のステージ変数] --(set)--> sendVariableMessage --(SkyWay)--> 他ピア
+                                                                    └─> setVariable
+                                                                          └─> this.variables (受信ストア)
+                                                                                └─> getVariable / getSensorValue
+```
+
+## 調査結果: 自身のグローバル変数はセンサーの値で参照できるか → **参照できない**
+
+**結論: 旧 Mesh では、`センサーの値`ブロックで自分自身が設定したグローバル変数を読み取ることはできない。**
+
+理由（コードレベル）:
+
+1. 自分が変数を設定する経路（差し替えた `setVariableTo` 等 → `sendVariableMessage`）は、**送信するだけ**で受信ストア `this.variables` には一切書き込まない。
+2. `this.variables` への書き込みは `setVariable()` だけが行い、それは `variableAction` / `variablesAction`、すなわち **`onRoomData`（他ピアからの受信）経由でしか呼ばれない**。
+3. `getVariable(name)` は `this.variables[name]` が無ければ空文字 `''` を返す（`mesh-service.js:389-395`）。
+
+したがって、自分の変数名を `センサーの値`に指定しても、
+
+- 同名の変数を**他のピアが設定して送ってきた場合のみ**その値が返る（= 他人の値で上書きされる）。
+- 誰も送ってきていなければ `''` が返る。
+
+メニュー候補にも自分の変数名は現れない（受信した名前しか出ない）。
+
+> 補足: ピア参加時 (`onRoomPeerJoin`) に `getGlobalVariables()` で自分の全グローバル変数を相手へ一括送信するが (`mesh-service.js:294-319`)、これも**送信側自身の受信ストアには入らない**ため、自分での参照可否には影響しない。
+
+## 後継 Mesh v2 との関係
+
+Mesh v2 も**同じ設計思想**（送信専用 / 受信専用ストアを分離し、自ノードを参照対象から除外）を踏襲しており、`meshV2_getSensorValue` でも**自身のグローバル変数は参照できない**。詳細と、自身の変数も参照可能にする拡張案は [`docs/extension-mesh-v2/`](../extension-mesh-v2/) を参照。
+
+## 関連ドキュメント
+
+- **[`docs/extension-mesh-v2/`](../extension-mesh-v2/)** — 後継拡張機能（推奨）
+- **[`docs/mesh-v2/`](../mesh-v2/)** — Mesh v2 のシステム全体像
+- [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) — 各ブロックの Ruby 表現（`mesh.sensor_value(名前)`）

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -39,6 +39,7 @@ src/components/*
 !src/components/google-drive-save-dialog/
 !src/components/dncl-mode-notice/
 !src/components/koshien-test-modal/
+!src/components/mesh-v2-upgrade-modal/
 !src/components/mobile-bottom-tabs/
 !src/components/mobile-drawer/
 !src/components/mobile-gui/
@@ -101,6 +102,7 @@ src/containers/*
 !src/containers/use-teacher-submissions.js
 !src/containers/extension-library.css
 !src/containers/google-drive-loader-hoc.jsx
+!src/containers/mesh-v2-upgrade-modal.jsx
 !src/containers/google-drive-saver-hoc.jsx
 !src/containers/ruby-downloader.jsx
 !src/containers/ruby-tab.jsx
@@ -271,6 +273,7 @@ test/unit/components/*
 !test/unit/components/dncl-mode-notice.test.jsx
 !test/unit/components/extension-button-dncl.test.jsx
 !test/unit/components/connected-step.test.jsx
+!test/unit/components/mesh-v2-upgrade-modal.test.jsx
 !test/unit/components/mobile-bottom-tabs.test.jsx
 !test/unit/components/mobile-drawer.test.jsx
 !test/unit/components/mobile-orientation-gate.test.jsx

--- a/packages/scratch-gui/pages/mesh-self-sensor.html
+++ b/packages/scratch-gui/pages/mesh-self-sensor.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>メッシュの「センサーの値」が自分の変数も読めるようになりました | スモウルビー</title>
+    <meta name="description" content="スモウルビーのメッシュ機能で、「センサーの値」ブロックが自分のグローバル変数も読めるようになりました。変更の理由・新旧の違い・切り替え方法・後方互換性をわかりやすく説明します。">
+    <meta name="robots" content="index, follow">
+    <link rel="shortcut icon" href="static/favicon.ico">
+    <meta property="og:title" content="メッシュの「センサーの値」が自分の変数も読めるようになりました">
+    <meta property="og:description" content="新しい動きでは、自分のグローバル変数も「センサーの値」で読めます。変更の理由と切り替え方法を説明します。">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="スモウルビー">
+    <meta property="og:locale" content="ja_JP">
+    <style>
+        :root {
+            --ruby-red: #e60012;
+            --purple: #6a1b9a;
+            --purple-deep: #4a148c;
+            --purple-light: #9c27b0;
+            --gold: #ffeb3b;
+            --bg: #fafbff;
+            --text: #2d3748;
+            --text-light: #718096;
+            --block-event: #ffbf00;
+            --block-control: #ffab19;
+            --block-motion: #4c97ff;
+            --block-sensing: #5cb1d6;
+            --block-variable: #ff8c1a;
+            --ok: #2e9e4f;
+            --warn: #c0392b;
+        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+            line-height: 1.8;
+            color: var(--text);
+            background: var(--bg);
+        }
+        .container { max-width: 820px; margin: 0 auto; padding: 0 1.25rem; }
+        a { color: var(--purple); }
+
+        .hero {
+            background: linear-gradient(135deg, var(--purple-deep), var(--purple) 50%, var(--purple-light));
+            color: #fff;
+            padding: 2.5rem 1.25rem;
+            text-align: center;
+        }
+        .hero .badge {
+            display: inline-block;
+            background: rgba(255,255,255,0.18);
+            border: 1px solid rgba(255,255,255,0.25);
+            border-radius: 50px;
+            padding: 0.3rem 1rem;
+            font-size: 0.8rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+        }
+        .hero h1 { font-size: clamp(1.4rem, 4.5vw, 2rem); line-height: 1.4; }
+        .hero p { opacity: 0.92; margin-top: 0.75rem; font-size: 1rem; }
+
+        section { padding: 2.5rem 0; }
+        section + section { border-top: 1px solid rgba(0,0,0,0.06); }
+        h2 {
+            font-size: 1.3rem;
+            font-weight: 800;
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        h2 .num {
+            background: linear-gradient(135deg, var(--ruby-red), var(--purple));
+            color: #fff;
+            width: 1.9rem;
+            height: 1.9rem;
+            border-radius: 50%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.95rem;
+            flex-shrink: 0;
+        }
+        p { margin-bottom: 0.9rem; }
+        .lead { font-size: 1.05rem; }
+
+        /* Scratch-style block mock */
+        .blocks { display: flex; flex-direction: column; align-items: flex-start; gap: 3px; }
+        .block {
+            display: inline-flex;
+            align-items: center;
+            padding: 6px 12px;
+            border-radius: 8px;
+            color: #fff;
+            font-size: 0.9rem;
+            font-weight: 700;
+            box-shadow: 0 2px 0 rgba(0,0,0,0.15);
+            white-space: nowrap;
+        }
+        .block .slot {
+            background: rgba(255,255,255,0.3);
+            border-radius: 12px;
+            padding: 1px 9px;
+            margin: 0 4px;
+        }
+        .b-event { background: var(--block-event); }
+        .b-control { background: var(--block-control); }
+        .b-sensing { background: var(--block-sensing); }
+        .b-variable { background: var(--block-variable); }
+        .indent { margin-left: 22px; }
+
+        /* Before / after comparison */
+        .compare { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.25rem 0; }
+        @media (max-width: 640px) { .compare { grid-template-columns: 1fr; } }
+        .panel {
+            background: #fff;
+            border-radius: 14px;
+            padding: 1.25rem;
+            box-shadow: 0 4px 18px rgba(0,0,0,0.06);
+            border-top: 4px solid #ccc;
+        }
+        .panel.before { border-top-color: var(--text-light); }
+        .panel.after { border-top-color: var(--ok); }
+        .panel h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+        .tag { font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 50px; color: #fff; }
+        .tag.old { background: var(--text-light); }
+        .tag.new { background: var(--ok); }
+        .result { margin-top: 0.85rem; font-size: 0.9rem; }
+        .result .empty { color: var(--warn); font-weight: 700; }
+        .result .value { color: var(--ok); font-weight: 700; }
+
+        /* Ruby code */
+        .ruby-code {
+            font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+            font-size: 0.88rem;
+            line-height: 1.9;
+            color: #334155;
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-left: 4px solid var(--purple);
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            overflow-x: auto;
+            white-space: pre;
+        }
+        .ruby-code .kw { color: #7c3aed; font-weight: 600; }
+        .ruby-code .fn { color: #2563eb; }
+        .ruby-code .num { color: #d97706; font-weight: 600; }
+        .ruby-code .str { color: #059669; }
+        .ruby-code .cm { color: #94a3b8; }
+        .ruby-code .var { color: #dc2626; }
+
+        .callout {
+            background: #fff8e1;
+            border: 1px solid #f4d35e;
+            border-left: 4px solid var(--gold);
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            margin: 1.25rem 0;
+        }
+        .callout strong { color: var(--warn); }
+
+        .steps { list-style: none; counter-reset: step; }
+        .steps li {
+            position: relative;
+            padding: 0.4rem 0 0.4rem 2.4rem;
+            margin-bottom: 0.4rem;
+        }
+        .steps li::before {
+            counter-increment: step;
+            content: counter(step);
+            position: absolute;
+            left: 0;
+            top: 0.4rem;
+            width: 1.7rem;
+            height: 1.7rem;
+            border-radius: 50%;
+            background: var(--purple);
+            color: #fff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            font-size: 0.85rem;
+        }
+        .modal-mock {
+            max-width: 360px;
+            margin: 1.25rem 0;
+            border-radius: 12px;
+            box-shadow: 0 8px 28px rgba(0,0,0,0.12);
+            overflow: hidden;
+            border: 1px solid rgba(0,0,0,0.08);
+        }
+        .modal-mock .body { padding: 1.1rem 1.2rem; background: #fff; }
+        .modal-mock .body h4 { font-size: 1rem; margin-bottom: 0.5rem; text-align: center; }
+        .modal-mock .body p { font-size: 0.85rem; color: var(--text-light); margin: 0; }
+        .modal-mock .btns { padding: 0.9rem 1.2rem; background: #fff; border-top: 1px solid rgba(0,0,0,0.08); display: flex; flex-direction: column; gap: 0.5rem; }
+        .btn-primary { background: var(--block-motion); color: #fff; border: none; border-radius: 8px; padding: 0.6rem; font-weight: 700; }
+        .btn-secondary { background: #fff; color: var(--block-motion); border: 1px solid var(--block-motion); border-radius: 8px; padding: 0.6rem; }
+
+        footer {
+            background: #1a1a2e;
+            color: rgba(255,255,255,0.7);
+            text-align: center;
+            padding: 2rem 1rem;
+            font-size: 0.8rem;
+        }
+        footer a { color: rgba(255,255,255,0.9); }
+        .home { text-align: center; margin-top: 2rem; }
+        .home a {
+            display: inline-block;
+            background: linear-gradient(135deg, var(--ruby-red), #b8000e);
+            color: #fff;
+            padding: 0.8rem 2rem;
+            border-radius: 50px;
+            font-weight: 700;
+        }
+    </style>
+</head>
+<body>
+
+<header class="hero">
+    <div class="badge">メッシュ機能のアップデート</div>
+    <h1>「センサーの値」が<br>自分の変数も読めるようになりました</h1>
+    <p>このページでは、何が変わったのか・なぜ変えたのか・どう切り替えるのかを説明します。</p>
+</header>
+
+<main class="container">
+
+    <section>
+        <p class="lead">
+            メッシュ機能は、複数のスモウルビーをつないで、<strong>グローバル変数</strong>や<strong>メッセージ</strong>を
+            リアルタイムに共有する機能です。<br>
+            「センサーの値」ブロックは、つながっている仲間のグローバル変数を読み取るためのブロックです。
+        </p>
+        <p>
+            これまでは「センサーの値」は<strong>ほかのプロジェクトの変数だけ</strong>を読み、
+            自分自身が設定したグローバル変数は読めませんでした（いつも空っぽでした）。<br>
+            新しい動きでは、<strong>自分の変数も、仲間の変数と同じように</strong>「センサーの値」で読めるようになります。
+        </p>
+    </section>
+
+    <section>
+        <h2><span class="num">1</span>何が変わったの？</h2>
+        <p>同じプログラムでも、古い動きと新しい動きで結果が変わります。例として、自分で <code>スコア</code> という
+        グローバル変数を <code>100</code> にして、それを「センサーの値」で読んでみます。</p>
+
+        <div class="blocks" style="margin:1rem 0;">
+            <div class="block b-event">旗が押されたとき</div>
+            <div class="block b-variable"><span class="slot">スコア</span> を <span class="slot">100</span> にする</div>
+            <div class="block b-sensing">センサーの値 <span class="slot">スコア</span></div>
+        </div>
+
+        <div class="compare">
+            <div class="panel before">
+                <h3><span class="tag old">これまでの動き</span></h3>
+                <p style="font-size:0.9rem;">「センサーの値（スコア）」は自分の変数を見ないので…</p>
+                <div class="result">結果: <span class="empty">（空っぽ）</span></div>
+            </div>
+            <div class="panel after">
+                <h3><span class="tag new">新しい動き</span></h3>
+                <p style="font-size:0.9rem;">自分の変数も読めるので…</p>
+                <div class="result">結果: <span class="value">100</span></div>
+            </div>
+        </div>
+
+        <p>Rubyで書くと、こんなプログラムです。</p>
+<div class="ruby-code"><span class="cm"># 自分のグローバル変数「スコア」を設定する</span>
+<span class="var">$スコア</span> = <span class="num">100</span>
+
+<span class="cm"># これまで: 空っぽ ("")  /  新しい動き: "100"</span>
+<span class="fn">puts</span>(mesh.<span class="fn">sensor_value</span>(<span class="str">"スコア"</span>))</div>
+    </section>
+
+    <section>
+        <h2><span class="num">2</span>なぜ変えたの？</h2>
+        <p>
+            「自分が送った値を、自分でも確認したい」「送ったデータを画面に表示したい」という使い方が、
+            これまではできませんでした。自分の変数も読めるようにすることで、
+            メッシュのプログラムがもっとわかりやすく、作りやすくなります。
+        </p>
+        <p>
+            新しい動きでは、<strong>自分の値も仲間の値も、いったんネットワークを通って戻ってくる</strong>という
+            同じ仕組みで届きます。だから「自分」と「ほかの人」を特別扱いせず、いちばん新しい値が選ばれます。
+        </p>
+    </section>
+
+    <section>
+        <h2><span class="num">3</span>これまでのプログラムは大丈夫？</h2>
+        <p>
+            メッシュは、<strong>同じ名前のグローバル変数を複数の人で共有しない</strong>ことを前提にしています
+            （同じ名前を別々の人が使うと、どの値が表示されるのかわかりにくくなるためです）。
+        </p>
+        <p>この前提のもとでは、これまでのプログラムへの影響は次のとおりです。</p>
+        <ul style="margin:0 0 0.9rem 1.4rem;">
+            <li><strong>ほかの人の変数を読む</strong>（本来の使い方）→ これまでどおり、変わりません。</li>
+            <li><strong>自分の変数を読む</strong> → これまでは空っぽでしたが、新しい動きでは自分の値が読めます。</li>
+        </ul>
+        <div class="callout">
+            <p style="margin:0;">
+                ⚠️ ひとつだけ注意があります。<strong>同じ名前のグローバル変数を、自分とほかの人の両方が使っていた</strong>
+                場合だけ、表示される値が変わることがあります（いちばん新しく更新した人の値になります）。
+                そのため、古いプロジェクトを開いてメッシュを使うときは、
+                <strong>「このまま続ける」か「新しい動きに切り替える」かを選べる案内</strong>を表示します。
+            </p>
+        </div>
+    </section>
+
+    <section>
+        <h2><span class="num">4</span>どうやって切り替えるの？</h2>
+        <p>
+            メッシュ拡張機能を有効にしたとき、まだ古い動きのままなら、次のような案内が表示されます。
+            「新しい動きに切り替える」を押すと、そのプロジェクトは新しい動きになります（保存すると次回も新しい動きです）。
+        </p>
+
+        <div class="modal-mock">
+            <div class="body">
+                <h4>メッシュの「センサーの値」について</h4>
+                <p>このプロジェクトは古い動きです。新しい動きに切り替えると、自分の変数も読めるようになります。</p>
+            </div>
+            <div class="btns">
+                <div class="btn-primary">新しい動きに切り替える</div>
+                <div class="btn-secondary">このまま続ける</div>
+            </div>
+        </div>
+
+        <ol class="steps">
+            <li>「このまま続ける」を選ぶと、これまでどおりの動きのままです。次にメッシュを有効にしたとき、また案内が出ます。</li>
+            <li>「新しい動きに切り替える」を選ぶと、自分の変数も読めるようになります。プロジェクトを保存すると、その設定が保存されます。</li>
+        </ol>
+    </section>
+
+    <section>
+        <h2><span class="num">5</span>メッセージ（ブロードキャスト）は？</h2>
+        <p>
+            今回の変更は<strong>「センサーの値」（グローバル変数）だけ</strong>です。
+            メッセージ（ブロードキャスト）は、これまでどおり<strong>自分が送ったメッセージは自分には届きません</strong>。
+            変数とメッセージで動きが違う点に注意してください。
+        </p>
+    </section>
+
+    <div class="home">
+        <a href="https://smalruby.app">スモウルビーを開く</a>
+    </div>
+</main>
+
+<footer>
+    <p>NPO法人Rubyプログラミング少年団</p>
+    <p style="margin-top:0.4rem;opacity:0.6;">&copy; 2026 Smalruby Project.</p>
+</footer>
+
+</body>
+</html>

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -45,6 +45,10 @@ import ClassroomTeacherModal from '../../containers/classroom-teacher-modal.jsx'
 // === Smalruby: Start of meshV2 classroom binding ===
 import MeshV2ClassroomBinding from '../../lib/mesh-v2-classroom-binding.jsx';
 // === Smalruby: End of meshV2 classroom binding ===
+
+// === Smalruby: Start of meshV2 self-inclusive upgrade modal ===
+import MeshV2UpgradeModal from '../../containers/mesh-v2-upgrade-modal.jsx';
+// === Smalruby: End of meshV2 self-inclusive upgrade modal ===
 // === Smalruby: Start of welcome modal ===
 import WelcomeModalHOC from '../../containers/welcome-modal-hoc.jsx';
 // === Smalruby: End of welcome modal ===
@@ -454,6 +458,9 @@ const GUIComponent = props => {
                     {/* === Smalruby: Start of meshV2 classroom binding === */}
                     <MeshV2ClassroomBinding />
                     {/* === Smalruby: End of meshV2 classroom binding === */}
+                    {/* === Smalruby: Start of meshV2 self-inclusive upgrade modal === */}
+                    <MeshV2UpgradeModal />
+                    {/* === Smalruby: End of meshV2 self-inclusive upgrade modal === */}
                     {/* === Smalruby: End of smalrubot firmware modal === */}
                     {/* === Smalruby: Start of welcome modal === */}
                     <WelcomeModalHOC />

--- a/packages/scratch-gui/src/components/mesh-v2-upgrade-modal/mesh-v2-upgrade-modal.css
+++ b/packages/scratch-gui/src/components/mesh-v2-upgrade-modal/mesh-v2-upgrade-modal.css
@@ -1,0 +1,107 @@
+@import "../../css/colors.css";
+@import "../../css/units.css";
+@import "../../css/z-index.css";
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: $ui-black-transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: $z-index-modal;
+    padding: 1rem;
+}
+
+.dialog {
+    background: white;
+    border-radius: 12px;
+    width: 480px;
+    max-width: 100%;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 8px 32px $ui-black-transparent;
+    overflow: hidden;
+}
+
+.dialog-body {
+    padding: 1.5rem 2rem 0.5rem;
+    overflow-y: auto;
+    flex: 1 1 auto;
+}
+
+.title {
+    font-size: 1.4rem;
+    margin: 0 0 0.75rem 0;
+    color: $text-primary;
+    text-align: center;
+}
+
+.body {
+    margin: 0 0 0.5rem 0;
+    color: $text-primary;
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: stretch;
+    padding: 1rem 2rem 1.25rem;
+    background: white;
+    border-top: 1px solid $ui-black-transparent-10;
+    flex-shrink: 0;
+}
+
+.primary-button {
+    padding: 0.75rem 1.25rem;
+    border: none;
+    border-radius: 8px;
+    background: $motion-primary;
+    color: white;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: bold;
+    min-height: 44px;
+}
+
+.primary-button:hover {
+    opacity: 0.9;
+}
+
+.secondary-button {
+    padding: 0.75rem 1.25rem;
+    border: 1px solid $motion-primary;
+    border-radius: 8px;
+    background: white;
+    color: $motion-primary;
+    cursor: pointer;
+    font-size: 1rem;
+    min-height: 44px;
+}
+
+.secondary-button:hover {
+    opacity: 0.7;
+}
+
+.link-button {
+    padding: 0.5rem 0.75rem;
+    border: none;
+    background: transparent;
+    color: $motion-primary;
+    cursor: pointer;
+    font-size: 0.9rem;
+    text-decoration: underline;
+    min-height: 44px;
+    align-self: flex-start;
+}
+
+.link-button:hover {
+    opacity: 0.7;
+}

--- a/packages/scratch-gui/src/components/mesh-v2-upgrade-modal/mesh-v2-upgrade-modal.jsx
+++ b/packages/scratch-gui/src/components/mesh-v2-upgrade-modal/mesh-v2-upgrade-modal.jsx
@@ -1,0 +1,90 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import styles from './mesh-v2-upgrade-modal.css';
+
+const messages = defineMessages({
+    title: {
+        id: 'gui.meshV2UpgradeModal.title',
+        defaultMessage: 'About the Mesh "sensor value" block',
+        description: 'Mesh v2 self-inclusive upgrade modal title',
+    },
+    body: {
+        id: 'gui.meshV2UpgradeModal.body',
+        defaultMessage:
+            'This project uses the old behavior: the "sensor value" block does not ' +
+            'read your own global variables, only those of other connected projects. ' +
+            'You can switch to the new behavior, where the block also reads your own ' +
+            'variables. Keep going as is, or switch now?',
+        description: 'Mesh v2 upgrade modal explanation paragraph',
+    },
+    switchToNew: {
+        id: 'gui.meshV2UpgradeModal.switchToNew',
+        defaultMessage: 'Switch to the new behavior',
+        description: 'Mesh v2 upgrade modal primary button — opt into self-inclusive behavior',
+    },
+    keepLegacy: {
+        id: 'gui.meshV2UpgradeModal.keepLegacy',
+        defaultMessage: 'Keep going as is',
+        description: 'Mesh v2 upgrade modal secondary button — keep legacy behavior',
+    },
+    learnMore: {
+        id: 'gui.meshV2UpgradeModal.learnMore',
+        defaultMessage: 'Learn more',
+        description: 'Mesh v2 upgrade modal link to the explanation page',
+    },
+});
+
+const MeshV2UpgradeModal = ({ onSwitchToNew, onKeepLegacy, onLearnMore }) => (
+    <div
+        className={styles.overlay}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mesh-v2-upgrade-modal-title"
+        data-testid="mesh-v2-upgrade-modal"
+    >
+        <div className={styles.dialog}>
+            <div className={styles.dialogBody}>
+                <h2 className={styles.title} id="mesh-v2-upgrade-modal-title">
+                    <FormattedMessage {...messages.title} />
+                </h2>
+                <p className={styles.body}>
+                    <FormattedMessage {...messages.body} />
+                </p>
+                <button
+                    className={styles.linkButton}
+                    onClick={onLearnMore}
+                    data-testid="mesh-v2-upgrade-learn-more"
+                >
+                    <FormattedMessage {...messages.learnMore} />
+                </button>
+            </div>
+            <div className={styles.buttons}>
+                <button
+                    className={styles.primaryButton}
+                    onClick={onSwitchToNew}
+                    data-testid="mesh-v2-upgrade-switch"
+                >
+                    <FormattedMessage {...messages.switchToNew} />
+                </button>
+                <button
+                    className={styles.secondaryButton}
+                    onClick={onKeepLegacy}
+                    data-testid="mesh-v2-upgrade-keep"
+                >
+                    <FormattedMessage {...messages.keepLegacy} />
+                </button>
+            </div>
+        </div>
+    </div>
+);
+
+MeshV2UpgradeModal.propTypes = {
+    onKeepLegacy: PropTypes.func.isRequired,
+    onLearnMore: PropTypes.func.isRequired,
+    onSwitchToNew: PropTypes.func.isRequired,
+};
+
+export { messages };
+export default MeshV2UpgradeModal;

--- a/packages/scratch-gui/src/containers/mesh-v2-upgrade-modal.jsx
+++ b/packages/scratch-gui/src/containers/mesh-v2-upgrade-modal.jsx
@@ -1,0 +1,85 @@
+import PropTypes from 'prop-types';
+import { useCallback, useEffect, useRef } from 'react';
+import { connect } from 'react-redux';
+import MeshV2UpgradeModal from '../components/mesh-v2-upgrade-modal/mesh-v2-upgrade-modal.jsx';
+import { closeMeshV2UpgradeModal, openMeshV2UpgradeModal } from '../reducers/mesh-v2.js';
+
+const MESH_V2_EXTENSION_ID = 'meshV2';
+
+// Static page served alongside about.html (see packages/scratch-gui/pages/).
+const LEARN_MORE_URL = 'mesh-self-sensor.html';
+
+// Always-mounted container that watches for the Mesh v2 extension being enabled
+// and, when the current project has not opted into the self-inclusive "sensor
+// value" behavior, prompts the user to switch. Shown every time the extension is
+// enabled (Issue #707) so there is always a path to the new behavior, even for
+// projects that were left on the legacy behavior.
+const MeshV2UpgradeModalContainer = ({ vm, isOpen, onOpen, onClose }) => {
+    // Keep the latest dispatchers in refs so the EXTENSION_ADDED listener is
+    // attached once and never re-subscribes (mirrors mesh-v2-classroom-binding).
+    const onOpenRef = useRef(onOpen);
+    onOpenRef.current = onOpen;
+
+    useEffect(() => {
+        if (!vm) return () => {};
+        const handleExtensionAdded = (categoryInfo) => {
+            if (!categoryInfo || categoryInfo.id !== MESH_V2_EXTENSION_ID) return;
+            if (vm.runtime && vm.runtime.meshSelfInclusive) return;
+            onOpenRef.current();
+        };
+        vm.on('EXTENSION_ADDED', handleExtensionAdded);
+        return () => vm.off('EXTENSION_ADDED', handleExtensionAdded);
+    }, [vm]);
+
+    const handleSwitchToNew = useCallback(() => {
+        if (vm && vm.runtime) {
+            vm.runtime.meshSelfInclusive = true;
+            // Mark the project dirty so the choice gets persisted on save.
+            if (typeof vm.emitProjectChanged === 'function') {
+                vm.emitProjectChanged();
+            }
+        }
+        onClose();
+    }, [vm, onClose]);
+
+    const handleKeepLegacy = useCallback(() => {
+        // Persist nothing: the modal will appear again next time the extension is
+        // enabled, keeping the upgrade path available.
+        onClose();
+    }, [onClose]);
+
+    const handleLearnMore = useCallback(() => {
+        if (typeof window !== 'undefined') {
+            window.open(LEARN_MORE_URL, '_blank', 'noopener,noreferrer');
+        }
+    }, []);
+
+    if (!isOpen) return null;
+
+    return (
+        <MeshV2UpgradeModal
+            onKeepLegacy={handleKeepLegacy}
+            onLearnMore={handleLearnMore}
+            onSwitchToNew={handleSwitchToNew}
+        />
+    );
+};
+
+MeshV2UpgradeModalContainer.propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onOpen: PropTypes.func.isRequired,
+    vm: PropTypes.object,
+};
+
+const mapStateToProps = (state) => ({
+    isOpen: Boolean(state.scratchGui.meshV2.upgradeModalVisible),
+    vm: state.scratchGui.vm,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    onOpen: () => dispatch(openMeshV2UpgradeModal()),
+    onClose: () => dispatch(closeMeshV2UpgradeModal()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MeshV2UpgradeModalContainer);

--- a/packages/scratch-gui/src/containers/mesh-v2-upgrade-modal.jsx
+++ b/packages/scratch-gui/src/containers/mesh-v2-upgrade-modal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import MeshV2UpgradeModal from '../components/mesh-v2-upgrade-modal/mesh-v2-upgrade-modal.jsx';
 import { closeMeshV2UpgradeModal, openMeshV2UpgradeModal } from '../reducers/mesh-v2.js';

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -60,6 +60,14 @@ export default {
     'gui.welcomeModal.learnMore': 'スモウルビーについてくわしく',
     'gui.welcomeModal.leadShort': 'ブロックからはじめて、Rubyのコードまでちょうせんできます。',
     'gui.welcomeModal.later': 'あとでみる',
+    'gui.meshV2UpgradeModal.title': 'メッシュの「センサーのあたい」について',
+    'gui.meshV2UpgradeModal.body':
+        'このプロジェクトはふるいうごきです。「センサーのあたい」ブロックは、つながっているほかのプロジェクトのへんすうだけをよみ、' +
+        'じぶんのへんすうはよみません。じぶんのへんすうもよむあたらしいうごきにきりかえられます。' +
+        'このままつづけますか？それともあたらしいうごきにきりかえますか？',
+    'gui.meshV2UpgradeModal.switchToNew': 'あたらしいうごきにきりかえる',
+    'gui.meshV2UpgradeModal.keepLegacy': 'このままつづける',
+    'gui.meshV2UpgradeModal.learnMore': 'くわしくはこちら',
     'gui.mobile.drawer.section.help': 'ヘルプ',
     'gui.mobile.drawer.help.showWelcome': 'ウェルカムをもういちどみる',
     'gui.classroom.management.title': 'クラスかんり',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -59,6 +59,14 @@ export default {
     'gui.welcomeModal.learnMore': 'スモウルビーについて詳しく',
     'gui.welcomeModal.leadShort': 'ブロックから始めて、Rubyのコードまで挑戦できます。',
     'gui.welcomeModal.later': 'あとで見る',
+    'gui.meshV2UpgradeModal.title': 'メッシュの「センサーの値」について',
+    'gui.meshV2UpgradeModal.body':
+        'このプロジェクトは古い動きです。「センサーの値」ブロックは、つながっているほかのプロジェクトの変数だけを読み、' +
+        '自分の変数は読みません。自分の変数も読む新しい動きに切り替えられます。' +
+        'このまま続けますか？それとも新しい動きに切り替えますか？',
+    'gui.meshV2UpgradeModal.switchToNew': '新しい動きに切り替える',
+    'gui.meshV2UpgradeModal.keepLegacy': 'このまま続ける',
+    'gui.meshV2UpgradeModal.learnMore': 'くわしくはこちら',
     'gui.mobile.drawer.section.help': 'ヘルプ',
     'gui.mobile.drawer.help.showWelcome': 'ウェルカムをもう一度見る',
     'gui.classroom.management.title': 'クラス管理',

--- a/packages/scratch-gui/src/reducers/mesh-v2.js
+++ b/packages/scratch-gui/src/reducers/mesh-v2.js
@@ -1,7 +1,12 @@
 const SET_DOMAIN = 'scratch-gui/mesh-v2/SET_DOMAIN';
+const OPEN_UPGRADE_MODAL = 'scratch-gui/mesh-v2/OPEN_UPGRADE_MODAL';
+const CLOSE_UPGRADE_MODAL = 'scratch-gui/mesh-v2/CLOSE_UPGRADE_MODAL';
 
 const initialState = {
     domain: null,
+    // Issue #707: shown when the Mesh v2 extension is enabled while the project
+    // has not opted into the self-inclusive sensor value behavior.
+    upgradeModalVisible: false,
 };
 
 const reducer = function (state, action) {
@@ -10,6 +15,14 @@ const reducer = function (state, action) {
         case SET_DOMAIN:
             return Object.assign({}, state, {
                 domain: action.domain,
+            });
+        case OPEN_UPGRADE_MODAL:
+            return Object.assign({}, state, {
+                upgradeModalVisible: true,
+            });
+        case CLOSE_UPGRADE_MODAL:
+            return Object.assign({}, state, {
+                upgradeModalVisible: false,
             });
         default:
             return state;
@@ -23,4 +36,18 @@ const setDomain = function (domain) {
     };
 };
 
-export { reducer as default, initialState as meshV2InitialState, setDomain };
+const openMeshV2UpgradeModal = function () {
+    return { type: OPEN_UPGRADE_MODAL };
+};
+
+const closeMeshV2UpgradeModal = function () {
+    return { type: CLOSE_UPGRADE_MODAL };
+};
+
+export {
+    reducer as default,
+    initialState as meshV2InitialState,
+    setDomain,
+    openMeshV2UpgradeModal,
+    closeMeshV2UpgradeModal,
+};

--- a/packages/scratch-gui/test/unit/components/mesh-v2-upgrade-modal.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mesh-v2-upgrade-modal.test.jsx
@@ -3,7 +3,6 @@ import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
-
 import MeshV2UpgradeModal from '../../../src/components/mesh-v2-upgrade-modal/mesh-v2-upgrade-modal.jsx';
 
 const renderModal = (props) =>

--- a/packages/scratch-gui/test/unit/components/mesh-v2-upgrade-modal.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mesh-v2-upgrade-modal.test.jsx
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import MeshV2UpgradeModal from '../../../src/components/mesh-v2-upgrade-modal/mesh-v2-upgrade-modal.jsx';
+
+const renderModal = (props) =>
+    render(
+        <IntlProvider locale="en">
+            <MeshV2UpgradeModal
+                onKeepLegacy={jest.fn()}
+                onLearnMore={jest.fn()}
+                onSwitchToNew={jest.fn()}
+                {...props}
+            />
+        </IntlProvider>,
+    );
+
+describe('MeshV2UpgradeModal', () => {
+    test('renders the dialog with the three actions', () => {
+        const { getByTestId } = renderModal();
+        expect(getByTestId('mesh-v2-upgrade-modal')).toBeInTheDocument();
+        expect(getByTestId('mesh-v2-upgrade-switch')).toBeInTheDocument();
+        expect(getByTestId('mesh-v2-upgrade-keep')).toBeInTheDocument();
+        expect(getByTestId('mesh-v2-upgrade-learn-more')).toBeInTheDocument();
+    });
+
+    test('switch button invokes onSwitchToNew', () => {
+        const onSwitchToNew = jest.fn();
+        const { getByTestId } = renderModal({ onSwitchToNew });
+        fireEvent.click(getByTestId('mesh-v2-upgrade-switch'));
+        expect(onSwitchToNew).toHaveBeenCalledTimes(1);
+    });
+
+    test('keep button invokes onKeepLegacy', () => {
+        const onKeepLegacy = jest.fn();
+        const { getByTestId } = renderModal({ onKeepLegacy });
+        fireEvent.click(getByTestId('mesh-v2-upgrade-keep'));
+        expect(onKeepLegacy).toHaveBeenCalledTimes(1);
+    });
+
+    test('learn-more link invokes onLearnMore', () => {
+        const onLearnMore = jest.fn();
+        const { getByTestId } = renderModal({ onLearnMore });
+        fireEvent.click(getByTestId('mesh-v2-upgrade-learn-more'));
+        expect(onLearnMore).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/scratch-vm/.prettierignore
+++ b/packages/scratch-vm/.prettierignore
@@ -91,6 +91,7 @@ test/unit/*
 !test/unit/mesh_service_v2_subscription.js
 !test/unit/mesh_service_v2_timestamp.js
 !test/unit/mesh_service_v2.js
+!test/unit/mesh_v2_self_inclusive_serialization.js
 !test/unit/rate_limiter.js
 !test/unit/scratch3_mesh_v2_rate_limiter_repro.js
 !test/unit/smalruby_migration.js

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/subscription-manager.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/subscription-manager.js
@@ -61,7 +61,15 @@ const SubscriptionManagerMixin = {
     },
 
     handleDataUpdate(nodeStatus) {
-        if (!nodeStatus || nodeStatus.nodeId === this.meshId) return;
+        if (!nodeStatus) return;
+
+        // AppSync echoes the sender's own nodeStatus back. By default we drop it
+        // (legacy behavior: a node only reads other nodes' variables). Issue #707:
+        // when the project opts into self-inclusive mode, store own data too so
+        // the sensor value block reads this node's own global variables. Self and
+        // peer data are then treated uniformly (both arrive via the network with
+        // server timestamps), avoiding any client/server clock mismatch.
+        if (nodeStatus.nodeId === this.meshId && !this.runtime.meshSelfInclusive) return;
 
         const nodeId = nodeStatus.nodeId;
         if (!this.remoteData[nodeId]) {

--- a/packages/scratch-vm/src/serialization/sb3.js
+++ b/packages/scratch-vm/src/serialization/sb3.js
@@ -665,6 +665,15 @@ const serialize = function (runtime, targetId) {
     meta.agent = 'none';
     if (typeof navigator !== 'undefined') meta.agent = navigator.userAgent;
 
+    // === Smalruby: Start of mesh self-inclusive flag ===
+    // Persist whether the Mesh v2 "sensor value" block reads this node's own
+    // global variables (self-inclusive / new behavior). Absent or false means
+    // the legacy behavior where a node only reads other nodes' variables.
+    if (runtime.meshSelfInclusive) {
+        meta.smalruby = Object.assign(meta.smalruby || {}, {meshSelfInclusive: true});
+    }
+    // === Smalruby: End of mesh self-inclusive flag ===
+
     // Assemble payload and return
     obj.meta = meta;
     return obj;
@@ -1455,6 +1464,14 @@ const deserialize = function (json, runtime, zip, isSingleSprite) {
     } else {
         runtime.origin = null;
     }
+
+    // === Smalruby: Start of mesh self-inclusive flag ===
+    // Default to legacy behavior (a node does not read its own variables via the
+    // Mesh v2 sensor value block) unless the project explicitly opted in. Always
+    // set the flag so that loading a non-opted-in project after an opted-in one
+    // resets it (mirrors the origin handling above).
+    runtime.meshSelfInclusive = !!(json.meta && json.meta.smalruby && json.meta.smalruby.meshSelfInclusive);
+    // === Smalruby: End of mesh self-inclusive flag ===
 
     // First keep track of the current target order in the json,
     // then sort by the layer order property before parsing the targets

--- a/packages/scratch-vm/test/integration/extensions/mesh-v2-variable-sync.test.js
+++ b/packages/scratch-vm/test/integration/extensions/mesh-v2-variable-sync.test.js
@@ -126,6 +126,63 @@ test('MeshV2Service Variable Sync Integration', async (t) => {
     t.end();
 });
 
+// Issue #707: the sensor value block should read this node's own global
+// variables when the project opts into self-inclusive mode, while peer variable
+// reads stay unchanged. AppSync echoes the sender's own nodeStatus back, so we
+// simulate that echo via handleDataUpdate (the shared ingestion path for
+// subscription / polling / periodic-sync).
+test('MeshV2Service self-inclusive sensor value (Issue #707)', (t) => {
+    const ownEcho = {
+        nodeId: 'self-node',
+        timestamp: '2026-01-01T00:00:02Z',
+        data: [{ key: 'myScore', value: '100' }],
+    };
+    const peerData = {
+        nodeId: 'peer-node',
+        timestamp: '2026-01-01T00:00:01Z',
+        data: [{ key: 'peerScore', value: '7' }],
+    };
+
+    t.test('legacy mode (default): own data ignored, peer data read', (st) => {
+        const service = new MeshV2Service(createMockBlocks(), 'self-node', 'domain1');
+        service.handleDataUpdate({ ...ownEcho });
+        service.handleDataUpdate({ ...peerData });
+
+        st.equal(service.getRemoteVariable('myScore'), null, 'own variable is not readable');
+        st.equal(service.getRemoteVariable('peerScore'), '7', 'peer variable is read as before');
+        service.cleanup();
+        st.end();
+    });
+
+    t.test('new mode: own data read alongside peer data, latest timestamp wins', (st) => {
+        const service = new MeshV2Service(createMockBlocks(), 'self-node', 'domain1');
+        service.runtime.meshSelfInclusive = true;
+        service.handleDataUpdate({ ...peerData });
+        service.handleDataUpdate({ ...ownEcho });
+
+        st.equal(service.getRemoteVariable('myScore'), '100', 'own variable is now readable');
+        st.equal(service.getRemoteVariable('peerScore'), '7', 'peer variable unchanged (no regression)');
+
+        // A shared variable name resolves to the latest timestamp, self included.
+        service.handleDataUpdate({
+            nodeId: 'peer-node',
+            timestamp: '2026-01-01T00:00:05Z',
+            data: [{ key: 'shared', value: 'peer-newer' }],
+        });
+        service.handleDataUpdate({
+            nodeId: 'self-node',
+            timestamp: '2026-01-01T00:00:10Z',
+            data: [{ key: 'shared', value: 'self-newest' }],
+        });
+        st.equal(service.getRemoteVariable('shared'), 'self-newest', 'latest timestamp wins across self and peers');
+
+        service.cleanup();
+        st.end();
+    });
+
+    t.end();
+});
+
 test('MeshV2Service fetch existing nodes data on joinGroup', async (t) => {
     const blocks = {
         runtime: {

--- a/packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js
+++ b/packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js
@@ -58,6 +58,39 @@ test('MeshV2Service Timestamp-based getRemoteVariable', (t) => {
         st.end();
     });
 
+    t.test('handleDataUpdate ignores own node data in legacy mode (default)', (st) => {
+        const legacy = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        // runtime.meshSelfInclusive is falsy by default → legacy behavior.
+        legacy.handleDataUpdate({
+            nodeId: 'node-self',
+            timestamp: new Date().toISOString(),
+            data: [{ key: 'self-var', value: 'mine' }],
+        });
+
+        st.notOk(legacy.remoteData['node-self'], 'own node data is not stored in legacy mode');
+        st.equal(legacy.getRemoteVariable('self-var'), null, 'own variable is not readable in legacy mode');
+        st.end();
+    });
+
+    t.test('handleDataUpdate stores own node data when self-inclusive (Issue #707)', (st) => {
+        const selfInclusive = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        selfInclusive.runtime.meshSelfInclusive = true;
+
+        const serverTimestamp = new Date().toISOString();
+        const expectedTimestamp = new Date(serverTimestamp).getTime();
+        selfInclusive.handleDataUpdate({
+            nodeId: 'node-self',
+            timestamp: serverTimestamp,
+            data: [{ key: 'self-var', value: 'mine' }],
+        });
+
+        st.ok(selfInclusive.remoteData['node-self'], 'own node is stored when self-inclusive');
+        st.equal(selfInclusive.remoteData['node-self']['self-var'].value, 'mine');
+        st.equal(selfInclusive.remoteData['node-self']['self-var'].timestamp, expectedTimestamp);
+        st.equal(selfInclusive.getRemoteVariable('self-var'), 'mine', 'own variable is readable');
+        st.end();
+    });
+
     t.test('fetchAllNodesData should add timestamp from status', async (st) => {
         const serverTimestamp = new Date().toISOString();
         const expectedTimestamp = new Date(serverTimestamp).getTime();

--- a/packages/scratch-vm/test/unit/mesh_v2_self_inclusive_serialization.js
+++ b/packages/scratch-vm/test/unit/mesh_v2_self_inclusive_serialization.js
@@ -1,0 +1,45 @@
+const test = require('tap').test;
+const VirtualMachine = require('../../src/index');
+const sb3 = require('../../src/serialization/sb3');
+
+// Issue #707: the Mesh v2 self-inclusive behavior is gated by a per-project
+// flag persisted in project meta (`meta.smalruby.meshSelfInclusive`). Absent or
+// false = legacy behavior, true = self-inclusive (new) behavior.
+
+test('serialize writes meta.smalruby.meshSelfInclusive only when enabled', (t) => {
+    const vm = new VirtualMachine();
+    vm.runtime.meshSelfInclusive = true;
+    const enabled = sb3.serialize(vm.runtime);
+    t.equal(enabled.meta.smalruby.meshSelfInclusive, true, 'flag is persisted when enabled');
+
+    vm.runtime.meshSelfInclusive = false;
+    const disabled = sb3.serialize(vm.runtime);
+    t.equal(disabled.meta.smalruby, undefined, 'no smalruby meta when disabled (default)');
+
+    t.end();
+});
+
+test('deserialize restores meshSelfInclusive from meta', (t) => {
+    const vm = new VirtualMachine();
+    sb3.deserialize({ meta: { smalruby: { meshSelfInclusive: true } } }, vm.runtime).then(() => {
+        t.equal(vm.runtime.meshSelfInclusive, true, 'enabled project sets the flag');
+
+        // Loading a project without the flag must reset it (mirrors origin handling).
+        return sb3.deserialize({ meta: {} }, vm.runtime).then(() => {
+            t.equal(vm.runtime.meshSelfInclusive, false, 'absent flag resets to legacy behavior');
+            t.end();
+        });
+    });
+});
+
+test('serialize -> deserialize roundtrip preserves the flag', (t) => {
+    const vm = new VirtualMachine();
+    vm.runtime.meshSelfInclusive = true;
+    const serialized = sb3.serialize(vm.runtime);
+
+    const vm2 = new VirtualMachine();
+    sb3.deserialize(serialized, vm2.runtime).then(() => {
+        t.equal(vm2.runtime.meshSelfInclusive, true, 'roundtrip preserves enabled flag');
+        t.end();
+    });
+});

--- a/tools/playwright-verify/verify-mesh-self-sensor-ui.mjs
+++ b/tools/playwright-verify/verify-mesh-self-sensor-ui.mjs
@@ -1,0 +1,61 @@
+// Issue #707: drive the REAL extension-library UI to add Mesh (meshV2) and
+// confirm the upgrade modal appears via genuine user clicks (not loadExtensionURL).
+// This mirrors what a Playwright-MCP interactive session would do.
+// HEADLESS=0 for a visible (headful) run on a machine with a display.
+import { chromium } from 'playwright';
+
+const URL = 'http://localhost:8601/?no_beforeunload=1';
+const log = (...a) => console.log('[verify-ui]', ...a);
+const fail = (m) => { console.error('[FAIL]', m); process.exitCode = 1; };
+
+const headful = process.env.HEADLESS === '0';
+const browser = await chromium.launch({ headless: !headful, slowMo: headful ? 600 : 0 });
+const page = await (await browser.newContext({ viewport: { width: 1280, height: 800 } })).newPage();
+
+await page.goto(URL);
+await page.evaluate(() => localStorage.clear());
+await page.reload();
+
+// 1) Open the extension library via the bottom-left "+" button.
+await page.waitForSelector('[data-testid="extension-button"]', { timeout: 30000 });
+await page.click('[data-testid="extension-button"]');
+await page.waitForSelector('#meshV2', { timeout: 10000 });
+log('1 extension library opened OK (Mesh tile present)');
+await page.screenshot({ path: 'tmp/mesh-ui-1-library.png' });
+
+// 2) Click the Mesh tile (extensionId becomes the button id).
+await page.waitForSelector('#meshV2', { timeout: 10000 });
+await page.click('#meshV2');
+log('2 clicked Mesh tile');
+
+// 3) The upgrade modal should appear from the genuine EXTENSION_ADDED path.
+const modal = await page.waitForSelector('[data-testid="mesh-v2-upgrade-modal"]', { timeout: 10000 }).catch(() => null);
+log('3 upgrade modal appears via real UI add =', !!modal, modal ? 'OK' : 'FAIL');
+if (!modal) fail('upgrade modal did not appear after adding Mesh from the library');
+await page.waitForTimeout(500);
+await page.screenshot({ path: 'tmp/mesh-ui-2-upgrade-modal.png' });
+
+// Observe whether the peripheral connection modal also opened (meshV2 has
+// launchPeripheralConnectionFlow: true) — both overlays may be present.
+const connCount = await page.evaluate(() => {
+    const hits = [];
+    document.querySelectorAll('[class*="connection" i], [data-testid*="mesh-v2-"]').forEach((el) => {
+        const tid = el.getAttribute('data-testid');
+        if (tid && tid !== 'mesh-v2-upgrade-modal' && !tid.startsWith('mesh-v2-upgrade')) hits.push(tid);
+    });
+    return [...new Set(hits)].slice(0, 8);
+});
+log('   other mesh/connection elements present:', JSON.stringify(connCount));
+
+// 4) Click "Switch to the new behavior" → modal closes, flag set.
+await page.click('[data-testid="mesh-v2-upgrade-switch"]');
+await page.waitForTimeout(400);
+const flag = await page.evaluate(() => !!(window.smalruby && window.smalruby.vm.runtime.meshSelfInclusive));
+const gone = (await page.locator('[data-testid="mesh-v2-upgrade-modal"]').count()) === 0;
+log('4 after switch: modal gone =', gone, '| flag true =', flag, gone && flag ? 'OK' : 'FAIL');
+if (!(gone && flag)) fail('switch did not close modal / set flag');
+await page.screenshot({ path: 'tmp/mesh-ui-3-after-switch.png' });
+
+if (headful) await page.waitForTimeout(2500);
+await browser.close();
+log(process.exitCode ? 'DONE WITH FAILURES' : 'ALL UI CHECKS PASSED');

--- a/tools/playwright-verify/verify-mesh-self-sensor.mjs
+++ b/tools/playwright-verify/verify-mesh-self-sensor.mjs
@@ -1,0 +1,169 @@
+// Issue #707 browser verification: Mesh v2 self-inclusive sensor value.
+// Part A: upgrade modal flow (keep / switch / persistence) — no live backend.
+// Part B: live AppSync round-trip — own variable readable in new mode + peer read.
+import { chromium } from 'playwright';
+
+const URL = 'http://localhost:8601/?no_beforeunload=1&tab=ruby&ruby_version=2';
+const log = (...a) => console.log('[verify]', ...a);
+const fail = (m) => {
+    console.error('[FAIL]', m);
+    process.exitCode = 1;
+};
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await context.newPage();
+page.on('console', (m) => {
+    const t = m.text();
+    if (t.includes('Mesh') || t.includes('mesh')) log('page:', t);
+});
+
+await page.goto(URL);
+await page.evaluate(() => localStorage.clear());
+await page.reload();
+// Wait for the VM debug global exposed by the Ruby tab.
+await page.waitForFunction(() => window.smalruby && window.smalruby.vm, { timeout: 30000 });
+log('VM ready');
+
+// ============================================================
+// Part A: upgrade modal flow
+// ============================================================
+const before = await page.evaluate(() => !!window.smalruby.vm.runtime.meshSelfInclusive);
+log('A0 runtime.meshSelfInclusive before enable =', before, before === false ? 'OK' : 'UNEXPECTED');
+if (before !== false) fail('flag should default to false');
+
+// Enable the mesh extension → EXTENSION_ADDED → modal should appear (flag falsy).
+await page.evaluate(() => window.smalruby.vm.extensionManager.loadExtensionURL('meshV2'));
+let modal = await page.waitForSelector('[data-testid="mesh-v2-upgrade-modal"]', { timeout: 10000 }).catch(() => null);
+log('A1 modal visible on enable =', !!modal, modal ? 'OK' : 'FAIL');
+if (!modal) fail('modal did not appear on mesh enable');
+await page.screenshot({ path: 'tmp/mesh-self-sensor-A1-modal.png' });
+
+// "Keep going as is" → closes, persists nothing.
+await page.click('[data-testid="mesh-v2-upgrade-keep"]');
+await page.waitForTimeout(300);
+let present = await page.locator('[data-testid="mesh-v2-upgrade-modal"]').count();
+let flagAfterKeep = await page.evaluate(() => !!window.smalruby.vm.runtime.meshSelfInclusive);
+log('A2 after keep: modal gone =', present === 0, '| flag still false =', flagAfterKeep === false, present === 0 && !flagAfterKeep ? 'OK' : 'FAIL');
+if (present !== 0 || flagAfterKeep) fail('keep should close modal without setting flag');
+
+// Re-trigger enable (keep path keeps prompting) → modal reappears.
+await page.evaluate(() => {
+    const ci = window.smalruby.vm.runtime._blockInfo.find((c) => c.id === 'meshV2');
+    window.smalruby.vm.emit('EXTENSION_ADDED', ci);
+});
+modal = await page.waitForSelector('[data-testid="mesh-v2-upgrade-modal"]', { timeout: 5000 }).catch(() => null);
+log('A3 modal reappears after re-enable (keep path) =', !!modal, modal ? 'OK' : 'FAIL');
+if (!modal) fail('modal should reappear while still legacy');
+
+// "Switch to the new behavior" → closes, sets the flag.
+await page.click('[data-testid="mesh-v2-upgrade-switch"]');
+await page.waitForTimeout(300);
+present = await page.locator('[data-testid="mesh-v2-upgrade-modal"]').count();
+let flagAfterSwitch = await page.evaluate(() => !!window.smalruby.vm.runtime.meshSelfInclusive);
+log('A4 after switch: modal gone =', present === 0, '| flag true =', flagAfterSwitch === true, present === 0 && flagAfterSwitch ? 'OK' : 'FAIL');
+if (present !== 0 || !flagAfterSwitch) fail('switch should close modal and set flag');
+
+// Re-trigger enable now that flag is true → modal must NOT appear.
+await page.evaluate(() => {
+    const ci = window.smalruby.vm.runtime._blockInfo.find((c) => c.id === 'meshV2');
+    window.smalruby.vm.emit('EXTENSION_ADDED', ci);
+});
+await page.waitForTimeout(800);
+present = await page.locator('[data-testid="mesh-v2-upgrade-modal"]').count();
+log('A5 modal suppressed once flag set =', present === 0, present === 0 ? 'OK' : 'FAIL');
+if (present !== 0) fail('modal should be suppressed when flag is true');
+
+// learn-more opens the explanation page in a new tab. Reset the flag so the
+// modal shows again, then re-fire the real categoryInfo.
+await page.evaluate(() => {
+    window.smalruby.vm.runtime.meshSelfInclusive = false;
+    const ci = window.smalruby.vm.runtime._blockInfo.find((c) => c.id === 'meshV2');
+    window.smalruby.vm.emit('EXTENSION_ADDED', ci);
+});
+await page.waitForSelector('[data-testid="mesh-v2-upgrade-modal"]', { timeout: 5000 }).catch(() => null);
+const popupP = context.waitForEvent('page', { timeout: 5000 }).catch(() => null);
+await page.click('[data-testid="mesh-v2-upgrade-learn-more"]');
+const popup = await popupP;
+const popupUrl = popup ? popup.url() : '(none)';
+log('A6 learn-more opened =', popupUrl, popupUrl.includes('mesh-self-sensor.html') ? 'OK' : 'FAIL');
+if (!popupUrl.includes('mesh-self-sensor.html')) fail('learn-more should open mesh-self-sensor.html');
+if (popup) await popup.close();
+
+// ============================================================
+// Part B: live AppSync round-trip (new mode)
+// ============================================================
+log('--- Part B: live AppSync round-trip ---');
+const result = await page.evaluate(async () => {
+    // Obtain webpack require and locate MeshV2Service.
+    let req;
+    await new Promise((resolve) => {
+        window.webpackChunkGUI.push([['__probe707__'], {}, (r) => { req = r; resolve(); }]);
+    });
+    let MeshV2Service = null;
+    for (const id in req.c) {
+        const exp = req.c[id] && req.c[id].exports;
+        if (typeof exp === 'function' && exp.prototype &&
+            typeof exp.prototype.createGroup === 'function' &&
+            typeof exp.prototype.getRemoteVariable === 'function' &&
+            typeof exp.prototype.handleDataUpdate === 'function') {
+            MeshV2Service = exp;
+            break;
+        }
+    }
+    if (!MeshV2Service) return { error: 'MeshV2Service not found in bundle' };
+
+    const vm = window.smalruby.vm;
+    vm.runtime.meshSelfInclusive = true; // new mode for this round-trip
+    const ts = Date.now();
+    const domain = `v707-${ts}`;
+    const blocks = { runtime: vm.runtime, opcodeFunctions: { event_broadcast: () => {} } };
+
+    const host = new MeshV2Service(blocks, `host-${ts}`, domain);
+    host.testWebSocket = () => Promise.resolve(true);
+    const node = new MeshV2Service(blocks, `node-${ts}`, domain);
+    node.testWebSocket = () => Promise.resolve(true);
+
+    const out = { useWebSocketHost: null, ownReadable: null, peerReadable: null, nodeOwn: null, nodePeer: null, error: null };
+    try {
+        await host.createGroup(`grp-${ts}`);
+        await node.joinGroup(host.groupId, host.domain, `grp-${ts}`);
+        out.useWebSocketHost = host.useWebSocket;
+
+        await host.sendData([{ key: 'ownH', value: '100' }]);
+        await node.sendData([{ key: 'ownN', value: '7' }]);
+        await host.dataRateLimiter.waitForCompletion();
+        await node.dataRateLimiter.waitForCompletion();
+        // Wait for subscription echoes to arrive.
+        await new Promise((r) => setTimeout(r, 4500));
+
+        out.ownReadable = host.getRemoteVariable('ownH'); // NEW: own var via round-trip
+        out.peerReadable = host.getRemoteVariable('ownN'); // peer var (regression check)
+        out.nodeOwn = node.getRemoteVariable('ownN');
+        out.nodePeer = node.getRemoteVariable('ownH');
+    } catch (e) {
+        out.error = String(e && e.message ? e.message : e);
+    } finally {
+        try { host.cleanup(); } catch (_e) {}
+        try { node.cleanup(); } catch (_e) {}
+    }
+    return out;
+});
+
+log('B result =', JSON.stringify(result));
+if (result.error) {
+    fail(`Part B errored (likely no live AppSync endpoint): ${result.error}`);
+} else {
+    const okOwn = result.ownReadable === '100';
+    const okPeer = result.peerReadable === '7';
+    const okNodeOwn = result.nodeOwn === '7';
+    const okNodePeer = result.nodePeer === '100';
+    log('B1 host reads OWN var (new behavior) =', result.ownReadable, okOwn ? 'OK' : 'FAIL');
+    log('B2 host reads PEER var (no regression) =', result.peerReadable, okPeer ? 'OK' : 'FAIL');
+    log('B3 node reads OWN var =', result.nodeOwn, okNodeOwn ? 'OK' : 'FAIL');
+    log('B4 node reads PEER var =', result.nodePeer, okNodePeer ? 'OK' : 'FAIL');
+    if (!(okOwn && okPeer && okNodeOwn && okNodePeer)) fail('Part B assertions failed');
+}
+
+await browser.close();
+log(process.exitCode ? 'DONE WITH FAILURES' : 'ALL CHECKS PASSED');

--- a/tools/playwright-verify/verify-mesh-self-sensor.mjs
+++ b/tools/playwright-verify/verify-mesh-self-sensor.mjs
@@ -10,7 +10,9 @@ const fail = (m) => {
     process.exitCode = 1;
 };
 
-const browser = await chromium.launch({ headless: true });
+// HEADLESS=0 で headful 実行（手元の host など、ディスプレイがある環境向け）。
+const headful = process.env.HEADLESS === '0';
+const browser = await chromium.launch({ headless: !headful, slowMo: headful ? 500 : 0 });
 const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
 const page = await context.newPage();
 page.on('console', (m) => {


### PR DESCRIPTION
## Summary

Mesh v2 の「センサーの値」ブロックで、**自ノードを含む全ノードの同名グローバル変数の最新値**を参照できるようにする。後方互換性を最優先し、**プロジェクト単位のフラグでゲート**する方式（互換ゲート方式）を採用する。

Fixes #707

## 設計（合意済み）

- **既定は旧動作**（自ノード除外を維持）。プロジェクト `meta.smalruby.meshSelfInclusive` が `true` のときだけ新動作。検出スキャンは行わず、判定はフラグの値のみ。
- **新動作の実現方法**: AppSync が送信者にもエコーする自ノードの nodeStatus を `remoteData` に取り込むだけ。自ノードも他ノードも**サーバータイムスタンプで同列に扱う**ため、クライアント/サーバー間のクロック不整合が起きない（ローカルシードはしない）。
- 旧動作のまま固定されないよう、**mesh 拡張を有効化するたび**にフラグが新でなければアップグレード用モーダルを表示。「新しい動きに切り替える」でフラグを永続化、「このまま続ける」は何も保存せず次回も表示（常に切替導線を確保）。
- broadcast の自ノード除外は対象外（現状維持）。変数とメッセージの非対称は解説ページに明記。

## 進捗（全フェーズ完了）

- [x] Phase 1: `meta.smalruby.meshSelfInclusive` を sb3 serialize/deserialize で永続化（`runtime.meshSelfInclusive`）
- [x] Phase 2: `handleDataUpdate` の自ノード除外をフラグでゲート
- [x] Phase 3: mesh 有効化時のアップグレードモーダル（毎回・新動作切替で永続化）
- [x] Phase 4: i18n（ja / ja-Hira、en は inline defaultMessage）
- [x] Phase 5: 解説 HTML ページ `pages/mesh-self-sensor.html`（新旧比較・Ruby 例・切替手順・互換性）
- [x] Phase 6: 統合テスト（新動作で自分を読める／旧動作は回帰なし／同名は最新勝ち）
- [x] Phase 7: `docs/extension-mesh-v2/README.md` 更新 + 旧 Mesh 参照 doc 追加

## Test Coverage

- `test/unit/mesh_v2_self_inclusive_serialization.js` — フラグの serialize/deserialize/roundtrip
- `test/unit/mesh_service_v2_timestamp.js` — 旧動作で自ノード除外維持 / 新動作で自ノード格納＋読み取り
- `test/integration/extensions/mesh-v2-variable-sync.test.js` — 両モードの ingestion 経路＋同名最新勝ち
- `test/unit/components/mesh-v2-upgrade-modal.test.jsx` — モーダルの 3 アクション

## 後方互換性

「同一グローバル変数名を複数ノードで共有しない」前提のもと、既定（旧動作）では挙動が一切変わらない。新動作はフラグで明示的にオプトインしたプロジェクトのみ。詳細は #707 と解説ページを参照。

## SP / iPad

新規モーダルを追加（`overlay` 中央寄せ・`max-width`・44px タッチ領域）。ボタンに `data-testid` 付与。

## 残作業（DoD）

- [ ] CI green 確認
- [ ] ブラウザ確認（2 インスタンスで自分の変数を読める／他ノードは従来どおり／ドロップダウンに自分の変数名／モーダルの切替動線）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
