### PR TITLE
chore: enable CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT in devcontainer template

### DIFF
--- a/.devcontainer/devcontainer.json.example
+++ b/.devcontainer/devcontainer.json.example
@@ -47,7 +47,13 @@
     "containerEnv": {
         // container 内 Claude が host の ~/.claude.json のバージョンを
         // 勝手に書き換えるのを防ぐ。host との version drift 防止。
-        "DISABLE_AUTOUPDATER": "1"
+        "DISABLE_AUTOUPDATER": "1",
+
+        // devpod ssh (OpenSSH ではない独自プロキシ) 経由だと Claude Code の
+        // fullscreen レンダラが差分描画で全角セルを消し残し、行頭に前フレームの
+        // 全角文字 (例: "こ") が残るアーティファクトが出る。毎フレーム全画面を
+        // 描き直すことで解消する (Ctrl+L 相当を常時適用)。
+        "CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT": "1"
     },
 
     "forwardPorts": [8601],


### PR DESCRIPTION
## Summary
devpod + `devpod ssh`（OpenSSH ではない独自プロキシ）経由で Claude Code を使うと、ストリーミング出力中に行頭の左2列（=全角1文字分）に前フレームの全角文字（例: `こ`）が消し残るアーティファクトが発生する。`devcontainer.json` テンプレートの `containerEnv` に `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1` を追加し、全 devpod worktree でこの問題を解消する。

## 原因
- Claude Code の fullscreen レンダラが**差分描画で全角セルを消し残す**（devpod ssh 経由で顕在化）
- `Ctrl+L`（全画面リフレッシュ）で一時的に直るが、出力が進むと再発
- ロケール（`C.UTF-8`）・iTerm2 の ambiguous-width 設定（OFF）・winsize はいずれも無関係（全画面再描画は正しく描けるため幅は合っている）

## 修正
`CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1`（公式 env var: "Use if fullscreen shows stale or misplaced text fragments."）を毎フレーム全画面再描画として常時適用。

## Changes Made
- `.devcontainer/devcontainer.json.example` の `containerEnv` に `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1` を追加（理由をコメントで併記）

## Test Coverage
- 実機（macOS + iTerm2 + devpod ssh、tmux なし）で `export CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1` → 再起動でアーティファクト解消を確認
- テンプレート（チェックイン）のみの変更。コード挙動・テスト対象には影響なし
