### PR TITLE
fix(scratch-vm): re-align comment handling to upstream v13.7.2 (Step 2, #752)

### DIFF
--- a/.claude/rules/scratch-vm/development.md
+++ b/.claude/rules/scratch-vm/development.md
@@ -216,6 +216,8 @@ The mesh v2 extension uses AWS AppSync for real-time collaboration:
 | `src/blocks/scratch3_operators.js` | regex support | operator_contains で正規表現マッチングをサポート |
 | `src/engine/comment.js` | toXML modernization | Blockly v12 対応: `pinned="${!minimized}"` + `collapsed="${minimized}"` (v2.1.19 deserializer が読む属性、v13.7.2 整合 #751) + (0,0) 時の x/y 属性省略 (Smalruby 独自) |
 | `src/engine/runtime.js` | toolboxitemid for extension categories | Blockly v12 対応: 拡張機能のカテゴリ XML に `toolboxitemid` 属性を追加。Blockly v12 の ContinuousToolbox は `toolboxitemid` から id を読むため、未指定だと `blockly-XXX` の auto-id が StatusIndicatorLabel.extensionId に伝搬し、`!` 接続モーダルが拡張機能を見つけられず scanning で固まる |
+| `src/engine/blocks.js` | XML coords guard | `blockToXML` で x/y が finite number のときだけ XML 属性を出力。Ruby → blocks 変換の x/y 未指定 (undefined) を scratch-blocks v2 に正しく伝え、`fromRuby` 再レイアウト経路を維持する |
+| `src/engine/blocks.js` | orphaned-parent guard | `getTopLevelScript` で `block.parent` が this._blocks に存在しない場合に停止。Ruby → blocks 変換中の孤立 parent id で `undefined.parent` 参照クラッシュを防ぐ |
 
 ### 関連ファイル
 

--- a/packages/scratch-vm/src/engine/adapter.js
+++ b/packages/scratch-vm/src/engine/adapter.js
@@ -88,7 +88,7 @@ const domToBlock = function (blockDOM, blocks, isTopBlock, parent) {
         }
         case 'comment':
         {
-            block.comment = xmlChild.attribs.id;
+            block.comment = `${block.id}_comment`;
             break;
         }
         case 'value':

--- a/packages/scratch-vm/src/engine/blocks.js
+++ b/packages/scratch-vm/src/engine/blocks.js
@@ -214,9 +214,15 @@ class Blocks {
         let block = this._blocks[id];
         if (typeof block === 'undefined') return null;
         while (block.parent !== null) {
+            // === Smalruby: Start of orphaned-parent guard ===
+            // Ruby → blocks conversion can transiently leave a block whose
+            // `parent` id points at a block not (yet) in this._blocks. Upstream
+            // walks `block = this._blocks[block.parent]` unguarded, which would
+            // dereference `undefined.parent` and throw. Stop at the orphan.
             const parentBlock = this._blocks[block.parent];
             if (typeof parentBlock === 'undefined') return block.id;
             block = parentBlock;
+            // === Smalruby: End of orphaned-parent guard ===
         }
         return block.id;
     }
@@ -436,17 +442,8 @@ class Blocks {
         case 'comment_create':
             if (this.runtime.getEditingTarget()) {
                 const currTarget = this.runtime.getEditingTarget();
-                // Modern (Blockly v12) `block_comment_create` events carry
-                // x/y/width/height under e.json and have no `text`/`minimized`
-                // payload. The legacy v1 `comment_create` shape used
-                // e.xy/e.width/e.height/e.text/e.minimized. Normalize both.
-                const xy = e.json || e.xy || {};
-                const width = (e.json && e.json.width) || e.width;
-                const height = (e.json && e.json.height) || e.height;
-                const text = e.text || '';
-                const minimized = e.minimized || false;
-                currTarget.createComment(e.commentId, e.blockId, text,
-                    xy.x, xy.y, width, height, minimized);
+                currTarget.createComment(e.commentId, e.blockId, '',
+                    e.json.x, e.json.y, e.json.width, e.json.height, false);
 
                 if (currTarget.comments[e.commentId].x === null &&
                     currTarget.comments[e.commentId].y === null) {
@@ -456,8 +453,8 @@ class Blocks {
                     // comments, then the auto positioning should have taken place.
                     // Update the x and y position of these comments to match the
                     // one from the event.
-                    currTarget.comments[e.commentId].x = xy.x;
-                    currTarget.comments[e.commentId].y = xy.y;
+                    currTarget.comments[e.commentId].x = e.json.x;
+                    currTarget.comments[e.commentId].y = e.json.y;
                 }
             }
             this.emitProjectChanged();
@@ -471,49 +468,7 @@ class Blocks {
                     return;
                 }
                 const comment = currTarget.comments[e.commentId];
-                const change = e.newContents_;
-                // Modern Blockly v12 fires `block_comment_change` with
-                // e.newContents_ as a plain string (the new text). Legacy
-                // v1 used a structured object. Handle both.
-                if (typeof change === 'string') {
-                    comment.text = change;
-                } else if (change && typeof change === 'object') {
-                    if (Object.prototype.hasOwnProperty.call(change, 'minimized')) {
-                        comment.minimized = change.minimized;
-                    }
-                    if (Object.prototype.hasOwnProperty.call(change, 'width') &&
-                        Object.prototype.hasOwnProperty.call(change, 'height')) {
-                        comment.width = change.width;
-                        comment.height = change.height;
-                    }
-                    if (Object.prototype.hasOwnProperty.call(change, 'text')) {
-                        comment.text = change.text;
-                    }
-                }
-                this.emitProjectChanged();
-            }
-            break;
-        case 'block_comment_collapse':
-            if (this.runtime.getEditingTarget()) {
-                const currTarget = this.runtime.getEditingTarget();
-                if (!Object.prototype.hasOwnProperty.call(currTarget.comments, e.commentId)) {
-                    log.warn(`Cannot collapse comment with id ${e.commentId} because it does not exist.`);
-                    return;
-                }
-                currTarget.comments[e.commentId].minimized = !!e.newCollapsed;
-                this.emitProjectChanged();
-            }
-            break;
-        case 'block_comment_resize':
-            if (this.runtime.getEditingTarget()) {
-                const currTarget = this.runtime.getEditingTarget();
-                if (!Object.prototype.hasOwnProperty.call(currTarget.comments, e.commentId)) {
-                    log.warn(`Cannot resize comment with id ${e.commentId} because it does not exist.`);
-                    return;
-                }
-                const newSize = e.newSize || {};
-                currTarget.comments[e.commentId].width = newSize.width;
-                currTarget.comments[e.commentId].height = newSize.height;
+                comment.text = e.newContents_;
                 this.emitProjectChanged();
             }
             break;
@@ -530,6 +485,49 @@ class Blocks {
                 comment.x = newCoord.x;
                 comment.y = newCoord.y;
 
+                this.emitProjectChanged();
+            }
+            break;
+        case 'block_comment_collapse':
+        case 'comment_collapse':
+            if (this.runtime.getEditingTarget()) {
+                const currTarget = this.runtime.getEditingTarget();
+                if (
+                    currTarget &&
+                        !Object.prototype.hasOwnProperty.call(
+                            currTarget.comments,
+                            e.commentId
+                        )
+                ) {
+                    log.warn(
+                        `Cannot collapse comment with id ${e.commentId} because it does not exist.`
+                    );
+                    return;
+                }
+                const comment = currTarget.comments[e.commentId];
+                comment.minimized = e.newCollapsed;
+                this.emitProjectChanged();
+            }
+            break;
+        case 'block_comment_resize':
+        case 'comment_resize':
+            if (this.runtime.getEditingTarget()) {
+                const currTarget = this.runtime.getEditingTarget();
+                if (
+                    currTarget &&
+                        !Object.prototype.hasOwnProperty.call(
+                            currTarget.comments,
+                            e.commentId
+                        )
+                ) {
+                    log.warn(
+                        `Cannot resize comment with id ${e.commentId} because it does not exist.`
+                    );
+                    return;
+                }
+                const comment = currTarget.comments[e.commentId];
+                comment.width = e.newSize.width;
+                comment.height = e.newSize.height;
                 this.emitProjectChanged();
             }
             break;
@@ -560,7 +558,10 @@ class Blocks {
         case 'click':
             // UI event: clicked scripts toggle in the runtime.
             if (e.targetType === 'block') {
-                this.runtime.toggleScript(this.getTopLevelScript(e.blockId), {stackClick: true});
+                this.runtime.toggleScript(
+                    this.getTopLevelScript(e.blockId),
+                    {stackClick: true}
+                );
             }
             break;
         }
@@ -684,9 +685,9 @@ class Blocks {
 
                 // This block has an argument which needs to get separated out into
                 // multiple monitor blocks with ids based on the selected argument
-                const newId = getMonitorIdForBlockWithArgs(block.id, block.fields);
                 // Note: we're not just constantly creating a longer and longer id everytime we check
                 // the checkbox because we're using the id of the block in the flyout as the base
+                const newId = getMonitorIdForBlockWithArgs(block.id, block.fields);
 
                 // check if a block with the new id already exists, otherwise create
                 let newBlock = this.runtime.monitorBlocks.getBlock(newId);

--- a/packages/scratch-vm/test/fixtures/events.json
+++ b/packages/scratch-vm/test/fixtures/events.json
@@ -89,7 +89,7 @@
         "name": "comment",
         "type": "comment_create",
         "commentId": "a comment",
-        "xy": {"x": 10, "y": 20}
+        "json": { "x": 10, "y": 20 }
     },
     "mockVariableBlock": {
         "name": "block",

--- a/packages/scratch-vm/test/unit/engine_adapter.js
+++ b/packages/scratch-vm/test/unit/engine_adapter.js
@@ -52,8 +52,12 @@ test('create with comment', t => {
     t.ok(Array.isArray(result));
     t.equal(result.length, 2);
 
+    t.type(result[0].id, 'string');
     t.type(result[0].comment, 'string');
-    t.equal(result[0].comment, 'aCommentId');
+
+    // as of scratch-blocks@^2, the comment ID is derived from the block ID
+    t.equal(result[0].id, 'z!+#Nqr,_(V=xz0y7a@d');
+    t.equal(result[0].comment, 'z!+#Nqr,_(V=xz0y7a@d_comment');
 
     t.end();
 });

--- a/packages/scratch-vm/test/unit/project_changed_state_blocks.js
+++ b/packages/scratch-vm/test/unit/project_changed_state_blocks.js
@@ -268,11 +268,11 @@ test('Creating a block comment should emit a project changed event', t => {
         type: 'comment_create',
         blockId: 'a new block',
         commentId: 'a new comment',
-        height: 250,
-        width: 400,
-        xy: {
+        json: {
             x: -40,
-            y: 27
+            y: 27,
+            height: 250,
+            width: 400
         },
         minimized: false,
         text: 'comment'
@@ -287,11 +287,11 @@ test('Creating a workspace comment should emit a project changed event', t => {
         type: 'comment_create',
         blockId: null,
         commentId: 'a new comment',
-        height: 250,
-        width: 400,
-        xy: {
+        json: {
             x: -40,
-            y: 27
+            y: 27,
+            height: 250,
+            width: 400
         },
         minimized: false,
         text: 'comment'
@@ -306,11 +306,11 @@ test('Changing a comment should emit a project changed event', t => {
         type: 'comment_create',
         blockId: null,
         commentId: 'a new comment',
-        height: 250,
-        width: 400,
-        xy: {
+        json: {
             x: -40,
-            y: 27
+            y: 27,
+            height: 250,
+            width: 400
         },
         minimized: false,
         text: 'comment'
@@ -356,11 +356,11 @@ test('Deleting a block comment should emit a project changed event', t => {
         type: 'comment_create',
         blockId: 'a new block',
         commentId: 'a new comment',
-        height: 250,
-        width: 400,
-        xy: {
+        json: {
             x: -40,
-            y: 27
+            y: 27,
+            height: 250,
+            width: 400
         },
         minimized: false,
         text: 'comment'
@@ -391,11 +391,11 @@ test('Deleting a workspace comment should emit a project changed event', t => {
         type: 'comment_create',
         blockId: null,
         commentId: 'a new comment',
-        height: 250,
-        width: 400,
-        xy: {
+        json: {
             x: -40,
-            y: 27
+            y: 27,
+            height: 250,
+            width: 400
         },
         minimized: false,
         text: 'comment'
@@ -445,11 +445,11 @@ test('Moving a comment should emit a project changed event', t => {
         type: 'comment_create',
         blockId: null,
         commentId: 'a new comment',
-        height: 250,
-        width: 400,
-        xy: {
+        json: {
             x: -40,
-            y: 27
+            y: 27,
+            height: 250,
+            width: 400
         },
         minimized: false,
         text: 'comment'


### PR DESCRIPTION
## Summary（Step 2 / 段階再整合）

pre-spork 巻き戻し (#270) の取り残しのうち **コメント処理** を upstream **v13.7.2** へ再整合する。Step 1 (#751) に積み上げるスタック PR（base = `fix/upstream-realign-pre-spork-749`）。

- `blocks.js`: コメントイベント (`block_comment_create/change/move/collapse/resize`) の v1/modern dual-path を v13.7.2 の **modern-only** へ統合。v1 `comment_*` shape は scratch-blocks v2.1.19 では発火しない。
- `adapter.js`: block 付属コメント id を `${block.id}_comment` に（v13.7.2 + sb3.js の JSON 経路と一致。従来 XML 経路と JSON 経路が不一致だった）。
- blocks.js に残す 2 つの Smalruby ガード（Ruby 再レイアウト用 XML coords guard、`getTopLevelScript` の orphaned-parent guard）を**マーカー化**。
- テスト/フィクスチャ (`project_changed_state_blocks`, `engine_adapter`, `events.json`) を modern event shape に整合。

## Verification（Playwright + unit, 0 page errors）

- unit: `engine_adapter`(100) / `project_changed_state_blocks` / `virtual-machine` / `engine_target` / `serialization_sb3`(153) ほか green
- コメントイベントハンドラ（modern shape を直接 fire）: text/move/collapse/resize すべて VM に正しく反映
- **sb3 ラウンドトリップ**: コメントの block 紐付けが保持される
- **Ruby タブのコメント**: `# コメント` が block 付属コメントとして変換・紐付けされる（adapter.js 経路の確認）

エビデンス（スクリーンショット/JSON）は作業者の git 管理外 `notes/` に保存。

## Related
- Step 1: #751 / Audit: #749 / 残債追跡: #752
- マージ先は最終的に topic ブランチ `topic/upstream-realign-v13.7.2`（Step 1 が topic に入ったら base を topic に切替）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
