### PR TITLE
chore(test): headless-capable mesh verify script + document playwright-verify in rules

### DIFF
--- a/.claude/rules/scratch-gui/e2e-test.md
+++ b/.claude/rules/scratch-gui/e2e-test.md
@@ -2,6 +2,16 @@
 
 > **SP / iPad 対応の動作確認は最初に [`docs/mobile-ui/playwright.md`](../../../docs/mobile-ui/playwright.md) を参照する。** viewport プリセット、Mobile* 系コンポーネントの data-testid 一覧、共通操作パターン、リグレッションチェックリストがすべて集約してある。本ファイルは SP に限らない一般則 (data-testid 命名規則、Ruby Toolbar / Classroom Modal の testid、Monaco 操作) を扱う。レビュー観点や影響範囲は [`.claude/rules/scratch-gui/mobile-ui.md`](mobile-ui.md) を参照。
 
+## 準備済み E2E / リグレッションスクリプトの置き場所: `tools/playwright-verify/`
+
+複数タブ連動 (Mesh v2 ↔ クラス管理) など unit/integration で網羅しづらい挙動の **スタンドアロン Playwright スクリプト** は `tools/playwright-verify/` にある（CI 非組込・手動 `node <script>.mjs`、独自 browser を起動）。一覧と前提・実行方法は **`tools/playwright-verify/README.md`**。機能を変更したらまず該当スクリプトを探す:
+
+- **mesh** リグレッション → `mesh-v2-classroom-binding.mjs` ほか（詳細は [`mesh.md`](mesh.md) の「準備済み E2E リグレッションスクリプト」）
+- classroom → `smoke-teacher-dashboard.mjs` / `verify-co-teacher.mjs`
+- Ruby 基礎 → `verify-ruby-basics-1.mjs` / iPad キーボード → `verify-issue-727-ipad-keyboard.mjs`
+
+**コンテナ（devpod）は画面が無いので headless で実行**（`HEADLESS=false CHANNEL=chrome` はホスト側で目視するとき）。`xvfb-run` は使わない。Playwright MCP でホスト Chrome を直接操作する方法は memory `reference_host_playwright_mcp.md` 参照。
+
 ## data-testid Convention
 
 **Playwright MCP と Selenium integration tests の両方で `data-testid` 属性を使用する。**

--- a/.claude/rules/scratch-gui/mesh.md
+++ b/.claude/rules/scratch-gui/mesh.md
@@ -113,6 +113,28 @@ Object.assign(MeshV2Service.prototype, NewMixin);
 
 mesh 関連の変更時は必ず実行する。 **5 分以内** に完了すること (heartbeat TTL 制約)。
 
+### 準備済み E2E リグレッションスクリプト (`tools/playwright-verify/`)
+
+mesh のリグレッション確認には `tools/playwright-verify/` の **スタンドアロン Playwright スクリプト**が用意されている（CI 非組込・手動 `node <script>.mjs`、各自の browser を起動）。一覧は `tools/playwright-verify/README.md`。
+
+| スクリプト | 検証対象 |
+|-----------|---------|
+| `mesh-v2-classroom-binding.mjs` | **mesh v2 ↔ クラス管理ドメイン連動の本命リグレッション**。teacher/student 2 タブで参加コード→ `state.scratchGui.meshV2.domain` 一致、接続モーダル入力欄 disabled、解除時の復元 |
+| `verify-mesh-collision-paths.mjs` | mesh センサー衝突パス |
+| `verify-mesh-self-sensor-notice.mjs` | グローバル変数名と mesh センサー値の重複通知 (#707) |
+| `verify-tutorial-mesh-categories.mjs` | チュートリアルの mesh カテゴリ |
+
+実行（dev server 起動 + `.env` の `DEV_BYPASS_TOKEN`/mesh/classroom エンドポイントが前提）:
+
+```bash
+cd tools/playwright-verify
+node mesh-v2-classroom-binding.mjs           # コンテナ内: headless 既定で実行・assert 後 exit 0
+HEADLESS=false CHANNEL=chrome node mesh-v2-classroom-binding.mjs   # ホスト: 実 Chrome で目視
+```
+
+- **コンテナ（devpod）は画面が無いので必ず headless で実行**。`xvfb-run` は使わない。headful で見たいときはホスト側で `HEADLESS=false CHANNEL=chrome`（`KEEP_OPEN=1` で終了後も開いたまま）。
+- mesh の**ユニット/インテグレーション**回帰は `bin/dx`/コンテナ内で: `npm exec tap -- test/unit/mesh_service_v2*.js test/unit/extension_mesh_v2*.js` と `test/integration/extensions/mesh-v2-*.test.js`。
+
 ### 事前準備
 
 1. dev server を **対象の worktree** からマウントする:

--- a/tools/playwright-verify/mesh-v2-classroom-binding.mjs
+++ b/tools/playwright-verify/mesh-v2-classroom-binding.mjs
@@ -67,9 +67,16 @@ const getState = (page, path) =>
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// HEADLESS defaults to true so the script runs in the (display-less) devpod
+// container. Set HEADLESS=false (and optionally CHANNEL=chrome) on the host to
+// watch it run in a real window.
+const HEADLESS = process.env.HEADLESS !== 'false';
+const extraLaunch = process.env.CHANNEL ? { channel: process.env.CHANNEL } : {};
+
 // Use persistent contexts so the Google login survives script restarts.
 const teacherCtx = await chromium.launchPersistentContext(resolve(PROFILE_DIR, 'teacher'), {
-    headless: false,
+    headless: HEADLESS,
+    ...extraLaunch,
     viewport: { width: 1280, height: 800 },
     args: ['--window-position=0,0'],
 });
@@ -83,7 +90,8 @@ let student = null;
 const ensureStudent = async () => {
     if (student && !student.isClosed()) return student;
     studentCtx = await chromium.launchPersistentContext(resolve(PROFILE_DIR, 'student'), {
-        headless: false,
+        headless: HEADLESS,
+        ...extraLaunch,
         viewport: { width: 1280, height: 800 },
         args: ['--window-position=640,40'],
     });
@@ -410,6 +418,15 @@ log('teacher domain:', teacherMeshDomain, 'student domain:', studentMeshDomain);
 log('teacher input:', teacherInput);
 log('student input:', studentInput);
 
-log('done. browser will stay open for inspection. Ctrl+C to exit.');
-// Keep the browser open so the user can inspect both tabs.
-await new Promise(() => {});
+// Keep the browser open for inspection only when running headful (or when
+// KEEP_OPEN=1). In headless/container runs, close cleanly and exit 0 so the
+// script is usable as a regression check (no hanging on the timeout).
+if (!HEADLESS || process.env.KEEP_OPEN === '1') {
+    log('done. browser will stay open for inspection. Ctrl+C to exit.');
+    await new Promise(() => {});
+} else {
+    log('done (headless). all checks passed.');
+    await teacherCtx.close();
+    if (studentCtx) await studentCtx.close();
+    process.exit(0);
+}


### PR DESCRIPTION
## Summary（doc / tools のみ・app 変更なし）

mesh リグレッションの実行性改善とリグレッションスクリプトの発見性向上。topic ブランチ（v13.7.2 再整合シリーズ）へ取り込む。

- `tools/playwright-verify/mesh-v2-classroom-binding.mjs`: `HEADLESS` env を尊重（既定 true = 画面の無い devpod コンテナで実行可）+ `CHANNEL` 対応。headless 実行時は assert 後に context を閉じて exit 0（従来は `headless:false` ハードコードでホストでしか動かなかった）。
- `.claude/rules/scratch-gui/mesh.md`: 「準備済み E2E リグレッションスクリプト」節を追加（`tools/playwright-verify/` の mesh スクリプト一覧 + 実行方法）。
- `.claude/rules/scratch-gui/e2e-test.md`: `tools/playwright-verify/` を「準備済み E2E/リグレッションスクリプトの置き場所」として明記。

app コード変更なし（CI の lint/test 対象外の doc + tools のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
