### PR TITLE
feat(mesh-v2): self-inclusive sensor value + one-time collision notice (alt to #708)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -46,6 +46,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/components/gui/gui.jsx` | smalrubot firmware modal | SmalrubotS1 ファームウェアモーダルの import と配置 |
 | `src/components/gui/gui.jsx` | classroom modal | クラスルームモーダルの import と配置 |
 | `src/components/gui/gui.jsx` | meshV2 classroom binding | クラス状態に応じて Mesh v2 ドメインを参加コードに固定する常時マウントの binding |
+| `src/components/gui/gui.jsx` | meshV2 self-sensor notice | グローバル変数名と mesh センサーの値の重複を検出し初回のみ通知する常時マウントのバナー (Issue #707) の import と配置 |
 | `src/components/gui/gui.jsx` | welcome modal | 初回訪問者向けウェルカムモーダル HOC の import と配置、`onShowWelcomeModal` prop |
 | `src/containers/gui.jsx` | welcome modal | `onShowWelcomeModal` を Redux `openWelcomeModal()` にマップ |
 | `src/components/gui/gui.jsx` | DNCL mode notice | DnclModeNotice コンポーネントの import・配置・`onRequestExitDnclMode` prop |

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -22,6 +22,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/components/blocks-screenshot-button/`
 - `src/components/google-drive-save-dialog/`
 - `src/components/koshien-test-modal/`
+- `src/components/mesh-self-sensor-notice/`
 - `src/components/mobile-bottom-tabs/`
 - `src/components/mobile-drawer/`
 - `src/components/mobile-gui/`
@@ -76,6 +77,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/containers/use-teacher-submissions.js`
 - `src/containers/extension-library.css`
 - `src/containers/google-drive-loader-hoc.jsx`
+- `src/containers/mesh-self-sensor-notice.jsx`
 - `src/containers/google-drive-saver-hoc.jsx`
 - `src/containers/ruby-downloader.jsx`
 - `src/containers/ruby-tab.jsx`
@@ -119,6 +121,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/lib/join-code-history.js`
 - `src/lib/log-suppression.js`
 - `src/lib/mesh-v2-classroom-binding.jsx`
+- `src/lib/mesh-v2-sensor-collision.js`
 - `src/lib/microsoft-auth.js`
 - `src/lib/microbit-more-update.js`
 - `src/lib/teacher-auth.js`
@@ -208,6 +211,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/components/dncl-mode-notice.test.jsx`
 - `test/unit/components/extension-button-dncl.test.jsx`
 - `test/unit/components/connected-step.test.jsx`
+- `test/unit/components/mesh-self-sensor-notice.test.jsx`
 - `test/unit/components/mobile-bottom-tabs.test.jsx`
 - `test/unit/components/mobile-drawer.test.jsx`
 - `test/unit/components/mobile-orientation-gate.test.jsx`
@@ -258,6 +262,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/lib/layout-constants.test.js`
 - `test/unit/lib/legacy-storage.test.js`
 - `test/unit/lib/mesh-v2-classroom-binding.test.js`
+- `test/unit/lib/mesh-v2-sensor-collision.test.js`
 - `test/unit/lib/make-toolbox-xml.test.js`
 - `test/unit/lib/module-sync.test.js`
 - `test/unit/lib/prism-parser.test.js`

--- a/docs/extension-mesh-v2/README.md
+++ b/docs/extension-mesh-v2/README.md
@@ -41,9 +41,31 @@
 | `meshV2_broadcast` | 名前付きイベントを送信 |
 | `meshV2_broadcastAndWait` | イベント送信して受信側の処理完了を待つ |
 | `meshV2_whenIReceive` | イベント受信時の Hat ブロック |
-| `meshV2_getSensorValue` | 他ノードのグローバル変数を読み取り |
+| `meshV2_getSensorValue` | グローバル変数を読み取り（**自ノードを含む**全ノードの同名変数の最新値） |
 
 > 各ブロックの Ruby 表現は [`docs/smalruby-language-spec-extensions.ja.md`](../smalruby-language-spec-extensions.ja.md) を参照。
+
+## センサーの値の自己参照（自分のグローバル変数も読む）
+
+`meshV2_getSensorValue` は、**自ノードを含む**全ノードの同名グローバル変数のうち、最新タイムスタンプの値を返す。
+
+- **仕組み**: AppSync は送信者にも自分の更新をエコーする。`handleDataUpdate`（`subscription-manager.js`）は自ノードのエコーも `remoteData` に取り込む（自ノード除外なし）。自分も他ノードも**サーバータイムスタンプで同列**に扱うため、クライアント/サーバー間のクロック不整合が起きない（ローカルシードはしない）。`getRemoteVariable` は `remoteData` を全ノード横断で最新勝ちで読む。
+- **ドロップダウン候補**: `getVariableNamesMenuItems`（`index.js`）は、ネットワーク受信名（`remoteData`）に加えて**自プロジェクトのグローバルスカラー変数名**（`getGlobalVariables()`）を合算する。これにより、起動直後・接続前でもプリセット変数を含む自分の変数が候補に出る（ネットワーク往復に依存しない）。
+- **broadcast は対象外**: メッセージ（`meshV2_broadcast` 系）は従来どおり自ノードを除外する（自分が送ったメッセージは自分には届かない）。変数とメッセージで非対称。
+
+### 後方互換性と一度きりの通知
+
+「同一グローバル変数名を複数ノードで共有しない」前提のもとでは、他ノード変数の読み取り（本来の用途）は不変で、変わるのは「自分の変数を読むと空文字ではなく自分の値が返る」点のみ。
+
+唯一挙動が変わりうるのは **グローバル変数名とセンサーの値の指定が重複** しているプロジェクト。これを検出したとき、**ブラウザで一度だけ**「動作が変わった」ことを非ブロッキングのバナーで知らせる（`localStorage: smalruby:meshSelfSensorNoticeShown`）。重複は読込・変数追加・リネーム・ドロップダウン変更・Ruby 編集のいずれでも生じうるため、全経路が集約される `PROJECT_LOADED` / `PROJECT_CHANGED` を監視して検出する。
+
+関連実装（scratch-gui）:
+
+- `src/lib/mesh-v2-sensor-collision.js` — 重複検出（センサーの値の名前はメニュー shadow ブロック `meshV2_menu_variableNames` の `variableNames` フィールドに入る）
+- `src/components/mesh-self-sensor-notice/` — バナー / `src/containers/mesh-self-sensor-notice.jsx` — 監視と初回ガード
+- `pages/mesh-self-sensor.html` — 解説ページ（バナーの「くわしくはこちら」から開く）
+
+> 詳細経緯は Issue #707。実装回帰の確認は `packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js`、`packages/scratch-gui/test/unit/lib/mesh-v2-sensor-collision.test.js`、`tools/playwright-verify/verify-mesh-collision-paths.mjs` を参照。
 
 ## 関連ドキュメント
 

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -39,6 +39,7 @@ src/components/*
 !src/components/google-drive-save-dialog/
 !src/components/dncl-mode-notice/
 !src/components/koshien-test-modal/
+!src/components/mesh-self-sensor-notice/
 !src/components/mobile-bottom-tabs/
 !src/components/mobile-drawer/
 !src/components/mobile-gui/
@@ -101,6 +102,7 @@ src/containers/*
 !src/containers/use-teacher-submissions.js
 !src/containers/extension-library.css
 !src/containers/google-drive-loader-hoc.jsx
+!src/containers/mesh-self-sensor-notice.jsx
 !src/containers/google-drive-saver-hoc.jsx
 !src/containers/ruby-downloader.jsx
 !src/containers/ruby-tab.jsx
@@ -144,6 +146,7 @@ src/lib/*
 !src/lib/join-code-history.js
 !src/lib/log-suppression.js
 !src/lib/mesh-v2-classroom-binding.jsx
+!src/lib/mesh-v2-sensor-collision.js
 !src/lib/microsoft-auth.js
 !src/lib/microbit-more-update.js
 !src/lib/teacher-auth.js
@@ -271,6 +274,7 @@ test/unit/components/*
 !test/unit/components/dncl-mode-notice.test.jsx
 !test/unit/components/extension-button-dncl.test.jsx
 !test/unit/components/connected-step.test.jsx
+!test/unit/components/mesh-self-sensor-notice.test.jsx
 !test/unit/components/mobile-bottom-tabs.test.jsx
 !test/unit/components/mobile-drawer.test.jsx
 !test/unit/components/mobile-orientation-gate.test.jsx
@@ -333,6 +337,7 @@ test/unit/lib/*
 !test/unit/lib/legacy-storage.test.js
 !test/unit/lib/make-toolbox-xml.test.js
 !test/unit/lib/mesh-v2-classroom-binding.test.js
+!test/unit/lib/mesh-v2-sensor-collision.test.js
 !test/unit/lib/responsive-gui.test.jsx
 !test/unit/lib/scratch-blocks-auto-style-patch.test.js
 !test/unit/lib/use-is-narrow-screen.test.js

--- a/packages/scratch-gui/pages/mesh-self-sensor.html
+++ b/packages/scratch-gui/pages/mesh-self-sensor.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>メッシュの「センサーの値」が自分の変数も読めるようになりました | スモウルビー</title>
+    <meta name="description" content="スモウルビーのメッシュ機能で、「センサーの値」ブロックが自分のグローバル変数も読めるようになりました。変更の理由・新旧の違い・後方互換性・お知らせについてわかりやすく説明します。">
+    <meta name="robots" content="index, follow">
+    <link rel="shortcut icon" href="static/favicon.ico">
+    <meta property="og:title" content="メッシュの「センサーの値」が自分の変数も読めるようになりました">
+    <meta property="og:description" content="新しい動きでは、自分のグローバル変数も「センサーの値」で読めます。変更の理由とお知らせについて説明します。">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="スモウルビー">
+    <meta property="og:locale" content="ja_JP">
+    <style>
+        :root {
+            --ruby-red: #e60012;
+            --purple: #6a1b9a;
+            --purple-deep: #4a148c;
+            --purple-light: #9c27b0;
+            --gold: #ffeb3b;
+            --bg: #fafbff;
+            --text: #2d3748;
+            --text-light: #718096;
+            --block-event: #ffbf00;
+            --block-control: #ffab19;
+            --block-motion: #4c97ff;
+            --block-sensing: #5cb1d6;
+            --block-variable: #ff8c1a;
+            --ok: #2e9e4f;
+            --warn: #c0392b;
+        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+            line-height: 1.8;
+            color: var(--text);
+            background: var(--bg);
+        }
+        .container { max-width: 820px; margin: 0 auto; padding: 0 1.25rem; }
+        a { color: var(--purple); }
+
+        .hero {
+            background: linear-gradient(135deg, var(--purple-deep), var(--purple) 50%, var(--purple-light));
+            color: #fff;
+            padding: 2.5rem 1.25rem;
+            text-align: center;
+        }
+        .hero .badge {
+            display: inline-block;
+            background: rgba(255,255,255,0.18);
+            border: 1px solid rgba(255,255,255,0.25);
+            border-radius: 50px;
+            padding: 0.3rem 1rem;
+            font-size: 0.8rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+        }
+        .hero h1 { font-size: clamp(1.4rem, 4.5vw, 2rem); line-height: 1.4; }
+        .hero p { opacity: 0.92; margin-top: 0.75rem; font-size: 1rem; }
+
+        section { padding: 2.5rem 0; }
+        section + section { border-top: 1px solid rgba(0,0,0,0.06); }
+        h2 {
+            font-size: 1.3rem;
+            font-weight: 800;
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        h2 .num {
+            background: linear-gradient(135deg, var(--ruby-red), var(--purple));
+            color: #fff;
+            width: 1.9rem;
+            height: 1.9rem;
+            border-radius: 50%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.95rem;
+            flex-shrink: 0;
+        }
+        p { margin-bottom: 0.9rem; }
+        .lead { font-size: 1.05rem; }
+
+        /* Scratch-style block mock */
+        .blocks { display: flex; flex-direction: column; align-items: flex-start; gap: 3px; }
+        .block {
+            display: inline-flex;
+            align-items: center;
+            padding: 6px 12px;
+            border-radius: 8px;
+            color: #fff;
+            font-size: 0.9rem;
+            font-weight: 700;
+            box-shadow: 0 2px 0 rgba(0,0,0,0.15);
+            white-space: nowrap;
+        }
+        .block .slot {
+            background: rgba(255,255,255,0.3);
+            border-radius: 12px;
+            padding: 1px 9px;
+            margin: 0 4px;
+        }
+        .b-event { background: var(--block-event); }
+        .b-control { background: var(--block-control); }
+        .b-sensing { background: var(--block-sensing); }
+        .b-variable { background: var(--block-variable); }
+        .indent { margin-left: 22px; }
+
+        /* Before / after comparison */
+        .compare { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.25rem 0; }
+        @media (max-width: 640px) { .compare { grid-template-columns: 1fr; } }
+        .panel {
+            background: #fff;
+            border-radius: 14px;
+            padding: 1.25rem;
+            box-shadow: 0 4px 18px rgba(0,0,0,0.06);
+            border-top: 4px solid #ccc;
+        }
+        .panel.before { border-top-color: var(--text-light); }
+        .panel.after { border-top-color: var(--ok); }
+        .panel h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+        .tag { font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 50px; color: #fff; }
+        .tag.old { background: var(--text-light); }
+        .tag.new { background: var(--ok); }
+        .result { margin-top: 0.85rem; font-size: 0.9rem; }
+        .result .empty { color: var(--warn); font-weight: 700; }
+        .result .value { color: var(--ok); font-weight: 700; }
+
+        /* Ruby code */
+        .ruby-code {
+            font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+            font-size: 0.88rem;
+            line-height: 1.9;
+            color: #334155;
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-left: 4px solid var(--purple);
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            overflow-x: auto;
+            white-space: pre;
+        }
+        .ruby-code .kw { color: #7c3aed; font-weight: 600; }
+        .ruby-code .fn { color: #2563eb; }
+        .ruby-code .num { color: #d97706; font-weight: 600; }
+        .ruby-code .str { color: #059669; }
+        .ruby-code .cm { color: #94a3b8; }
+        .ruby-code .var { color: #dc2626; }
+
+        .callout {
+            background: #fff8e1;
+            border: 1px solid #f4d35e;
+            border-left: 4px solid var(--gold);
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            margin: 1.25rem 0;
+        }
+        .callout strong { color: var(--warn); }
+
+        .steps { list-style: none; counter-reset: step; }
+        .steps li {
+            position: relative;
+            padding: 0.4rem 0 0.4rem 2.4rem;
+            margin-bottom: 0.4rem;
+        }
+        .steps li::before {
+            counter-increment: step;
+            content: counter(step);
+            position: absolute;
+            left: 0;
+            top: 0.4rem;
+            width: 1.7rem;
+            height: 1.7rem;
+            border-radius: 50%;
+            background: var(--purple);
+            color: #fff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            font-size: 0.85rem;
+        }
+        .modal-mock {
+            max-width: 360px;
+            margin: 1.25rem 0;
+            border-radius: 12px;
+            box-shadow: 0 8px 28px rgba(0,0,0,0.12);
+            overflow: hidden;
+            border: 1px solid rgba(0,0,0,0.08);
+        }
+        .modal-mock .body { padding: 1.1rem 1.2rem; background: #fff; }
+        .modal-mock .body h4 { font-size: 1rem; margin-bottom: 0.5rem; text-align: center; }
+        .modal-mock .body p { font-size: 0.85rem; color: var(--text-light); margin: 0; }
+        .modal-mock .btns { padding: 0.9rem 1.2rem; background: #fff; border-top: 1px solid rgba(0,0,0,0.08); display: flex; flex-direction: column; gap: 0.5rem; }
+        .btn-primary { background: var(--block-motion); color: #fff; border: none; border-radius: 8px; padding: 0.6rem; font-weight: 700; }
+        .btn-secondary { background: #fff; color: var(--block-motion); border: 1px solid var(--block-motion); border-radius: 8px; padding: 0.6rem; }
+
+        footer {
+            background: #1a1a2e;
+            color: rgba(255,255,255,0.7);
+            text-align: center;
+            padding: 2rem 1rem;
+            font-size: 0.8rem;
+        }
+        footer a { color: rgba(255,255,255,0.9); }
+        .home { text-align: center; margin-top: 2rem; }
+        .home a {
+            display: inline-block;
+            background: linear-gradient(135deg, var(--ruby-red), #b8000e);
+            color: #fff;
+            padding: 0.8rem 2rem;
+            border-radius: 50px;
+            font-weight: 700;
+        }
+    </style>
+</head>
+<body>
+
+<header class="hero">
+    <div class="badge">メッシュ機能のアップデート</div>
+    <h1>「センサーの値」が<br>自分の変数も読めるようになりました</h1>
+    <p>このページでは、何が変わったのか・なぜ変えたのか・お知らせについて説明します。</p>
+</header>
+
+<main class="container">
+
+    <section>
+        <p class="lead">
+            メッシュ機能は、複数のスモウルビーをつないで、<strong>グローバル変数</strong>や<strong>メッセージ</strong>を
+            リアルタイムに共有する機能です。<br>
+            「センサーの値」ブロックは、つながっている仲間のグローバル変数を読み取るためのブロックです。
+        </p>
+        <p>
+            これまでは「センサーの値」は<strong>ほかのプロジェクトの変数だけ</strong>を読み、
+            自分自身が設定したグローバル変数は読めませんでした（いつも空っぽでした）。<br>
+            新しい動きでは、<strong>自分の変数も、仲間の変数と同じように</strong>「センサーの値」で読めるようになります。
+        </p>
+    </section>
+
+    <section>
+        <h2><span class="num">1</span>何が変わったの？</h2>
+        <p>同じプログラムでも、古い動きと新しい動きで結果が変わります。例として、自分で <code>スコア</code> という
+        グローバル変数を <code>100</code> にして、それを「センサーの値」で読んでみます。</p>
+
+        <div class="blocks" style="margin:1rem 0;">
+            <div class="block b-event">旗が押されたとき</div>
+            <div class="block b-variable"><span class="slot">スコア</span> を <span class="slot">100</span> にする</div>
+            <div class="block b-sensing">センサーの値 <span class="slot">スコア</span></div>
+        </div>
+
+        <div class="compare">
+            <div class="panel before">
+                <h3><span class="tag old">これまでの動き</span></h3>
+                <p style="font-size:0.9rem;">「センサーの値（スコア）」は自分の変数を見ないので…</p>
+                <div class="result">結果: <span class="empty">（空っぽ）</span></div>
+            </div>
+            <div class="panel after">
+                <h3><span class="tag new">新しい動き</span></h3>
+                <p style="font-size:0.9rem;">自分の変数も読めるので…</p>
+                <div class="result">結果: <span class="value">100</span></div>
+            </div>
+        </div>
+
+        <p>Rubyで書くと、こんなプログラムです。</p>
+<div class="ruby-code"><span class="cm"># 自分のグローバル変数「スコア」を設定する</span>
+<span class="var">$スコア</span> = <span class="num">100</span>
+
+<span class="cm"># これまで: 空っぽ ("")  /  新しい動き: "100"</span>
+<span class="fn">puts</span>(mesh.<span class="fn">sensor_value</span>(<span class="str">"スコア"</span>))</div>
+    </section>
+
+    <section>
+        <h2><span class="num">2</span>なぜ変えたの？</h2>
+        <p>
+            「自分が送った値を、自分でも確認したい」「送ったデータを画面に表示したい」という使い方が、
+            これまではできませんでした。自分の変数も読めるようにすることで、
+            メッシュのプログラムがもっとわかりやすく、作りやすくなります。
+        </p>
+        <p>
+            新しい動きでは、<strong>自分の値も仲間の値も、いったんネットワークを通って戻ってくる</strong>という
+            同じ仕組みで届きます。だから「自分」と「ほかの人」を特別扱いせず、いちばん新しい値が選ばれます。
+        </p>
+    </section>
+
+    <section>
+        <h2><span class="num">3</span>これまでのプログラムは大丈夫？</h2>
+        <p>
+            メッシュは、<strong>同じ名前のグローバル変数を複数の人で共有しない</strong>ことを前提にしています
+            （同じ名前を別々の人が使うと、どの値が表示されるのかわかりにくくなるためです）。
+        </p>
+        <p>この前提のもとでは、これまでのプログラムへの影響は次のとおりです。</p>
+        <ul style="margin:0 0 0.9rem 1.4rem;">
+            <li><strong>ほかの人の変数を読む</strong>（本来の使い方）→ これまでどおり、変わりません。</li>
+            <li><strong>自分の変数を読む</strong> → これまでは空っぽでしたが、新しい動きでは自分の値が読めます。</li>
+        </ul>
+        <div class="callout">
+            <p style="margin:0;">
+                ⚠️ ひとつだけ注意があります。<strong>同じ名前のグローバル変数を、自分とほかの人の両方が使っていた</strong>
+                場合だけ、表示される値が変わることがあります（いちばん新しく更新した人の値になります）。
+                この前提のもとでは、ほかの人の変数を読む本来の使い方は変わりません。
+            </p>
+        </div>
+    </section>
+
+    <section>
+        <h2><span class="num">4</span>「お知らせ」が出たときは？</h2>
+        <p>
+            グローバル変数の名前と「センサーの値」で読む名前が同じになっていると、動きが変わったことを伝える
+            <strong>お知らせ（バナー）</strong>が、画面の上に<strong>最初の一回だけ</strong>表示されます。
+            読んだら「✕」で閉じてください。次からは表示されません。
+        </p>
+
+        <div class="modal-mock" style="max-width:520px;">
+            <div class="body" style="display:flex; align-items:center; gap:10px;">
+                <span style="font-size:18px;">🌐</span>
+                <p style="flex:1; color:var(--text);">メッシュの「センサーの値」は、同じ名前のグローバル変数があると、自分の値も読むようになりました。</p>
+                <span style="color:#1a73e8; text-decoration:underline; white-space:nowrap;">くわしくはこちら</span>
+                <span style="color:var(--text-light);">✕</span>
+            </div>
+        </div>
+
+        <p>
+            動きの切り替えはありません。新しい動きは<strong>つねに有効</strong>で、お知らせはその変更に気づいてもらうための
+            ものです。「くわしくはこちら」を押すと、このページが開きます。
+        </p>
+    </section>
+
+    <section>
+        <h2><span class="num">5</span>メッセージ（ブロードキャスト）は？</h2>
+        <p>
+            今回の変更は<strong>「センサーの値」（グローバル変数）だけ</strong>です。
+            メッセージ（ブロードキャスト）は、これまでどおり<strong>自分が送ったメッセージは自分には届きません</strong>。
+            変数とメッセージで動きが違う点に注意してください。
+        </p>
+    </section>
+
+    <div class="home">
+        <a href="https://smalruby.app">スモウルビーを開く</a>
+    </div>
+</main>
+
+<footer>
+    <p>NPO法人Rubyプログラミング少年団</p>
+    <p style="margin-top:0.4rem;opacity:0.6;">&copy; 2026 Smalruby Project.</p>
+</footer>
+
+</body>
+</html>

--- a/packages/scratch-gui/pages/mesh-self-sensor.html
+++ b/packages/scratch-gui/pages/mesh-self-sensor.html
@@ -207,13 +207,16 @@
         }
         footer a { color: rgba(255,255,255,0.9); }
         .home { text-align: center; margin-top: 2rem; }
-        .home a {
+        .home a, .home button {
             display: inline-block;
             background: linear-gradient(135deg, var(--ruby-red), #b8000e);
             color: #fff;
             padding: 0.8rem 2rem;
+            border: none;
             border-radius: 50px;
             font-weight: 700;
+            font-size: 1rem;
+            cursor: pointer;
         }
     </style>
 </head>
@@ -338,7 +341,7 @@
     </section>
 
     <div class="home">
-        <a href="https://smalruby.app">スモウルビーを開く</a>
+        <button type="button" onclick="window.close()">閉じる</button>
     </div>
 </main>
 

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -45,6 +45,10 @@ import ClassroomTeacherModal from '../../containers/classroom-teacher-modal.jsx'
 // === Smalruby: Start of meshV2 classroom binding ===
 import MeshV2ClassroomBinding from '../../lib/mesh-v2-classroom-binding.jsx';
 // === Smalruby: End of meshV2 classroom binding ===
+
+// === Smalruby: Start of meshV2 self-sensor notice ===
+import MeshSelfSensorNotice from '../../containers/mesh-self-sensor-notice.jsx';
+// === Smalruby: End of meshV2 self-sensor notice ===
 // === Smalruby: Start of welcome modal ===
 import WelcomeModalHOC from '../../containers/welcome-modal-hoc.jsx';
 // === Smalruby: End of welcome modal ===
@@ -454,6 +458,9 @@ const GUIComponent = props => {
                     {/* === Smalruby: Start of meshV2 classroom binding === */}
                     <MeshV2ClassroomBinding />
                     {/* === Smalruby: End of meshV2 classroom binding === */}
+                    {/* === Smalruby: Start of meshV2 self-sensor notice === */}
+                    <MeshSelfSensorNotice />
+                    {/* === Smalruby: End of meshV2 self-sensor notice === */}
                     {/* === Smalruby: End of smalrubot firmware modal === */}
                     {/* === Smalruby: Start of welcome modal === */}
                     <WelcomeModalHOC />

--- a/packages/scratch-gui/src/components/mesh-self-sensor-notice/mesh-self-sensor-notice.css
+++ b/packages/scratch-gui/src/components/mesh-self-sensor-notice/mesh-self-sensor-notice.css
@@ -43,7 +43,7 @@
     white-space: nowrap;
     flex-shrink: 0;
     padding: 4px 6px;
-    min-height: 32px;
+    min-height: 44px;
 }
 
 .learnMore:hover {
@@ -59,7 +59,8 @@
     line-height: 1;
     flex-shrink: 0;
     padding: 4px 8px;
-    min-height: 32px;
+    min-width: 44px;
+    min-height: 44px;
 }
 
 .close:hover {

--- a/packages/scratch-gui/src/components/mesh-self-sensor-notice/mesh-self-sensor-notice.css
+++ b/packages/scratch-gui/src/components/mesh-self-sensor-notice/mesh-self-sensor-notice.css
@@ -1,0 +1,67 @@
+@import "../../css/z-index.css";
+
+/* Non-blocking banner pinned to the top-center of the viewport. It must not
+   cover the editor (pointer-events only on the banner itself). */
+.notice {
+    position: fixed;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: $z-index-modal;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: min(92vw, 720px);
+    padding: 10px 12px 10px 14px;
+    background-color: rgba(255, 248, 225, 0.98);
+    border: 1px solid #f4d35e;
+    border-left: 4px solid #f9a825;
+    border-radius: 10px;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.16);
+    font-size: 13px;
+    color: #6b5200;
+}
+
+.icon {
+    font-size: 16px;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.message {
+    flex: 1;
+    line-height: 1.5;
+}
+
+.learnMore {
+    background: none;
+    border: none;
+    color: #1a73e8;
+    cursor: pointer;
+    font-size: 13px;
+    text-decoration: underline;
+    white-space: nowrap;
+    flex-shrink: 0;
+    padding: 4px 6px;
+    min-height: 32px;
+}
+
+.learnMore:hover {
+    opacity: 0.8;
+}
+
+.close {
+    background: none;
+    border: none;
+    color: #6b5200;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    flex-shrink: 0;
+    padding: 4px 8px;
+    min-height: 32px;
+}
+
+.close:hover {
+    opacity: 0.7;
+}

--- a/packages/scratch-gui/src/components/mesh-self-sensor-notice/mesh-self-sensor-notice.jsx
+++ b/packages/scratch-gui/src/components/mesh-self-sensor-notice/mesh-self-sensor-notice.jsx
@@ -1,0 +1,69 @@
+import PropTypes from 'prop-types';
+import React, { useCallback } from 'react';
+import { defineMessages, injectIntl } from 'react-intl';
+
+import intlShape from '../../lib/intlShape.js';
+import styles from './mesh-self-sensor-notice.css';
+
+const messages = defineMessages({
+    message: {
+        id: 'gui.meshSelfSensorNotice.message',
+        defaultMessage: 'Mesh "sensor value" now also reads your own variable of the same name.',
+        description: 'One-time notice that the Mesh v2 sensor value behavior changed (self-inclusive)',
+    },
+    learnMore: {
+        id: 'gui.meshSelfSensorNotice.learnMore',
+        defaultMessage: 'Learn more',
+        description: 'Link to the explanation page in the mesh self sensor notice',
+    },
+    dismiss: {
+        id: 'gui.meshSelfSensorNotice.dismiss',
+        defaultMessage: 'Close',
+        description: 'Dismiss the mesh self sensor notice',
+    },
+});
+
+const MeshSelfSensorNotice = ({ visible, onDismiss, onLearnMore, intl }) => {
+    const handleLearnMore = useCallback(() => {
+        if (typeof window !== 'undefined') {
+            window.open('mesh-self-sensor.html', '_blank', 'noopener,noreferrer');
+        }
+        onLearnMore?.();
+    }, [onLearnMore]);
+
+    if (!visible) return null;
+
+    return (
+        <div className={styles.notice} role="status" data-testid="mesh-self-sensor-notice">
+            <span className={styles.icon} aria-hidden="true">
+                {'🌐'}
+            </span>
+            <span className={styles.message}>{intl.formatMessage(messages.message)}</span>
+            <button
+                className={styles.learnMore}
+                onClick={handleLearnMore}
+                data-testid="mesh-self-sensor-notice-learn-more"
+            >
+                {intl.formatMessage(messages.learnMore)}
+            </button>
+            <button
+                className={styles.close}
+                onClick={onDismiss}
+                aria-label={intl.formatMessage(messages.dismiss)}
+                data-testid="mesh-self-sensor-notice-dismiss"
+            >
+                {'×'}
+            </button>
+        </div>
+    );
+};
+
+MeshSelfSensorNotice.propTypes = {
+    intl: intlShape.isRequired,
+    onDismiss: PropTypes.func.isRequired,
+    onLearnMore: PropTypes.func,
+    visible: PropTypes.bool,
+};
+
+export { messages };
+export default injectIntl(MeshSelfSensorNotice);

--- a/packages/scratch-gui/src/containers/mesh-self-sensor-notice.jsx
+++ b/packages/scratch-gui/src/containers/mesh-self-sensor-notice.jsx
@@ -1,0 +1,96 @@
+import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { connect } from 'react-redux';
+import MeshSelfSensorNotice from '../components/mesh-self-sensor-notice/mesh-self-sensor-notice.jsx';
+import { hasSensorValueCollision } from '../lib/mesh-v2-sensor-collision.js';
+import { hideMeshV2SelfSensorNotice, showMeshV2SelfSensorNotice } from '../reducers/mesh-v2.js';
+
+// Shown at most once per browser (Issue #707). Once shown we never check again.
+const SHOWN_KEY = 'smalruby:meshSelfSensorNoticeShown';
+
+const alreadyShown = () => {
+    try {
+        return (
+            typeof window !== 'undefined' && window.localStorage && window.localStorage.getItem(SHOWN_KEY) === 'true'
+        );
+    } catch (_e) {
+        return false;
+    }
+};
+
+const markShown = () => {
+    try {
+        if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(SHOWN_KEY, 'true');
+    } catch (_e) {
+        // localStorage unavailable (private mode etc.) — fall back to per-session.
+    }
+};
+
+// Always-mounted container. While the one-time notice has not yet been shown, it
+// watches the VM for any change that could introduce a collision between a global
+// variable name and a Mesh v2 "sensor value" lookup (project load, variable
+// add/rename, sensor dropdown change, Ruby tab edit — all surface as
+// PROJECT_LOADED / PROJECT_CHANGED), and shows the notice the first time one is found.
+const MeshSelfSensorNoticeContainer = ({ vm, isOpen, onShow, onHide }) => {
+    const onShowRef = useRef(onShow);
+    onShowRef.current = onShow;
+
+    useEffect(() => {
+        if (!vm || alreadyShown()) return () => {};
+        let timer = null;
+        let detached = false;
+
+        const detach = () => {
+            if (timer) clearTimeout(timer);
+            timer = null;
+            vm.off('PROJECT_LOADED', schedule);
+            vm.off('PROJECT_CHANGED', schedule);
+            detached = true;
+        };
+
+        const run = () => {
+            if (detached) return;
+            if (hasSensorValueCollision(vm)) {
+                markShown();
+                onShowRef.current();
+                detach();
+            }
+        };
+
+        // PROJECT_CHANGED fires on every edit; debounce so we check once per burst.
+        const schedule = () => {
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(run, 300);
+        };
+
+        vm.on('PROJECT_LOADED', schedule);
+        vm.on('PROJECT_CHANGED', schedule);
+        // Also check the current project once (it may already be loaded with a collision).
+        schedule();
+
+        return detach;
+    }, [vm]);
+
+    const handleDismiss = useCallback(() => onHide(), [onHide]);
+
+    return <MeshSelfSensorNotice onDismiss={handleDismiss} visible={isOpen} />;
+};
+
+MeshSelfSensorNoticeContainer.propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onHide: PropTypes.func.isRequired,
+    onShow: PropTypes.func.isRequired,
+    vm: PropTypes.object,
+};
+
+const mapStateToProps = (state) => ({
+    isOpen: Boolean(state.scratchGui.meshV2.selfSensorNoticeVisible),
+    vm: state.scratchGui.vm,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    onShow: () => dispatch(showMeshV2SelfSensorNotice()),
+    onHide: () => dispatch(hideMeshV2SelfSensorNotice()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MeshSelfSensorNoticeContainer);

--- a/packages/scratch-gui/src/lib/mesh-v2-sensor-collision.js
+++ b/packages/scratch-gui/src/lib/mesh-v2-sensor-collision.js
@@ -1,0 +1,79 @@
+// Issue #707: detect when the Mesh v2 "sensor value" block looks up a name that
+// is also one of this project's own global (stage scalar) variables.
+//
+// Since the sensor value block now reads this node's own variables too
+// (self-inclusive behavior), such a collision means the value the block returns
+// may have changed for projects authored before this change. When a collision is
+// first detected we show a one-time, non-blocking notice.
+
+const SENSOR_VALUE_OPCODE = 'meshV2_getSensorValue';
+// scratch-vm Variable.SCALAR_TYPE is the empty string.
+const SCALAR_TYPE = '';
+
+/**
+ * Collect the names of the project's global scalar variables (stored on the stage).
+ * @param {object} vm - The Scratch VM instance.
+ * @returns {Set<string>} Set of global scalar variable names.
+ */
+const getGlobalScalarVariableNames = (vm) => {
+    const names = new Set();
+    const stage = vm && vm.runtime && vm.runtime.getTargetForStage && vm.runtime.getTargetForStage();
+    if (!stage || !stage.variables) return names;
+    for (const id in stage.variables) {
+        const variable = stage.variables[id];
+        if (variable && variable.type === SCALAR_TYPE && typeof variable.name === 'string') {
+            names.add(variable.name);
+        }
+    }
+    return names;
+};
+
+/**
+ * Collect the literal NAME values selected on every Mesh v2 sensor value block,
+ * across all targets. Reporter-driven lookups (a block plugged into NAME) are
+ * not literals and cannot be matched statically, so they are skipped.
+ * @param {object} vm - The Scratch VM instance.
+ * @returns {Set<string>} Set of sensor value lookup names.
+ */
+const getSensorValueLookupNames = (vm) => {
+    const names = new Set();
+    const targets = (vm && vm.runtime && vm.runtime.targets) || [];
+    for (const target of targets) {
+        const blocks = target && target.blocks && target.blocks._blocks;
+        if (!blocks) continue;
+        for (const blockId in blocks) {
+            const block = blocks[blockId];
+            if (block && block.opcode === SENSOR_VALUE_OPCODE && block.fields && block.fields.NAME) {
+                const value = block.fields.NAME.value;
+                if (typeof value === 'string' && value !== '') names.add(value);
+            }
+        }
+    }
+    return names;
+};
+
+/**
+ * Return the names that are both a global scalar variable and a sensor value
+ * lookup in the current project.
+ * @param {object} vm - The Scratch VM instance.
+ * @returns {Array<string>} Colliding names (empty when there is no collision).
+ */
+const getSensorValueCollisions = (vm) => {
+    const lookups = getSensorValueLookupNames(vm);
+    if (lookups.size === 0) return [];
+    const globals = getGlobalScalarVariableNames(vm);
+    const collisions = [];
+    for (const name of lookups) {
+        if (globals.has(name)) collisions.push(name);
+    }
+    return collisions;
+};
+
+/**
+ * Whether the current project has any sensor-value / global-variable collision.
+ * @param {object} vm - The Scratch VM instance.
+ * @returns {boolean} True when at least one name collides.
+ */
+const hasSensorValueCollision = (vm) => getSensorValueCollisions(vm).length > 0;
+
+export { getSensorValueCollisions, hasSensorValueCollision, getGlobalScalarVariableNames, getSensorValueLookupNames };

--- a/packages/scratch-gui/src/lib/mesh-v2-sensor-collision.js
+++ b/packages/scratch-gui/src/lib/mesh-v2-sensor-collision.js
@@ -7,6 +7,9 @@
 // first detected we show a one-time, non-blocking notice.
 
 const SENSOR_VALUE_OPCODE = 'meshV2_getSensorValue';
+// The sensor value block's NAME is an input wired to a shadow menu block of this
+// opcode, whose `variableNames` field holds the selected name.
+const SENSOR_VALUE_MENU_OPCODE = 'meshV2_menu_variableNames';
 // scratch-vm Variable.SCALAR_TYPE is the empty string.
 const SCALAR_TYPE = '';
 
@@ -37,16 +40,27 @@ const getGlobalScalarVariableNames = (vm) => {
  */
 const getSensorValueLookupNames = (vm) => {
     const names = new Set();
+    const add = (value) => {
+        if (typeof value === 'string' && value !== '') names.add(value);
+    };
     const targets = (vm && vm.runtime && vm.runtime.targets) || [];
     for (const target of targets) {
         const blocks = target && target.blocks && target.blocks._blocks;
         if (!blocks) continue;
         for (const blockId in blocks) {
             const block = blocks[blockId];
-            if (block && block.opcode === SENSOR_VALUE_OPCODE && block.fields && block.fields.NAME) {
-                const value = block.fields.NAME.value;
-                if (typeof value === 'string' && value !== '') names.add(value);
+            if (!block || block.opcode !== SENSOR_VALUE_OPCODE) continue;
+            // Real blocks store the selected name in a shadow menu block wired to
+            // the NAME input. Read that shadow's `variableNames` field.
+            const input = block.inputs && block.inputs.NAME;
+            if (input) {
+                const menu = blocks[input.shadow || input.block];
+                if (menu && menu.opcode === SENSOR_VALUE_MENU_OPCODE && menu.fields && menu.fields.variableNames) {
+                    add(menu.fields.variableNames.value);
+                }
             }
+            // Defensive: also accept a plain NAME field, should one ever appear.
+            if (block.fields && block.fields.NAME) add(block.fields.NAME.value);
         }
     }
     return names;

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -1015,6 +1015,10 @@ export default {
         'にほんごモードではかくちょうきのうはつかえません。\nRubyふりがなモードにもどすとかくちょうきのうがつかえるようになります。\nもどしますか？',
     'gui.dnclModeNotice.message': 'にほんごモード：ブロックがせいげんされています',
     'gui.dnclModeNotice.exitButton': 'Rubyふりがなモードにもどす',
+    'gui.meshSelfSensorNotice.message':
+        'メッシュの「センサーのあたい」は、おなじなまえのグローバルへんすうがあると、じぶんのあたいもよむようになりました。',
+    'gui.meshSelfSensorNotice.learnMore': 'くわしくはこちら',
+    'gui.meshSelfSensorNotice.dismiss': 'とじる',
     'gui.rubyTab.dnclValidationError':
         'にほんごモードではたいおうしていないきじゅつです。\nたいおうしているめいれいのみにしてから、モードきりかえをおこなってください。',
     'gui.mobile.drawer.title': 'メニュー',

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -988,6 +988,10 @@ export default {
         '日本語モードでは拡張機能は使えません。\nRubyふりがなモードに戻すと拡張機能が使えるようになります。\n戻しますか？',
     'gui.dnclModeNotice.message': '日本語モード：ブロックが制限されています',
     'gui.dnclModeNotice.exitButton': 'Rubyふりがなモードに戻す',
+    'gui.meshSelfSensorNotice.message':
+        'メッシュの「センサーの値」は、同じ名前のグローバル変数があると、自分の値も読むようになりました。',
+    'gui.meshSelfSensorNotice.learnMore': 'くわしくはこちら',
+    'gui.meshSelfSensorNotice.dismiss': '閉じる',
     'gui.rubyTab.dnclValidationError':
         '日本語モードでは対応していない記述です。\n対応している命令のみにしてから、モード切り替えを行ってください。',
     'gui.mobile.drawer.title': 'メニュー',

--- a/packages/scratch-gui/src/reducers/mesh-v2.js
+++ b/packages/scratch-gui/src/reducers/mesh-v2.js
@@ -1,7 +1,12 @@
 const SET_DOMAIN = 'scratch-gui/mesh-v2/SET_DOMAIN';
+const SHOW_SELF_SENSOR_NOTICE = 'scratch-gui/mesh-v2/SHOW_SELF_SENSOR_NOTICE';
+const HIDE_SELF_SENSOR_NOTICE = 'scratch-gui/mesh-v2/HIDE_SELF_SENSOR_NOTICE';
 
 const initialState = {
     domain: null,
+    // Issue #707: one-time notice shown when a project's global variable name
+    // collides with a Mesh v2 "sensor value" lookup (behavior changed).
+    selfSensorNoticeVisible: false,
 };
 
 const reducer = function (state, action) {
@@ -10,6 +15,14 @@ const reducer = function (state, action) {
         case SET_DOMAIN:
             return Object.assign({}, state, {
                 domain: action.domain,
+            });
+        case SHOW_SELF_SENSOR_NOTICE:
+            return Object.assign({}, state, {
+                selfSensorNoticeVisible: true,
+            });
+        case HIDE_SELF_SENSOR_NOTICE:
+            return Object.assign({}, state, {
+                selfSensorNoticeVisible: false,
             });
         default:
             return state;
@@ -23,4 +36,18 @@ const setDomain = function (domain) {
     };
 };
 
-export { reducer as default, initialState as meshV2InitialState, setDomain };
+const showMeshV2SelfSensorNotice = function () {
+    return { type: SHOW_SELF_SENSOR_NOTICE };
+};
+
+const hideMeshV2SelfSensorNotice = function () {
+    return { type: HIDE_SELF_SENSOR_NOTICE };
+};
+
+export {
+    reducer as default,
+    initialState as meshV2InitialState,
+    setDomain,
+    showMeshV2SelfSensorNotice,
+    hideMeshV2SelfSensorNotice,
+};

--- a/packages/scratch-gui/test/unit/components/mesh-self-sensor-notice.test.jsx
+++ b/packages/scratch-gui/test/unit/components/mesh-self-sensor-notice.test.jsx
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import MeshSelfSensorNotice from '../../../src/components/mesh-self-sensor-notice/mesh-self-sensor-notice.jsx';
+
+const renderNotice = (props) =>
+    render(
+        <IntlProvider locale="en">
+            <MeshSelfSensorNotice onDismiss={jest.fn()} visible {...props} />
+        </IntlProvider>,
+    );
+
+describe('MeshSelfSensorNotice', () => {
+    test('renders the banner with learn-more and dismiss when visible', () => {
+        const { getByTestId } = renderNotice();
+        expect(getByTestId('mesh-self-sensor-notice')).toBeInTheDocument();
+        expect(getByTestId('mesh-self-sensor-notice-learn-more')).toBeInTheDocument();
+        expect(getByTestId('mesh-self-sensor-notice-dismiss')).toBeInTheDocument();
+    });
+
+    test('renders nothing when not visible', () => {
+        const { queryByTestId } = renderNotice({ visible: false });
+        expect(queryByTestId('mesh-self-sensor-notice')).not.toBeInTheDocument();
+    });
+
+    test('dismiss button invokes onDismiss', () => {
+        const onDismiss = jest.fn();
+        const { getByTestId } = renderNotice({ onDismiss });
+        fireEvent.click(getByTestId('mesh-self-sensor-notice-dismiss'));
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    test('learn-more opens the explanation page and invokes onLearnMore', () => {
+        const onLearnMore = jest.fn();
+        const open = jest.spyOn(window, 'open').mockImplementation(() => null);
+        const { getByTestId } = renderNotice({ onLearnMore });
+        fireEvent.click(getByTestId('mesh-self-sensor-notice-learn-more'));
+        expect(open).toHaveBeenCalledWith('mesh-self-sensor.html', '_blank', 'noopener,noreferrer');
+        expect(onLearnMore).toHaveBeenCalledTimes(1);
+        open.mockRestore();
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/mesh-v2-sensor-collision.test.js
+++ b/packages/scratch-gui/test/unit/lib/mesh-v2-sensor-collision.test.js
@@ -1,9 +1,9 @@
 /* eslint-env jest */
 import { getSensorValueCollisions, hasSensorValueCollision } from '../../../src/lib/mesh-v2-sensor-collision.js';
 
-// Build a minimal VM-like object. Global scalar variables live on the stage;
-// sensor value blocks live on any target with opcode meshV2_getSensorValue and a
-// literal NAME field.
+// Build a minimal VM-like object matching the REAL block shape: the sensor value
+// block stores its selected name in a shadow menu block (meshV2_menu_variableNames)
+// wired to its NAME input. Global scalar variables live on the stage.
 const makeVm = ({ globals = [], sensorNames = [], lists = [] } = {}) => {
     const variables = {};
     globals.forEach((name, i) => {
@@ -14,7 +14,18 @@ const makeVm = ({ globals = [], sensorNames = [], lists = [] } = {}) => {
     });
     const blocks = {};
     sensorNames.forEach((name, i) => {
-        blocks[`b${i}`] = { opcode: 'meshV2_getSensorValue', fields: { NAME: { value: name } } };
+        const menuId = `m${i}`;
+        blocks[`b${i}`] = {
+            opcode: 'meshV2_getSensorValue',
+            fields: {},
+            inputs: { NAME: { name: 'NAME', block: menuId, shadow: menuId } },
+        };
+        blocks[menuId] = {
+            opcode: 'meshV2_menu_variableNames',
+            shadow: true,
+            fields: { variableNames: { name: 'variableNames', value: name } },
+            inputs: {},
+        };
     });
     const stage = { isStage: true, variables, blocks: { _blocks: {} } };
     const sprite = { isStage: false, variables: {}, blocks: { _blocks: blocks } };

--- a/packages/scratch-gui/test/unit/lib/mesh-v2-sensor-collision.test.js
+++ b/packages/scratch-gui/test/unit/lib/mesh-v2-sensor-collision.test.js
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+import { getSensorValueCollisions, hasSensorValueCollision } from '../../../src/lib/mesh-v2-sensor-collision.js';
+
+// Build a minimal VM-like object. Global scalar variables live on the stage;
+// sensor value blocks live on any target with opcode meshV2_getSensorValue and a
+// literal NAME field.
+const makeVm = ({ globals = [], sensorNames = [], lists = [] } = {}) => {
+    const variables = {};
+    globals.forEach((name, i) => {
+        variables[`g${i}`] = { name, type: '' };
+    });
+    lists.forEach((name, i) => {
+        variables[`l${i}`] = { name, type: 'list' };
+    });
+    const blocks = {};
+    sensorNames.forEach((name, i) => {
+        blocks[`b${i}`] = { opcode: 'meshV2_getSensorValue', fields: { NAME: { value: name } } };
+    });
+    const stage = { isStage: true, variables, blocks: { _blocks: {} } };
+    const sprite = { isStage: false, variables: {}, blocks: { _blocks: blocks } };
+    return {
+        runtime: {
+            targets: [stage, sprite],
+            getTargetForStage: () => stage,
+        },
+    };
+};
+
+describe('mesh-v2 sensor value collision detection', () => {
+    test('no collision when names differ', () => {
+        const vm = makeVm({ globals: ['score'], sensorNames: ['other'] });
+        expect(hasSensorValueCollision(vm)).toBe(false);
+        expect(getSensorValueCollisions(vm)).toEqual([]);
+    });
+
+    test('collision when a sensor value name matches a global scalar variable', () => {
+        const vm = makeVm({ globals: ['score', 'lives'], sensorNames: ['score'] });
+        expect(hasSensorValueCollision(vm)).toBe(true);
+        expect(getSensorValueCollisions(vm)).toEqual(['score']);
+    });
+
+    test('no collision when there are no sensor value blocks', () => {
+        const vm = makeVm({ globals: ['score'], sensorNames: [] });
+        expect(hasSensorValueCollision(vm)).toBe(false);
+    });
+
+    test('no collision when there are no global variables', () => {
+        const vm = makeVm({ globals: [], sensorNames: ['score'] });
+        expect(hasSensorValueCollision(vm)).toBe(false);
+    });
+
+    test('list variables do not count as a collision', () => {
+        const vm = makeVm({ lists: ['score'], sensorNames: ['score'] });
+        expect(hasSensorValueCollision(vm)).toBe(false);
+    });
+
+    test('empty sensor NAME (no selection) is ignored', () => {
+        const vm = makeVm({ globals: [''], sensorNames: [''] });
+        expect(hasSensorValueCollision(vm)).toBe(false);
+    });
+
+    test('is null/undefined safe', () => {
+        expect(hasSensorValueCollision(undefined)).toBe(false);
+        expect(hasSensorValueCollision({})).toBe(false);
+        expect(hasSensorValueCollision({ runtime: {} })).toBe(false);
+    });
+});

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/index.js
@@ -194,9 +194,13 @@ class Scratch3MeshV2Blocks {
     /* istanbul ignore next */
     getVariableNamesMenuItems () {
         if (!this.meshService) return [' '];
-        const names = Object.values(this.meshService.remoteData)
+        // Include this project's own global variables so the dropdown is useful
+        // immediately (e.g. the preset variable) before any network round-trip,
+        // in addition to names received from other nodes.
+        const ownNames = this.meshService.getGlobalVariables().map(v => v.key);
+        const remoteNames = Object.values(this.meshService.remoteData)
             .reduce((acc, nodeData) => acc.concat(Object.keys(nodeData)), []);
-        return [' '].concat([...new Set(names)]);
+        return [' '].concat([...new Set([...ownNames, ...remoteNames])]);
     }
 
     /* istanbul ignore next */

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/subscription-manager.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/subscription-manager.js
@@ -61,7 +61,13 @@ const SubscriptionManagerMixin = {
     },
 
     handleDataUpdate(nodeStatus) {
-        if (!nodeStatus || nodeStatus.nodeId === this.meshId) return;
+        // Issue #707: store data from every node, including this node itself.
+        // AppSync echoes the sender's own nodeStatus back; we keep it so the
+        // "sensor value" block can read this node's own global variables, treating
+        // self and peers uniformly (all values arrive via the network with server
+        // timestamps). A one-time UI notice informs users whose project has a
+        // global variable name colliding with a sensor value lookup.
+        if (!nodeStatus) return;
 
         const nodeId = nodeStatus.nodeId;
         if (!this.remoteData[nodeId]) {

--- a/packages/scratch-vm/test/integration/extensions/mesh-v2-variable-sync.test.js
+++ b/packages/scratch-vm/test/integration/extensions/mesh-v2-variable-sync.test.js
@@ -126,6 +126,45 @@ test('MeshV2Service Variable Sync Integration', async (t) => {
     t.end();
 });
 
+// Issue #707: the sensor value block reads this node's own global variables.
+// AppSync echoes the sender's own nodeStatus back; we keep it (no self-exclusion)
+// so self and peers are read uniformly via the shared handleDataUpdate path.
+test('MeshV2Service self-inclusive sensor value (Issue #707)', (t) => {
+    const service = new MeshV2Service(createMockBlocks(), 'self-node', 'domain1');
+
+    // Own echoed data is stored and readable.
+    service.handleDataUpdate({
+        nodeId: 'self-node',
+        timestamp: '2026-01-01T00:00:02Z',
+        data: [{ key: 'myScore', value: '100' }],
+    });
+    // Peer data is read as before (no regression).
+    service.handleDataUpdate({
+        nodeId: 'peer-node',
+        timestamp: '2026-01-01T00:00:01Z',
+        data: [{ key: 'peerScore', value: '7' }],
+    });
+
+    t.equal(service.getRemoteVariable('myScore'), '100', 'own variable is readable');
+    t.equal(service.getRemoteVariable('peerScore'), '7', 'peer variable unchanged');
+
+    // Shared name resolves to the latest timestamp, self included.
+    service.handleDataUpdate({
+        nodeId: 'peer-node',
+        timestamp: '2026-01-01T00:00:05Z',
+        data: [{ key: 's', value: 'peer' }],
+    });
+    service.handleDataUpdate({
+        nodeId: 'self-node',
+        timestamp: '2026-01-01T00:00:10Z',
+        data: [{ key: 's', value: 'self' }],
+    });
+    t.equal(service.getRemoteVariable('s'), 'self', 'latest timestamp wins across self and peers');
+
+    service.cleanup();
+    t.end();
+});
+
 test('MeshV2Service fetch existing nodes data on joinGroup', async (t) => {
     const blocks = {
         runtime: {

--- a/packages/scratch-vm/test/unit/extension_mesh_v2.js
+++ b/packages/scratch-vm/test/unit/extension_mesh_v2.js
@@ -365,6 +365,27 @@ test('Mesh V2 Blocks', (t) => {
         st.end();
     });
 
+    t.test('getVariableNamesMenuItems includes own globals and remote names', (st) => {
+        const mockRuntime = createMockRuntime();
+        const blocks = new MeshV2Blocks(mockRuntime);
+        // Own global variables show immediately (no network round-trip needed).
+        blocks.meshService.getGlobalVariables = () => [
+            { key: 'score', value: '0' },
+            { key: '変数', value: '0' },
+        ];
+        blocks.meshService.remoteData = {
+            node2: { score: { value: '5' }, remoteOnly: { value: '1' } },
+        };
+
+        const items = blocks.getVariableNamesMenuItems();
+        st.equal(items[0], ' ', 'first item is the empty placeholder');
+        st.ok(items.includes('変数'), 'preset own variable is present');
+        st.ok(items.includes('score'), 'own variable is present');
+        st.ok(items.includes('remoteOnly'), 'remote-only variable is present');
+        st.equal(items.filter((n) => n === 'score').length, 1, 'shared name is de-duplicated');
+        st.end();
+    });
+
     t.test('variable synchronization', (st) => {
         const mockRuntime = createMockRuntime();
         const blocks = new MeshV2Blocks(mockRuntime);

--- a/packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js
+++ b/packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js
@@ -58,6 +58,23 @@ test('MeshV2Service Timestamp-based getRemoteVariable', (t) => {
         st.end();
     });
 
+    t.test('handleDataUpdate stores own node data (self-inclusive, Issue #707)', (st) => {
+        // The sensor value block must read this node's own global variables, which
+        // arrive as the AppSync echo of our own nodeStatus.
+        const own = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        const serverTimestamp = new Date().toISOString();
+        own.handleDataUpdate({
+            nodeId: 'node-self',
+            timestamp: serverTimestamp,
+            data: [{ key: 'self-var', value: 'mine' }],
+        });
+
+        st.ok(own.remoteData['node-self'], 'own node is stored in remoteData');
+        st.equal(own.remoteData['node-self']['self-var'].value, 'mine');
+        st.equal(own.getRemoteVariable('self-var'), 'mine', 'own variable is readable');
+        st.end();
+    });
+
     t.test('fetchAllNodesData should add timestamp from status', async (st) => {
         const serverTimestamp = new Date().toISOString();
         const expectedTimestamp = new Date(serverTimestamp).getTime();

--- a/tools/playwright-verify/verify-mesh-collision-paths.mjs
+++ b/tools/playwright-verify/verify-mesh-collision-paths.mjs
@@ -1,0 +1,144 @@
+import { chromium } from 'playwright';
+const URL = 'http://localhost:8601/?no_beforeunload=1&tab=ruby&ruby_version=2';
+const log = (...a) => console.log('[all]', ...a);
+let failed = false;
+const fail = (m) => { console.error('[FAIL]', m); failed = true; };
+const browser = await chromium.launch({ headless: process.env.HEADLESS !== "0", slowMo: process.env.HEADLESS === "0" ? 400 : 0 });
+
+const fresh = async () => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(URL);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForFunction(() => window.smalruby && window.smalruby.vm, { timeout: 30000 });
+    return { ctx, page };
+};
+
+// Run Ruby through the real converter to build real-shape blocks/variables.
+const convert = (page, code) =>
+    page.evaluate(async (code) => {
+        let req;
+        await new Promise((r) => window.webpackChunkGUI.push([['__c__'], {}, (x) => { req = x; r(); }]));
+        let tc;
+        for (const id in req.c) {
+            const e = req.c[id] && req.c[id].exports;
+            if (e && typeof e.targetCodeToBlocks === 'function') { tc = e.targetCodeToBlocks; break; }
+        }
+        const vm = window.smalruby.vm;
+        const t = vm.editingTarget || vm.runtime.targets.find((x) => !x.isStage);
+        const conv = await tc(vm, t, code, { formatMessage: (m) => (m && m.defaultMessage) || '' }, {});
+        if (conv.result) await conv.apply();
+        return !!conv.result;
+    }, code);
+
+const bannerShows = (page) =>
+    page.waitForSelector('[data-testid="mesh-self-sensor-notice"]', { timeout: 5000 }).then(() => true).catch(() => false);
+const bannerCount = (page) => page.locator('[data-testid="mesh-self-sensor-notice"]').count();
+
+// ---- Path 1: file load ----
+{
+    const { ctx, page } = await fresh();
+    await convert(page, '$score = 0\nmove(mesh.sensor_value("score"))\n'); // collision built
+    const b64 = await page.evaluate(async () => {
+        const blob = await window.smalruby.vm.saveProjectSb3();
+        const buf = await blob.arrayBuffer(); const bytes = new Uint8Array(buf);
+        let s = ''; for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+        return btoa(s);
+    });
+    await page.reload();
+    await page.waitForFunction(() => window.smalruby && window.smalruby.vm, { timeout: 30000 });
+    await page.evaluate(() => localStorage.clear());
+    await page.evaluate(async (b64) => {
+        const bin = atob(b64); const bytes = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        await window.smalruby.vm.loadProject(bytes.buffer);
+    }, b64);
+    const ok = await bannerShows(page);
+    log('1 file load → banner =', ok, ok ? 'OK' : 'FAIL');
+    if (!ok) fail('path 1');
+    await ctx.close();
+}
+
+// ---- Path 2: manual global variable add ----
+{
+    const { ctx, page } = await fresh();
+    await convert(page, 'move(mesh.sensor_value("score"))\n'); // sensor 'score', no global 'score'
+    await page.waitForTimeout(400);
+    await page.evaluate(() => localStorage.clear());
+    const pre = (await bannerCount(page)) === 0;
+    await page.evaluate(() => {
+        const vm = window.smalruby.vm;
+        const t = vm.editingTarget || vm.runtime.targets.find((x) => !x.isStage);
+        t.blocks.blocklyListen({ type: 'var_create', varId: 'v-score', varName: 'score', varType: '', isLocal: false, isCloud: false });
+    });
+    const ok = await bannerShows(page);
+    log('2 var add → pre-clean =', pre, '| banner =', ok, pre && ok ? 'OK' : 'FAIL');
+    if (!(pre && ok)) fail('path 2');
+    await ctx.close();
+}
+
+// ---- Path 3: rename existing global variable ----
+{
+    const { ctx, page } = await fresh();
+    await convert(page, 'move(mesh.sensor_value("score"))\n'); // sensor 'score'
+    await page.evaluate(() => {
+        const vm = window.smalruby.vm;
+        const t = vm.editingTarget || vm.runtime.targets.find((x) => !x.isStage);
+        t.blocks.blocklyListen({ type: 'var_create', varId: 'v-foo', varName: 'foo', varType: '', isLocal: false, isCloud: false });
+    });
+    await page.waitForTimeout(400);
+    await page.evaluate(() => localStorage.clear());
+    const pre = (await bannerCount(page)) === 0;
+    await page.evaluate(() => {
+        const vm = window.smalruby.vm;
+        const t = vm.editingTarget || vm.runtime.targets.find((x) => !x.isStage);
+        t.blocks.blocklyListen({ type: 'var_rename', varId: 'v-foo', newName: 'score', isLocal: false, isCloud: false });
+    });
+    const ok = await bannerShows(page);
+    log('3 rename → pre-clean =', pre, '| banner =', ok, pre && ok ? 'OK' : 'FAIL');
+    if (!(pre && ok)) fail('path 3');
+    await ctx.close();
+}
+
+// ---- Path 4: sensor dropdown change (changes the menu shadow's field) ----
+{
+    const { ctx, page } = await fresh();
+    await convert(page, '$score = 0\nmove(mesh.sensor_value("other"))\n'); // global 'score' + sensor 'other'
+    await page.waitForTimeout(400);
+    await page.evaluate(() => localStorage.clear());
+    const pre = (await bannerCount(page)) === 0;
+    const changed = await page.evaluate(() => {
+        const vm = window.smalruby.vm;
+        let menuId = null;
+        for (const t of vm.runtime.targets) {
+            const blks = t.blocks && t.blocks._blocks; if (!blks) continue;
+            for (const id in blks) if (blks[id].opcode === 'meshV2_menu_variableNames') menuId = id;
+            if (menuId) {
+                const t2 = t;
+                t2.blocks.changeBlock({ id: menuId, element: 'field', name: 'variableNames', value: 'score' });
+                return true;
+            }
+        }
+        return false;
+    });
+    const ok = await bannerShows(page);
+    log('4 dropdown change → pre-clean =', pre, '| changed =', changed, '| banner =', ok, pre && changed && ok ? 'OK' : 'FAIL');
+    if (!(pre && changed && ok)) fail('path 4');
+    await ctx.close();
+}
+
+// ---- Path 5: Ruby tab edit (real conversion creating the collision) ----
+{
+    const { ctx, page } = await fresh();
+    await page.evaluate(() => localStorage.clear());
+    await convert(page, '$score = 0\nmove(mesh.sensor_value("score"))\n');
+    const ok = await bannerShows(page);
+    log('5 ruby edit → banner =', ok, ok ? 'OK' : 'FAIL');
+    if (!ok) fail('path 5');
+    await ctx.close();
+}
+
+await browser.close();
+log(failed ? 'DONE WITH FAILURES' : 'ALL 5 PATHS PASSED');
+process.exitCode = failed ? 1 : 0;

--- a/tools/playwright-verify/verify-mesh-self-sensor-notice.mjs
+++ b/tools/playwright-verify/verify-mesh-self-sensor-notice.mjs
@@ -1,0 +1,81 @@
+// Issue #707 (collision-notice approach): verify the one-time notice wiring.
+// Introduces a global-variable / sensor-value collision in VM state, fires the
+// same PROJECT_CHANGED event the real edits fire, and checks the banner shows
+// once per browser (localStorage guard).
+import { chromium } from 'playwright';
+
+const URL = 'http://localhost:8601/?no_beforeunload=1&tab=ruby&ruby_version=2';
+const log = (...a) => console.log('[notice]', ...a);
+const fail = (m) => { console.error('[FAIL]', m); process.exitCode = 1; };
+
+const headful = process.env.HEADLESS === '0';
+const browser = await chromium.launch({ headless: !headful, slowMo: headful ? 500 : 0 });
+const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await context.newPage();
+
+await page.goto(URL);
+await page.evaluate(() => localStorage.clear());
+await page.reload();
+await page.waitForFunction(() => window.smalruby && window.smalruby.vm, { timeout: 30000 });
+
+// Introduce a collision: a global scalar variable "score" + a meshV2 sensor
+// value block reading "score" on a sprite, then fire PROJECT_CHANGED.
+const introduceCollision = () =>
+    page.evaluate(() => {
+        const vm = window.smalruby.vm;
+        const stage = vm.runtime.getTargetForStage();
+        stage.variables['score-id'] = { id: 'score-id', name: 'score', type: '', value: 0 };
+        const sprite = vm.runtime.targets.find((t) => !t.isStage);
+        sprite.blocks._blocks['sensor-blk'] = {
+            id: 'sensor-blk',
+            opcode: 'meshV2_getSensorValue',
+            fields: { NAME: { name: 'NAME', value: 'score' } },
+            inputs: {},
+        };
+        vm.runtime.emitProjectChanged();
+    });
+
+// 0: no banner before any collision.
+await page.waitForTimeout(500);
+let pre = await page.locator('[data-testid="mesh-self-sensor-notice"]').count();
+log('0 no banner initially =', pre === 0, pre === 0 ? 'OK' : 'FAIL');
+if (pre !== 0) fail('banner should not show without a collision');
+
+// 1: collision → banner appears (after debounce).
+await introduceCollision();
+const banner = await page.waitForSelector('[data-testid="mesh-self-sensor-notice"]', { timeout: 5000 }).catch(() => null);
+log('1 banner appears on collision =', !!banner, banner ? 'OK' : 'FAIL');
+if (!banner) fail('banner did not appear on collision');
+await page.screenshot({ path: 'tmp/mesh-notice-1-shown.png' });
+
+// localStorage guard set.
+const shownFlag = await page.evaluate(() => localStorage.getItem('smalruby:meshSelfSensorNoticeShown'));
+log('2 localStorage guard set =', shownFlag === 'true', shownFlag === 'true' ? 'OK' : 'FAIL');
+if (shownFlag !== 'true') fail('localStorage guard not set');
+
+// 3: dismiss closes the banner.
+await page.click('[data-testid="mesh-self-sensor-notice-dismiss"]');
+await page.waitForTimeout(300);
+let afterDismiss = await page.locator('[data-testid="mesh-self-sensor-notice"]').count();
+log('3 dismiss closes banner =', afterDismiss === 0, afterDismiss === 0 ? 'OK' : 'FAIL');
+if (afterDismiss !== 0) fail('dismiss did not close banner');
+
+// 4: another collision change does NOT re-show (guard, same session).
+await introduceCollision();
+await page.waitForTimeout(600);
+let reshow = await page.locator('[data-testid="mesh-self-sensor-notice"]').count();
+log('4 not re-shown after guard (same session) =', reshow === 0, reshow === 0 ? 'OK' : 'FAIL');
+if (reshow !== 0) fail('banner re-shown despite guard');
+
+// 5: reload (localStorage persists) → collision → still not shown.
+await page.reload();
+await page.waitForFunction(() => window.smalruby && window.smalruby.vm, { timeout: 30000 });
+await introduceCollision();
+await page.waitForTimeout(600);
+let afterReload = await page.locator('[data-testid="mesh-self-sensor-notice"]').count();
+log('5 not shown after reload (once per browser) =', afterReload === 0, afterReload === 0 ? 'OK' : 'FAIL');
+if (afterReload !== 0) fail('banner shown again after reload despite once-per-browser guard');
+
+if (headful) await page.waitForTimeout(2000);
+await browser.close();
+log(process.exitCode ? 'DONE WITH FAILURES' : 'ALL NOTICE CHECKS PASSED');


### PR DESCRIPTION
## Summary

Issue #707 の**別案**（互換ゲート方式の PR #708 とは独立）。Mesh v2 の「センサーの値」を**常に自己参照（新動作）**にし、**グローバル変数名とセンサーの値の指定が重複したときだけ、ブラウザで一度だけ**「動作が変わった」ことを非ブロッキングのバナーで知らせる。

Related #707 / 代替案: #708

## 方針（合意済み）

- **常に新動作**（フラグ・有効化モーダルなし）。自ノードのエコーも `remoteData` に取り込み、自分の変数も他ノードと同列に読める。
- **重複検出 → 初回のみ通知**: グローバル(スカラー)変数名と `meshV2_getSensorValue` の NAME が一致したら、**ブラウザで1回だけ** バナーを表示（localStorage `smalruby:meshSelfSensorNoticeShown`）。
- **非ブロッキングのバナー**（画面上部中央、`dncl-mode-notice` 系の流儀）。接続モーダル等と重ならない。「くわしくはこちら」→ `mesh-self-sensor.html`。
- 検出は全経路（ファイル読込・変数追加・リネーム・ドロップダウン変更・Ruby編集）が集約される **`PROJECT_LOADED` / `PROJECT_CHANGED`** に統一フックし、各経路を1つずつ検証していく。

## 実装

- `scratch-vm/.../subscription-manager.js`: 自ノード除外を**無条件で撤廃**（+ unit test）
- `scratch-gui/src/lib/mesh-v2-sensor-collision.js`: 純粋な重複検出（+ unit test 7 件）
- `src/components/mesh-self-sensor-notice/`: バナー（+ component test 4 件）
- `src/containers/mesh-self-sensor-notice.jsx`: `PROJECT_LOADED`/`PROJECT_CHANGED` を監視（初回まで）、localStorage 一度きりガード
- `src/reducers/mesh-v2.js`: 通知表示 state / `gui.jsx` マウント（マーカー）/ ja・ja-Hira
- `pages/mesh-self-sensor.html`: 解説ページ（常時有効＋お知らせモデルに更新）

## 検証

- 単体: 検出ロジック 7 件 / バナー 4 件 / scratch-vm timestamp すべて green
- ブラウザ（`tools/playwright-verify/verify-mesh-self-sensor-notice.mjs`）: 重複発生でバナー1回表示 → localStorage ガード設定 → ✕で閉じる → 同一セッション再発火でも非表示 → リロード後も非表示（ブラウザで1回）

## 残（一緒に1つずつ確認予定）

- [ ] ファイルから読み込んだ場合
- [ ] 手動でグローバル変数を追加した場合
- [ ] 既存のグローバル変数の名前を変更した場合
- [ ] センサーの値ブロックのドロップダウンを変えた場合
- [ ] Ruby タブで直接コードを変更した場合

各ジェスチャが `PROJECT_CHANGED`/`PROJECT_LOADED` を確かに発火し、バナーが（初回のみ）出ることを 1 つずつ確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
