### PR TITLE
fix(dncl): issue #701 follow-up — banner layout fix, integration tests, docs

### DIFF
--- a/.claude/rules/scratch-gui/smalruby-markers.md
+++ b/.claude/rules/scratch-gui/smalruby-markers.md
@@ -51,6 +51,8 @@ upstream ファイルに追加した Smalruby 固有コードのマーカー一�
 | `src/containers/gui.jsx` | welcome modal | `onShowWelcomeModal` を Redux `openWelcomeModal()` にマップ |
 | `src/components/gui/gui.jsx` | DNCL mode notice | DnclModeNotice コンポーネントの import・配置・`onRequestExitDnclMode` prop |
 | `src/containers/gui.jsx` | DNCL mode notice | `onRequestExitDnclMode` を Redux `setDnclMode(false)` + `requestExternalExitDnclMode()` にマップ |
+| `src/components/extension-button/extension-button.jsx` | DNCL extension confirm | DNCL モード時の拡張機能ボタンを confirm ダイアログ化（メッセージ定義 + クリックハンドラの 2 箇所）。OK でふりがなモードに戻して拡張機能ライブラリを開く |
+| `src/components/extension-button/extension-button.css` | DNCL extension disabled | DNCL モード時の拡張機能ボタンの無効化スタイル |
 | `src/components/gui/gui.jsx` | Redux action props prevention | Redux action props の伝播防止 |
 | `src/components/gui/gui.jsx` | iPad portrait narrow desktop stage size | 744〜1023px viewport で stage を small に強制 (issue #572 Phase 3-C, #599 で 768→744 拡張) |
 | `src/components/gui/gui.css` | iPad portrait narrow desktop layout | 744〜1023px viewport で editor-wrapper の flex-basis を緩める (issue #572 Phase 3-C, #599 で 768→744 拡張) |

--- a/docs/dncl/README.md
+++ b/docs/dncl/README.md
@@ -39,6 +39,24 @@ DNCL モードに切り替えると：
 
 DNCL モードと**ふりがな**は排他（DNCL 自体が日本語のためふりがな不要）。
 
+### ブロック制限の通知と DNCL モードからの復帰
+
+DNCL モードではコードタブのブロックが制限される（後述の「関連ブロック」参照）ため、想定外に DNCL モードになっているユーザーが「ブロックが少ない・拡張機能が選べない」状態に気づけるよう、2 つの復帰導線を用意している。
+
+**通知バナー（コードタブ）**: DNCL モード中はワークスペース右上に「日本語モード：ブロックが制限されています」バナー（`data-testid: dncl-mode-notice`）を常時表示する。「Rubyふりがなモードに戻す」ボタン（`data-testid: dncl-mode-notice-exit-button`）を押すと confirm ダイアログを表示し、OK でふりがなモードに戻してタブ切り替えなしで全ブロックを即時復元する。
+
+**拡張機能ボタンの confirm ダイアログ**: DNCL モード中に拡張機能ボタン（`data-testid: extension-button`）を押すと、「日本語モードでは拡張機能は使えません。Rubyふりがなモードに戻すと拡張機能が使えるようになります。戻しますか？」の confirm ダイアログを表示する。OK でふりがなモードに戻して拡張機能ライブラリを開く。キャンセルでは何も変わらない（DNCL モード継続）。
+
+どちらの導線も Redux signal パターンで実装している:
+
+```
+バナー / 拡張機能ボタン (OK)
+  → dispatch(setDnclMode(false))             ← blocks.jsx が即座に全ブロック表示に更新
+  → dispatch(requestExternalExitDnclMode())  ← ruby-tab の wasDncl 復元をスキップするシグナル
+```
+
+Ruby タブを次に開いたとき、`exitDnclModeExternallyRequested` フラグが立っていれば DNCL 表示の復元（wasDncl パス）をスキップして Ruby コードを表示し、フラグをクリアする。これにより「バナーで戻したのに Ruby タブを開くと日本語モードに戻ってしまう」事故を防ぐ。
+
 ## 主要ファイル
 
 ### scratch-gui
@@ -73,9 +91,13 @@ DNCL モードと**ふりがな**は排他（DNCL 自体が日本語のためふ
 #### UI / 状態管理
 
 - `packages/scratch-gui/src/components/ruby-toolbar/ruby-toolbar.jsx` — DNCL モード切替ボタン
-- `packages/scratch-gui/src/containers/ruby-tab.jsx` — DNCL モード state、エディタ切替制御
-- `packages/scratch-gui/src/reducers/dncl-mode.js` — DNCL モードの Redux state
+- `packages/scratch-gui/src/containers/ruby-tab.jsx` — DNCL モード state、エディタ切替制御、外部終了要求時の wasDncl 復元スキップ
+- `packages/scratch-gui/src/reducers/dncl-mode.js` — DNCL モードの Redux state（`dnclMode` + `exitDnclModeExternallyRequested` シグナル）
 - `packages/scratch-gui/src/lib/locale-utils.js` — `isJapaneseLocale` (DNCL は日本語ロケール限定)
+- `packages/scratch-gui/src/components/dncl-mode-notice/` — コードタブの「日本語モード：ブロックが制限されています」通知バナー
+- `packages/scratch-gui/src/components/extension-button/extension-button.jsx` — DNCL モード時の confirm ダイアログ（upstream ファイル、Smalruby マーカー付き）
+- `packages/scratch-gui/src/components/gui/gui.jsx` / `src/containers/gui.jsx` — DnclModeNotice の配置と `onRequestExitDnclMode` の Redux 配線（upstream ファイル、Smalruby マーカー付き）
+- `packages/scratch-gui/src/containers/blocks.jsx` — DNCL モードのブロックフィルタ適用と即時再レンダリング（upstream ファイル、Smalruby マーカー付き）
 
 ### scratch-vm
 
@@ -198,7 +220,11 @@ Smalruby は **DNCLv2 形式のプログラムをそのまま実行** できる�
   - `ruby-to-dncl.test.js` — Ruby → DNCL 逆変換ユニットテスト
   - `dncl-roundtrip.test.js` — DNCL ↔ Ruby round-trip 安定性
 - Round-trip テスト (左結合演算子の括弧除去): `packages/scratch-gui/test/unit/lib/ruby-roundtrip-puts-concat.test.js`
-- 結合テスト: `packages/scratch-gui/test/integration/dncl-mode-validation.test.js`
+- ブロック制限 UX の単体テスト:
+  - `packages/scratch-gui/test/unit/reducers/dncl-mode-reducer.test.js` — `exitDnclModeExternallyRequested` シグナル
+  - `packages/scratch-gui/test/unit/components/extension-button-dncl.test.jsx` — 拡張機能ボタンの confirm フロー
+  - `packages/scratch-gui/test/unit/components/dncl-mode-notice.test.jsx` — 通知バナー
+- 結合テスト: `packages/scratch-gui/test/integration/dncl-mode-validation.test.js`（DNCL バリデーション + 通知バナー/confirm フロー）
 
 ## 関連ドキュメント
 

--- a/packages/scratch-gui/src/components/dncl-mode-notice/dncl-mode-notice.css
+++ b/packages/scratch-gui/src/components/dncl-mode-notice/dncl-mode-notice.css
@@ -2,9 +2,15 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 10;
+    /* Above .blocklyFlyout (z-index: 20): on narrow layouts (iPad portrait)
+       the workspace area is narrower than the banner, which would otherwise
+       slide under the flyout and become unreadable */
+    z-index: 25;
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    max-width: calc(100% - 8px);
     padding: 6px 12px;
     background-color: rgba(255, 243, 205, 0.95);
     border-bottom: 1px solid #ffc107;

--- a/packages/scratch-gui/test/integration/dncl-mode-validation.test.js
+++ b/packages/scratch-gui/test/integration/dncl-mode-validation.test.js
@@ -58,6 +58,64 @@ const waitForActiveState = (d, testId, expected) =>
 const clickCodeTab = (d) => d.executeScript(`document.querySelector('[role="tab"]').click()`);
 
 /**
+ * Click the Ruby tab (last tab: Code / Costumes / Sounds / Ruby).
+ * Uses index instead of text matching because the label is locale-dependent.
+ * @param {import('selenium-webdriver').WebDriver} d - WebDriver instance.
+ */
+const clickRubyTab = (d) =>
+    d.executeScript(`const tabs = document.querySelectorAll('[role="tab"]'); tabs[tabs.length - 1].click()`);
+
+const existsByTestId = (d, testId) =>
+    d.executeScript(`return document.querySelector('[data-testid="${testId}"]') !== null`);
+
+const waitForTestIdPresence = (d, testId, expected) =>
+    d.wait(
+        async () => (await existsByTestId(d, testId)) === expected,
+        10000,
+        `Element ${testId} did not become ${expected ? 'present' : 'absent'}`,
+    );
+
+/**
+ * Stub window.confirm so native dialogs do not block Selenium, recording call count.
+ * @param {import('selenium-webdriver').WebDriver} d - WebDriver instance.
+ * @param {boolean} result - Value the stubbed confirm should return.
+ */
+const setConfirmResult = (d, result) =>
+    d.executeScript(
+        `window.__confirmCalls = 0; window.confirm = () => { window.__confirmCalls += 1; return ${result}; }`,
+    );
+
+const getConfirmCallCount = (d) => d.executeScript('return window.__confirmCalls || 0');
+
+const isExtensionButtonDisabled = (d) =>
+    d.executeScript(
+        `return document.querySelector('[data-testid="extension-button"]')` +
+            `?.className?.includes('disabled') ?? false`,
+    );
+
+const isExtensionLibraryOpen = (d) =>
+    d.executeScript(`return document.querySelector('[class*="library-scroll-grid"]') !== null`);
+
+const getToolboxCategoryCount = (d) =>
+    d.executeScript(
+        `const toolbox = document.querySelector('.blocklyToolbox');` +
+            `if (!toolbox || toolbox.style.display === 'none') return 0;` +
+            `return toolbox.querySelectorAll('.blocklyToolboxCategory').length;`,
+    );
+
+const waitForMonacoLanguage = (d, expected) =>
+    d.wait(
+        async () => {
+            const lang = await d.executeScript(
+                'return window.monacoEditor && window.monacoEditor.getModel().getLanguageId()',
+            );
+            return lang === expected;
+        },
+        10000,
+        `Monaco language did not become "${expected}"`,
+    );
+
+/**
  * Load the editor in Ruby mode (not DNCL), clearing any localStorage state.
  * Uses locale=ja because furigana/DNCL modes are only available in Japanese locales.
  * @param {import('selenium-webdriver').WebDriver} d - WebDriver instance.
@@ -172,6 +230,101 @@ describe('DNCL mode validation on switch', () => {
         );
         // Non-DNCL mode should have more categories than DNCL mode (which filters heavily)
         expect(categoryCount).toBeGreaterThan(3);
+    });
+
+    test('notice banner is shown on Code tab in DNCL mode', async () => {
+        await loadUri(`${uri}?rubyMode=dncl&locale=ja&tab=ruby`);
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', true);
+        await clickCodeTab(driver);
+
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', true);
+        // Extension button is rendered in disabled style while DNCL mode is on
+        expect(await isExtensionButtonDisabled(driver)).toBe(true);
+    });
+
+    test('banner exit button: cancel keeps DNCL mode', async () => {
+        await loadUri(`${uri}?rubyMode=dncl&locale=ja&tab=ruby`);
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', true);
+        await clickCodeTab(driver);
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', true);
+
+        await setConfirmResult(driver, false);
+        await clickByTestId(driver, 'dncl-mode-notice-exit-button');
+        expect(await getConfirmCallCount(driver)).toBe(1);
+
+        // Banner stays and blocks remain restricted
+        expect(await existsByTestId(driver, 'dncl-mode-notice')).toBe(true);
+        expect(await isExtensionButtonDisabled(driver)).toBe(true);
+    });
+
+    test('banner exit button: OK exits DNCL mode and restores full toolbox', async () => {
+        await loadUri(`${uri}?rubyMode=dncl&locale=ja&tab=ruby`);
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', true);
+        await clickCodeTab(driver);
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', true);
+
+        await setConfirmResult(driver, true);
+        await clickByTestId(driver, 'dncl-mode-notice-exit-button');
+
+        // Banner disappears and full toolbox is restored without tab switching
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', false);
+        await driver.wait(
+            async () => (await getToolboxCategoryCount(driver)) > 3,
+            10000,
+            'Toolbox categories were not restored after exiting DNCL mode via banner',
+        );
+        expect(await isExtensionButtonDisabled(driver)).toBe(false);
+    });
+
+    test('extension button: cancel keeps DNCL mode and does not open library', async () => {
+        await loadUri(`${uri}?rubyMode=dncl&locale=ja&tab=ruby`);
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', true);
+        await clickCodeTab(driver);
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', true);
+
+        await setConfirmResult(driver, false);
+        await clickByTestId(driver, 'extension-button');
+        expect(await getConfirmCallCount(driver)).toBe(1);
+
+        // Extension library does not open, DNCL mode continues
+        expect(await isExtensionLibraryOpen(driver)).toBe(false);
+        expect(await existsByTestId(driver, 'dncl-mode-notice')).toBe(true);
+        expect(await isExtensionButtonDisabled(driver)).toBe(true);
+    });
+
+    test('extension button: OK exits DNCL mode and opens extension library', async () => {
+        await loadUri(`${uri}?rubyMode=dncl&locale=ja&tab=ruby`);
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', true);
+        await clickCodeTab(driver);
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', true);
+
+        await setConfirmResult(driver, true);
+        await clickByTestId(driver, 'extension-button');
+
+        // Extension library opens and DNCL restriction is lifted
+        await driver.wait(
+            () => isExtensionLibraryOpen(driver),
+            10000,
+            'Extension library did not open after confirming exit from DNCL mode',
+        );
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', false);
+    });
+
+    test('Ruby tab shows Ruby code after exiting DNCL mode via banner', async () => {
+        await loadUri(`${uri}?rubyMode=dncl&locale=ja&tab=ruby`);
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', true);
+        await waitForMonacoLanguage(driver, 'dncl');
+
+        await clickCodeTab(driver);
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', true);
+        await setConfirmResult(driver, true);
+        await clickByTestId(driver, 'dncl-mode-notice-exit-button');
+        await waitForTestIdPresence(driver, 'dncl-mode-notice', false);
+
+        // Reopen the Ruby tab: the wasDncl restore path must be skipped
+        await clickRubyTab(driver);
+        await waitForMonacoLanguage(driver, 'smalruby');
+        await waitForActiveState(driver, 'ruby-toolbar-mode-dncl', false);
     });
 
     test('DNCL to furigana switch restores block palette on Code tab', async () => {


### PR DESCRIPTION
## Summary

Issue #701 の残作業フォローアップ。主実装は PR #702 でマージ済み。本 PR は DoD の未完了項目（integration テスト追加・docs 更新・iPad/SP レイアウト確認）を完了させる。レイアウト確認の過程で iPad portrait でバナーがフライアウトの下に潜るリグレッションを発見したため、その修正も含む。

## Changes Made

### fix: iPad portrait でバナーがフライアウトに隠れる問題
- `dncl-mode-notice.css`: バナーは `z-index: 10` だが scratch-blocks のフライアウト svg は `z-index: 20` のため、ワークスペースの空き幅が固定幅バナー (426px) より狭い iPad portrait (768×1024) ではメッセージがフライアウトの下に潜って読めなかった
- `z-index: 25` に引き上げ + `max-width: calc(100% - 8px)` + `flex-wrap` で全ビューポートで読める・押せる状態を保証

### test: integration テスト 6 件追加（issue #701 Phase 5 の残作業）
- DNCL モード時のコードタブでバナー表示
- バナー: confirm キャンセル → DNCL モード維持
- バナー: confirm OK → タブ切り替えなしで全ツールボックス復元
- 拡張機能ボタン: キャンセル → DNCL モード維持、ライブラリは開かない
- 拡張機能ボタン: OK → 拡張機能ライブラリが開く
- 外部終了後に Ruby タブを開く → Ruby コード表示（wasDncl 復元のスキップ）

### docs: ドキュメント更新（documentation DoD）
- `docs/dncl/README.md`: 通知バナー・confirm ダイアログの UX、Redux signal パターン、新規ファイル一覧、テスト一覧を追記
- `.claude/rules/scratch-gui/smalruby-markers.md`: 漏れていた `extension-button.jsx` / `extension-button.css` のマーカーを追加

## Test Coverage

- `test/integration/dncl-mode-validation.test.js`: 12 件 pass（新規 6 件含む）
- `test/unit/components/dncl-mode-notice.test.jsx` / `extension-button-dncl.test.jsx` / `dncl-mode-reducer.test.js`: 21 件 pass
- lint (eslint --max-warnings 0 + prettier): pass

## Playwright 確認（issue #701 DoD 残項目）

| Viewport | 結果 |
|---|---|
| iPhone 14 横 844×390 (MobileGui) | ✅ バナー表示・viewport 内・読める |
| iPad portrait 768×1024 | ✅ 修正後に読める（修正前はフライアウト下に潜っていた）・ボタン動作確認済み |
| iPad mini portrait 744×1133 | ✅ |
| iPad landscape 1024×768 | ✅ |
| Desktop 1280×800 | ✅ フライアウトと重ならず挙動変化なし |

## Related Issues

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)
