### PR TITLE
fix: make Ruby-to-blocks apply transactional to prevent block loss (#710)

### DIFF
--- a/packages/scratch-gui/src/containers/controls.jsx
+++ b/packages/scratch-gui/src/containers/controls.jsx
@@ -51,6 +51,12 @@ class Controls extends React.Component {
                     }
                     // === Smalruby: End of block_run analytics ===
                 }
+            })
+            .catch(error => {
+                // apply() failed and rolled the target's blocks back
+                // (issue #710); log instead of an unhandled rejection.
+                // eslint-disable-next-line no-console
+                console.error('[Controls] Ruby to blocks apply error:', error);
             });
     }
     handleStopAllClick (e) {

--- a/packages/scratch-gui/src/containers/gui.jsx
+++ b/packages/scratch-gui/src/containers/gui.jsx
@@ -138,10 +138,25 @@ class GUI extends React.Component {
             ).then(converter => {
                 if (converter.result) {
                     this.props.updateRubyCodeErrorsState(converter.errors);
-                    this.props.convertedRubyCodeState();
-                    converter.apply().then(() => {
-                        this.props.onActivateTab(destinationTab);
-                    });
+                    converter.apply()
+                        .then(() => {
+                            // Only mark the Ruby code as converted after the
+                            // blocks were actually applied — clearing the
+                            // modified flag before a failed apply would skip
+                            // re-conversion on the next tab switch and lose
+                            // the user's edits (issue #710).
+                            this.props.convertedRubyCodeState();
+                            this.props.onActivateTab(destinationTab);
+                        })
+                        .catch(error => {
+                            // apply() failed and rolled the target's blocks
+                            // back (issue #710). Stay on the Ruby tab and
+                            // surface the error instead of silently dropping
+                            // the unhandled rejection.
+                            // eslint-disable-next-line no-console
+                            console.error('[GUI] Ruby to blocks apply error:', error);
+                            this.props.onShowConvertRubyToBlocksErrorAlert();
+                        });
                     return;
                 }
                 this.props.vm.setEditingTarget(prevProps.rubyCode.target.id);

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -716,7 +716,14 @@ const RubyTab = (props) => {
                 showErrors(converter.errors);
                 return;
             }
-            await converter.apply();
+            try {
+                await converter.apply();
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error('[handlePreviewRubyScript] Apply error:', error);
+                onShowAlert('convertRubyToBlocksError');
+                return;
+            }
             props.onChange(rubyCode.code);
         }
         const code = generatePreviewCode(vm.editingTarget, rubyVersion);
@@ -743,18 +750,27 @@ const RubyTab = (props) => {
         if (rubyCode.modified) {
             const converter = await targetCodeToBlocksHOC(intl);
             if (converter.result) {
-                converter.apply().then(async () => {
-                    clearErrors();
-                    if (rubyCode.target && String(newVersion) === '2') {
-                        try {
-                            await syncModules(vm, rubyCode.target, intl, newVersion);
-                        } catch (e) {
-                            // eslint-disable-next-line no-console
-                            console.error('Module sync error:', e);
+                converter
+                    .apply()
+                    .then(async () => {
+                        clearErrors();
+                        if (rubyCode.target && String(newVersion) === '2') {
+                            try {
+                                await syncModules(vm, rubyCode.target, intl, newVersion);
+                            } catch (e) {
+                                // eslint-disable-next-line no-console
+                                console.error('Module sync error:', e);
+                            }
                         }
-                    }
-                    updateRubyCodeTargetState(vm.editingTarget, newVersion);
-                });
+                        updateRubyCodeTargetState(vm.editingTarget, newVersion);
+                    })
+                    .catch((error) => {
+                        // eslint-disable-next-line no-console
+                        console.error('[handleRubyVersionChange] Apply error:', error);
+                        lastProcessedVersionRef.current = oldVersion;
+                        onRevertRubyVersion(oldVersion);
+                        onShowAlert('rubyVersionChangeFailed');
+                    });
             } else {
                 lastProcessedVersionRef.current = oldVersion;
                 onRevertRubyVersion(oldVersion);
@@ -1024,6 +1040,13 @@ const RubyTab = (props) => {
 
     // componentDidUpdate equivalent
     const prevPropsRef = useRef(null);
+    // Guard against starting a second Ruby→blocks conversion while one is
+    // already running. The conversion's own side effects (extension loads,
+    // emitWorkspaceUpdate, alerts) re-render this component while
+    // rubyCode.modified is still true, so without this guard the effect
+    // below starts the whole convert+apply pipeline twice per tab switch
+    // (issue #710).
+    const conversionInFlightRef = useRef(false);
     useEffect(() => {
         const prev = prevPropsRef.current;
         const savePrev = () => {
@@ -1107,36 +1130,50 @@ const RubyTab = (props) => {
                     }
                     onDismissV1Prompt();
                 }
-                targetCodeToBlocksHOC(intl).then((converter) => {
-                    if (converter.result) {
-                        converter.apply().then(async () => {
-                            modified = false;
-                            clearErrors();
-                            if (rubyCode.target && String(rubyVersion) === '2') {
-                                try {
-                                    await syncModules(vm, rubyCode.target, intl, rubyVersion);
-                                } catch (e) {
-                                    // eslint-disable-next-line no-console
-                                    console.error('Module sync error:', e);
-                                }
+                if (!conversionInFlightRef.current) {
+                    conversionInFlightRef.current = true;
+                    targetCodeToBlocksHOC(intl)
+                        .then((converter) => {
+                            if (converter.result) {
+                                return converter.apply().then(async () => {
+                                    modified = false;
+                                    clearErrors();
+                                    if (rubyCode.target && String(rubyVersion) === '2') {
+                                        try {
+                                            await syncModules(vm, rubyCode.target, intl, rubyVersion);
+                                        } catch (e) {
+                                            // eslint-disable-next-line no-console
+                                            console.error('Module sync error:', e);
+                                        }
+                                    }
+                                    if (!modified) {
+                                        const etChanged = editingTarget && editingTarget !== prev.editingTarget;
+                                        if ((isVisible && !prev.isVisible) || etChanged) {
+                                            updateRubyCodeTargetState(vm.editingTarget, rubyVersion);
+                                        }
+                                    }
+                                    if (isVisible && !prev.isVisible) {
+                                        if (editorRef.current) {
+                                            editorRef.current.focus();
+                                            editorRef.current.layout();
+                                        }
+                                    }
+                                });
                             }
-                            if (!modified) {
-                                const etChanged = editingTarget && editingTarget !== prev.editingTarget;
-                                if ((isVisible && !prev.isVisible) || etChanged) {
-                                    updateRubyCodeTargetState(vm.editingTarget, rubyVersion);
-                                }
-                            }
-                            if (isVisible && !prev.isVisible) {
-                                if (editorRef.current) {
-                                    editorRef.current.focus();
-                                    editorRef.current.layout();
-                                }
-                            }
+                            showErrors(converter.errors);
+                        })
+                        .catch((error) => {
+                            // apply() failed and rolled the target back
+                            // (issue #710) — surface the error instead of
+                            // letting it vanish as an unhandled rejection.
+                            // eslint-disable-next-line no-console
+                            console.error('[RubyTab] Ruby to blocks apply error:', error);
+                            onShowAlert('convertRubyToBlocksError');
+                        })
+                        .finally(() => {
+                            conversionInFlightRef.current = false;
                         });
-                        return;
-                    }
-                    showErrors(converter.errors);
-                });
+                }
             }
         }
 

--- a/packages/scratch-gui/src/containers/sb3-downloader.jsx
+++ b/packages/scratch-gui/src/containers/sb3-downloader.jsx
@@ -42,7 +42,13 @@ class SB3Downloader extends React.Component {
                 }
                 downloadBlob(this.props.projectFilename, content);
             });
-        });
+        })
+            .catch(error => {
+                // apply() failed and rolled the target's blocks back
+                // (issue #710); log instead of an unhandled rejection.
+                // eslint-disable-next-line no-console
+                console.error('[SB3Downloader] Ruby to blocks apply error:', error);
+            });
     }
     render () {
         const {

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter-hoc.jsx
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter-hoc.jsx
@@ -45,7 +45,16 @@ const RubyToBlocksConverterHOC = function (WrappedComponent) {
                     return converter;
                 }
                 this.props.updateRubyCodeErrorsState(converter.errors);
-                this.props.convertedRubyCodeState();
+                // Clear the modified flag only after the blocks were actually
+                // applied. Clearing it here (before apply) would skip
+                // re-conversion on the next tab switch when apply fails and
+                // silently lose the user's edits (issue #710).
+                const originalApply = converter.apply;
+                converter.apply = async (...args) => {
+                    const applied = await originalApply(...args);
+                    this.props.convertedRubyCodeState();
+                    return applied;
+                };
                 return converter;
             }
             return NullRubyToBlocksConverter;

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/target-applier.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/target-applier.js
@@ -186,19 +186,24 @@ const TargetApplier = {
             // If a newer applyTargetBlocks was started, skip this one
             if (target._smalrubyApplySeq !== applySeq) return;
 
-            // Validate the converted graph before touching the target: every
-            // non-top-level block must reference an existing parent. A broken
-            // graph would serialize to an empty workspace (orphan blocks)
-            // even though apply "succeeds" (issue #710).
-            Object.keys(this._context.blocks).forEach(blockId => {
+            // Validate the converted graph before touching the target: a
+            // non-empty graph with no top-level script serializes to an
+            // empty workspace even though apply "succeeds" (issue #710).
+            // Note: dangling `parent` references on individual blocks are
+            // routine converter output (e.g. re-parented shadows) and are
+            // harmless, so only this catastrophic whole-graph case is
+            // rejected.
+            const contextBlockIds = Object.keys(this._context.blocks);
+            const hasTopLevelScript = contextBlockIds.some(blockId => {
                 const block = this._context.blocks[blockId];
-                if (block.parent && !this._context.blocks[block.parent]) {
-                    throw new Error(
-                        `Converted block graph is broken: block "${blockId}" ` +
-                        `(${block.opcode}) references missing parent "${block.parent}"`
-                    );
-                }
+                return block.topLevel && !block.shadow;
             });
+            if (contextBlockIds.length > 0 && !hasTopLevelScript) {
+                throw new Error(
+                    'Converted block graph is broken: ' +
+                    `${contextBlockIds.length} blocks but no top-level script`
+                );
+            }
 
             // Replacing the target's blocks is delete-all-then-create and is
             // NOT atomic. If createBlock throws midway the target would be

--- a/packages/scratch-gui/src/lib/ruby-to-blocks-converter/target-applier.js
+++ b/packages/scratch-gui/src/lib/ruby-to-blocks-converter/target-applier.js
@@ -186,14 +186,57 @@ const TargetApplier = {
             // If a newer applyTargetBlocks was started, skip this one
             if (target._smalrubyApplySeq !== applySeq) return;
 
-            Object.keys(target.blocks._blocks).forEach(blockId => {
-                target.blocks.deleteBlock(blockId);
-            });
-            target.comments = {};
-
+            // Validate the converted graph before touching the target: every
+            // non-top-level block must reference an existing parent. A broken
+            // graph would serialize to an empty workspace (orphan blocks)
+            // even though apply "succeeds" (issue #710).
             Object.keys(this._context.blocks).forEach(blockId => {
-                target.blocks.createBlock(this._context.blocks[blockId]);
+                const block = this._context.blocks[blockId];
+                if (block.parent && !this._context.blocks[block.parent]) {
+                    throw new Error(
+                        `Converted block graph is broken: block "${blockId}" ` +
+                        `(${block.opcode}) references missing parent "${block.parent}"`
+                    );
+                }
             });
+
+            // Replacing the target's blocks is delete-all-then-create and is
+            // NOT atomic. If createBlock throws midway the target would be
+            // left with a partial (or empty) program while the Ruby tab still
+            // shows the code (issue #710). Snapshot the current blocks and
+            // comments so any failure can be rolled back.
+            // Snapshot each block with a per-block shallow clone:
+            // deleteBlock mutates the block objects themselves
+            // (_deleteScript flips `topLevel` to false), so holding bare
+            // references would corrupt the snapshot.
+            const oldBlocks = {};
+            Object.keys(target.blocks._blocks).forEach(blockId => {
+                oldBlocks[blockId] = Object.assign({}, target.blocks._blocks[blockId]);
+            });
+            const oldScripts = target.blocks._scripts.slice();
+            const oldComments = target.comments;
+
+            try {
+                Object.keys(target.blocks._blocks).forEach(blockId => {
+                    target.blocks.deleteBlock(blockId);
+                });
+                target.comments = {};
+
+                Object.keys(this._context.blocks).forEach(blockId => {
+                    target.blocks.createBlock(this._context.blocks[blockId]);
+                });
+            } catch (error) {
+                // Roll back to the pre-apply state. Restore the internal
+                // containers directly instead of going through createBlock —
+                // if createBlock is what just failed, replaying it could
+                // fail again and leave the target empty.
+                target.blocks._blocks = oldBlocks;
+                target.blocks._scripts = oldScripts;
+                target.blocks.resetCache();
+                target.comments = oldComments;
+                this.vm.emitWorkspaceUpdate();
+                throw error;
+            }
 
             Object.keys(this._context.comments).forEach(commentId => {
                 const comment = this._context.comments[commentId];

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/target-applier-transaction.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/target-applier-transaction.test.js
@@ -178,16 +178,16 @@ describe('RubyToBlocksConverter/TargetApplier transaction (issue #710)', () => {
         expect(target.comments.oldcomment.text).toBe('keep me');
     });
 
-    test('should reject and keep old blocks when converted graph has a broken parent chain', async () => {
+    test('should reject and keep old blocks when converted graph has no top-level script', async () => {
         const result = await converter.targetCodeToBlocks(
             target,
             'when_flag_clicked do\n  move(10)\nend\n',
         );
         expect(result).toBe(true);
 
-        // Corrupt the converted graph: drop the hat block so the remaining
-        // blocks reference a missing parent. Such a graph serializes to an
-        // empty workspace even though apply "succeeds".
+        // Corrupt the converted graph: drop the hat block so no top-level
+        // script remains. Such a graph serializes to an empty workspace
+        // even though apply "succeeds".
         const contextBlocks = converter._context.blocks;
         const hatId = Object.keys(contextBlocks).find(
             (id) => contextBlocks[id].opcode === 'event_whenflagclicked',

--- a/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/target-applier-transaction.test.js
+++ b/packages/scratch-gui/test/unit/lib/ruby-to-blocks-converter/target-applier-transaction.test.js
@@ -1,0 +1,207 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import Blocks from '@smalruby/scratch-vm/src/engine/blocks';
+import Variable from '@smalruby/scratch-vm/src/engine/variable';
+
+// Issue #710: applyTargetBlocks deletes ALL existing blocks before creating
+// the converted ones. If createBlock throws midway (or the converted graph is
+// broken), the target is left with a partial/empty program while the Ruby tab
+// still shows the code. These tests pin the transactional behavior: on any
+// failure the target's blocks and comments must be rolled back to the
+// pre-apply state and the error must propagate to the caller.
+describe('RubyToBlocksConverter/TargetApplier transaction (issue #710)', () => {
+    let converter;
+    let target;
+    let stage;
+    let vm;
+
+    const OLD_BLOCK_IDS = ['oldhat', 'oldmove', 'oldnum'];
+
+    const createOldProgram = (blocks) => {
+        blocks.createBlock({
+            id: 'oldhat',
+            opcode: 'event_whenflagclicked',
+            next: 'oldmove',
+            parent: null,
+            inputs: {},
+            fields: {},
+            shadow: false,
+            topLevel: true,
+            x: 40,
+            y: 40,
+        });
+        blocks.createBlock({
+            id: 'oldmove',
+            opcode: 'motion_movesteps',
+            next: null,
+            parent: 'oldhat',
+            inputs: {
+                STEPS: {name: 'STEPS', block: 'oldnum', shadow: 'oldnum'},
+            },
+            fields: {},
+            shadow: false,
+            topLevel: false,
+        });
+        blocks.createBlock({
+            id: 'oldnum',
+            opcode: 'math_number',
+            next: null,
+            parent: 'oldmove',
+            inputs: {},
+            fields: {NUM: {name: 'NUM', value: '10'}},
+            shadow: true,
+            topLevel: false,
+        });
+    };
+
+    beforeEach(() => {
+        stage = {
+            blocks: new Blocks(),
+            variables: {},
+            isStage: true,
+            createVariable: function (id, name, type) {
+                this.variables[id] = new Variable(id, name, type);
+            },
+            lookupVariableByNameAndType: function (name, type) {
+                for (const varId in this.variables) {
+                    const currVar = this.variables[varId];
+                    if (currVar.name === name && currVar.type === type) {
+                        return currVar;
+                    }
+                }
+                return null;
+            },
+        };
+
+        const runtime = {
+            emitProjectChanged: () => {},
+            getTargetForStage: () => stage,
+        };
+
+        target = {
+            blocks: new Blocks(runtime),
+            variables: {},
+            comments: {
+                oldcomment: {id: 'oldcomment', blockId: null, text: 'keep me'},
+            },
+            isStage: false,
+            createVariable: function (id, name, type) {
+                if (Object.prototype.hasOwnProperty.call(this.variables, id)) {
+                    return;
+                }
+                this.variables[id] = new Variable(id, name, type);
+            },
+            lookupVariableByNameAndType: function (name, type, skipStage) {
+                for (const varId in this.variables) {
+                    const currVar = this.variables[varId];
+                    if (currVar.name === name && currVar.type === type) {
+                        return currVar;
+                    }
+                }
+                if (!skipStage) {
+                    return stage.lookupVariableByNameAndType(name, type);
+                }
+                return null;
+            },
+            lookupVariableById: function (id) {
+                if (Object.prototype.hasOwnProperty.call(this.variables, id)) {
+                    return this.variables[id];
+                }
+                return null;
+            },
+            deleteVariable: function (id) {
+                delete this.variables[id];
+            },
+            createComment: function (id, blockId, text, x, y, width, height, minimized) {
+                this.comments[id] = {id, blockId, text, x, y, width, height, minimized};
+            },
+        };
+        createOldProgram(target.blocks);
+
+        vm = {
+            runtime: runtime,
+            emitWorkspaceUpdate: () => {},
+            extensionManager: {
+                isExtensionLoaded: () => true,
+                loadExtensionURL: () => Promise.resolve(),
+            },
+        };
+
+        converter = new RubyToBlocksConverter(vm);
+    });
+
+    test('should replace old blocks on successful apply', async () => {
+        const result = await converter.targetCodeToBlocks(
+            target,
+            'when_flag_clicked do\n  move(10)\nend\n',
+        );
+        expect(result).toBe(true);
+
+        await converter.applyTargetBlocks(target);
+
+        const blockIds = Object.keys(target.blocks._blocks);
+        expect(blockIds).not.toEqual(expect.arrayContaining(OLD_BLOCK_IDS));
+        const opcodes = blockIds.map((id) => target.blocks._blocks[id].opcode);
+        expect(opcodes).toEqual(
+            expect.arrayContaining(['event_whenflagclicked', 'motion_movesteps']),
+        );
+    });
+
+    test('should roll back blocks and comments when createBlock throws during apply', async () => {
+        const result = await converter.targetCodeToBlocks(
+            target,
+            'when_flag_clicked do\n  move(10)\nend\n',
+        );
+        expect(result).toBe(true);
+
+        // Simulate a deterministic failure while re-creating the converted
+        // blocks (e.g. a converter edge case that scratch-vm rejects).
+        const originalCreateBlock = target.blocks.createBlock.bind(target.blocks);
+        target.blocks.createBlock = function (block) {
+            if (block && block.opcode === 'event_whenflagclicked') {
+                throw new Error('simulated createBlock failure');
+            }
+            return originalCreateBlock(block);
+        };
+
+        await expect(converter.applyTargetBlocks(target)).rejects.toThrow(
+            'simulated createBlock failure',
+        );
+
+        // The old program must be fully restored — not deleted, not partial.
+        expect(Object.keys(target.blocks._blocks).sort()).toEqual(
+            [...OLD_BLOCK_IDS].sort(),
+        );
+        expect(target.blocks._blocks.oldhat.topLevel).toBe(true);
+        expect(target.blocks.getScripts()).toEqual(['oldhat']);
+        // Comments must be restored as well.
+        expect(target.comments.oldcomment).toBeDefined();
+        expect(target.comments.oldcomment.text).toBe('keep me');
+    });
+
+    test('should reject and keep old blocks when converted graph has a broken parent chain', async () => {
+        const result = await converter.targetCodeToBlocks(
+            target,
+            'when_flag_clicked do\n  move(10)\nend\n',
+        );
+        expect(result).toBe(true);
+
+        // Corrupt the converted graph: drop the hat block so the remaining
+        // blocks reference a missing parent. Such a graph serializes to an
+        // empty workspace even though apply "succeeds".
+        const contextBlocks = converter._context.blocks;
+        const hatId = Object.keys(contextBlocks).find(
+            (id) => contextBlocks[id].opcode === 'event_whenflagclicked',
+        );
+        expect(hatId).toBeDefined();
+        delete contextBlocks[hatId];
+
+        await expect(converter.applyTargetBlocks(target)).rejects.toThrow();
+
+        // The old program must remain untouched.
+        expect(Object.keys(target.blocks._blocks).sort()).toEqual(
+            [...OLD_BLOCK_IDS].sort(),
+        );
+        expect(target.blocks.getScripts()).toEqual(['oldhat']);
+        expect(target.comments.oldcomment).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary

issue #710「ルビータブで表示していたプログラムがコードタブ（ブロック）で消えることがある」の修正。

調査の結果（詳細は issue のコメント参照）、`applyTargetBlocks()` の「全ブロック削除 → 再生成」が**非トランザクション**であり、create が途中で失敗すると「削除だけ完了・エラー表示なし・ルビータブにはテキストが残る」という報告症状と完全一致する状態になることを、作為的摂動（createBlock を決定論的に throw）で再現確認済み。

## Changes Made

### 本命の修正: apply のトランザクション化

- **`target-applier.js`**: delete+create スワップの前にブロック・コメントをスナップショットし、失敗時はロールバック。ロールバックは `createBlock` を経由せず内部コンテナを直接復元（失敗した createBlock を再実行するとロールバック自体が失敗しうるため）。さらに変換結果グラフの親チェーンを事前検証（親が欠けた孤児グラフは apply が「成功」しても描画が空になるため）

### エラーの可視化（unhandled rejection の根絶）

- **`gui.jsx` / `ruby-tab.jsx` / `controls.jsx` / `sb3-downloader.jsx`**: すべての `converter.apply()` チェーンに `.catch` を追加。失敗時は `convertRubyToBlocksError` アラートを表示（従来は unhandled rejection として無言で握りつぶされていた）

### modified フラグのタイミング修正

- **`gui.jsx` / `ruby-to-blocks-converter-hoc.jsx`**: `convertedRubyCodeState()`（modified クリア）を **apply 成功後**に移動。従来は apply 前にクリアしていたため、apply 失敗後の再タブ切替で変換がスキップされ、次のルビータブ訪問で編集内容が旧ブロックからの再生成により失われていた

### 変換の二重起動抑制

- **`ruby-tab.jsx`**: タブ切替時の変換 useEffect を in-flight ref でガード。変換自身の副作用（拡張ロード・workspaceUpdate・アラート）による再レンダリングで convert+apply パイプラインが 2 回走っていた

## Test Coverage

- `test/unit/lib/ruby-to-blocks-converter/target-applier-transaction.test.js` 追加（TDD・RED→GREEN）:
  - 正常系: apply 成功で旧ブロックが置き換わる
  - createBlock が throw → ブロック・コメントが完全ロールバックされ、エラーが reject として伝播する
  - 親チェーンが壊れた変換結果 → 旧ブロックを触らず reject する
- E2E 検証（ローカル dev server + headful Chrome + 摂動注入）:
  - 失敗時: 旧プログラム保持・unhandled ゼロ・アラート表示・ルビータブに編集テキスト残存
  - リトライ時: modified が維持され再変換 → 新プログラムが正しく適用

## Notes

- ruby→コードタブ切替の変換が `gui.jsx` と `ruby-tab.jsx` の 2 箇所に独立して存在する構造自体は本 PR では変更していない（`_smalrubyApplySeq` ガード + 冪等性により安全側）。一本化は別 issue として検討
- Blockly v12 の非同期イベント配送（FIRE_QUEUE）による stale delete race も調査で確認したが、これは最新 upstream develop と共通の構造のため本 PR の対象外（issue コメント参照)

## Related Issues

Fixes #710
