### PR TITLE
feat(upstream-merge): add divergence audit step against merged upstream ref

### DIFF
--- a/.claude/skills/upstream-merge/SKILL.md
+++ b/.claude/skills/upstream-merge/SKILL.md
@@ -13,7 +13,7 @@ upstream scratch-editor の変更を Smalruby fork に取り込む半自動ワ�
 |-------|----------|------|
 | 1 | `phase1-prepare.md` | Prerequisites確認 → ブランチ作成 → マージ実行 |
 | 2 | `phase2-conflicts.md` | コンフリクト解決ガイド（既知パターン + ガイダンス） |
-| 3 | `phase3-validation.md` | コミット → lint → build → テスト → CI |
+| 3 | `phase3-validation.md` | コミット → divergence 監査 → lint → build → テスト → CI |
 | 4 | `phase4-finalize.md` | merge history更新 → PR作成 → 手動テスト |
 
 リファレンス（必要時に読み込む）:

--- a/.claude/skills/upstream-merge/phase3-validation.md
+++ b/.claude/skills/upstream-merge/phase3-validation.md
@@ -26,7 +26,39 @@ merge commit の hash を記録しておく（Phase 4 で使用）。
 
 ---
 
-## Step 2: Lint
+## Step 2: Upstream Divergence Audit（取り落とし検査）
+
+**背景**: git の 3-way merge は「過去に取り込み済みの upstream コードをローカルで変更（削除）した箇所」を尊重するため、ロールバックや restore コミットで upstream 修正を一度消すと、**以後どれだけ upstream merge を重ねても自動では戻らない**。実例: moveBlock の top-level shadow ガード（issue #710 / PR #717）は restore コミットで消えた後、upstream merge を経ても戻らず、ブロック全消失バグの根本原因になった。
+
+マージ直後に、upstream 由来の重要ファイルが「説明のつく差分」だけを持つことを検査する:
+
+```bash
+# <upstream-ref> は今回マージした upstream コミット (例: upstream/develop の merge 時点 SHA)
+bin/upstream-divergence-audit <upstream-ref>
+```
+
+- `OK` — upstream と一致。問題なし
+- `DIFF` — 差分あり。**各 hunk をレビュー**する:
+  ```bash
+  git diff <upstream-ref> HEAD -- <file>
+  ```
+  すべての hunk が以下のどれかで説明できること:
+  1. `=== Smalruby:` マーカーで囲まれた Smalruby 固有コード
+  2. `.claude/rules/` 等に文書化された意図的な divergence（cherry-pick 済みの先行修正など）
+  3. 今回のマージで意図的に解決した差分
+- **説明のつかない hunk が見つかった場合**: upstream 修正の取り落とし（または upstream 領域へのローカルコードの混入）。原因を特定し、復元コミットを作成してから次へ進む
+
+監査結果（DIFF ファイル一覧と各差分の説明）は PR 説明文に記載する。
+
+curated リスト以外でコンフリクトが発生したファイルがあれば、それらも個別に監査する:
+
+```bash
+bin/upstream-divergence-audit <upstream-ref> <conflicted-file>...
+```
+
+---
+
+## Step 3: Lint
 
 ```bash
 docker compose run --rm app npm run lint
@@ -47,7 +79,7 @@ PR も早めに作成すると CI が走る（Phase 4 の PR 作成を先にや�
 
 ---
 
-## Step 3: Build
+## Step 4: Build
 
 ```bash
 docker compose run --rm app npm run build:dev
@@ -58,7 +90,7 @@ docker compose run --rm app npm run build:dev
 
 ---
 
-## Step 4: Unit Tests
+## Step 5: Unit Tests
 
 ```bash
 docker compose run --rm app npm run test:unit
@@ -69,7 +101,7 @@ docker compose run --rm app npm run test:unit
 
 ---
 
-## Step 5: Integration Tests
+## Step 6: Integration Tests
 
 統合テストはタイムアウト回避のためバッチ実行する（5-6ファイルずつ）:
 
@@ -91,7 +123,7 @@ ls packages/scratch-vm/test/integration/*.js
 
 ---
 
-## Step 6: CI Status Check
+## Step 7: CI Status Check
 
 push 済みなら CI の状態を確認:
 

--- a/bin/upstream-divergence-audit
+++ b/bin/upstream-divergence-audit
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# bin/upstream-divergence-audit — detect unexplained divergence from upstream
+# in upstream-owned source files after an upstream merge.
+#
+# Why: git's 3-way merge respects local changes to lines upstream has not
+# touched since the merge base. If an upstream fix that was already merged
+# gets reverted locally (e.g. a rollback/restore commit), later upstream
+# merges will NEVER bring it back — the loss is invisible to `git merge`.
+# This happened with the moveBlock top-level shadow guard (issue #710 /
+# PR #717): the guard from upstream commit ae67b9bf was dropped by a local
+# restore commit and survived a full upstream merge unnoticed.
+#
+# What it does: for each audited file, diff HEAD against the given upstream
+# ref (the upstream commit being merged, e.g. `upstream/develop`). Files are
+# reported as:
+#   OK    — identical to upstream
+#   DIFF  — differs; every hunk must be explainable as a Smalruby change
+#           (marker comments, documented divergence) — review them manually
+#   SKIP  — file does not exist on the upstream ref
+#
+# The script only gathers facts; reviewing each DIFF hunk is the caller's
+# job (see .claude/skills/upstream-merge/phase3-validation.md).
+#
+# Usage:
+#   bin/upstream-divergence-audit <upstream-ref> [file...]
+#   bin/upstream-divergence-audit upstream/develop
+#   bin/upstream-divergence-audit upstream/develop packages/scratch-vm/src/engine/blocks.js
+#
+# With no file arguments, a curated list of high-risk upstream files is
+# audited (engine/runtime files where silent regressions are catastrophic).
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: bin/upstream-divergence-audit <upstream-ref> [file...]" >&2
+    exit 2
+fi
+
+REF="$1"
+shift
+
+if ! git rev-parse --verify --quiet "$REF^{commit}" > /dev/null; then
+    echo "error: '$REF' is not a commit (run 'git fetch -p upstream develop' first?)" >&2
+    exit 2
+fi
+
+# Curated high-risk upstream files: VM engine + the GUI containers that
+# wire Blockly to the VM. Extend as needed.
+DEFAULT_FILES=(
+    packages/scratch-vm/src/engine/blocks.js
+    packages/scratch-vm/src/engine/runtime.js
+    packages/scratch-vm/src/engine/target.js
+    packages/scratch-vm/src/engine/execute.js
+    packages/scratch-vm/src/virtual-machine.js
+    packages/scratch-vm/src/serialization/sb3.js
+    packages/scratch-vm/src/sprites/rendered-target.js
+    packages/scratch-gui/src/containers/blocks.jsx
+    packages/scratch-gui/src/containers/gui.jsx
+    packages/scratch-gui/src/lib/blocks.js
+    packages/scratch-gui/src/lib/vm-listener-hoc.jsx
+    packages/scratch-gui/src/lib/vm-manager-hoc.jsx
+)
+
+if [[ $# -gt 0 ]]; then
+    FILES=("$@")
+else
+    FILES=("${DEFAULT_FILES[@]}")
+fi
+
+diff_count=0
+for f in "${FILES[@]}"; do
+    if ! git cat-file -e "$REF:$f" 2> /dev/null; then
+        echo "SKIP  $f (not on $REF)"
+        continue
+    fi
+    if git diff --quiet "$REF" HEAD -- "$f"; then
+        echo "OK    $f"
+        continue
+    fi
+    diff_count=$((diff_count + 1))
+    stat=$(git diff --shortstat "$REF" HEAD -- "$f" | sed 's/^ //')
+    marker_lines=$(git diff "$REF" HEAD -- "$f" | grep -c "Smalruby" || true)
+    echo "DIFF  $f (${stat}; ${marker_lines} diff lines mention Smalruby)"
+done
+
+echo
+if [[ $diff_count -gt 0 ]]; then
+    echo "${diff_count} file(s) diverge from $REF."
+    echo "Review each hunk: git diff $REF HEAD -- <file>"
+    echo "Every hunk must be an intentional Smalruby change (marker comments"
+    echo "or documented divergence). An unexplained hunk means an upstream"
+    echo "fix was lost or local code leaked into upstream-owned regions."
+else
+    echo "No divergence in audited files."
+fi


### PR DESCRIPTION
## Summary

issue #710 の根本原因(PR #717)から得た教訓「**ロールバック/restore で一度消した upstream 修正は、その後の upstream merge では二度と自動復元されない**」への再発防止策。

git の 3-way merge は「merge base 以降 upstream が触っていない行へのローカル変更」を尊重する。取り込み済みの upstream 修正をローカルで削除すると、その消失は `git merge` からは不可視になる — 実際に moveBlock の top-level shadow ガード(upstream `ae67b9bf`)は pre-spork restore(`84f87e9152`)で消えた後、**v13.7.2 相当までの upstream merge を経ても戻らず**、ブロック全消失バグの根本原因になった。

## Changes Made

### `bin/upstream-divergence-audit`(新規)

マージした upstream ref と HEAD を、**upstream 由来の高リスクファイル**(VM engine・serialization・Blockly↔VM を配線する GUI containers の curated リスト)について diff し、レビューが必要な divergence を報告するスクリプト。

```
$ bin/upstream-divergence-audit upstream/develop
OK    packages/scratch-vm/src/engine/execute.js
DIFF  packages/scratch-vm/src/engine/blocks.js (1 file changed, ...; 3 diff lines mention Smalruby)
...
```

- 比較先は「リリースタグ」ではなく**今回マージした upstream コミット**(リリースタグ比較だと未リリースの upstream 変更がノイズになるため)
- ファイル引数で curated リスト外(コンフリクトしたファイル等)も個別監査可能

### `upstream-merge` スキルへの組み込み

`phase3-validation.md` に **Step 2: Upstream Divergence Audit(取り落とし検査)** を追加(以降の Step は番号繰り下げ):

- マージコミット直後に監査を実行
- `DIFF` ファイルは hunk 単位でレビューし、すべての hunk が「Smalruby マーカー」「文書化された意図的 divergence」「今回の意図的解決」のどれかで説明できることを要求
- 説明のつかない hunk = upstream 修正の取り落とし(または upstream 領域へのローカルコード混入)→ 復元コミットを作ってから先へ進む
- 監査結果は PR 説明文に記載

## 検証

- `bin/upstream-divergence-audit upstream/develop` を現リポジトリで実行し、OK/DIFF/SKIP の分類・マーカー言及行数の表示・hunk レビュー誘導が機能することを確認(PR #717 の欠落もこの方法で検出可能だったことを確認済み)

## Related Issues

Refs #710
