### PR TITLE
feat: 不具合報告の初回案内を軽量化（18歳/保護者同意の撤去）

### DIFF
--- a/docs/bug-report/README.md
+++ b/docs/bug-report/README.md
@@ -21,8 +21,10 @@ Google / Microsoft アカウントでログインし、開発者 (管理者) が
 
 1. エディタ右下の「フィードバックを送信」の隣にある **「不具合を報告」** をクリック
    （`BUG_REPORT_API_ENDPOINT` が設定されているときのみ表示）
-2. 初回は **同意ダイアログ** が出る。「作品が開発者に共有される」「ログインが必要」
-   「説明に個人情報を書かない」ことに同意する (1 回だけ。`localStorage` に記録)
+2. 初回は **軽いおしらせ** が出る。「作品が開発者に送られる（公開はされない・見えるのは
+   本人と開発者だけ）」「直ったら知らせるのでログインが必要」「個人情報は書かない」を案内し、
+   **OK で進む**（18歳/保護者同意のチェックは無く、生徒が気軽に進められる。保護者向けの
+   1 行は情報提供のみ。1 回だけ表示、`localStorage` に記録）
 3. **Google または Microsoft でログイン**
 4. 不具合の説明 (何をした / どうなった / どうなってほしかった) を入力して送信。
    今編集している作品 (sb3)・サムネイル・ブロックのスクリーンショットが自動添付される
@@ -97,7 +99,7 @@ API では削除できない。
 |---------|------|
 | `src/components/gui/gui.jsx` | `legalLinks` の「不具合を報告」リンク + モーダル配置 (Smalruby マーカー) |
 | `src/components/bug-report-modal/bug-report-modal.jsx` | モーダル UI (login / form / submitting / success / myReports) |
-| `src/components/bug-report-consent/bug-report-consent.jsx` | 初回共有同意ダイアログ |
+| `src/components/bug-report-consent/bug-report-consent.jsx` | 初回の軽いおしらせダイアログ（同意ゲートなし） |
 | `src/containers/bug-report-modal.jsx` | 状態管理・同意・ログイン・送信・一覧のオーケストレーション |
 | `src/containers/use-bug-report-submit.js` | 作品 sb3 + サムネ + スクショの presigned アップロード |
 | `src/lib/bug-report-api.js` | API クライアント |

--- a/packages/scratch-gui/src/components/bug-report-consent/bug-report-consent.css
+++ b/packages/scratch-gui/src/components/bug-report-consent/bug-report-consent.css
@@ -48,48 +48,17 @@
     margin-bottom: 0.25rem;
 }
 
-.details {
+/* One-line informational note for guardians (not a consent gate). */
+.guardian-note {
     margin: 0 0 1rem 0;
-    border: 1px solid $ui-black-transparent-10;
-    border-radius: 4px;
-    padding: 0.5rem;
-}
-
-.details-summary {
-    cursor: pointer;
-    font-size: 0.9rem;
-    color: $motion-primary;
-}
-
-.details-content {
-    margin-top: 0.5rem;
-    font-size: 0.85rem;
-    color: $text-primary;
+    font-size: 0.8rem;
     line-height: 1.5;
+    color: $text-primary-transparent;
 }
 
-.links {
-    margin-top: 0.5rem;
-}
-
-.links a {
+.guardian-note a {
     color: $motion-primary;
     text-decoration: underline;
-}
-
-.checkbox-label {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
-    margin: 1rem 0;
-    font-size: 0.9rem;
-    cursor: pointer;
-    color: $text-primary;
-}
-
-.checkbox {
-    margin-top: 0.15rem;
-    flex-shrink: 0;
 }
 
 .buttons {

--- a/packages/scratch-gui/src/components/bug-report-consent/bug-report-consent.jsx
+++ b/packages/scratch-gui/src/components/bug-report-consent/bug-report-consent.jsx
@@ -33,29 +33,18 @@ const messages = defineMessages({
         defaultMessage: 'Do not write personal information (name, address, etc.) in the description.',
         description: 'Warning about personal information',
     },
-    detailsToggle: {
-        id: 'gui.bugReportConsent.detailsToggle',
-        defaultMessage: 'More details (for parents/guardians)',
-        description: 'Toggle label for detailed explanation',
-    },
-    detailsText: {
-        id: 'gui.bugReportConsent.detailsText',
+    guardianNote: {
+        id: 'gui.bugReportConsent.guardianNote',
         defaultMessage:
-            'Your project file, a thumbnail, screenshots, your description and your account email ' +
-            'are stored securely and are visible only to you and the Smalruby developers. ' +
-            'They are deleted after the bug is resolved.',
-        description: 'Detailed explanation for parents',
+            'For parents/guardians: the project, thumbnail, screenshots, description and account ' +
+            'email are stored securely, handled only by the Smalruby developers, and deleted after ' +
+            'the bug is resolved.',
+        description: 'One-line informational note for guardians (not a consent gate)',
     },
     privacyLink: {
         id: 'gui.bugReportConsent.privacyLink',
         defaultMessage: 'Privacy Policy',
         description: 'Link text for privacy policy',
-    },
-    consentCheckbox: {
-        id: 'gui.bugReportConsent.consentCheckbox',
-        defaultMessage:
-            'I am 18 or older, or I have permission from a parent/guardian, and I agree to share my project.',
-        description: 'Consent checkbox label',
     },
     cancel: {
         id: 'gui.bugReportConsent.cancel',
@@ -70,111 +59,76 @@ const messages = defineMessages({
 });
 
 /**
- * Consent dialog shown before the first program bug report. Ensures the user
- * understands that their project is shared with the developers, that login is
- * required so the result can be communicated back, and (for minors) that they
- * have a guardian's permission.
+ * Light, one-time notice shown before the first program bug report. It is a
+ * heads-up (not a consent gate): the project is shared only with the Smalruby
+ * developers (never published), login lets us tell the reporter when it's
+ * fixed, and personal info should not be written. Students can proceed casually
+ * — no age/guardian-consent checkbox (data stays on our own infra, handled only
+ * by the admin). A one-line guardian note is informational only.
  * @param {object} props - Component props
- * @param {function} props.onAccept - Called when the user accepts
+ * @param {function} props.onAccept - Called when the user taps OK
  * @param {function} props.onCancel - Called when the user cancels
  * @param {object} props.intl - react-intl object
- * @returns {React.Element} Consent dialog
+ * @returns {React.Element} Notice dialog
  */
-const BugReportConsent = ({ onAccept, onCancel, intl }) => {
-    const [checked, setChecked] = React.useState(false);
-    const [detailsOpen, setDetailsOpen] = React.useState(false);
+const BugReportConsent = ({ onAccept, onCancel, intl }) => (
+    <div
+        className={styles.overlay}
+        data-testid="bug-report-consent"
+    >
+        <div className={styles.dialog}>
+            <h2 className={styles.title}>
+                {'🐛 '}
+                <FormattedMessage {...messages.title} />
+            </h2>
 
-    const handleToggleDetails = React.useCallback(e => {
-        setDetailsOpen(e.target.open);
-    }, []);
+            <p className={styles.intro}>
+                <FormattedMessage {...messages.intro} />
+            </p>
 
-    const handleCheckboxChange = React.useCallback(e => {
-        setChecked(e.target.checked);
-    }, []);
+            <ul className={styles.points}>
+                <li>
+                    <FormattedMessage {...messages.pointShared} />
+                </li>
+                <li>
+                    <FormattedMessage {...messages.pointLogin} />
+                </li>
+                <li>
+                    <FormattedMessage {...messages.pointNoPersonalInfo} />
+                </li>
+            </ul>
 
-    return (
-        <div
-            className={styles.overlay}
-            data-testid="bug-report-consent"
-        >
-            <div className={styles.dialog}>
-                <h2 className={styles.title}>
-                    {'🐛 '}
-                    <FormattedMessage {...messages.title} />
-                </h2>
-
-                <p className={styles.intro}>
-                    <FormattedMessage {...messages.intro} />
-                </p>
-
-                <ul className={styles.points}>
-                    <li>
-                        <FormattedMessage {...messages.pointShared} />
-                    </li>
-                    <li>
-                        <FormattedMessage {...messages.pointLogin} />
-                    </li>
-                    <li>
-                        <FormattedMessage {...messages.pointNoPersonalInfo} />
-                    </li>
-                </ul>
-
-                <details
-                    className={styles.details}
-                    open={detailsOpen}
-                    onToggle={handleToggleDetails}
+            {/* Informational note for guardians — NOT a consent gate. */}
+            <p className={styles.guardianNote}>
+                <FormattedMessage {...messages.guardianNote} />{' '}
+                <a
+                    href="/privacy-policy.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
                 >
-                    <summary className={styles.detailsSummary}>
-                        <FormattedMessage {...messages.detailsToggle} />
-                    </summary>
-                    <div className={styles.detailsContent}>
-                        <p>
-                            <FormattedMessage {...messages.detailsText} />
-                        </p>
-                        <p className={styles.links}>
-                            <a
-                                href="/privacy-policy.html"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                {intl.formatMessage(messages.privacyLink)}
-                            </a>
-                        </p>
-                    </div>
-                </details>
+                    {intl.formatMessage(messages.privacyLink)}
+                </a>
+            </p>
 
-                <label className={styles.checkboxLabel}>
-                    <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={handleCheckboxChange}
-                        className={styles.checkbox}
-                        data-testid="bug-report-consent-checkbox"
-                    />
-                    <FormattedMessage {...messages.consentCheckbox} />
-                </label>
-
-                <div className={styles.buttons}>
-                    <button
-                        className={styles.cancelButton}
-                        onClick={onCancel}
-                        data-testid="bug-report-consent-cancel"
-                    >
-                        <FormattedMessage {...messages.cancel} />
-                    </button>
-                    <button
-                        className={styles.acceptButton}
-                        disabled={!checked}
-                        onClick={onAccept}
-                        data-testid="bug-report-consent-accept"
-                    >
-                        <FormattedMessage {...messages.accept} />
-                    </button>
-                </div>
+            <div className={styles.buttons}>
+                <button
+                    className={styles.cancelButton}
+                    onClick={onCancel}
+                    data-testid="bug-report-consent-cancel"
+                >
+                    <FormattedMessage {...messages.cancel} />
+                </button>
+                <button
+                    className={styles.acceptButton}
+                    onClick={onAccept}
+                    data-testid="bug-report-consent-accept"
+                >
+                    <FormattedMessage {...messages.accept} />
+                </button>
             </div>
         </div>
-    );
-};
+    </div>
+);
 
 BugReportConsent.propTypes = {
     intl: intlShape.isRequired,

--- a/packages/scratch-gui/src/locales/en.js
+++ b/packages/scratch-gui/src/locales/en.js
@@ -374,12 +374,9 @@ export default {
     'gui.bugReportConsent.pointLogin': 'You sign in with Google or Microsoft so we can tell you when it is fixed.',
     'gui.bugReportConsent.pointNoPersonalInfo':
         'Do not write personal information (name, address, etc.) in the description.',
-    'gui.bugReportConsent.detailsToggle': 'More details (for parents/guardians)',
-    'gui.bugReportConsent.detailsText':
-        'Your project file, a thumbnail, screenshots, your description and your account email are stored securely and are visible only to you and the Smalruby developers. They are deleted after the bug is resolved.',
+    'gui.bugReportConsent.guardianNote':
+        'For parents/guardians: the project, thumbnail, screenshots, description and account email are stored securely, handled only by the Smalruby developers, and deleted after the bug is resolved.',
     'gui.bugReportConsent.privacyLink': 'Privacy Policy',
-    'gui.bugReportConsent.consentCheckbox':
-        'I am 18 or older, or I have permission from a parent/guardian, and I agree to share my project.',
     'gui.bugReportConsent.cancel': 'Not now',
     'gui.bugReportConsent.accept': 'OK',
 

--- a/packages/scratch-gui/src/locales/ja-Hira.js
+++ b/packages/scratch-gui/src/locales/ja-Hira.js
@@ -626,12 +626,9 @@ export default {
     'gui.bugReportConsent.pointLogin': 'なおったときにおしらせできるように、GoogleまたはMicrosoftでログインします。',
     'gui.bugReportConsent.pointNoPersonalInfo':
         'せつめいにはこじんじょうほう（なまえ・じゅうしょなど）をかかないでください。',
-    'gui.bugReportConsent.detailsToggle': 'くわしく（ほごしゃのかたへ）',
-    'gui.bugReportConsent.detailsText':
-        'さくひんファイル・サムネイル・スクリーンショット・せつめいぶん・アカウントのメールアドレスはあんぜんにほかんされ、あなたとかいはつしゃだけがみられます。ふぐあいのたいおうがおわったあとにさくじょされます。',
+    'gui.bugReportConsent.guardianNote':
+        'ほごしゃのかたへ：おくられたさくひん・サムネイル・スクリーンショット・せつめい・アカウントのメールアドレスはあんぜんにほかんされ、スモウルビーのかいはつしゃのみがあつかいます。たいおうがおわったあとにさくじょされます。',
     'gui.bugReportConsent.privacyLink': 'プライバシーポリシー',
-    'gui.bugReportConsent.consentCheckbox':
-        'わたしは18さいいじょう、またはほごしゃのどういがあり、さくひんのきょうゆうにどういします。',
     'gui.bugReportConsent.cancel': 'いまはやめる',
     'gui.bugReportConsent.accept': 'OK',
 

--- a/packages/scratch-gui/src/locales/ja.js
+++ b/packages/scratch-gui/src/locales/ja.js
@@ -598,11 +598,9 @@ export default {
     'gui.bugReportConsent.pointShared': '送った作品を見られるのは、あなたと開発者だけです。',
     'gui.bugReportConsent.pointLogin': '直ったときにお知らせできるように、GoogleまたはMicrosoftでログインします。',
     'gui.bugReportConsent.pointNoPersonalInfo': '説明には個人情報（名前・住所など）を書かないでください。',
-    'gui.bugReportConsent.detailsToggle': 'くわしく（保護者の方へ）',
-    'gui.bugReportConsent.detailsText':
-        '作品ファイル・サムネイル・スクリーンショット・説明文・アカウントのメールアドレスは安全に保管され、あなたと開発者だけが見られます。不具合の対応が終わったあとに削除されます。',
+    'gui.bugReportConsent.guardianNote':
+        '保護者の方へ：送られた作品・サムネイル・スクリーンショット・説明・アカウントのメールアドレスは安全に保管され、スモウルビーの開発者のみが扱います。対応が終わったあとに削除されます。',
     'gui.bugReportConsent.privacyLink': 'プライバシーポリシー',
-    'gui.bugReportConsent.consentCheckbox': '私は18歳以上、または保護者の同意があり、作品の共有に同意します。',
     'gui.bugReportConsent.cancel': 'いまはやめる',
     'gui.bugReportConsent.accept': 'OK',
 

--- a/packages/scratch-gui/test/unit/components/bug-report-consent.test.jsx
+++ b/packages/scratch-gui/test/unit/components/bug-report-consent.test.jsx
@@ -18,20 +18,15 @@ describe('BugReportConsent', () => {
         expect(queryByTestId('bug-report-consent')).toBeInTheDocument();
     });
 
-    test('accept is disabled until the checkbox is checked', () => {
+    test('OK is enabled immediately (no consent checkbox) and calls onAccept', () => {
         const onAccept = jest.fn();
-        const { getByTestId } = renderConsent({ onAccept, onCancel: jest.fn() });
+        const { getByTestId, queryByTestId } = renderConsent({ onAccept, onCancel: jest.fn() });
+
+        // The lighter notice has no 18+/guardian-consent checkbox.
+        expect(queryByTestId('bug-report-consent-checkbox')).not.toBeInTheDocument();
 
         const acceptButton = getByTestId('bug-report-consent-accept');
-        expect(acceptButton).toBeDisabled();
-
-        // Clicking while disabled does nothing.
-        fireEvent.click(acceptButton);
-        expect(onAccept).not.toHaveBeenCalled();
-
-        fireEvent.click(getByTestId('bug-report-consent-checkbox'));
         expect(acceptButton).not.toBeDisabled();
-
         fireEvent.click(acceptButton);
         expect(onAccept).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## Summary

不具合報告の初回ダイアログから **「18歳以上 or 保護者の同意」チェックを撤去**し、生徒が気軽に進められる**軽いおしらせ**に変更。

不具合報告は公開されず、データは自分たちの AWS 内で**管理者のみが扱う**（流出すればプロジェクト自体が大ダメージ＝起こさない前提）。Rubytee（第三者 AI にデータ送信）由来の重い同意文面は不要との判断。

## Before → After

- **Before**: ☑「私は18歳以上、または保護者の同意があり…」にチェックしないと進めない＋保護者向けの折りたたみ長文
- **After**: 軽いおしらせ（作品が開発者に送られる・公開されない／見えるのは本人と開発者だけ・なおったら知らせるのでログイン・個人情報は書かない）＋ **OK はいつでも押せる**。保護者向けは1行の情報提供のみ（同意ゲートなし）。

安全のため「個人情報を書かない」注意と、透明性のための「開発者だけが扱う／対応後に削除」1行は残しています。

## Changes
- `bug-report-consent.jsx` / `.css`: チェックボックス・折りたたみ撤去、guardianNote 1行化、OK 常時有効
- locales ja/ja-Hira/en: `detailsToggle`・`consentCheckbox` 削除、`detailsText`→`guardianNote`
- consent unit test 更新（チェックボックス無し・OK 即有効）
- docs/bug-report/README 更新

frontend のみ。マージ→本番デプロイで反映。headful で新ダイアログ（チェック無し・OK 有効）を確認済み（`tmp/consent-lighter.png`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
