### PR TITLE
fix: drop stale block delete events delivered after a workspace reload (#710)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -103,6 +103,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/containers/blocks.jsx` | palette-toggle initial render | `componentDidMount` 末尾で `_applyPaletteVisibility` を呼び `forceUpdate()` を起動。`this.workspace` はインスタンス変数なので `inject()` 後に再レンダーが走らず、初回 `render()` で workspace=null のまま PaletteToggle がスキップされる問題への対応 (issue #695) |
 | `src/containers/blocks.jsx` | iOS flyout touch bleed fix | MobileGui (SP) で「ブロックを作る」タップ時に iOS の SVG タッチイベントが「変数を作る」にも伝播する問題の修正。`handlePromptStart` を 50ms 遅延して `externalProcedureDefCallback` が先に呼ばれた場合にキャンセル (issue #698) |
 | `src/containers/blocks.jsx` | DNCL block filtering | `shouldComponentUpdate` に `dnclMode` を追加して日本語モード切り替え時に即時再レンダリングを保証。import・`getToolboxXML` 内フィルター・`mapStateToProps` への `dnclMode` 追加も含む |
+| `src/containers/blocks.jsx` | stale block delete event guard | scratch-blocks v2 の非同期イベント配送で、ワークスペースリロードを跨いで届いた stale な delete イベントが VM のスクリプトを消す問題のガード。`attachVM` で `vm.blockListener` を `createStaleBlockDeleteGuard` でラップ (issue #710)。import も含む |
 
 ## 関連ファイル
 

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -134,6 +134,7 @@ upstream (Scratch) ファイルは対象外。
 - `src/lib/ruby-parser.js`
 - `src/lib/ruby-screenshot.js`
 - `src/lib/smalrubot-firmware-flasher.js`
+- `src/lib/stale-block-delete-guard.js`
 - `src/lib/smalrubot-firmware.hex.js`
 - `src/lib/storage-worker-timeout.js`
 - `src/lib/storage-worker-timeout-hoc.jsx`
@@ -281,6 +282,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/unit/lib/ruby-screenshot.test.js`
 - `test/unit/lib/smalruby-original-sprites.test.js`
 - `test/unit/lib/smalrubot-firmware-flasher.test.js`
+- `test/unit/lib/stale-block-delete-guard.test.js`
 - `test/unit/lib/ruby-script-preview.test.js`
 - `test/unit/lib/ruby-to-blocks-converter-version.test.js`
 - `test/unit/lib/rubytee-api.test.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -160,6 +160,7 @@ src/lib/*
 !src/lib/ruby-screenshot.js
 !src/lib/smalrubot-firmware-flasher.js
 !src/lib/smalrubot-firmware.hex.js
+!src/lib/stale-block-delete-guard.js
 !src/lib/storage-worker-timeout.js
 !src/lib/storage-worker-timeout-hoc.jsx
 !src/lib/ruby-script-preview.js
@@ -362,6 +363,7 @@ test/unit/lib/*
 !test/unit/lib/rubytee-api.test.js
 !test/unit/lib/rubytee-context.test.js
 !test/unit/lib/screen-utils.test.js
+!test/unit/lib/stale-block-delete-guard.test.js
 !test/unit/lib/smalrubot-firmware-flasher.test.js
 !test/unit/lib/smalruby-original-sprites.test.js
 !test/unit/lib/setup-prism.js

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -47,6 +47,9 @@ import {downloadBlocksAsImage} from '../lib/blocks-screenshot';
 // === Smalruby: Start of DNCL block filtering ===
 import {DNCL_ALLOWED_BLOCKS} from '../lib/dncl/dncl-block-filter';
 // === Smalruby: End of DNCL block filtering ===
+// === Smalruby: Start of stale block delete event guard ===
+import {createStaleBlockDeleteGuard} from '../lib/stale-block-delete-guard';
+// === Smalruby: End of stale block delete event guard ===
 
 const addFunctionListener = (object, property, callback) => {
     const oldFn = object[property];
@@ -557,7 +560,16 @@ class Blocks extends React.Component {
     }
 
     attachVM () {
-        this.workspace.addChangeListener(this.props.vm.blockListener);
+        // === Smalruby: Start of stale block delete event guard ===
+        // scratch-blocks v2 delivers events asynchronously (~1 frame later),
+        // so a queued delete can arrive after onWorkspaceUpdate reloaded the
+        // workspace and wipe the just-reloaded script from the VM
+        // (issue #710). Drop deletes for blocks that are still rendered —
+        // only possible when the event is stale.
+        this.workspace.addChangeListener(
+            createStaleBlockDeleteGuard(this.workspace, this.props.vm.blockListener)
+        );
+        // === Smalruby: End of stale block delete event guard ===
         this.flyoutWorkspace = this.workspace
             .getFlyout()
             .getWorkspace();

--- a/packages/scratch-gui/src/lib/stale-block-delete-guard.js
+++ b/packages/scratch-gui/src/lib/stale-block-delete-guard.js
@@ -1,0 +1,43 @@
+/**
+ * Guard against stale `delete` events reaching the VM (issue #710).
+ *
+ * Blockly v12 (scratch-blocks v2) delivers workspace events to listeners
+ * asynchronously, about one animation frame after they are created
+ * (FIRE_QUEUE). When the workspace is reloaded from VM XML
+ * (`clearWorkspaceAndLoadFromXml` in blocks.jsx `onWorkspaceUpdate`) while a
+ * `delete` event is still queued, the event is delivered AFTER the reload and
+ * applied to the VM against the freshly re-rendered state. Because
+ * `Blocks.deleteBlock` recursively deletes the `next` chain and inputs,
+ * a single stale delete of a top block silently wipes the whole script from
+ * the VM while the workspace still shows it — the blocks then vanish on the
+ * next tab switch.
+ *
+ * Invariant used here: a genuine deletion always disposes the block from the
+ * workspace BEFORE the event is delivered, so `getBlockById` returns null by
+ * the time the listener runs. If the block still exists in the workspace,
+ * the only way that can happen is that the workspace was reloaded in between
+ * — i.e. the event is stale. Dropping it keeps the VM consistent with what
+ * the user sees (the block stays), which is the data-preserving outcome.
+ *
+ * Note this divergence from upstream exists because upstream's historic
+ * listener detach/re-attach pattern only worked with scratch-blocks v1's
+ * synchronous event dispatch; with v2 both we and upstream share this race.
+ * @param {object} workspace - Blockly workspace to check rendered blocks on.
+ * @param {Function} blockListener - The VM's blockListener to wrap.
+ * @returns {Function} A listener that forwards everything except stale
+ *     `delete` events.
+ */
+export const createStaleBlockDeleteGuard = (workspace, blockListener) => (e) => {
+    if (e && e.type === 'delete' && typeof e.blockId === 'string' && workspace.getBlockById(e.blockId)) {
+        // Stale delete: the block was re-rendered by a workspace reload
+        // after this event was queued. Applying it to the VM would lose
+        // the script while it is still visible.
+        // eslint-disable-next-line no-console
+        console.warn(
+            `Dropping stale block delete event for "${e.blockId}" — ` +
+                'the block was re-rendered by a workspace reload (issue #710)',
+        );
+        return;
+    }
+    blockListener(e);
+};

--- a/packages/scratch-gui/test/unit/lib/stale-block-delete-guard.test.js
+++ b/packages/scratch-gui/test/unit/lib/stale-block-delete-guard.test.js
@@ -1,0 +1,77 @@
+import { createStaleBlockDeleteGuard } from '../../../src/lib/stale-block-delete-guard';
+
+// Issue #710: Blockly v12 (scratch-blocks v2) delivers workspace events to
+// vm.blockListener asynchronously (~1 frame later via FIRE_QUEUE). When the
+// workspace is reloaded from VM XML (clearWorkspaceAndLoadFromXml) before a
+// queued `delete` event is delivered, the stale delete is applied to the VM
+// even though the block was just re-rendered — deleting a top block this way
+// wipes the whole script from the VM while the workspace still shows it.
+//
+// The guard drops `delete` events whose block still exists in the rendered
+// workspace: a genuine delete always disposes the block from the workspace
+// BEFORE the event is delivered, so "block still rendered" can only mean the
+// workspace was reloaded in between (= the event is stale).
+describe('createStaleBlockDeleteGuard', () => {
+    let workspaceBlocks;
+    let workspace;
+    let received;
+    let listener;
+    let guarded;
+
+    beforeEach(() => {
+        workspaceBlocks = {};
+        workspace = {
+            getBlockById: (id) => workspaceBlocks[id] || null,
+        };
+        received = [];
+        listener = (e) => {
+            received.push(e);
+        };
+        guarded = createStaleBlockDeleteGuard(workspace, listener);
+    });
+
+    test('should pass through non-delete block events', () => {
+        const events = [
+            { type: 'create', blockId: 'a' },
+            { type: 'move', blockId: 'a' },
+            { type: 'change', blockId: 'a' },
+        ];
+        workspaceBlocks.a = {}; // block exists — must not matter for these
+        events.forEach(guarded);
+        expect(received).toEqual(events);
+    });
+
+    test('should pass through events without blockId (e.g. var/comment events)', () => {
+        const events = [
+            { type: 'var_create', varId: 'v1' },
+            { type: 'delete', varId: 'v1' },
+        ];
+        events.forEach(guarded);
+        expect(received).toEqual(events);
+    });
+
+    test('should pass through delete events when the block is gone from the workspace', () => {
+        // Genuine deletion: Blockly disposed the block before delivering
+        // the event, so getBlockById returns null.
+        const e = { type: 'delete', blockId: 'top1' };
+        guarded(e);
+        expect(received).toEqual([e]);
+    });
+
+    test('should drop delete events when the block still exists in the workspace', () => {
+        // Stale deletion: the workspace was reloaded from the VM after the
+        // delete was queued, so the block is rendered again. Applying the
+        // delete to the VM would desync it from the view and lose data.
+        workspaceBlocks.top1 = { id: 'top1' };
+        guarded({ type: 'delete', blockId: 'top1' });
+        expect(received).toEqual([]);
+    });
+
+    test('should keep passing subsequent events after dropping a stale delete', () => {
+        workspaceBlocks.top1 = { id: 'top1' };
+        guarded({ type: 'delete', blockId: 'top1' });
+        const create = { type: 'create', blockId: 'b' };
+        guarded(create);
+        expect(received).toEqual([create]);
+    });
+});


### PR DESCRIPTION
## Summary

issue #710 の本命容疑である **Blockly v12 (scratch-blocks v2) の stale イベント race** への対策。

scratch-blocks v2 ではワークスペースのイベントが FIRE_QUEUE 経由で**非同期配送**される（実測 ~16ms = 1 フレーム。低速端末ではさらに延び、ページ非表示中は rAF 停止により無期限に滞留）。`delete` イベントが queue にある間に `onWorkspaceUpdate` のワークスペースリロード（`clearWorkspaceAndLoadFromXml`）が走ると、**リロード後の VM に stale な delete が適用される**。`Blocks.deleteBlock` は `next` 連鎖を再帰削除するため、トップブロック 1 件の stale delete で**スクリプト全体が VM から消える**。画面には直前のリロードで描画されたブロックが残るため、消失が見えるのは次のタブ切替時 — 「ルビータブにはプログラムが残っているのに、コードタブのブロックだけが消える」という報告症状と一致する。

## Changes Made

- **`src/lib/stale-block-delete-guard.js`** (新規): `vm.blockListener` をラップするガード。`delete` イベント到着時に**そのブロックがまだワークスペースに描画されている場合は破棄**する
  - 不変条件: 正当な削除では Blockly がイベント配送**前**にブロックを dispose 済み → `getBlockById` は null。「まだ描画されている」のは間にリロードが挟まった場合のみ = stale と判定できる
  - 破棄時はブロックが画面に残る（= データ保全側に倒れる）。`console.warn` で記録
- **`src/containers/blocks.jsx`**: `attachVM` でガードを配線（マーカー付き）
- `.prettierignore` / `smalruby-prettier-files.md` / `smalruby-markers.md` 更新

## 再現手順（作為的なソース変更による before/after 検証）

race の窓（通常 ~16ms）は手操作では狙えないため、**低速端末をシミュレートするソース摂動**を加えて決定論的に再現した。

### 1. 摂動パッチ（修正前 = develop の `blocks.jsx` `attachVM` に適用）

```diff
     attachVM () {
-        this.workspace.addChangeListener(this.props.vm.blockListener);
+        // PERTURBATION: simulate slow async event delivery (slow device /
+        // long frame) — deliver all workspace events to the VM 500ms late.
+        this.workspace.addChangeListener(e => {
+            setTimeout(() => this.props.vm.blockListener(e), 500);
+        });
```

修正後ブランチでは同じ遅延をガード済みリスナーに適用する（`createStaleBlockDeleteGuard(...)` の戻り値を 500ms 遅延で呼ぶ）。

### 2. 操作シーケンス（dev server + 実ブラウザ）

1. コードタブにプログラムを用意する（旗 → 10歩動かす）
2. コードタブ上でスクリプトのトップブロックを削除する（`block.dispose(true)` = ゴミ箱/右クリック削除相当。delete イベントが queue に入る）
3. **遅延窓(500ms)内に** コスチュームタブ → コードタブ と切り替える（コードタブ復帰時の `vm.refreshWorkspace()` がワークスペースをリロードし、VM にまだ存在するブロックが再描画される）
4. 遅延配送を待ち、VM ブロック数と描画ブロック数を確認する
5. もう一度タブを往復して最終表示を確認する

### 3. 結果

| 観測点 | 修正前 (develop + 摂動) | 修正後 (本 PR + 摂動) |
|---|---|---|
| リロード直後 | ブロック再描画・VM 3 個 | ブロック再描画・VM 3 個 |
| 遅延配送後 | **VM 0 個 / 描画 1 個（desync 発生）** | **VM 3 個 / 描画 1 個 + stale warn 記録** |
| タブ往復後の最終表示 | **VM 0 個 / 描画 0 個（全消失）** | **VM 3 個 / 描画 1 個（保持）** |

修正前は報告症状（次のタブ切替でブロックが全消失）が完全に再現し、修正後は同一摂動・同一操作でもスクリプトが保持される。

## Test Coverage

- `test/unit/lib/stale-block-delete-guard.test.js` (TDD・5 テスト):
  - delete 以外のイベントは素通し
  - blockId を持たないイベント（var 系等）は素通し
  - 正当な削除（ブロックがワークスペースにない）は素通し
  - **stale な削除（ブロックがまだ描画されている）は破棄**
  - 破棄後も後続イベントは正常配送
- headful E2E（dev server + ホスト Chrome、摂動なし）:
  - `dispose → 同一タスクで refreshWorkspace`（stale ケース）: スクリプト保持 + warn 記録
  - `dispose` のみ（正当ケース）: 従来どおり VM から削除される

## Notes

- この race は**最新 upstream develop と共通**（scratch-blocks 2.1.19・`onWorkspaceUpdate` の `Events.disable()` パターンともに同一）。本ガードは upstream マージの摩擦を最小化するため blocks.jsx + Smalruby 独自モジュールに閉じて実装した。upstream への報告は別途検討
- 破壊的でない stale イベント（move/change/create）はデータ消失を起こさないため対象外
- 実際の報告の発生条件（ルビータブ遷移を伴わない）と整合する: コスチューム/音タブ切替・スプライト切替・ロケール変更などあらゆる `workspaceUpdate` リロードが race の窓になる

## Related Issues

Refs #710（実環境での再発有無を確認するまでクローズしない）
