### PR TITLE
refactor: make RubyTab the single owner of the leave-Ruby-tab conversion (#710)

### DIFF
--- a/packages/scratch-gui/src/containers/gui.jsx
+++ b/packages/scratch-gui/src/containers/gui.jsx
@@ -36,20 +36,10 @@ import {
 import {setPlatform} from '../reducers/platform';
 import {setTheme} from '../reducers/settings';
 import {setDynamicAssets} from '../reducers/dynamic-assets';
-import {showAlertWithTimeout} from '../reducers/alerts';
 import { // === Smalruby: DNCL mode notice ===
     setDnclMode,
     requestExternalExitDnclMode,
 } from '../reducers/dncl-mode'; // === Smalruby: DNCL mode notice ===
-import {highlightTarget} from '../reducers/targets';
-import {
-    rubyCodeShape,
-    updateRubyCodeErrors,
-    convertedRubyCode
-} from '../reducers/ruby-code';
-import {
-    targetCodeToBlocks
-} from '../lib/ruby-to-blocks-converter';
 
 import FontLoaderHOC from '../lib/font-loader-hoc.jsx';
 import LocalizationHOC from '../lib/localization-hoc.jsx';
@@ -122,51 +112,8 @@ class GUI extends React.Component {
         if (this.props.shouldStopProject && !prevProps.shouldStopProject) {
             this.props.vm.stopAll();
         }
-        // When leaving Ruby tab with modified code, convert Ruby to blocks
-        if (prevProps.activeTabIndex === RUBY_TAB_INDEX &&
-            this.props.activeTabIndex !== RUBY_TAB_INDEX &&
-            prevProps.rubyCode.modified) {
-            const destinationTab = this.props.activeTabIndex;
-            // Immediately switch back to Ruby tab while conversion runs
-            this.props.onActivateTab(RUBY_TAB_INDEX);
-            targetCodeToBlocks(
-                this.props.vm,
-                prevProps.rubyCode.target,
-                prevProps.rubyCode.code,
-                this.props.intl,
-                {version: prevProps.rubyVersion}
-            ).then(converter => {
-                if (converter.result) {
-                    this.props.updateRubyCodeErrorsState(converter.errors);
-                    converter.apply()
-                        .then(() => {
-                            // Only mark the Ruby code as converted after the
-                            // blocks were actually applied — clearing the
-                            // modified flag before a failed apply would skip
-                            // re-conversion on the next tab switch and lose
-                            // the user's edits (issue #710).
-                            this.props.convertedRubyCodeState();
-                            this.props.onActivateTab(destinationTab);
-                        })
-                        .catch(error => {
-                            // apply() failed and rolled the target's blocks
-                            // back (issue #710). Stay on the Ruby tab and
-                            // surface the error instead of silently dropping
-                            // the unhandled rejection.
-                            // eslint-disable-next-line no-console
-                            console.error('[GUI] Ruby to blocks apply error:', error);
-                            this.props.onShowConvertRubyToBlocksErrorAlert();
-                        });
-                    return;
-                }
-                this.props.vm.setEditingTarget(prevProps.rubyCode.target.id);
-                if (!prevProps.rubyCode.target.isStage) {
-                    this.props.onHighlightTarget(prevProps.rubyCode.target.id);
-                }
-                this.props.onShowConvertRubyToBlocksErrorAlert();
-                this.props.updateRubyCodeErrorsState(converter.errors);
-            });
-        }
+        // NOTE: the "leaving Ruby tab with modified code" conversion is
+        // owned by containers/ruby-tab.jsx (single owner — issue #710).
     }
     handleActivateTab (tab) {
         this.props.onActivateTab(tab);
@@ -195,12 +142,6 @@ class GUI extends React.Component {
             isLoading,
             loadingStateVisible,
             onActivateTab: _onActivateTab,
-            rubyCode: _rubyCode,
-            rubyVersion: _rubyVersion,
-            convertedRubyCodeState: _convertedRubyCodeState,
-            onHighlightTarget: _onHighlightTarget,
-            onShowConvertRubyToBlocksErrorAlert: _onShowConvertRubyToBlocksErrorAlert,
-            updateRubyCodeErrorsState: _updateRubyCodeErrorsState,
             ...componentProps
         } = this.props;
 
@@ -272,12 +213,6 @@ GUI.propTypes = {
     theme: PropTypes.string,
     blockDisplayModalVisible: PropTypes.bool,
     onSetTheme: PropTypes.func,
-    rubyCode: rubyCodeShape,
-    rubyVersion: PropTypes.string,
-    convertedRubyCodeState: PropTypes.func,
-    onHighlightTarget: PropTypes.func,
-    onShowConvertRubyToBlocksErrorAlert: PropTypes.func,
-    updateRubyCodeErrorsState: PropTypes.func,
     username: PropTypes.string,
     userOwnsProject: PropTypes.bool,
     // TODO: Is this unused?
@@ -339,8 +274,6 @@ const mapStateToProps = (state, ownProps) => {
         teacherModalVisible: state.scratchGui.classroom ? state.scratchGui.classroom.teacherModalVisible : false,
         // === Smalruby: End of classroom modal ===
         dnclMode: state.scratchGui.dnclMode.dnclMode, // === Smalruby: DNCL block filtering ===
-        rubyCode: state.scratchGui.rubyCode,
-        rubyVersion: state.scratchGui.settings.rubyVersion,
         vm: state.scratchGui.vm
     };
 };
@@ -367,10 +300,6 @@ const mapDispatchToProps = dispatch => ({
     onRequestCloseKoshienTestModal: () => dispatch(closeKoshienTestModal()),
     onRequestCloseUrlLoaderModal: () => dispatch(closeUrlLoaderModal()),
     onRequestCloseTipsLibrary: () => dispatch(closeTipsLibrary()),
-    convertedRubyCodeState: () => dispatch(convertedRubyCode()),
-    onHighlightTarget: id => dispatch(highlightTarget(id)),
-    onShowConvertRubyToBlocksErrorAlert: () => showAlertWithTimeout(dispatch, 'convertRubyToBlocksError'),
-    updateRubyCodeErrorsState: errors => dispatch(updateRubyCodeErrors(errors)),
     // === Smalruby: Start of classcode auto-open ===
     onOpenClassroomModal: () => dispatch(openClassroomModal()),
     // === Smalruby: End of classcode auto-open ===

--- a/packages/scratch-gui/src/containers/ruby-tab.jsx
+++ b/packages/scratch-gui/src/containers/ruby-tab.jsx
@@ -31,7 +31,7 @@ import { containsV1Code } from '../lib/ruby-to-blocks-converter/v1-detection';
 import { getUrlParams } from '../lib/url-params';
 import { showAlertWithTimeout, closeAlertWithId } from '../reducers/alerts';
 import { setDnclMode as setDnclModeAction, clearExternalExitDnclModeRequest } from '../reducers/dncl-mode';
-import { BLOCKS_TAB_INDEX, RUBY_TAB_INDEX } from '../reducers/editor-tab';
+import { BLOCKS_TAB_INDEX, RUBY_TAB_INDEX, activateTab } from '../reducers/editor-tab';
 import { setAiSaveStatus, clearAiSaveStatus } from '../reducers/koshien-file';
 import { closeFileMenu } from '../reducers/menus.js';
 import { setProjectChanged } from '../reducers/project-changed';
@@ -125,6 +125,7 @@ const RubyTab = (props) => {
         onSetDnclMode,
         exitDnclModeExternallyRequested,
         onClearExitDnclModeRequest,
+        onActivateTab,
     } = props;
 
     // --- State ---
@@ -1047,6 +1048,13 @@ const RubyTab = (props) => {
     // below starts the whole convert+apply pipeline twice per tab switch
     // (issue #710).
     const conversionInFlightRef = useRef(false);
+    // When the user leaves the Ruby tab with modified code, this holds the
+    // tab they were headed to. The effect below bounces back to the Ruby tab
+    // while the conversion runs and activates this destination once the
+    // blocks were applied successfully. RubyTab is the single owner of this
+    // transition (the equivalent hook that used to live in containers/gui.jsx
+    // was removed to stop the two pipelines from racing — issue #710).
+    const pendingDestinationTabRef = useRef(null);
     useEffect(() => {
         const prev = prevPropsRef.current;
         const savePrev = () => {
@@ -1093,6 +1101,16 @@ const RubyTab = (props) => {
             handleDismissBubbleStable();
         }
 
+        // Leaving the Ruby tab with modified code: remember the destination
+        // tab and immediately bounce back to the Ruby tab while the
+        // conversion runs. The conversion itself is started by the
+        // `modified` block below, and the destination is activated once the
+        // blocks were applied successfully.
+        if (prev.activeTabIndex === RUBY_TAB_INDEX && activeTabIndex !== RUBY_TAB_INDEX && rubyCode.modified) {
+            pendingDestinationTabRef.current = activeTabIndex;
+            onActivateTab(RUBY_TAB_INDEX);
+        }
+
         // Visibility off → clear errors
         if (prev.isVisible && !isVisible) {
             if (editorRef.current && monacoRef.current) {
@@ -1115,7 +1133,7 @@ const RubyTab = (props) => {
         if (modified) {
             const targetId = rubyCode.target ? rubyCode.target.id : null;
             const changedTarget = vm.editingTarget && rubyCode.target && vm.editingTarget.id !== targetId;
-            if (changedTarget || blocksTabVisible) {
+            if (changedTarget || blocksTabVisible || pendingDestinationTabRef.current !== null) {
                 if (String(rubyVersion) === '2' && !v1PromptDismissed && containsV1Code(rubyCode.code)) {
                     const message = intlRef.current.formatMessage({
                         id: 'gui.rubyTab.v1CodeDetected',
@@ -1125,6 +1143,9 @@ const RubyTab = (props) => {
                     });
                     // eslint-disable-next-line no-alert
                     if (window.confirm(message)) {
+                        // Stay on the Ruby tab after switching versions; the
+                        // version-change flow runs its own conversion.
+                        pendingDestinationTabRef.current = null;
                         onRevertRubyVersion('1');
                         return;
                     }
@@ -1158,6 +1179,14 @@ const RubyTab = (props) => {
                                             editorRef.current.layout();
                                         }
                                     }
+                                    // The user was headed to another tab when
+                                    // the conversion started — take them
+                                    // there now that the blocks are applied.
+                                    if (pendingDestinationTabRef.current !== null) {
+                                        const destination = pendingDestinationTabRef.current;
+                                        pendingDestinationTabRef.current = null;
+                                        onActivateTab(destination);
+                                    }
                                 });
                             }
                             showErrors(converter.errors);
@@ -1172,6 +1201,9 @@ const RubyTab = (props) => {
                         })
                         .finally(() => {
                             conversionInFlightRef.current = false;
+                            // Conversion failed or produced errors: stay on
+                            // the Ruby tab so the user can fix the code.
+                            pendingDestinationTabRef.current = null;
                         });
                 }
             }
@@ -1374,6 +1406,7 @@ RubyTab.propTypes = {
     onSetDnclMode: PropTypes.func,
     exitDnclModeExternallyRequested: PropTypes.bool,
     onClearExitDnclModeRequest: PropTypes.func,
+    onActivateTab: PropTypes.func,
 };
 
 const mapStateToProps = (state) => ({
@@ -1407,6 +1440,7 @@ const mapDispatchToProps = (dispatch) => ({
     onDismissV1Prompt: () => dispatch(dismissV1Prompt()),
     onSetDnclMode: (dnclMode) => dispatch(setDnclModeAction(dnclMode)),
     onClearExitDnclModeRequest: () => dispatch(clearExternalExitDnclModeRequest()),
+    onActivateTab: (tab) => dispatch(activateTab(tab)),
 });
 
 const ConnectedRubyTab = RubyteeModalHOC(


### PR DESCRIPTION
## Summary

issue #710 の調査で判明した「**ruby→コードタブ切替時の Ruby→ブロック変換が `containers/gui.jsx` と `containers/ruby-tab.jsx` の 2 箇所で独立に実行される**」構造の一本化。

実測で、タブ切替 1 回につき `applyTargetBlocks` が **2 回**走り(呼び出し元スタックで gui.jsx と ruby-tab.jsx 双方を確認)、エラーアラートも重複表示されていた。2 つの独立した変換パイプラインが同一ターゲットの「全削除→再生成」を競争する構造は、#714/#715 で対策した消失バグの温床でもあった。

## Changes Made

### ruby-tab.jsx — 変換の唯一のオーナーに

v1 構文プロンプト・syncModules・DNCL 処理・エラー表示が元々すべて ruby-tab 側にあるため、gui.jsx 側のフックの機能(bounce-back UX)を ruby-tab に移植して一本化:

- ルビータブ離脱 + modified を検出したら **目的タブを `pendingDestinationTabRef` に記録してルビータブへ即時バウンス**(変換中はルビータブに留まる従来 UX を維持)
- 変換+apply 成功後に記録した目的タブへ遷移
- 変換失敗/apply 失敗時はルビータブに留まりエラーアラート表示(従来 UX 維持)
- v1 プロンプトで v1 へ切り替えた場合はルビータブに留まる(pending クリア)
- 変換トリガー条件を `changedTarget || blocksTabVisible || pending` に統合

### gui.jsx — 変換フックと専用配線を削除

- componentDidUpdate の変換フック本体を削除
- 専用だった props/propTypes/mapStateToProps/mapDispatchToProps/import(`rubyCode`, `rubyVersion`, `convertedRubyCodeState`, `onHighlightTarget`, `onShowConvertRubyToBlocksErrorAlert`, `updateRubyCodeErrorsState`, `targetCodeToBlocks` 等)を削除
- **upstream ファイルからの Smalruby 挿入が 1 つ減り、upstream マージの摩擦も削減**

## Test Coverage

headful E2E(dev server + ホスト Chrome、`applyTargetBlocks` 呼び出しカウンタ計測):

| シナリオ | 結果 |
|---|---|
| ruby→コード(modified・変換成功) | **apply 1 回**(従来 2 回)・コードタブへ遷移・新ブロック反映 |
| ruby→コスチューム(modified・変換成功) | **apply 1 回**・コスチュームタブへ遷移・ブロック反映(pending 経由トリガーの検証) |
| ruby→コード(構文エラー) | apply 0 回・**ルビータブに留まる**・エラーアラート表示・既存ブロック保全・編集テキスト保持 |

unit: `ruby-tab-project-changed` / `target-applier-transaction` pass。v1 プロンプト・DNCL・タブ切替の網羅的な検証は CI の integration tests(`v1-detection-prompt.test.js`, `ruby-tab.test.js`, `dncl-mode-validation.test.js` 等)でカバー。

## Related Issues

Refs #710
