### PR TITLE
fix: defer fromRuby updateToolbox until after Events.enable() (issue #719)

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -104,6 +104,7 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/containers/blocks.jsx` | iOS flyout touch bleed fix | MobileGui (SP) で「ブロックを作る」タップ時に iOS の SVG タッチイベントが「変数を作る」にも伝播する問題の修正。`handlePromptStart` を 50ms 遅延して `externalProcedureDefCallback` が先に呼ばれた場合にキャンセル (issue #698) |
 | `src/containers/blocks.jsx` | DNCL block filtering | `shouldComponentUpdate` に `dnclMode` を追加して日本語モード切り替え時に即時再レンダリングを保証。import・`getToolboxXML` 内フィルター・`mapStateToProps` への `dnclMode` 追加も含む |
 | `src/containers/blocks.jsx` | stale block delete event guard | scratch-blocks v2 の非同期イベント配送で、ワークスペースリロードを跨いで届いた stale な delete イベントが VM のスクリプトを消す問題のガード。`attachVM` で `vm.blockListener` を `createStaleBlockDeleteGuard` でラップ (issue #710)。import も含む |
+| `src/containers/blocks.jsx` | Ruby-converted toolbox update deferral | `onWorkspaceUpdate` の fromRuby 分岐の `updateToolbox()` を `Events.disable()` 窓の外 (finally 後) へ移動。窓内では flyout 再構築の create イベントが破棄され、新規変数が `runtime.monitorBlocks` / `flyoutBlocks` に登録されずモニタチェックボックスが無反応になる問題の修正 (issue #719)。フラグ宣言部と実行部の 2 箇所 |
 
 ## 関連ファイル
 

--- a/.claude/rules/scratch-gui/smalruby-prettier-files.md
+++ b/.claude/rules/scratch-gui/smalruby-prettier-files.md
@@ -199,6 +199,7 @@ upstream (Scratch) ファイルは対象外。
 - `test/integration/ruby-super.test.js`
 - `test/integration/ruby-tab-completion-and-indent.test.js`
 - `test/integration/ruby-tab-furigana-zoom.test.js`
+- `test/integration/ruby-tab-monitor-sync.test.js`
 - `test/integration/ruby-tab.test.js`
 - `test/integration/smalrubot-firmware.test.js`
 - `test/integration/smalrubot-s1-connection-flow.test.js`

--- a/packages/scratch-gui/.prettierignore
+++ b/packages/scratch-gui/.prettierignore
@@ -243,6 +243,7 @@ test/integration/*
 !test/integration/ruby-super.test.js
 !test/integration/ruby-tab-completion-and-indent.test.js
 !test/integration/ruby-tab-furigana-zoom.test.js
+!test/integration/ruby-tab-monitor-sync.test.js
 !test/integration/ruby-tab.test.js
 !test/integration/smalrubot-firmware.test.js
 !test/integration/smalrubot-s1-connection-flow.test.js

--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -774,6 +774,14 @@ class Blocks extends React.Component {
         // Disabling events entirely during the load ensures nothing is queued.
         this.workspace.removeChangeListener(this.toolboxUpdateChangeListener);
         let fromRuby = false;
+        // === Smalruby: Ruby-converted toolbox update deferral (issue #719) ===
+        // Set inside the fromRuby branch below; the actual updateToolbox()
+        // call runs after `finally { Events.enable(); }` so the flyout
+        // rebuild's create/delete events reach vm.flyoutBlockListener /
+        // vm.monitorBlockListener instead of being discarded by the
+        // disable window (Blockly v12 drops events fired while disabled).
+        let toolboxNeedsUpdate = false;
+        // === Smalruby: End of Ruby-converted toolbox update deferral ===
 
         try {
             this.ScratchBlocks.Events.disable();
@@ -821,7 +829,9 @@ class Blocks extends React.Component {
                         }
                     }
 
-                    this.updateToolbox();
+                    // Defer the flyout rebuild until events are re-enabled
+                    // (issue #719) — see toolboxNeedsUpdate above.
+                    toolboxNeedsUpdate = true;
                 }
             }
             // === Smalruby: End of Ruby-converted block positioning ===
@@ -842,6 +852,29 @@ class Blocks extends React.Component {
         } finally {
             this.ScratchBlocks.Events.enable();
         }
+
+        // === Smalruby: Start of Ruby-converted toolbox update deferral ===
+        // Now that events are enabled, rebuild the toolbox/flyout so the
+        // flyout workspace's create events (e.g. data_variable reporters for
+        // variables created by the Ruby -> blocks conversion) are fired and
+        // reach runtime.flyoutBlocks / runtime.monitorBlocks. Running this
+        // inside the disable window silently dropped those events, leaving
+        // monitor checkboxes inert for newly created variables (issue #719).
+        if (toolboxNeedsUpdate) {
+            try {
+                this.updateToolbox();
+            } catch (error) {
+                // Keep the original swallow-and-log semantics this call had
+                // when it lived inside the try block above: a toolbox
+                // rebuild failure must not break the rest of the workspace
+                // update (metrics restore, clearUndo, listener re-add).
+                if (error.message) {
+                    error.message = `Workspace Update Error: ${error.message}`;
+                }
+                log.error(error);
+            }
+        }
+        // === Smalruby: End of Ruby-converted toolbox update deferral ===
 
         if (!fromRuby &&
             this.props.vm.editingTarget &&

--- a/packages/scratch-gui/test/integration/ruby-tab-monitor-sync.test.js
+++ b/packages/scratch-gui/test/integration/ruby-tab-monitor-sync.test.js
@@ -1,0 +1,133 @@
+import path from 'path';
+import RubyHelper from '../helpers/ruby-helper';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const seleniumHelper = new SeleniumHelper();
+const {
+    /* eslint-disable no-unused-vars */
+    clickText,
+    clickButton,
+    clickXpath,
+    findByText,
+    findByXpath,
+    getDriver,
+    getLogs,
+    loadUri,
+    waitForLoadingFinished,
+    notExistsByXpath,
+    rightClickText,
+    scope,
+    /* eslint-enable no-unused-vars */
+} = seleniumHelper;
+const rubyHelper = new RubyHelper(seleniumHelper);
+const { fillInRubyProgram } = rubyHelper;
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+// Regression tests for issue #719: onWorkspaceUpdate used to call
+// updateToolbox() inside the ScratchBlocks.Events.disable() window, so the
+// flyout rebuild's BLOCK_CREATE events were silently discarded (Blockly v12
+// drops events fired while disabled) and never reached
+// vm.flyoutBlockListener / vm.monitorBlockListener. Variables created by the
+// Ruby -> blocks conversion were then missing from runtime.monitorBlocks and
+// runtime.flyoutBlocks, leaving their monitor checkboxes inert.
+describe('Ruby conversion keeps flyout/monitor block containers in sync (issue #719)', () => {
+    beforeAll(async () => {
+        driver = await getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    // Probe the VM containers for the block belonging to a stage variable.
+    // Returns null when the variable itself does not exist yet.
+    const probeVariableSync = (d, varName) =>
+        d.executeScript(
+            `
+            const vm = window.smalruby && window.smalruby.vm;
+            if (!vm) return null;
+            const stage = vm.runtime.getTargetForStage();
+            const entry = Object.entries(stage.variables)
+                .find(([, v]) => v.name === arguments[0]);
+            if (!entry) return null;
+            const varId = entry[0];
+            return {
+                varId,
+                inMonitorBlocks: !!vm.runtime.monitorBlocks._blocks[varId],
+                inFlyoutBlocks: !!vm.runtime.flyoutBlocks._blocks[varId],
+                sameNameCount: Object.values(stage.variables)
+                    .filter(v => v.name === arguments[0]).length
+            };
+            `,
+            varName,
+        );
+
+    const waitForVariable = async (d, varName) => {
+        let probe = null;
+        for (let i = 0; i < 40 && !probe; i++) {
+            probe = await probeVariableSync(d, varName);
+            if (!probe) await d.sleep(250);
+        }
+        return probe;
+    };
+
+    test('clicking Go on the Ruby tab registers converted variables in monitorBlocks', async () => {
+        await loadUri(uri);
+
+        await clickText('Ruby', '*[@role="tab"]');
+        await fillInRubyProgram('$points = 0\\n');
+
+        // Convert while STAYING on the Ruby tab. This path has no
+        // code-tab visibility transition, so nothing rebuilds the flyout
+        // afterwards — before the fix the discarded create events left
+        // monitorBlocks/flyoutBlocks permanently out of sync.
+        await clickXpath('//img[@title="Go"]');
+
+        const probe = await waitForVariable(driver, 'points');
+        expect(probe).not.toBeNull();
+        // Allow one frame for Blockly's async event delivery.
+        await driver.sleep(500);
+        const synced = await probeVariableSync(driver, 'points');
+        expect(synced.inMonitorBlocks).toBe(true);
+        expect(synced.inFlyoutBlocks).toBe(true);
+        // Adversarial: the now-live flyout var_create events must not create
+        // duplicate (ghost) variables via blocks.blocklyListen.
+        expect(synced.sameNameCount).toBe(1);
+    });
+
+    test('monitor checkbox path works for a variable created by Ruby conversion', async () => {
+        await loadUri(uri);
+
+        await clickText('Ruby', '*[@role="tab"]');
+        await fillInRubyProgram('$score = 0\\n');
+        await clickXpath('//img[@title="Go"]');
+
+        const probe = await waitForVariable(driver, 'score');
+        expect(probe).not.toBeNull();
+        await driver.sleep(500);
+
+        // Drive the same VM entry point the flyout checkbox uses
+        // (monitorBlockListener -> changeBlock with element 'checkbox').
+        // Before the fix this silently no-oped because the block was
+        // missing from monitorBlocks, so no monitor ever appeared.
+        const monitorAdded = await driver.executeScript(
+            `
+            const vm = window.smalruby.vm;
+            vm.runtime.monitorBlocks.changeBlock({
+                id: arguments[0],
+                element: 'checkbox',
+                value: true
+            });
+            return vm.runtime._monitorState.has(arguments[0]);
+            `,
+            probe.varId,
+        );
+        expect(monitorAdded).toBe(true);
+
+        // The monitor should render on the stage.
+        await findByXpath('//*[contains(@class, "monitor_monitor-container")]');
+    });
+});


### PR DESCRIPTION
## Summary

Issue #719 の修正です。`onWorkspaceUpdate` の fromRuby 分岐が `ScratchBlocks.Events.disable()` 窓の**内側**で `updateToolbox()` を呼んでいたため、flyout 再構築の create/delete イベントがすべて破棄され、`vm.flyoutBlockListener` / `vm.monitorBlockListener` に届いていませんでした。

Blockly v12 の `Events.fire()` は **fire 時点**で `isEnabled()` をチェックするため、disable 窓内のイベントはキューイングされず恒久的に失われます。変数フィールドを持つブロック (`data_variable` 等) は flyout リサイクル対象外 (`referencesVariables()`) なので再構築のたびに create イベントが必要ですが、それが破棄されると Ruby→ブロック変換で新規作成された変数が `runtime.monitorBlocks` / `runtime.flyoutBlocks` に登録されません。

## ユーザー可視の症状 (Playwright で再現済み)

`Blocks.changeBlock()` は未知の block id に対して silent return するため:

1. ルビータブで `$points = 0` のような新規変数を作るコードを書く
2. 変換後、flyout の変数チェックボックスをクリック
3. **チェックは付くがステージにモニタが表示されない**
4. 次の toolbox 再構築でチェックボックスが勝手に外れる

タブ切替経路では `componentDidUpdate` の可視化遷移 (`vm.refreshWorkspace()` + `requestToolboxUpdate()`) が偶発的な回復として機能するため顕在化しにくいですが、**ルビータブに留まったまま Go (緑の旗) をクリックする経路では desync が持続**します。再現スクリーンショット・手順は issue のコメント参照（回復パスに 8 秒遅延を入れてレース窓を固定して確認）。

## Changes Made

- `blocks.jsx`: fromRuby 分岐の `updateToolbox()` 呼び出しをフラグ化し、`finally { Events.enable(); }` の**後**に移動。元の try/catch が持っていた swallow-and-log のエラーセマンティクスを維持
- 新規 integration テスト `ruby-tab-monitor-sync.test.js` を追加 (Prettier ホワイトリスト + `.claude/rules` の一覧も更新)
- `smalruby-markers.md` に新マーカー `Ruby-converted toolbox update deferral` を追記

## 影響範囲の安全性確認 (敵対的レビュー)

- flyout イベントは workspaceId 単位で配送されるため、main workspace のリスナー (`vm.blockListener` / stale-block-delete-guard / `toolboxUpdateChangeListener`) には届かない
- flyout 再構築で発火する `var_create` は `blocklyListen` の lookup ガードで no-op (既存変数のため)。ghost 変数が生まれないことを Playwright で確認
- `flyoutBlocks` / `monitorBlocks` は `forceNoGlow=true` のため `emitProjectChanged` は no-op (プロジェクトの dirty 化なし)
- `Events.disable()` を使う箇所は codebase 全体でこの 1 箇所のみ (同パターンの他インスタンスなし)
- 例外時の挙動: フラグは旧 `updateToolbox()` 呼び出し位置で設定するため、窓内で例外が出た場合のスキップ挙動は従来と同一

## Test Coverage

新規 integration テスト (TDD の RED/GREEN を実施):

- `clicking Go on the Ruby tab registers converted variables in monitorBlocks` — 回復が走らない経路での同期を検証 + ghost 変数がないことを検証
- `monitor checkbox path works for a variable created by Ruby conversion` — チェックボックスと同じ VM エントリポイント (`changeBlock` element:'checkbox') でモニタが追加されステージに表示されることを検証

**修正前のビルドでは両テストとも fail、修正後は pass することを確認済み。**

既存テストのデグレ確認 (すべて pass):

- `test/integration/ruby-tab.test.js` (7 tests)
- `test/integration/block-palette.test.js` (7 tests)
- `test/integration/ruby-editor-actions.test.js` (3 tests)
- `test/integration/workspace-glow-regression.test.js` (2 tests)
- `test/unit/containers/blocks.test.js` / `test/unit/lib/blockly-private-api.test.js` / `test/unit/lib/stale-block-delete-guard.test.js`
- `npm run lint` (eslint --max-warnings 0 + prettier) ✅

Playwright での追加コーナーケース確認:

- 緑の旗をルビータブで押す経路 (回復なし) → `monitorBlocks` / `flyoutBlocks` 同期 ✅
- 複雑な変換 (カスタムブロック定義 + リスト + ローカル変数 + コメント 5 個) → console error 0、すべての変数が同期 ✅
- ラウンドトリップ (Ruby→Code→Ruby) でコード維持 ✅
- スプライト切替 (fromRuby=false 経路) でブロック消失なし ✅

## Related Issues

Fixes #719
