### PR TITLE
feat(mesh-v2): sendData 時に自ノード値をローカルシードして sensor_value の即時自己参照を可能にする

### DIFF
--- a/docs/extension-mesh-v2/README.md
+++ b/docs/extension-mesh-v2/README.md
@@ -49,7 +49,9 @@
 
 `meshV2_getSensorValue` は、**自ノードを含む**全ノードの同名グローバル変数のうち、最新タイムスタンプの値を返す。
 
-- **仕組み**: AppSync は送信者にも自分の更新をエコーする。`handleDataUpdate`（`subscription-manager.js`）は自ノードのエコーも `remoteData` に取り込む（自ノード除外なし）。自分も他ノードも**サーバータイムスタンプで同列**に扱うため、クライアント/サーバー間のクロック不整合が起きない（ローカルシードはしない）。`getRemoteVariable` は `remoteData` を全ノード横断で最新勝ちで読む。
+- **仕組み**: 自ノード値は 2 経路で `remoteData` に入る。①**ローカルシード**: `sendData`（`data-sender.js`）がデルタフィルタ通過時に自ノード値をクライアントタイムスタンプ付きで即時格納する。ローカルの `broadcast` は同期実行されるため、エコー往復（レートリミット 1 秒 + ネットワーク）を待たずに `when_receive` ハンドラから設定直後の自分の変数を読める。②**エコー**: AppSync は送信者にも自分の更新をエコーし、`handleDataUpdate`（`subscription-manager.js`）が取り込む（自ノード除外なし）。`getRemoteVariable` は `remoteData` を全ノード横断で最新タイムスタンプ勝ちで読むため、常に自分の値を優先するのではなく、他ノードからより新しい値が届けばそちらが返る。
+- **クロックずれの自己修復**: シードはクライアント時計、他ノードの値はサーバー時計のため、エコー到着時に正規化する。自ノードのエコーが**シード値と同値**なら timestamp をサーバー時刻に置き換え（時間ドメインを統一）、**異値**なら古い書き込みのエコーなので無視する（連続書き込み時にシード値を保護）。クロックずれによる新旧逆転は最大でも次のエコー到着（1〜2 秒）までに収束する。
+- **同値再設定はシードしない**: デルタフィルタで送信されない変更はローカルにも反映しない。自分から見える状態とネットワークから見える状態が常に一致する。
 - **ドロップダウン候補**: `getVariableNamesMenuItems`（`index.js`）は、ネットワーク受信名（`remoteData`）に加えて**自プロジェクトのグローバルスカラー変数名**（`getGlobalVariables()`）を合算する。これにより、起動直後・接続前でもプリセット変数を含む自分の変数が候補に出る（ネットワーク往復に依存しない）。
 - **broadcast は対象外**: メッセージ（`meshV2_broadcast` 系）は従来どおり自ノードを除外する（自分が送ったメッセージは自分には届かない）。変数とメッセージで非対称。
 
@@ -65,7 +67,11 @@
 - `src/components/mesh-self-sensor-notice/` — バナー / `src/containers/mesh-self-sensor-notice.jsx` — 監視と初回ガード
 - `pages/mesh-self-sensor.html` — 解説ページ（バナーの「くわしくはこちら」から開く）
 
-> 詳細経緯は Issue #707。実装回帰の確認は `packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js`、`packages/scratch-gui/test/unit/lib/mesh-v2-sensor-collision.test.js`、`tools/playwright-verify/verify-mesh-collision-paths.mjs` を参照。
+> 詳細経緯は Issue #707（自己参照仕様）と Issue #713（即時参照のローカルシード）。実装回帰の確認は `packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js`、`packages/scratch-vm/test/integration/extensions/mesh-v2-variable-sync.test.js`、`packages/scratch-gui/test/unit/lib/mesh-v2-sensor-collision.test.js`、`tools/playwright-verify/verify-mesh-collision-paths.mjs` を参照。
+
+### 既知の制限（クロスノードのレース）
+
+他ノードが broadcast イベントを変数データより先に受信した場合、**受信側**で同様に「設定直後の変数がまだ届いていない」状態が起きうる（イベントと変数は別経路・別バッチで送信されるため）。解消にはイベントと変数のバンドル送信などプロトコル変更が必要で、本機能のスコープ外。
 
 ## 関連ドキュメント
 

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/data-sender.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/data-sender.js
@@ -41,6 +41,16 @@ const DataSenderMixin = {
             this.latestQueuedData[item.key] = item.value;
         });
 
+        // Issue #713: seed own values into remoteData immediately so the
+        // "sensor value" block can read this node's own variables without
+        // waiting for the AppSync echo round-trip (RateLimiter 1s + network).
+        // Local broadcast fires synchronously, so the echo would arrive too
+        // late for a when_receive handler reading its own just-set variable.
+        // The seed uses the client clock; handleDataUpdate normalizes the
+        // timestamp to server time when the echo arrives, so cross-node
+        // timestamp comparison self-heals within ~1-2s even with clock skew.
+        this._seedLocalData(filteredData);
+
         try {
             // Save Promise to track completion (including queue time)
             this.lastDataSendPromise = this.dataRateLimiter.send(filteredData, this._reportDataBound);
@@ -117,6 +127,25 @@ const DataSenderMixin = {
             }
             throw error;
         }
+    },
+
+    /**
+     * Seed this node's own values into remoteData with a local timestamp.
+     * Allows getRemoteVariable to return own values immediately; values from
+     * other nodes still win when they carry a newer timestamp.
+     * @param {Array} items - Array of {key, value} objects being queued.
+     * @private
+     */
+    _seedLocalData(items) {
+        if (!this.remoteData[this.meshId]) {
+            this.remoteData[this.meshId] = {};
+        }
+        items.forEach(item => {
+            this.remoteData[this.meshId][item.key] = {
+                value: item.value,
+                timestamp: Date.now(),
+            };
+        });
     },
 
     /**

--- a/packages/scratch-vm/src/extensions/scratch3_mesh_v2/subscription-manager.js
+++ b/packages/scratch-vm/src/extensions/scratch3_mesh_v2/subscription-manager.js
@@ -80,6 +80,20 @@ const SubscriptionManagerMixin = {
             : (log.warn('Mesh V2: Missing server timestamp, using client time'), Date.now());
 
         nodeStatus.data.forEach(item => {
+            // Issue #713: own values always originate locally (seeded by
+            // sendData with a client timestamp), so an echo can never carry
+            // newer information than the local seed.
+            // - Same value: store with the server timestamp, normalizing the
+            //   seed's client-clock timestamp into the server time domain so
+            //   cross-node comparison self-heals despite clock skew.
+            // - Different value: it is the echo of an OLDER local write
+            //   (rapid successive writes) — keep the seed untouched.
+            if (nodeId === this.meshId) {
+                const existing = this.remoteData[nodeId][item.key];
+                if (existing && existing.value !== item.value) {
+                    return;
+                }
+            }
             this.remoteData[nodeId][item.key] = {
                 value: item.value,
                 timestamp: serverTimestamp,

--- a/packages/scratch-vm/test/integration/extensions/mesh-v2-variable-sync.test.js
+++ b/packages/scratch-vm/test/integration/extensions/mesh-v2-variable-sync.test.js
@@ -165,6 +165,70 @@ test('MeshV2Service self-inclusive sensor value (Issue #707)', (t) => {
     t.end();
 });
 
+// Issue #713: a when_receive handler triggered by a LOCAL broadcast runs
+// synchronously, before the AppSync echo (RateLimiter 1s + network) brings the
+// just-set variables back. The local seed in sendData makes them readable
+// immediately, while values from other nodes still win when newer.
+test('MeshV2Service immediate self sensor value after set (Issue #713)', async (t) => {
+    mockClient.mutate = ({ mutation, variables }) => {
+        if (mutation === CREATE_GROUP) {
+            return Promise.resolve({
+                data: {
+                    createGroup: {
+                        id: 'group1',
+                        name: variables.name,
+                        domain: variables.domain,
+                        expiresAt: FAR_FUTURE,
+                    },
+                },
+            });
+        }
+        return Promise.resolve({ data: {} });
+    };
+    mockClient.query = () => Promise.resolve({ data: { listGroupStatuses: [] } });
+
+    const service = new MeshV2Service(createMockBlocks(), 'host-node', 'domain1');
+    service.client = mockClient;
+    service.forcePolling = true; // Skip WebSocket test in unit test environment
+
+    await service.createGroup('my-group');
+
+    // First message: $送信者 = "A"; $送信メッセージ = answer; broadcast(...)
+    // — when_receive reads the sensor values in the same tick.
+    service.sendData([
+        { key: '送信者', value: 'A' },
+        { key: '送信メッセージ', value: 'こんにちは' },
+    ]);
+    t.equal(
+        `${service.getRemoteVariable('送信者')}：${service.getRemoteVariable('送信メッセージ')}`,
+        'A：こんにちは',
+        'first read works immediately, without waiting for the echo',
+    );
+
+    // Second message before any echo: must read the LATEST value, not the previous one.
+    service.sendData([{ key: '送信メッセージ', value: '2かいめ' }]);
+    t.equal(service.getRemoteVariable('送信メッセージ'), '2かいめ', 'second read returns the latest value');
+
+    // Stale echo of the first write arrives late: the seed must be protected.
+    service.handleDataUpdate({
+        nodeId: 'host-node',
+        timestamp: FAR_FUTURE,
+        data: [{ key: '送信メッセージ', value: 'こんにちは' }],
+    });
+    t.equal(service.getRemoteVariable('送信メッセージ'), '2かいめ', 'stale echo does not revert the value');
+
+    // A NEWER value from another node still wins by timestamp.
+    service.handleDataUpdate({
+        nodeId: 'peer-node',
+        timestamp: new Date(Date.now() + 7200000).toISOString(),
+        data: [{ key: '送信メッセージ', value: 'from-peer' }],
+    });
+    t.equal(service.getRemoteVariable('送信メッセージ'), 'from-peer', 'newer peer value wins');
+
+    service.cleanup();
+    t.end();
+});
+
 test('MeshV2Service fetch existing nodes data on joinGroup', async (t) => {
     const blocks = {
         runtime: {

--- a/packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js
+++ b/packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js
@@ -143,6 +143,59 @@ test('MeshV2Service Timestamp-based getRemoteVariable', (t) => {
         st.end();
     });
 
+    t.test('self-echo with matching value normalizes timestamp to server time (issue #713)', (st) => {
+        // The seed uses the client clock; other nodes' entries use the server
+        // clock. When our own echo comes back with the same value, adopt the
+        // server timestamp so cross-node comparison happens in one time domain.
+        const service2 = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        service2.groupId = 'group1';
+        service2.client = { mutate: () => Promise.resolve({}) };
+
+        service2.sendData([{ key: 'shared', value: 'A' }]);
+
+        const serverTimestamp = new Date(Date.now() + 5000).toISOString();
+        const expectedTimestamp = new Date(serverTimestamp).getTime();
+        service2.handleDataUpdate({
+            nodeId: 'node-self',
+            timestamp: serverTimestamp,
+            data: [{ key: 'shared', value: 'A' }],
+        });
+
+        st.equal(service2.remoteData['node-self'].shared.value, 'A', 'value unchanged');
+        st.equal(
+            service2.remoteData['node-self'].shared.timestamp,
+            expectedTimestamp,
+            'timestamp normalized to server time',
+        );
+        st.end();
+    });
+
+    t.test('stale self-echo with different value does not overwrite seed (issue #713)', (st) => {
+        // Own values always originate locally, so an echo can never carry newer
+        // information than the seed. A different value means it is the echo of
+        // an OLDER local write (rapid successive writes) — keep the seed.
+        const service2 = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        service2.groupId = 'group1';
+        service2.client = { mutate: () => Promise.resolve({}) };
+
+        service2.sendData([{ key: 'shared', value: 'old' }]);
+        service2.sendData([{ key: 'shared', value: 'new' }]);
+        const seedTimestamp = service2.remoteData['node-self'].shared.timestamp;
+
+        // Echo of the FIRST write arrives after the second local write,
+        // with a server timestamp that may even be in the future (clock skew)
+        service2.handleDataUpdate({
+            nodeId: 'node-self',
+            timestamp: new Date(Date.now() + 5000).toISOString(),
+            data: [{ key: 'shared', value: 'old' }],
+        });
+
+        st.equal(service2.remoteData['node-self'].shared.value, 'new', 'seeded value is protected');
+        st.equal(service2.remoteData['node-self'].shared.timestamp, seedTimestamp, 'seed timestamp is kept');
+        st.equal(service2.getRemoteVariable('shared'), 'new', 'sensor value still reads the latest local write');
+        st.end();
+    });
+
     t.test('fetchAllNodesData should add timestamp from status', async (st) => {
         const serverTimestamp = new Date().toISOString();
         const expectedTimestamp = new Date(serverTimestamp).getTime();

--- a/packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js
+++ b/packages/scratch-vm/test/unit/mesh_service_v2_timestamp.js
@@ -75,6 +75,74 @@ test('MeshV2Service Timestamp-based getRemoteVariable', (t) => {
         st.end();
     });
 
+    t.test('sendData seeds own value locally for immediate read (issue #713)', (st) => {
+        // mesh.sensor_value must return this node's own value immediately after
+        // a variable set, without waiting for the AppSync echo round-trip
+        // (RateLimiter 1s + network), because local broadcast fires synchronously.
+        const service2 = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        service2.groupId = 'group1';
+        service2.client = { mutate: () => Promise.resolve({}) };
+
+        service2.sendData([{ key: '送信者', value: 'A' }]);
+
+        // Synchronous check: no await — the seed must be visible before any echo
+        st.equal(service2.getRemoteVariable('送信者'), 'A', 'own value is readable immediately after sendData');
+        st.ok(service2.remoteData['node-self']['送信者'].timestamp > 0, 'seeded entry has a timestamp');
+        st.end();
+    });
+
+    t.test('newer value from another node wins over local seed (issue #713)', (st) => {
+        const service2 = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        service2.groupId = 'group1';
+        service2.client = { mutate: () => Promise.resolve({}) };
+
+        service2.sendData([{ key: 'shared', value: 'mine' }]);
+        // Another node reports a NEWER value (timestamp in the future relative to seed)
+        service2.remoteData['node-other'] = {
+            shared: { value: 'theirs-newer', timestamp: Date.now() + 10000 },
+        };
+
+        st.equal(service2.getRemoteVariable('shared'), 'theirs-newer', 'newer remote value wins by timestamp');
+        st.end();
+    });
+
+    t.test('local seed wins over older value from another node (issue #713)', (st) => {
+        const service2 = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        service2.groupId = 'group1';
+        service2.client = { mutate: () => Promise.resolve({}) };
+
+        // Another node reported a value earlier
+        service2.remoteData['node-other'] = {
+            shared: { value: 'theirs-older', timestamp: Date.now() - 10000 },
+        };
+        service2.sendData([{ key: 'shared', value: 'mine' }]);
+
+        st.equal(service2.getRemoteVariable('shared'), 'mine', 'fresh local seed wins over older remote value');
+        st.end();
+    });
+
+    t.test('delta-filtered same-value resend does not bump seed timestamp (issue #713)', async (st) => {
+        // Re-setting the same value is filtered by latestQueuedData and never
+        // reaches the network, so the local view must not change either:
+        // what this node reads stays consistent with what other nodes read.
+        const service2 = new MeshV2Service(createMockBlocks(), 'node-self', 'domain1');
+        service2.groupId = 'group1';
+        service2.client = { mutate: () => Promise.resolve({}) };
+
+        service2.sendData([{ key: 'shared', value: 'same' }]);
+        const firstTimestamp = service2.remoteData['node-self'].shared.timestamp;
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        service2.sendData([{ key: 'shared', value: 'same' }]);
+
+        st.equal(
+            service2.remoteData['node-self'].shared.timestamp,
+            firstTimestamp,
+            'timestamp unchanged for delta-filtered resend',
+        );
+        st.end();
+    });
+
     t.test('fetchAllNodesData should add timestamp from status', async (st) => {
         const serverTimestamp = new Date().toISOString();
         const expectedTimestamp = new Date(serverTimestamp).getTime();


### PR DESCRIPTION
## Summary

Issue #713 の実装。Mesh v2 の `mesh.sensor_value`（センサーの値）で自ノードのグローバル変数を**設定直後に即時参照可能**にする。

#709 では自ノード値が AppSync エコー経由（RateLimiter 1秒 + ネットワーク往復）でしか `remoteData` に入らないため、ローカル `broadcast`（同期実行）の `when_receive` ハンドラから読むと 1 回目は空・2 回目は前回値になっていた（localhost ホスト接続の Playwright で再現確認済み）。

`sendData()` のデルタフィルタ通過時に自ノード値を `remoteData[meshId]` へローカルタイムスタンプ付きでシードする。`getRemoteVariable` の「全ノード横断・最新タイムスタンプ勝ち」ロジックは不変のため、他ノードのより新しい値はそちらが勝つ。

Fixes #713

## Implementation Steps

**Phase 1: sendData ローカルシード**
- [x] **[RED]** ユニットテスト追加: ①sendData 直後に getRemoteVariable が自値を返す ②より新しい他ノード値が勝つ ③より古い他ノード値には自値が勝つ ④デルタフィルタで落ちた同値再設定はタイムスタンプ不変
- [x] **[GREEN]** `data-sender.js` に `_seedLocalData` 実装
- [x] **[PASS]** lint + mesh v2 関連テスト 372 件 pass

**Phase 2: 自エコーの正規化と stale 保護**
- [x] **[RED]** ユニットテスト追加: ⑤同値エコーでタイムスタンプがサーバー時刻に正規化 ⑥異値（stale）エコーはシード値を上書きしない ⑦シードが無い場合は従来どおり格納（既存 #707 テストでカバー）
- [x] **[GREEN]** `subscription-manager.js` 実装
- [x] **[PASS]** lint + mesh v2 関連テスト 379 件 pass

**Phase Final: Integration テスト + docs**
- [x] repro 相当の integration テストを `mesh-v2-variable-sync.test.js` に追加
- [x] `docs/extension-mesh-v2/README.md` 更新（ローカルシード + エコー正規化 + 既知の制限）

## Definition of Done

- [x] ユニットテスト pass（①〜⑦）
- [x] Integration テスト pass
- [x] lint pass
- [x] CI green
- [x] ブラウザ確認（Playwright MCP、localhost ホスト接続）:
  - [x] repro 相当フロー（変数設定→即 sensor_value 読み）で 1 回目から `A：<入力値>` になる
  - [x] 2 回連続入力で毎回最新の入力値になる（前回値にならない）
  - [x] 2 ノード相互確認: 他ノードのより新しい値がタイムスタンプ比較で勝つ
  - [x] `.claude/rules/scratch-gui/mesh.md` デグレ確認手順 Step 1–4（WebSocket / Polling 両モード）
- [ ] コードレビュー対応

## Known Limitation（スコープ外）

クロスノードのレース（他ノードが broadcast イベントを変数データより先に受信するケース）はプロトコル変更が必要なため本 PR では扱わない（Issue #713 参照）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)




