### PR TITLE
docs: consolidate AWS SSO deploy config into infra/aws-sso.env

### DIFF
--- a/.claude/rules/devpod-workflow.md
+++ b/.claude/rules/devpod-workflow.md
@@ -100,7 +100,7 @@ compose で動かしている場合に違いを理解しておくため。
 | `docker compose run` でテスト | `docker compose run --rm app npm test` | container 内で `npm test` |
 | 単独のフリー仕事 (curl 確認等) | host 上で実行 | 任意。container 内でも OK |
 | Playwright MCP | host の Playwright が動く想定 | host の Playwright が container の `localhost:8601` (forwardPorts) を見る |
-| CDK deploy | host の `aws-vault` 等で | **同じく host で実行** (container には `~/.aws` を mount していないため) |
+| CDK deploy | host の `aws-vault` 等で | **container 内で AWS IAM Identity Center (SSO) ログインして実行**。`bin/setup-aws-sso` で `~/.aws/config` を生成 → `aws sso login --sso-session smalruby --use-device-code` の URL をホストのブラウザで承認 → 一時クレデンシャルがコンテナ内にキャッシュされる (詳細: `.claude/rules/infra/development.md` の AWS Credentials)。host で実行してもよい |
 
 ### named volume の共有挙動 (重要)
 
@@ -254,7 +254,7 @@ devpod では **複数 workspace が同時に container 起動可能**。これ�
 |---|---|---|
 | `bin/dx bash -c "..."` の手軽さ | container 内で同じことを 1 コマンドで | host 上 docker run が不便なので tmux に入って実行 |
 | 1 つの container で全 worktree を切替使用 | 各 worktree が独立 container | devpod の workspace 設計上 |
-| host の `~/.aws` を使った CDK deploy を container 内から | **そのまま host で実行** | secret leak 防止のため container には mount しない |
+| host の `~/.aws` を使った CDK deploy を container 内から | **container 内で SSO ログインして deploy** (`bin/setup-aws-sso` → `aws sso login --sso-session smalruby`) | host の `~/.aws` は mount しない (secret leak 防止)。代わりに IAM Identity Center の一時クレデンシャルをコンテナ内に取得する |
 | host の Claude Code 認証を共有 | container 内で別途ログイン | host secrets 持ち込み禁止原則 |
 | smalruby3 (Ruby gem) の SDL2 GUI | host で動かす (X server / SDL2 が container 内に無い) | devcontainer は GUI 想定外 |
 | docker compose の他サービス (`infra`, `smalruby3-gui`) との同時起動 | devpod は `app` 相当のみ。他サービスは host から `docker compose up <service>` | devcontainer は単一サービス |

--- a/.claude/rules/infra/development.md
+++ b/.claude/rules/infra/development.md
@@ -47,15 +47,74 @@ CDK のコンテキストキャッシュファイル `cdk.context.json` は **�
 
 ## AWS Credentials
 
-Set credentials via environment variables before running infra commands:
+CDK の synth/diff/deploy には AWS クレデンシャルが必要。**devpod / devcontainer の中から
+直接デプロイできる**（AWS IAM Identity Center の SSO ログインでコンテナ内に一時クレデン
+シャルを取得する。ホストの `~/.aws` を mount する必要はない）。
+
+### 推奨: AWS IAM Identity Center (SSO)
+
+接続先の値（start URL / account ID / role など）は **`infra/aws-sso.env` の 1 ファイルに集約**
+されている（非秘密・コミット済み）。**fork して別の AWS 組織で動かす場合は、このファイルの
+値だけを書き換える。**
+
+```bash
+# 1. infra/aws-sso.env から ~/.aws/config を生成 (1 度だけ)
+bin/setup-aws-sso
+
+# 2. ログイン (コンテナにブラウザが無い場合は URL + code が表示される。
+#    ホストのブラウザで開いて承認する。code には数分の有効期限あり)
+aws sso login --sso-session smalruby --use-device-code
+
+# 3. 以降は AWS_PROFILE を指定して実行
+export AWS_PROFILE=smalruby
+aws sts get-caller-identity   # 疎通確認
+
+# 4. デプロイ例
+cd infra/smalruby-bug-report
+AWS_PROFILE=smalruby AWS_REGION=ap-northeast-1 npx cdk deploy --context stage=stg --require-approval never
+```
+
+- 値の実体は `infra/aws-sso.env`（`AWS_SSO_PROFILE` / `AWS_SSO_START_URL` / `AWS_SSO_REGION` /
+  `AWS_SSO_ACCOUNT_ID` / `AWS_SSO_ROLE`）。`bin/setup-aws-sso` がこれを読んで `~/.aws/config`
+  を生成する（ハードコードしない）。
+- アカウント/ロールが分からないときは `aws configure sso` で対話的に選ぶか、ログイン後に
+  `aws sso list-accounts` / `aws sso list-account-roles` で確認できる。
+- トークンは `~/.aws/sso/cache/` にキャッシュされ、期限切れ後は `aws sso login` で再取得。
+- CDK CLI はクレデンシャルから account/region を自動解決するため、`bin/*.ts` の
+  `CDK_DEFAULT_ACCOUNT`/`AWS_REGION` は明示不要（`AWS_PROFILE` だけで足りる）。
+
+### 代替: 環境変数 / 静的プロファイル
+
+一時的なアクセスキー (STS) や既存プロファイルがある場合:
 
 ```bash
 export AWS_ACCESS_KEY_ID=your-key-id
 export AWS_SECRET_ACCESS_KEY=your-secret-key
+export AWS_SESSION_TOKEN=your-session-token   # 一時認証情報の場合
 export AWS_DEFAULT_REGION=ap-northeast-1
 # or
 export AWS_PROFILE=your-profile
 ```
+
+長期 (無期限) のアクセスキーは可能な限り避け、SSO か STS の一時クレデンシャルを使う。
+
+### セキュリティ: 記録してよい情報 / いけない情報
+
+リポジトリ (rules / docs / `infra/aws-sso.env` / コミット) に書いてよいのは **認証フローを
+開始するだけの固定識別子** に限る。クレデンシャルそのものや一時的な認可アーティファクトは
+書かない。
+
+| 記録可 ✅ | 記録不可 ❌ |
+|----------|-----------|
+| SSO start URL / region | デバイス認証コード (`XXXX-XXXX`、即失効) |
+| AWS account ID (`cdk.context.json` にも既出) | SSO アクセストークン / セッショントークン |
+| 許可セット名 (`AdministratorAccess`) | 承認 URL の `clientId` / `deviceContextId` |
+| プロファイル名・手順コマンド | `DEV_BYPASS_TOKEN` 等の値 (名前のみ可、値は gitignore の .env) |
+
+理由: start URL や account ID は単体ではアクセスできず (IdP ログイン + デバイス承認が必須)、
+account ID は CDK の `cdk.context.json` コミット方針で既にリポジトリに含まれる。一方、
+トークン類・認証コードは短命でも秘密であり、`~/.aws/sso/cache/` の中身を含めコミットや
+チャット転記をしない。
 
 ## Stage Switching via `.env` Symlink
 

--- a/bin/setup-aws-sso
+++ b/bin/setup-aws-sso
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Generate ~/.aws/config for CDK deploys from the single, committed,
+# non-secret source of truth: infra/aws-sso.env.
+#
+# Fork users only need to edit infra/aws-sso.env (not this script).
+# The actual credentials are a short-lived SSO token obtained separately via
+# `aws sso login` — never stored by this script.
+#
+# Usage:
+#   bin/setup-aws-sso              # write/refresh ~/.aws/config
+#   aws sso login --sso-session <profile> --use-device-code
+#   export AWS_PROFILE=<profile>
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$ROOT/infra/aws-sso.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "error: $ENV_FILE not found" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$ENV_FILE"
+
+: "${AWS_SSO_PROFILE:?set AWS_SSO_PROFILE in infra/aws-sso.env}"
+: "${AWS_SSO_START_URL:?set AWS_SSO_START_URL in infra/aws-sso.env}"
+: "${AWS_SSO_REGION:?set AWS_SSO_REGION in infra/aws-sso.env}"
+: "${AWS_SSO_ACCOUNT_ID:?set AWS_SSO_ACCOUNT_ID in infra/aws-sso.env}"
+: "${AWS_SSO_ROLE:?set AWS_SSO_ROLE in infra/aws-sso.env}"
+
+mkdir -p "$HOME/.aws"
+CONFIG="$HOME/.aws/config"
+
+# Back up an existing config once (do not clobber unrelated profiles silently).
+if [ -f "$CONFIG" ] && ! grep -q "\[sso-session ${AWS_SSO_PROFILE}\]" "$CONFIG"; then
+  cp "$CONFIG" "$CONFIG.bak.$(date +%s)"
+  echo "note: existing ~/.aws/config backed up" >&2
+fi
+
+cat > "$CONFIG" <<EOF
+[sso-session ${AWS_SSO_PROFILE}]
+sso_start_url = ${AWS_SSO_START_URL}
+sso_region = ${AWS_SSO_REGION}
+sso_registration_scopes = sso:account:access
+
+[profile ${AWS_SSO_PROFILE}]
+sso_session = ${AWS_SSO_PROFILE}
+sso_account_id = ${AWS_SSO_ACCOUNT_ID}
+sso_role_name = ${AWS_SSO_ROLE}
+region = ${AWS_SSO_REGION}
+output = json
+EOF
+
+echo "Wrote ~/.aws/config (profile: ${AWS_SSO_PROFILE})."
+echo "Next:"
+echo "  aws sso login --sso-session ${AWS_SSO_PROFILE} --use-device-code"
+echo "  export AWS_PROFILE=${AWS_SSO_PROFILE}"
+echo "  aws sts get-caller-identity   # verify"

--- a/infra/aws-sso.env
+++ b/infra/aws-sso.env
@@ -1,0 +1,14 @@
+# AWS IAM Identity Center (SSO) connection shared by all infra/* CDK deploys.
+#
+# NON-SECRET, intentionally committed. これらは秘密ではなく「fork 時に差し替える設定」。
+# 別の AWS 組織でこのリポジトリを動かす場合は、このファイルの値だけを書き換える。
+# （本当のクレデンシャルは `aws sso login` で取得する一時トークンで、ここには置かない。）
+#
+# 反映方法: `bin/setup-aws-sso` がこのファイルを読んで ~/.aws/config を生成する。
+# 詳細: .claude/rules/infra/development.md の「AWS Credentials」
+
+AWS_SSO_PROFILE=smalruby
+AWS_SSO_START_URL=https://d-956792721c.awsapps.com/start
+AWS_SSO_REGION=ap-northeast-1
+AWS_SSO_ACCOUNT_ID=007325983811
+AWS_SSO_ROLE=AdministratorAccess


### PR DESCRIPTION
## Summary

CDK デプロイを devcontainer の中から実行できるように、AWS IAM Identity Center (SSO) の接続設定を整理する。fork して別の AWS 組織で動かすときに差し替える非秘密の値を **`infra/aws-sso.env` の 1 ファイルに集約**し、`bin/setup-aws-sso` がそこから `~/.aws/config` を生成する。

#731 (bug-report) の stg デプロイ作業中に必要になった手順を、別トピックとして切り出したもの。

## Changes

- **`infra/aws-sso.env`** — fork 時に差し替える接続設定の単一ソース（非秘密・コミット対象）。`AWS_SSO_PROFILE` / `AWS_SSO_START_URL` / `AWS_SSO_REGION` / `AWS_SSO_ACCOUNT_ID` / `AWS_SSO_ROLE`。
- **`bin/setup-aws-sso`** — `infra/aws-sso.env` を読んで `~/.aws/config` を生成（ハードコードなし。無関係な既存 config は 1 度だけバックアップ）。
- **`development.md` AWS Credentials** — SSO を推奨フロー（`bin/setup-aws-sso` → `aws sso login` → `AWS_PROFILE`）として記載。env-var/STS を代替として残す。記録してよい/いけない情報のセキュリティ表を追加。
- **`devpod-workflow.md`** — CDK deploy はコンテナ内で SSO ログインして実行可能、と更新（「ホストで実行/`~/.aws` を mount しない」の文言を変更）。

## セキュリティ方針

| 記録可 ✅ | 記録不可 ❌ |
|----------|-----------|
| SSO start URL / region | デバイス認証コード（即失効） |
| AWS account ID（`cdk.context.json` に既出） | SSO アクセス/セッショントークン |
| 許可セット名 `AdministratorAccess` | 承認 URL の `clientId`/`deviceContextId` |
| プロファイル名・手順 | `DEV_BYPASS_TOKEN` の値（名前のみ可） |

一時トークンは `aws sso login` でのみ取得し、ファイルにもリポジトリにも置かない。ホストの `~/.aws` はコンテナに mount しない方針を維持。

## Test

- `bin/setup-aws-sso` 実行 → `~/.aws/config` 生成 → `aws sso login` → `aws sts get-caller-identity` で疎通確認済み（account `007325983811`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
