### PR TITLE
feat(devcontainer): add egress allowlist firewall

### DIFF
--- a/.claude/rules/devpod-workflow.md
+++ b/.claude/rules/devpod-workflow.md
@@ -10,6 +10,7 @@
 | エディタ | devpod ssh + tmux (VS Code Dev Containers でも可) |
 | **ホスト側ターミナル** | **iTerm2 必須**（macOS 標準 Terminal.app は OSC 52 非対応のためクリップボード連携不可） |
 | host から見える環境 | ブラウザ (port forwarding 経由)、git の push/PR (gh CLI 経由)、CDK deploy |
+| **通信 (egress)** | **無制限ではなく allowlist**。default-DROP の firewall で GitHub / npm / Anthropic / AWS のみ許可 (`init-firewall.sh`)。詳細は「egress allowlist firewall」 |
 | 採用していないもの | `docker compose run --rm app ...`, `bin/dx`, `bin/setup-worktree` (compose 前提なので不要) |
 | 例外的に host で必要 | `docker compose` 自体は dev server を host から開きたい人のために残してあるが、本人は使わない |
 
@@ -32,6 +33,57 @@ iTerm2 > Preferences > General > Selection >
   `gh auth setup-git`（global 書き込み）は使えない → repo-local 設定で回避している。
 - git push も `gh` の issue/PR 作成も同一の `GH_TOKEN` に一本化される。
 - `gh auth status` で `Logged in ... (GH_TOKEN)` を確認できれば push も通る。
+
+## egress allowlist firewall (重要・セキュリティ)
+
+このコンテナの外向き通信は **無制限ではなく allowlist** で限定する。
+`init-firewall.sh` を `postStartCommand` で**毎起動時**に実行し、iptables + ipset で
+**default-DROP** にして必要な宛先だけ通す。
+
+### なぜ必要か
+
+NaCl ガイドライン v0.2 は「隔離環境でもネットワーク接続先を限定する (firewall で
+ドメイン allowlist 等)」を **必須要件** とする。本 devcontainer は業務 PC 上で動き、
+かつ **AWS SSO の一時クレデンシャルをコンテナ内に取得** (`cdk deploy`) し、Claude も
+in-container ログインする。つまり **非公開認証情報がコンテナに到達する** ため、
+ガイドラインの考え方では firewall allowlist が必須になる。
+
+> 要件強度は階層ラベルではなく「隔離環境が到達できる資産の機微度」で決まる。
+> 顧客資産はディスク隔離で到達不能にし、非公開認証情報を持つ環境では egress を
+> allowlist で限定する。
+
+### 許可している宛先 (概要)
+
+- **GitHub** … `api.github.com/meta` の公開レンジ (git / gh / upstream fetch / 一部 npm 依存)
+- **npm** … `registry.npmjs.org` + バイナリ取得元 (`objects.githubusercontent.com` / `codeload.github.com` / `nodejs.org`)
+- **Anthropic** … `api.anthropic.com`, `sentry.io` (`statsig.anthropic.com` は A レコード無しなので除外)
+- **AWS** … `ip-ranges.json` の「デプロイリージョン + us-east-1 + GLOBAL」+ SSO 系。
+  リージョンと SSO ポータルは **`infra/aws-sso.env`** から自動取得 (fork 追従)
+- **DNS** … `/etc/resolv.conf` のリゾルバ + docker DNS のみ (任意 DNS への exfil 遮断)
+- IPv6 は egress 全遮断 (allowlist は IPv4 のみ。IPv6 を開けると抜け道になる)
+
+### 運用
+
+- **ビルド時の取得は firewall より前**に走る。影響するのは**起動後**の
+  `npm install` / `cdk` / `git fetch` など。取りこぼすと固まる/失敗するので
+  **段階的に allowlist を広げる**運用が現実的。
+- 詰まったら `curl -v <url>` で弾かれた宛先を特定し、`init-firewall.sh` の
+  `EXTRA_HOSTS`(全員)か `.devcontainer/firewall-allow.local`(自分だけ・gitignored)に足す。
+- 既存の自分の `devcontainer.json` には `runArgs` (`--cap-add=NET_ADMIN/NET_RAW`) と
+  `postStartCommand` を手で追記し、devcontainer を rebuild する。
+- 手順・検証・追加方法の詳細は `.devcontainer/README.md`「egress allowlist firewall」。
+
+## 認証はホストに rw マウントしない (原則)
+
+新しい認証をコンテナに持ち込むときは必ず守る:
+
+- **ホストの認証ディレクトリを rw bind マウントしない。** 「壊れた / 復号できない
+  認証を自動削除・再生成する」ツールは、コンテナ側で鍵が無く認証を誤って「壊れている」
+  と判定し削除すると、rw 共有では **ホスト側の認証ファイルまで巻き添えで消す**
+  (別案件で実際に発生した事故)。
+- 認証は **in-container login** で取得し、**コンテナ専用 fs / volume** に置いて分離する。
+- smalruby は既にこの原則に沿う: Claude=in-container ログイン、AWS=in-container SSO
+  ログイン、`~/.gitconfig`=read-only、gh=`GH_TOKEN` env のみ。**この方針を維持する。**
 
 ## 起動からの流れ (毎日のルーチン)
 
@@ -291,6 +343,27 @@ port 8601 は共有リソース** なので衝突しうる:
 
 `devpod stop` は container を止めるので session も消える。**永続化させる必要が
 ある作業 (長時間 build / 監視) は tmux + nohup or systemd など別途工夫が必要**。
+
+### firewall 導入後: `npm install` / `cdk deploy` / `git fetch` が固まる・失敗する
+
+egress allowlist で宛先が弾かれている可能性が高い (ビルド時ではなく**起動後**の取得が対象)。
+
+- 起動ログ末尾の `init-firewall: applied` / `verify OK` 行を確認
+- 弾かれた宛先を `curl -v <url>` で特定し、`init-firewall.sh` の `EXTRA_HOSTS` か
+  `.devcontainer/firewall-allow.local` に追加 → `init-firewall.sh` 再実行 (再起動でも可)
+- 一時的に切り分けたいときは `postStartCommand` をコメントアウトして無 firewall で再現確認
+- 詳細は `.devcontainer/README.md`「egress allowlist firewall」
+
+### firewall 適用後の `devpod ssh` で `Error tunneling to container ...` が出る
+
+コマンド出力自体は返っており、接続終了時の teardown の **cosmetic なメッセージ**。
+default-DROP が tunnel 終了パケットを落とすために出るだけで実害なし。
+
+### workspace 名が衝突する (同名 basename の worktree)
+
+devpod の workspace ID は **host の絶対パス** から生成されるが、basename が同じ
+リポジトリ (worktree 含む) が複数あると名前が衝突しうる。
+`devpod up . --id <一意な名前>` で明示すると安全。
 
 ## 参考
 

--- a/.claude/skills/devcontainer-setup/SKILL.md
+++ b/.claude/skills/devcontainer-setup/SKILL.md
@@ -131,6 +131,11 @@ devpod 利用の場合は:
 - README に「次のステップ」として以下を提示:
   - VS Code: `Cmd+Shift+P` → `Dev Containers: Reopen in Container`
   - devpod: `devpod up . --ide none`
+  - **egress allowlist firewall (既定で有効)**: `.example` には `runArgs`
+    (`--cap-add=NET_ADMIN/NET_RAW`) と `postStartCommand` (`init-firewall.sh`) が
+    含まれる。コンテナの外向き通信は default-DROP で GitHub / npm / Anthropic / AWS のみ
+    許可される。`npm install` / `cdk` が固まったら弾かれた宛先を allowlist に追加する
+    (詳細は `.devcontainer/README.md`「egress allowlist firewall」)
   - 詳細は `.devcontainer/README.md`
 
 ## 設計上の注意

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -8,6 +8,7 @@ Claude Code をホスト直接実行せず、隔離されたコンテナ内で�
 - **既存 `docker compose` ワークフローには影響なし**: `docker compose up app` / `docker compose run --rm app ...` / `bin/dx` は従来通り使える。devcontainer はそれと**別の経路**で動く。
 - **named volume を共有**: `docker compose run app npm install` で作った `node_modules` を devcontainer も使う。`bin/dx` の起動高速化メリットと同じ。git worktree 切替時も再インストール不要。
 - **個人別設定はテンプレート方式**: `.devcontainer/devcontainer.json` は `.gitignore` 対象。`devcontainer.json.example` をコピーして自分の mount を編集する。
+- **egress allowlist firewall**: コンテナの外向き通信を default-DROP にし、GitHub / npm / Anthropic / AWS など必要な宛先だけ許可する (`init-firewall.sh`)。AWS SSO の一時クレデンシャルや in-container Claude ログインなど非公開認証情報がコンテナに到達するため、隔離ガイドラインに沿って到達先を限定する。詳細は下記「egress allowlist firewall」。
 
 ## 利用者の前提
 
@@ -91,6 +92,89 @@ devpod delete smalruby3-editor
    と `gh` (issue/PR) を同一の `GH_TOKEN` に一本化する
 4. **worktree セットアップ**: git worktree であれば `bin/setup-worktree` を実行
    (env コピー + npm install + build:dev)。main checkout なら何もしない
+
+## egress allowlist firewall
+
+コンテナの外向き通信を **default-DROP** にし、必要な宛先のみ許可する firewall を
+`postStartCommand` で**毎起動時**に張る (`init-firewall.sh`)。iptables ルールは
+コンテナの network namespace に属し `devpod stop`/`up` で消えるため、起動のたびに
+張り直す必要がある。
+
+### なぜ必要か
+
+このコンテナは **非公開認証情報** を保持する:
+
+- `cdk deploy` 用の AWS SSO 一時クレデンシャル (in-container で `aws sso login`)
+- in-container でログインする Claude Code の認証
+
+NaCl の隔離ガイドラインでは「非公開認証情報が到達する隔離環境は egress を allowlist で
+限定する」ことが必須要件。よって本 devcontainer では firewall を**既定で有効**にしている。
+
+### 許可している宛先
+
+| 区分 | 宛先 | 用途 |
+|---|---|---|
+| GitHub | `api.github.com/meta` の公開レンジ (web/api/git) | git / gh / upstream fetch / 一部 npm 依存 |
+| npm | `registry.npmjs.org`, `objects.githubusercontent.com`, `codeload.github.com`, `nodejs.org` | `npm install` とバイナリ取得 |
+| Anthropic | `api.anthropic.com`, `sentry.io` | Claude Code |
+| AWS | `ip-ranges.json` のうち **デプロイリージョン + us-east-1 + GLOBAL**、加えて SSO 系 (`oidc/portal.sso/sso.<region>.amazonaws.com`, SSO ポータル) | `cdk deploy` / `aws sso login` |
+| DNS | `/etc/resolv.conf` のリゾルバ + docker DNS (127.0.0.11) の 53 番のみ | 名前解決 (任意 DNS への exfil を遮断) |
+
+- AWS のリージョンと SSO ポータルは **`infra/aws-sso.env`** から自動取得する
+  (fork 時はそのファイルだけ書き換えれば firewall も追従)。
+- IPv4 allowlist のみ。**IPv6 は egress を全遮断**する (allowlist を IPv4 で組むため、
+  IPv6 を開けると素通りの抜け道になる)。
+- **fail-closed**: allowlist の構築に一部失敗しても、最後の DROP は必ず適用される。
+
+### 重要な性質 (ハマりポイント)
+
+- **ビルド時 (Dockerfile / 最初の `postCreate`) の取得は firewall より前**に走るので
+  影響を受けない。影響するのは **コンテナ起動後**の `npm install` / `cdk` / `git fetch` など。
+- 取りこぼすと「npm install が固まる」「cdk deploy が失敗」になる。**段階的に
+  allowlist を広げる**運用が現実的。
+- `forwardPorts` (dev server の `localhost:8601` 転送) は firewall と無関係。
+
+### 許可先を追加する
+
+詰まったら、弾かれた宛先を `curl -v <url>` で特定して以下のいずれかに足す:
+
+1. **全員に効かせる**: `init-firewall.sh` の `EXTRA_HOSTS`(dig 解決する小規模サービス)
+   か、GitHub/AWS のようにレンジで取り込む箇所を編集する。
+2. **自分だけ一時的に**: `.devcontainer/firewall-allow.local` (gitignored) に
+   ホスト名か CIDR を 1 行ずつ書く (`#` でコメント可)。再起動 or `init-firewall.sh`
+   再実行で反映。
+
+```text
+# .devcontainer/firewall-allow.local の例
+example.internal.service.com
+203.0.113.0/24
+```
+
+### 検証
+
+起動ログ末尾に以下が出れば成功:
+
+```
+init-firewall: applied. allowlist entries: <N>
+init-firewall: verify OK: github reachable
+init-firewall: verify OK: example.com blocked
+```
+
+手動で張り直す / 状態を見るには (コンテナ内、root):
+
+```bash
+.devcontainer/init-firewall.sh          # 張り直す
+ipset list allowed-dst | head           # 許可宛先を確認
+iptables -L OUTPUT -n --line-numbers    # ルールを確認
+```
+
+### 既存コンテナへの反映 / 一時無効化
+
+- `.example` から作った**自分の `devcontainer.json`** に `runArgs` と
+  `postStartCommand` を追記する必要がある (テンプレ更新前に作った人は手で足す)。
+  `runArgs` を足したら devcontainer を rebuild (`devpod delete` → `devpod up`)。
+- 一時的に切りたいときは `devcontainer.json` の `postStartCommand` 行をコメントアウト
+  (非推奨)。次回起動から firewall 無しになる。
 
 ## tmux
 
@@ -182,6 +266,20 @@ Claude は自動アップデートしない。version 固定は IDE 側で featu
 `~/.claude/sessions/`, `~/.claude/history.jsonl`, `~/.claude/file-history/`,
 `~/.claude/shell-snapshots/`** (他プロジェクトの転写・履歴の漏れを防ぐ)。
 
+### 原則: ホストの認証ディレクトリを rw でマウントしない
+
+新たに何かの認証をコンテナに持ち込むときは、必ず次を守る:
+
+- **ホストの認証ディレクトリを rw bind マウントしない。** 特に「壊れた / 復号できない
+  認証ファイルを自動削除・再生成する」タイプのツールは危険。コンテナ側の環境 (鍵が
+  無い等) で認証を「壊れている」と誤判定して削除すると、rw 共有では **ホスト側の認証
+  ファイルまで巻き添えで消える** (別案件で実際に発生し、ホストの認証が切れた)。
+- 認証は **コンテナ内で取得 (in-container login)** し、**コンテナ専用の fs / volume** に
+  置いてホストと分離する。
+- 本 devcontainer はこの原則に沿っている: Claude 認証は in-container ログイン、AWS は
+  in-container SSO ログイン、`~/.gitconfig` は **read-only**、gh は `GH_TOKEN` env のみ
+  (`~/.config/gh` には PAT 本体を含めない)。
+
 ### Claude Code memory の共有メカニズム
 
 このプロジェクトの memory (`~/.claude/projects/<host slug>/memory/`) はホスト側スラッグがユーザーのパスに依存するため、`initialize.sh` がホスト側に
@@ -204,8 +302,24 @@ Dockerfile-only にすることで:
 
 ## AWS CDK deploy について
 
-`~/.aws` は **マウントしません**。`cdk deploy` は人間が diff を見て発動する操作なので、
-**ホスト側で実行** することを推奨します。コンテナ内では `cdk synth` / `cdk diff` まで (AWS 認証不要)。
+**ホストの `~/.aws` は mount しません** (host secrets をコンテナに持ち込まない原則)。
+コンテナ内で deploy する場合は、in-container で SSO ログインして一時クレデンシャルを
+取得する:
+
+```bash
+bin/setup-aws-sso                                       # ~/.aws/config を生成
+aws sso login --sso-session smalruby --use-device-code  # URL をホストのブラウザで承認
+export AWS_PROFILE=smalruby
+cdk diff && cdk deploy
+```
+
+egress firewall は `infra/aws-sso.env` のリージョンと SSO ポータルを allowlist に
+取り込むため、in-container での `aws sso login` / `cdk deploy` は通る。詰まる宛先が
+あれば「egress allowlist firewall」の手順で追加する。`cdk synth` / `cdk diff` は AWS
+認証不要なので firewall とも無関係に動く。ホスト側で deploy しても構わない。
+
+> 取得した一時クレデンシャル (`~/.aws/sso/cache`) はコンテナ fs に残り、ホストとは
+> 分離される。短命トークンなので volume 永続化は不要 (`devpod delete` で消えてよい)。
 
 ## トラブルシューティング
 

--- a/.devcontainer/devcontainer.json.example
+++ b/.devcontainer/devcontainer.json.example
@@ -58,8 +58,20 @@
 
     "forwardPorts": [8601],
 
+    // egress allowlist firewall (.devcontainer/init-firewall.sh) が iptables/ipset を
+    // 操作するための capability。これが無いと firewall は張られず警告で終わる。
+    "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
+
     "initializeCommand": ".devcontainer/initialize.sh",
     "postCreateCommand": ".devcontainer/post-create.sh",
+
+    // 毎起動時に egress allowlist firewall を張り直す (iptables ルールは
+    // コンテナの network namespace に属し stop/start で消えるため)。default-DROP で
+    // GitHub / npm / Anthropic / AWS (このリージョン) のみ許可する。許可先の調整は
+    // .devcontainer/init-firewall.sh の EXTRA_HOSTS か .devcontainer/firewall-allow.local
+    // (gitignored) で行う。詳細は .devcontainer/README.md「egress allowlist firewall」。
+    // 一時的に無効化したい場合のみこの行をコメントアウトする (非推奨)。
+    "postStartCommand": ".devcontainer/init-firewall.sh",
 
     "mounts": [
         // ----- 全員共通 (必須) -----

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# .devcontainer/init-firewall.sh — egress allowlist firewall for the devcontainer.
+#
+# Applied at every container start via devcontainer.json `postStartCommand` (iptables
+# rules live in the container's network namespace and are gone after a stop/start, so
+# they must be reapplied). Policy:
+#
+#   - default-DROP on INPUT / OUTPUT / FORWARD (IPv4 *and* IPv6).
+#   - allow loopback, ESTABLISHED/RELATED, and DNS only to the configured resolvers.
+#   - allow an IPv4 allowlist: GitHub + npm + Anthropic + AWS (this deploy region +
+#     global services) + a few small hosts resolved via dig.
+#
+# Why this exists: this container can hold non-public credentials (AWS SSO short-lived
+# tokens for `cdk deploy`, the in-container Claude login), so per the NaCl isolation
+# guideline the container's egress must be limited to known destinations.
+#
+# Fail-closed: `set -e` is intentionally NOT used — even if building the allowlist
+# partly fails, the DROP policy is still applied at the end. Broaden the allowlist via
+# EXTRA_HOSTS below or .devcontainer/firewall-allow.local (gitignored; one host or
+# CIDR per line). See .devcontainer/README.md "egress allowlist firewall".
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+log()  { echo "init-firewall: $*"; }
+warn() { echo "init-firewall: WARN $*" >&2; }
+
+# --- AWS settings (region + SSO portal) from the committed, non-secret source -----
+# infra/aws-sso.env is the single source of truth used by bin/setup-aws-sso. Reusing
+# it keeps the firewall fork-friendly: a different AWS org only edits that one file.
+AWS_REGION="ap-northeast-1"
+SSO_PORTAL_HOST=""
+if [[ -f "${ROOT}/infra/aws-sso.env" ]]; then
+  # shellcheck source=/dev/null
+  . "${ROOT}/infra/aws-sso.env" 2>/dev/null || true
+  [[ -n "${AWS_SSO_REGION:-}" ]] && AWS_REGION="${AWS_SSO_REGION}"
+  if [[ -n "${AWS_SSO_START_URL:-}" ]]; then
+    SSO_PORTAL_HOST="$(printf '%s' "${AWS_SSO_START_URL}" | sed -E 's#^https?://##; s#/.*$##')"
+  fi
+fi
+
+# Small / region-specific destinations that are easier to dig-resolve than to carve
+# out of the AWS range list. Add more here when something legitimate gets blocked.
+EXTRA_HOSTS=(
+  # Anthropic (Claude Code). statsig.anthropic.com has no A record, so it is omitted.
+  api.anthropic.com
+  sentry.io
+  # npm + packages that fetch binaries from GitHub asset / Node hosts
+  registry.npmjs.org
+  objects.githubusercontent.com
+  codeload.github.com
+  nodejs.org
+  # AWS IAM Identity Center (SSO) endpoints for the deploy region
+  "oidc.${AWS_REGION}.amazonaws.com"
+  "portal.sso.${AWS_REGION}.amazonaws.com"
+  "sso.${AWS_REGION}.amazonaws.com"
+)
+[[ -n "${SSO_PORTAL_HOST}" ]] && EXTRA_HOSTS+=("${SSO_PORTAL_HOST}")
+
+if [[ "$(id -u)" -ne 0 ]]; then warn "must run as root (needs NET_ADMIN/NET_RAW)"; exit 1; fi
+missing=(); for c in iptables ipset dig curl jq; do command -v "$c" >/dev/null 2>&1 || missing+=("$c"); done
+if [[ ${#missing[@]} -gt 0 ]]; then warn "missing tools: ${missing[*]} — firewall NOT applied"; exit 1; fi
+
+log "starting (AWS region: ${AWS_REGION}${SSO_PORTAL_HOST:+, SSO portal: ${SSO_PORTAL_HOST}})"
+
+# --- reset ------------------------------------------------------------------------
+# Flush rules AND reopen the policy to ACCEPT first. Flushing alone leaves a prior
+# DROP policy in place, which would block the dig/curl calls used to build the
+# allowlist if this script is re-run inside an already-firewalled container.
+iptables -F; iptables -X 2>/dev/null || true
+iptables -t nat -F 2>/dev/null || true; iptables -t mangle -F 2>/dev/null || true
+iptables -P INPUT ACCEPT; iptables -P FORWARD ACCEPT; iptables -P OUTPUT ACCEPT
+ipset destroy allowed-dst 2>/dev/null || true
+
+# Collect all CIDRs/IPs into a restore file and load them in a single ipset call —
+# far faster than per-entry `ipset add` for the thousands of AWS prefixes.
+SET_FILE="$(mktemp)"; trap 'rm -f "${SET_FILE}"' EXIT
+echo "create allowed-dst hash:net family inet hashsize 4096 maxelem 262144" > "${SET_FILE}"
+emit_cidr() { [[ "$1" =~ ^[0-9.]+(/[0-9]+)?$ ]] && echo "add allowed-dst $1" >> "${SET_FILE}"; }
+emit_host() {
+  local h="$1" ip f=0
+  while read -r ip; do [[ "$ip" =~ ^[0-9.]+$ ]] || continue; emit_cidr "$ip"; f=1; done \
+    < <(dig +short A "$h" 2>/dev/null)
+  [[ $f -eq 1 ]] && log "+ $h" || warn "could not resolve $h"
+}
+
+# GitHub public ranges (git / gh / scratchfoundation upstream fetch / some npm deps).
+gh_meta="$(curl -fsSL --max-time 20 https://api.github.com/meta 2>/dev/null || true)"
+if [[ -n "$gh_meta" ]]; then
+  n=0; while read -r c; do [[ "$c" =~ ^[0-9.]+/[0-9]+$ ]] || continue; emit_cidr "$c"; n=$((n+1)); done \
+    < <(echo "$gh_meta" | jq -r '((.web//[])+(.api//[])+(.git//[]))[]' 2>/dev/null)
+  log "GitHub ranges: $n"
+else
+  warn "github meta fetch failed — falling back to dig"
+  for h in github.com api.github.com; do emit_host "$h"; done
+fi
+
+# AWS public ranges: the deploy region + us-east-1 + GLOBAL (IAM/STS/Route53 and other
+# global endpoints resolve into us-east-1/GLOBAL). Narrow further with .service if the
+# set gets too large; broaden by adding regions to the jq select below.
+aws="$(curl -fsSL --max-time 20 https://ip-ranges.amazonaws.com/ip-ranges.json 2>/dev/null || true)"
+if [[ -n "$aws" ]]; then
+  n=0; while read -r c; do [[ "$c" =~ ^[0-9.]+/[0-9]+$ ]] || continue; emit_cidr "$c"; n=$((n+1)); done \
+    < <(echo "$aws" | jq -r --arg r "$AWS_REGION" \
+        '.prefixes[] | select(.region==$r or .region=="us-east-1" or .region=="GLOBAL") | .ip_prefix' 2>/dev/null)
+  log "AWS ranges (${AWS_REGION}+us-east-1+GLOBAL): $n"
+else
+  warn "aws ip-ranges fetch failed — cdk deploy / sso login may be blocked"
+fi
+
+for h in "${EXTRA_HOSTS[@]}"; do emit_host "$h"; done
+
+# Per-user additions (gitignored): one host or CIDR per line, '#' starts a comment.
+LOCAL_ALLOW="${ROOT}/.devcontainer/firewall-allow.local"
+if [[ -f "${LOCAL_ALLOW}" ]]; then
+  while read -r line; do
+    line="${line%%#*}"; line="$(printf '%s' "$line" | tr -d '[:space:]')"; [[ -z "$line" ]] && continue
+    if [[ "$line" =~ ^[0-9.]+(/[0-9]+)?$ ]]; then emit_cidr "$line"; log "+ (local) $line"; else emit_host "$line"; fi
+  done < "${LOCAL_ALLOW}"
+fi
+
+ipset restore -! < "${SET_FILE}" || warn "ipset restore reported errors"
+
+# --- IPv4 rules -------------------------------------------------------------------
+iptables -A INPUT  -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# DNS only to the configured resolvers (docker embedded DNS 127.0.0.11 +
+# /etc/resolv.conf nameservers). Blocks DNS exfiltration to arbitrary servers.
+resolvers="127.0.0.11"
+while read -r ns; do [[ -n "$ns" ]] && resolvers+=" $ns"; done < <(awk '/^nameserver/ {print $2}' /etc/resolv.conf 2>/dev/null)
+for r in $resolvers; do
+  [[ "$r" =~ ^[0-9.]+$ ]] || continue
+  iptables -A OUTPUT -p udp -d "$r" --dport 53 -j ACCEPT
+  iptables -A OUTPUT -p tcp -d "$r" --dport 53 -j ACCEPT
+done
+log "DNS resolvers allowed: $resolvers"
+
+iptables -A OUTPUT -m set --match-set allowed-dst dst -j ACCEPT
+iptables -P INPUT DROP; iptables -P FORWARD DROP; iptables -P OUTPUT DROP
+
+# --- IPv6: block entirely (allowlist is IPv4-only) --------------------------------
+# Without this, any IPv6 egress would bypass the IPv4 allowlist above. Loopback stays
+# open; everything else is dropped.
+if command -v ip6tables >/dev/null 2>&1; then
+  ip6tables -F 2>/dev/null || true
+  ip6tables -A INPUT  -i lo -j ACCEPT 2>/dev/null || true
+  ip6tables -A OUTPUT -o lo -j ACCEPT 2>/dev/null || true
+  ip6tables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || true
+  ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || true
+  ip6tables -P INPUT DROP 2>/dev/null && ip6tables -P FORWARD DROP 2>/dev/null && ip6tables -P OUTPUT DROP 2>/dev/null \
+    && log "IPv6 egress blocked" || warn "could not fully block IPv6 (kernel may lack ip6tables)"
+fi
+
+log "applied. allowlist entries: $(ipset list allowed-dst 2>/dev/null | grep -cE '^[0-9]+\.')"
+
+# --- verify -----------------------------------------------------------------------
+curl -fsSL --max-time 8 https://api.github.com/zen >/dev/null 2>&1 \
+  && log "verify OK: github reachable" || warn "verify: github NOT reachable"
+curl -fsSL --max-time 6 https://example.com >/dev/null 2>&1 \
+  && warn "verify FAIL: example.com reachable — allowlist too broad" || log "verify OK: example.com blocked"
+log "done"

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ infra/**/cdk-out-*/
 
 # devcontainer の個人別設定 (各自で .example からコピーして mounts を編集する)
 .devcontainer/devcontainer.json
+# egress allowlist firewall の個人別追加宛先 (host or CIDR を 1 行ずつ)
+.devcontainer/firewall-allow.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,16 @@ RUN \
     fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1
 
 # Development convenience tools (separate layer to avoid busting app build cache)
+#
+# iptables / ipset / dnsutils (dig) are required by .devcontainer/init-firewall.sh,
+# the egress allowlist firewall applied at devcontainer start. They are inert for the
+# docker-compose workflow (only exercised when that script runs under NET_ADMIN).
 RUN \
   set -eux \
   && apt install -y --no-install-recommends \
+    dnsutils \
+    iptables \
+    ipset \
     iputils-ping \
     jq \
     less \


### PR DESCRIPTION
## Summary

devpod / devcontainer のコンテナ外向き通信を **無制限 → egress allowlist** に変更する。

このコンテナは `cdk deploy` 用の **AWS SSO 一時クレデンシャル**と **in-container Claude ログイン**という非公開認証情報を保持するため、NaCl Claude Code 利用ガイドライン v0.2 の「隔離環境でもネットワーク接続先を限定する」必須要件に従い、firewall で到達先を限定する。

別案件 (ai-playground) の devpod 構築で本リポジトリの `devpod-workflow.md` を下敷きに作った firewall 実装と教訓の引き継ぎ (`.claude/HANDOFF-devpod-hardening-2026-06-28.md`)。

## Changes Made

- **新規 `.devcontainer/init-firewall.sh`**: iptables + ipset で default-DROP。loopback / ESTABLISHED / 設定済みリゾルバ宛 DNS と allowlist のみ許可。`postStartCommand` で毎起動時に適用 (iptables ルールは stop/start で消えるため)。
  - allowlist: GitHub 公開レンジ + npm (registry / GitHub asset / nodejs.org) + Anthropic (api / sentry) + AWS (**デプロイリージョン + us-east-1 + GLOBAL + SSO**)。
  - AWS リージョンと SSO ポータルは `infra/aws-sso.env` から自動取得 (fork 追従)。
  - **fail-closed** (allowlist 構築に失敗しても DROP は適用)。
- **`.devcontainer/devcontainer.json.example`**: `runArgs` (`--cap-add=NET_ADMIN/NET_RAW`) と `postStartCommand` を追加。
- **`Dockerfile`**: `iptables ipset dnsutils` を追加 (`jq`/`curl` は既存)。
- **`.gitignore`**: 個人別追加宛先 `.devcontainer/firewall-allow.local` を無視。
- **docs**: `.devcontainer/README.md` と `.claude/rules/devpod-workflow.md` に firewall の節を追加。通信方針を「無制限 → egress allowlist」に更新。「ホスト認証ディレクトリを rw マウントしない / in-container or volume」原則を明文化 (引き継ぎ事故報告の教訓)。`--id` 明示・`Error tunneling` cosmetic などの小ネタも追記。
- **`devcontainer-setup` スキル**: firewall が既定で有効である旨を追記。

### ai-playground 実績版からの改良 (3 点)

1. **再実行で自分を締め出さない**: allowlist 構築 (dig/curl) の前に iptables policy を ACCEPT へ戻す。flush だけでは前回の DROP policy が残り、再実行時に自分の DNS/fetch を弾く。
2. **AWS 数千 CIDR を `ipset restore` で一括投入**: per-entry `ipset add` は遅いため。
3. **IPv6 egress を全遮断**: allowlist は IPv4 のみ。IPv6 を開けると素通りの抜け道になるため塞ぐ。

## Test Coverage

- bash 構文チェック (`bash -n`) パス。
- JSONC パース + `runArgs`/`postStartCommand` キー存在を確認。
- パースロジック (SSO ポータルホスト抽出、GitHub/AWS の jq フィルタ) をサンプルデータで検証。

## ⚠️ レビュー前に必要な実機確認

iptables 適用は NET_ADMIN と実 netns が要るため CI / コンテナ内では検証不可。マージ前に **実機 devpod** で `.devcontainer/README.md`「egress allowlist firewall」の手順に従い確認すること:

1. 起動ログ末尾に `init-firewall: applied` / `verify OK: github reachable` / `verify OK: example.com blocked`。
2. コンテナ内 `npm install` が通る。
3. `aws sso login` + `cdk diff`/`cdk deploy` が通る。
4. `npm start` → ホストで `localhost:8601` が開ける。

詰まった宛先は `EXTRA_HOSTS` か `.devcontainer/firewall-allow.local` に段階的に追加。

## Note

SSH-agent-forwarding hardening は別 WIP (`check/koshien-all-20260613` で未コミット) で、本 PR には含まない。両者とも `devpod-workflow.md` / `README.md` を触るため、双方マージ時に軽微な conflict resolution が想定される。

## Related

引き継ぎメモ: `.claude/HANDOFF-devpod-hardening-2026-06-28.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
