### PR TITLE
fix: restore upstream guard against top-level shadow blocks in moveBlock (#710)

### DIFF
--- a/.claude/rules/scratch-vm/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-vm/smalruby-prettier-files.md
@@ -36,6 +36,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/integration/extensions/mesh-v1-migration.test.js`
 - `test/integration/extensions/mesh-v2-data-merge.test.js`
 - `test/integration/extensions/mesh-v2-variable-sync.test.js`
+- `test/unit/blocks_move_top_level_shadow.js`
 - `test/unit/blocks_operators_regex.js`
 - `test/unit/extension_koshien.js`
 - `test/unit/extension_mesh_v2_delta_repro.js`

--- a/packages/scratch-vm/.prettierignore
+++ b/packages/scratch-vm/.prettierignore
@@ -70,6 +70,7 @@ test/integration/extensions/*
 # Level 2: test/unit/*
 test/unit/*
 !test/unit/extensions/
+!test/unit/blocks_move_top_level_shadow.js
 !test/unit/blocks_operators_regex.js
 !test/unit/extension_koshien.js
 !test/unit/extension_mesh_v2_delta_repro.js

--- a/packages/scratch-vm/src/engine/blocks.js
+++ b/packages/scratch-vm/src/engine/blocks.js
@@ -801,14 +801,16 @@ class Blocks {
             } else if (oldParent.next === e.id) {
                 // This block was connected to the old parent's next connection.
                 oldParent.next = null;
+                this._blocks[e.id].parent = null;
             }
-            this._blocks[e.id].parent = null;
             didChange = true;
         }
 
         // Is this block a top-level block?
         if (typeof e.newParent === 'undefined') {
-            this._addScript(e.id);
+            if (!this._blocks[e.id].shadow) {
+                this._addScript(e.id);
+            }
         } else {
             // Remove script, if one exists.
             this._deleteScript(e.id);

--- a/packages/scratch-vm/test/unit/blocks_move_top_level_shadow.js
+++ b/packages/scratch-vm/test/unit/blocks_move_top_level_shadow.js
@@ -1,0 +1,114 @@
+// === Smalruby: This file is Smalruby-specific (regression tests for upstream
+// commit ae67b9bf "fix bug that could result in the VM's representation of
+// shadow blocks getting into a bad state", released in scratch-editor
+// v14.1.0 — issue #710) ===
+const test = require('tap').test;
+const Blocks = require('../../src/engine/blocks');
+
+const makeRuntime = () => ({
+    emitProjectChanged: () => {},
+    requestBlocksUpdate: () => {},
+    getTargetForStage: () => null,
+    getEditingTarget: () => null,
+    monitorBlocks: { changeBlock: () => {} },
+});
+
+const createProgram = (blocks) => {
+    blocks.createBlock({
+        id: 'hat1',
+        opcode: 'event_whenflagclicked',
+        next: 'move1',
+        parent: null,
+        inputs: {},
+        fields: {},
+        shadow: false,
+        topLevel: true,
+        x: 0,
+        y: 0,
+    });
+    blocks.createBlock({
+        id: 'move1',
+        opcode: 'motion_movesteps',
+        next: null,
+        parent: 'hat1',
+        inputs: { STEPS: { name: 'STEPS', block: 'steps1', shadow: 'steps1' } },
+        fields: {},
+        shadow: false,
+        topLevel: false,
+    });
+    blocks.createBlock({
+        id: 'steps1',
+        opcode: 'math_number',
+        next: null,
+        parent: 'move1',
+        inputs: {},
+        fields: { NUM: { name: 'NUM', value: '10' } },
+        shadow: true,
+        topLevel: false,
+    });
+};
+
+test('moveBlock must not promote a shadow block to a top-level script', (t) => {
+    const blocks = new Blocks(makeRuntime());
+    createProgram(blocks);
+
+    // Blockly v12 can emit a move event for a shadow block with no new
+    // parent. Promoting it into _scripts makes toXML() emit a top-level
+    // <shadow> element, which Blockly rejects with "Shadow block cannot
+    // be a top-level block" — clearing the whole workspace on the next
+    // reload while the VM data stays intact (issue #710).
+    blocks.blocklyListen({
+        type: 'move',
+        blockId: 'steps1',
+        oldParentId: 'move1',
+        oldInputName: 'STEPS',
+        // no newParentId
+    });
+
+    t.notOk(blocks.getScripts().includes('steps1'), 'shadow not in scripts');
+    t.equal(blocks._blocks.steps1.topLevel, false, 'shadow not topLevel');
+    t.ok(
+        blocks.getScripts().every((id) => !blocks._blocks[id].shadow),
+        'no script id refers to a shadow block',
+    );
+    t.end();
+});
+
+test('moveBlock keeps the shadow parent when the shadow itself moves', (t) => {
+    const blocks = new Blocks(makeRuntime());
+    createProgram(blocks);
+
+    blocks.blocklyListen({
+        type: 'move',
+        blockId: 'steps1',
+        oldParentId: 'move1',
+        oldInputName: 'STEPS',
+    });
+
+    // The unconditional outer `parent = null` (pre-upstream-fix layout)
+    // would clear the shadow's parent even though the input still
+    // references it as its shadow.
+    t.equal(blocks._blocks.steps1.parent, 'move1', 'shadow keeps its parent');
+    t.equal(blocks._blocks.move1.inputs.STEPS.shadow, 'steps1', 'input still references the shadow');
+    t.end();
+});
+
+test('moveBlock still promotes a regular block to top-level', (t) => {
+    const blocks = new Blocks(makeRuntime());
+    createProgram(blocks);
+
+    // Detach move1 from hat1's next connection — a normal drag-out.
+    blocks.blocklyListen({
+        type: 'move',
+        blockId: 'move1',
+        oldParentId: 'hat1',
+        newCoordinate: { x: 100, y: 100 },
+        // no newParentId → becomes its own script
+    });
+
+    t.ok(blocks.getScripts().includes('move1'), 'regular block added to scripts');
+    t.equal(blocks._blocks.move1.topLevel, true, 'regular block topLevel');
+    t.equal(blocks._blocks.move1.parent, null, 'detached block parent cleared');
+    t.equal(blocks._blocks.hat1.next, null, 'old parent next cleared');
+    t.end();
+});


### PR DESCRIPTION
## Summary

issue #710 の実際の発生条件「**コスチュームタブでコスチューム追加 → コードタブ遷移でブロック消失**(削除操作なし・ルビータブ不使用)」を説明できる根本原因の修正。

**前提「upstream には問題がない」に基づく調査**の結果、原因は本プロジェクトの変更履歴にあった: spork ロールバック時の `blocks.js` 復元 (`84f87e9152`) で、**upstream のリリース済み修正 (`ae67b9bf` / scratch-editor v14.1.0 収録) の 2 hunk を取り落とし**、scratch-blocks v2 再移行後も未復元のままだった。

## メカニズム (E1 摂動実験で再現確認済み)

1. `moveBlock` に shadow ガードがないため、shadow ブロックの「親なし move イベント」1 件で **shadow が `_scripts` (トップレベルスクリプト) に混入**する
2. `toXML()` がトップレベル `<shadow>` 要素を出力
3. `clearWorkspaceAndLoadFromXml` で scratch-blocks v2 が **`Shadow block cannot be a top-level block` を throw** — ワークスペースは clear 済みのため、**shadow 要素以降のスクリプトがすべて描画されない**
4. VM データは無傷なのでスクリプトは動き続け、ルビータブにはプログラムが表示される — **報告症状と完全一致**

### 間欠性の説明 (実測)

| `_scripts` 内の shadow の位置 | 症状 |
|---|---|
| 末尾 | **見た目は正常**(手前のスクリプトはロード済みで throw が握りつぶされる)= 潜伏状態 |
| 先頭側 | **後続スクリプトが全滅**(全消失) |

潜伏状態では気付かず、その後の何らかのタブ遷移(コスチューム→コード等の `refreshWorkspace`)で顕在化する。コンソールには `Workspace Update Error: Failed to load workspace XML (Shadow block cannot be a top-level block.)` が出る。

## Changes Made

`src/engine/blocks.js` の `moveBlock` を **upstream v14.1.0 と完全一致**させる(2 hunk):

1. `newParent` なしの move で **shadow を `_addScript` しない**ガード
2. `parent = null` を next-connection 分岐の内側へ移動(無条件クリアをやめ、obscured shadow の条件付き parent 処理を有効化)

upstream cherry-pick ポリシー準拠: 取り込み元 `ae67b9bfef7a95e856beb3396dbafd` は **scratch-editor v14.1.0 (2026-06-02) でリリース済み**。

## Test Coverage

- `test/unit/blocks_move_top_level_shadow.js` (TDD・tap・3 テスト):
  - shadow の親なし move → `_scripts` に入らない / topLevel false
  - shadow 自身の move でも parent が維持される(hunk 2 のリグレッション)
  - 通常ブロックのトップレベル昇格は従来どおり
- 既存 `engine_blocks.js` 147 テスト pass
- headful E2E:
  - 修正前: イベント注入 → shadow が `_scripts` 混入 → 潜伏/全消失の両状態 + console に throw を確認
  - 修正後: 同一注入でも `_scripts` クリーン・parent 維持 → **コスチューム追加→コードタブ遷移が正常描画**

## Notes

- 自然トリガー(Blockly v12 がどの実操作で shadow の親なし move を発火するか)は実マウス自動化では未特定だが、upstream がこのガードを意図的に追加した事実が実在の証拠。ガード復元によりトリガーの種類によらず無害化される
- 既に潜伏状態(`_scripts` に shadow 混入)のプロジェクトは、保存/読込で sb3 の両方向サニタイズ(取り込み済み)により治癒する
- 同種の取り落としがないか `engine/blocks.js` 全体を v14.1.0 と diff 済み — 残る差分は意図的な Smalruby 変更(コメントイベント正規化・XML coords guard 等)のみ

## Related Issues

Refs #710
