### PR TITLE
docs: add fixed-and-deployed workflow to /feedback skill

### DIFF
--- a/.claude/skills/feedback/SKILL.md
+++ b/.claude/skills/feedback/SKILL.md
@@ -210,6 +210,15 @@ rm /tmp/feedback-graphql-query.txt
    gh api graphql -f query='mutation { addLabelsToLabelable(input: { labelableId: "<discussion-node-id>", labelIds: ["LA_kwDOFahn7M8AAAACakeKNg"] }) { clientMutationId } }'
    ```
 
+### 対応完了したもの（修正がデプロイされたもの）
+
+修正完了・デプロイ済みを伝えるフォローアップコメント（PR リンク + 変更内容の要約 + リロード依頼）を投稿した上で、**必ず以下の 2 つを行う**:
+
+1. **タイトルに「【修正済み】」prefix を付与する**（mutation は上記「対応しないもの」と同じ。prefix のみ異なる）
+2. **`close` ラベルを付与する**（同上）
+
+prefix の使い分け: 「【回答済み】」= 対応しないと回答してクローズ、「【修正済み】」= 修正を完了してクローズ。
+
 ### コメント投稿方法
 
 本文は Write ツールで `/tmp/comment-N.md` に書き出し、`-F body=@` で投稿する（Phase 5 と同じ理由）:


### PR DESCRIPTION
## Summary

`/feedback` skill に「対応完了したもの（修正がデプロイされたもの）」のクローズ手順を追記する。

Discussion #87（Monaco キーボードボタン、#727 / PR #729 で修正済み）のクローズ運用で確立したルールの反映。

## Changes Made

- 「対応完了したもの」セクションを追加:
  - 修正完了・デプロイ済みを伝えるフォローアップコメント（PR リンク + 要約 + リロード依頼）を投稿
  - タイトルに「【修正済み】」prefix を付与 + `close` ラベルを付与
- prefix の使い分けを明記: 「【回答済み】」= 対応しないと回答してクローズ、「【修正済み】」= 修正を完了してクローズ

## Test Coverage

ドキュメント（スキル定義）のみの変更のため、テストなし。
